### PR TITLE
[codex] Improve parser tooling and isolate experimental wasm APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,17 +92,17 @@ Tests related to `eval`, `Function` constructor, and `with` statement are exclud
 - **TypedArray** - Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array, BigInt64Array, BigUint64Array
 - **BigInt** - Basic operations
 
-## Wasm Codegen Scope
+## Experimental Wasm Codegen Scope
 
-The Wasm codegen intentionally supports a strict subset and errors on
-dynamic JS features. Uses wasm-gc for arrays and structs.
+The experimental Wasm codegen intentionally supports a strict subset and errors on
+dynamic JS features. It currently uses wasm-gc for arrays and structs.
 
 - **Statements**: `let`/`const`, assignments, `if`, `while`, `do-while`, `for`, `for-of`
   (arrays), `switch`, `break`/`continue`, `return`, block/expr statements
 - **Expressions**: literals, variables, arithmetic/comparison/bitwise, string `+`,
   array access/length, struct field access, `new Array(size)`,
   `new <interface>` struct allocation, ternary, nullish coalescing (`??`)
-- **wasm-gc**: GC arrays, GC structs, generator state machines
+- **experimental wasm-gc**: GC arrays, GC structs, generator state machines
 
 **Explicitly unsupported in codegen**:
 - `throw`, `try`/`catch`/`finally`
@@ -125,10 +125,10 @@ moon fmt
 # Run test262 (requires test262 repo in ./test262)
 moon run src -- test262 test262.allowlist.txt
 
-# AOT compilation (wasm-gc)
-just aot-check      # Check AOT compilability
-just aot-compile    # Compile fixtures to wasm
-just aot-test       # Run with wasmtime
+# Experimental AOT compilation (wasm-gc)
+just experimental-aot-check      # Check AOT compilability
+just experimental-aot-compile    # Compile fixtures to wasm
+just experimental-aot-test       # Run with wasmtime
 ```
 
 ## License

--- a/justfile
+++ b/justfile
@@ -34,18 +34,18 @@ update:
 clean:
     rm -rf _build target
 
-# Emit wasm-gc binary
-emit-gc file output="out.wasm":
-    moon run src -- emit-gc {{file}} {{output}}
+# Emit experimental wasm-gc binary
+experimental-emit-gc file output="out.wasm":
+    moon run src -- experimental-emit-gc {{file}} {{output}}
 
-# Run wasm-gc tests with wasmtime
-wasmtime-test:
+# Run experimental wasm-gc tests with wasmtime
+experimental-wasmtime-test:
     #!/usr/bin/env bash
     set -e
     echo "=== wasmtime-gc integration tests ==="
 
     # Simple function tests
-    moon run src -- emit-gc tests/wasmtime/simple.ts tests/wasmtime/simple.wasm
+    moon run src -- experimental-emit-gc tests/wasmtime/simple.ts tests/wasmtime/simple.wasm
 
     # Test factorial (filter out warnings, get last line which is the result)
     result=$(wasmtime --wasm gc --invoke factorial tests/wasmtime/simple.wasm 5.0 2>&1 | tail -1)
@@ -66,7 +66,7 @@ wasmtime-test:
     fi
 
     # Struct tests
-    moon run src -- emit-gc tests/wasmtime/struct_basic.ts tests/wasmtime/struct_basic.wasm
+    moon run src -- experimental-emit-gc tests/wasmtime/struct_basic.ts tests/wasmtime/struct_basic.wasm
 
     result=$(wasmtime --wasm gc --invoke createPoint tests/wasmtime/struct_basic.wasm 2>&1 | tail -1)
     if [ "$result" = "30" ]; then
@@ -77,7 +77,7 @@ wasmtime-test:
     fi
 
     # Array tests
-    moon run src -- emit-gc tests/wasmtime/array.ts tests/wasmtime/array.wasm
+    moon run src -- experimental-emit-gc tests/wasmtime/array.ts tests/wasmtime/array.wasm
 
     result=$(wasmtime --wasm gc --invoke sumArray tests/wasmtime/array.wasm 2>&1 | tail -1)
     if [ "$result" = "60" ]; then
@@ -88,7 +88,7 @@ wasmtime-test:
     fi
 
     # Math function tests
-    moon run src -- emit-gc tests/wasmtime/math.ts tests/wasmtime/math.wasm
+    moon run src -- experimental-emit-gc tests/wasmtime/math.ts tests/wasmtime/math.wasm
 
     result=$(wasmtime --wasm gc --invoke testSqrt tests/wasmtime/math.wasm 16.0 2>&1 | tail -1)
     if [ "$result" = "4" ]; then
@@ -108,27 +108,27 @@ wasmtime-test:
 
     echo "=== All wasmtime tests passed ==="
 
-# AOT check - verify fixtures are AOT compilable
-aot-check:
+# Experimental AOT check - verify fixtures are AOT compilable
+experimental-aot-check:
     #!/usr/bin/env bash
     set -e
     echo "=== AOT Compilability Check ==="
 
     echo "Checking fixtures/aot/simple.ts..."
-    moon run src -- aot-check fixtures/aot/simple.ts
+    moon run src -- experimental-aot-check fixtures/aot/simple.ts
 
     echo "Checking fixtures/aot/closure_readonly.ts..."
-    moon run src -- aot-check fixtures/aot/closure_readonly.ts
+    moon run src -- experimental-aot-check fixtures/aot/closure_readonly.ts
 
     echo "Checking fixtures/aot/closure_mutable.ts..."
-    moon run src -- aot-check fixtures/aot/closure_mutable.ts
+    moon run src -- experimental-aot-check fixtures/aot/closure_mutable.ts
 
     echo "Checking fixtures/aot/generator.ts..."
-    moon run src -- aot-check fixtures/aot/generator.ts
+    moon run src -- experimental-aot-check fixtures/aot/generator.ts
 
     echo ""
     echo "Checking not_aot_compatible.ts (should fail)..."
-    if moon run src -- aot-check fixtures/aot/not_aot_compatible.ts 2>&1 | grep -q "not.*compilable\|incompatible"; then
+    if moon run src -- experimental-aot-check fixtures/aot/not_aot_compatible.ts 2>&1 | grep -q "not.*compilable\|incompatible"; then
         echo "PASS: Correctly identified as not AOT compilable"
     else
         echo "Note: May contain some AOT-incompatible functions"
@@ -136,39 +136,39 @@ aot-check:
 
     echo "=== AOT check complete ==="
 
-# AOT compile all fixtures to wasm
-aot-compile:
+# Experimental AOT compile all fixtures to wasm
+experimental-aot-compile:
     #!/usr/bin/env bash
     set -e
     mkdir -p _build/aot
     echo "=== AOT Compile Fixtures ==="
 
     echo "Compiling fixtures/aot/simple.ts..."
-    moon run src -- emit-gc fixtures/aot/simple.ts _build/aot/simple.wasm
+    moon run src -- experimental-emit-gc fixtures/aot/simple.ts _build/aot/simple.wasm
 
     echo "Compiling fixtures/aot/closure_readonly.ts..."
-    moon run src -- emit-gc fixtures/aot/closure_readonly.ts _build/aot/closure_readonly.wasm
+    moon run src -- experimental-emit-gc fixtures/aot/closure_readonly.ts _build/aot/closure_readonly.wasm
 
     echo "Compiling fixtures/aot/closure_mutable.ts..."
-    moon run src -- emit-gc fixtures/aot/closure_mutable.ts _build/aot/closure_mutable.wasm
+    moon run src -- experimental-emit-gc fixtures/aot/closure_mutable.ts _build/aot/closure_mutable.wasm
 
     echo "Compiling fixtures/aot/generator.ts..."
-    moon run src -- emit-gc fixtures/aot/generator.ts _build/aot/generator.wasm
+    moon run src -- experimental-emit-gc fixtures/aot/generator.ts _build/aot/generator.wasm
 
     echo ""
     echo "Generated files:"
     ls -la _build/aot/*.wasm
     echo "=== AOT compile complete ==="
 
-# AOT test - compile and run fixtures with wasmtime
-aot-test:
+# Experimental AOT test - compile and run fixtures with wasmtime
+experimental-aot-test:
     #!/usr/bin/env bash
     set -e
     echo "=== AOT Test with wasmtime ==="
 
     # Compile
     mkdir -p _build/aot
-    moon run src -- emit-gc fixtures/aot/simple.ts _build/aot/simple.wasm
+    moon run src -- experimental-emit-gc fixtures/aot/simple.ts _build/aot/simple.wasm
 
     # Test simple functions
     echo "Testing add(2.0, 3.0)..."
@@ -219,7 +219,7 @@ aot-test:
     echo "=== All AOT tests passed ==="
 
 # List available AOT fixtures
-aot-list:
+experimental-aot-list:
     @echo "AOT Fixtures:"
     @echo "  fixtures/aot/simple.ts           - Basic pure functions"
     @echo "  fixtures/aot/closure_readonly.ts - Closures with read-only captures"

--- a/src/analysis/alias.mbt
+++ b/src/analysis/alias.mbt
@@ -64,7 +64,7 @@ fn AliasInfo::merge_sets(self : AliasInfo, id1 : Int, id2 : Int) -> Unit {
   }
   // Move all variables from 'from' to 'to'
   for v in self.sets[from].variables {
-    if not(self.sets[to].variables.contains(v)) {
+    if !self.sets[to].variables.contains(v) {
       self.sets[to].variables.push(v)
     }
     self.var_to_set[v] = to
@@ -75,7 +75,7 @@ fn AliasInfo::merge_sets(self : AliasInfo, id1 : Int, id2 : Int) -> Unit {
 
 ///|
 fn AliasInfo::mark_escaped(self : AliasInfo, name : String) -> Unit {
-  if not(self.escaped.contains(name)) {
+  if !self.escaped.contains(name) {
     self.escaped.push(name)
   }
   // Mark the entire alias set as non-unique
@@ -109,7 +109,7 @@ pub fn analyze_aliases(func : @ast.TsFunc) -> AliasInfo {
   for entry in info.var_to_set {
     let name = entry.0
     let set_id = entry.1
-    if info.sets[set_id].is_unique && not(info.escaped.contains(name)) {
+    if info.sets[set_id].is_unique && !info.escaped.contains(name) {
       info.unique.push(name)
     }
   }

--- a/src/analysis/aot_check.mbt
+++ b/src/analysis/aot_check.mbt
@@ -78,7 +78,7 @@ pub fn check_func_aot_compatible(func : @ast.TsFunc) -> String? {
   // Check for generator-specific issues
   if func.is_generator {
     let analysis = analyze_generator(func)
-    if not(analysis.compilable) {
+    if !analysis.compilable {
       return analysis.not_compilable_reason
     }
   }
@@ -369,7 +369,7 @@ fn check_arrow_func_aot(
 ) -> String? {
   // Analyze the closure with empty outer scope (conservative)
   let info = analyze_arrow_func(params, body, [])
-  if not(info.compilable) {
+  if !info.compilable {
     return info.not_compilable_reason
   }
   // Mutable captures are now supported (Phase 3)
@@ -392,7 +392,7 @@ fn check_func_expr_aot(func : @ast.TsFunc) -> String? {
   }
   // Analyze the closure with empty outer scope (conservative)
   let info = analyze_func_expr(func, [])
-  if not(info.compilable) {
+  if !info.compilable {
     return info.not_compilable_reason
   }
   // Mutable captures are now supported (Phase 3)

--- a/src/analysis/callgraph.mbt
+++ b/src/analysis/callgraph.mbt
@@ -140,7 +140,7 @@ fn collect_calls_in_expr(expr : @ast.TsExpr, calls : Array[String]) -> Unit {
   match expr {
     @ast.TsExpr::Call(name, args) => {
       // Direct function call
-      if not(calls.contains(name)) {
+      if !calls.contains(name) {
         calls.push(name)
       }
       for arg in args {
@@ -229,7 +229,7 @@ fn try_build_aot_group(
 
   // Check if all reachable functions are AOT-compilable
   for name in reachable {
-    if not(is_function_aot_compatible(ts_module, name)) {
+    if !is_function_aot_compatible(ts_module, name) {
       return None
     }
   }
@@ -283,7 +283,7 @@ fn has_external_callers(
   match graph.callers.get(name) {
     Some(callers) =>
       for caller in callers {
-        if not(group.contains(caller)) {
+        if !group.contains(caller) {
           return true
         }
       }
@@ -316,7 +316,7 @@ fn is_func_body_aot_compatible(func : @ast.TsFunc) -> Bool {
 ///|
 fn is_block_aot_compatible(block : @ast.TsBlock) -> Bool {
   for stmt in block.stmts {
-    if not(is_stmt_aot_compatible(stmt)) {
+    if !is_stmt_aot_compatible(stmt) {
       return false
     }
   }
@@ -328,7 +328,7 @@ fn is_stmt_aot_compatible(stmt : @ast.TsStmt) -> Bool {
   match stmt {
     @ast.TsStmt::With(_, _) => false // with statement not compatible
     @ast.TsStmt::If(_, then_block, else_block) => {
-      if not(is_block_aot_compatible(then_block)) {
+      if !is_block_aot_compatible(then_block) {
         return false
       }
       match else_block {
@@ -343,11 +343,11 @@ fn is_stmt_aot_compatible(stmt : @ast.TsStmt) -> Bool {
     @ast.TsStmt::ForOf(_, _, _, _, body)
     | @ast.TsStmt::ForIn(_, _, _, _, body) => is_block_aot_compatible(body)
     @ast.TsStmt::Try(try_block, _, catch_block, finally_block) => {
-      if not(is_block_aot_compatible(try_block)) {
+      if !is_block_aot_compatible(try_block) {
         return false
       }
       match catch_block {
-        Some(cb) => if not(is_block_aot_compatible(cb)) { return false }
+        Some(cb) => if !is_block_aot_compatible(cb) { return false }
         None => ()
       }
       match finally_block {
@@ -357,7 +357,7 @@ fn is_stmt_aot_compatible(stmt : @ast.TsStmt) -> Bool {
     }
     @ast.TsStmt::Switch(_, cases) => {
       for c in cases {
-        if not(is_block_aot_compatible(c.body)) {
+        if !is_block_aot_compatible(c.body) {
           return false
         }
       }

--- a/src/analysis/cfg.mbt
+++ b/src/analysis/cfg.mbt
@@ -66,10 +66,10 @@ fn CFGBuilder::new_block(self : CFGBuilder) -> Int {
 
 ///|
 fn CFGBuilder::add_edge(self : CFGBuilder, from : Int, to : Int) -> Unit {
-  if not(self.blocks[from].successors.contains(to)) {
+  if !self.blocks[from].successors.contains(to) {
     self.blocks[from].successors.push(to)
   }
-  if not(self.blocks[to].predecessors.contains(from)) {
+  if !self.blocks[to].predecessors.contains(from) {
     self.blocks[to].predecessors.push(from)
   }
 }
@@ -93,7 +93,7 @@ pub fn build_cfg(func : @ast.TsFunc) -> CFG {
   // Find dead blocks
   let dead_blocks : Array[Int] = []
   for block in builder.blocks {
-    if not(block.is_reachable) {
+    if !block.is_reachable {
       dead_blocks.push(block.id)
     }
   }
@@ -157,12 +157,12 @@ fn build_stmt_cfg(
       }
       // Create merge block
       let merge_id = builder.new_block()
-      if not(builder.blocks[then_end].is_terminal) {
+      if !builder.blocks[then_end].is_terminal {
         builder.add_edge(then_end, merge_id)
       }
       match else_block {
         Some(_) =>
-          if not(builder.blocks[else_end].is_terminal) {
+          if !builder.blocks[else_end].is_terminal {
             builder.add_edge(else_end, merge_id)
           }
         None => builder.add_edge(cond_block, merge_id)
@@ -258,7 +258,7 @@ fn build_stmt_cfg(
         for s in case_.body.stmts {
           build_stmt_cfg(builder, s, exits)
         }
-        if not(builder.blocks[builder.current_block_id].is_terminal) {
+        if !builder.blocks[builder.current_block_id].is_terminal {
           builder.add_edge(builder.current_block_id, exit_id)
         }
       }
@@ -301,7 +301,7 @@ fn mark_reachable(blocks : Array[BasicBlock], entry : Int) -> Unit {
     }
     blocks[id].is_reachable = true
     for succ in blocks[id].successors {
-      if not(blocks[succ].is_reachable) {
+      if !blocks[succ].is_reachable {
         worklist.push(succ)
       }
     }

--- a/src/analysis/closure_analysis.mbt
+++ b/src/analysis/closure_analysis.mbt
@@ -189,7 +189,7 @@ fn find_captures_in_stmt(
       find_captures_in_expr(init, local_vars, outer_scope, captures)
     @ast.TsStmt::Assign(name, expr) => {
       // Check if assigning to captured variable
-      if not(local_vars.contains(name)) && outer_scope.contains(name) {
+      if !local_vars.contains(name) && outer_scope.contains(name) {
         match captures.get(name) {
           Some(cap) => captures[name] = { ..cap, is_mutated: true }
           None => captures[name] = { name, is_mutated: true, type_hint: None }
@@ -199,7 +199,7 @@ fn find_captures_in_stmt(
     }
     @ast.TsStmt::CompoundAssign(name, _, expr) => {
       // Check if compound assigning to captured variable
-      if not(local_vars.contains(name)) && outer_scope.contains(name) {
+      if !local_vars.contains(name) && outer_scope.contains(name) {
         match captures.get(name) {
           Some(cap) => captures[name] = { ..cap, is_mutated: true }
           None => captures[name] = { name, is_mutated: true, type_hint: None }
@@ -287,8 +287,8 @@ pub fn find_captures_in_expr(
   match expr {
     @ast.TsExpr::Var(name) =>
       // Check if it's from outer scope (not local)
-      if not(local_vars.contains(name)) && outer_scope.contains(name) {
-        if not(captures.contains(name)) {
+      if !local_vars.contains(name) && outer_scope.contains(name) {
+        if !captures.contains(name) {
           captures[name] = { name, is_mutated: false, type_hint: None }
         }
       }
@@ -335,7 +335,7 @@ pub fn find_captures_in_expr(
     }
     @ast.TsExpr::AssignExpr(name, value) => {
       // Assignment to captured variable
-      if not(local_vars.contains(name)) && outer_scope.contains(name) {
+      if !local_vars.contains(name) && outer_scope.contains(name) {
         match captures.get(name) {
           Some(cap) => captures[name] = { ..cap, is_mutated: true }
           None => captures[name] = { name, is_mutated: true, type_hint: None }
@@ -374,7 +374,7 @@ pub fn find_captures_in_expr(
       // Extend outer scope with current locals for nested closure
       let extended_scope = outer_scope.copy()
       for v in local_vars {
-        if not(extended_scope.contains(v)) {
+        if !extended_scope.contains(v) {
           extended_scope.push(v)
         }
       }
@@ -392,7 +392,7 @@ pub fn find_captures_in_expr(
       }
       let extended_scope = outer_scope.copy()
       for v in local_vars {
-        if not(extended_scope.contains(v)) {
+        if !extended_scope.contains(v) {
           extended_scope.push(v)
         }
       }

--- a/src/analysis/const_fold.mbt
+++ b/src/analysis/const_fold.mbt
@@ -10,12 +10,12 @@ pub(all) enum ConstValue {
   Null
   Undefined
   NotConst // Cannot be computed at compile time
-} derive(Show, Eq)
+} derive(Eq, Debug)
 
 ///|
 /// Check if this value is a compile-time constant.
 pub fn ConstValue::is_const(self : ConstValue) -> Bool {
-  not(self is NotConst)
+  !(self is NotConst)
 }
 
 ///|
@@ -183,7 +183,7 @@ fn eval_unary_const(op : @ast.TsUnaryOp, operand : @ast.TsExpr) -> ConstValue {
     (@ast.TsUnaryOp::Neg, Number(n)) => Number(-n)
     (@ast.TsUnaryOp::Plus, Int(n)) => Int(n)
     (@ast.TsUnaryOp::Plus, Number(n)) => Number(n)
-    (@ast.TsUnaryOp::Not, Boolean(b)) => Boolean(not(b))
+    (@ast.TsUnaryOp::Not, Boolean(b)) => Boolean(!b)
     (@ast.TsUnaryOp::Not, Int(0)) => Boolean(true)
     (@ast.TsUnaryOp::Not, Int(_)) => Boolean(false)
     (@ast.TsUnaryOp::Not, Number(0.0)) => Boolean(true)

--- a/src/analysis/cycle_detect.mbt
+++ b/src/analysis/cycle_detect.mbt
@@ -51,7 +51,7 @@ pub fn analyze_cycles(func : @ast.TsFunc) -> CycleInfo {
   for edge in info.edges {
     match adj.get(edge.from_var) {
       Some(neighbors) =>
-        if not(neighbors.contains(edge.to_var)) {
+        if !neighbors.contains(edge.to_var) {
           neighbors.push(edge.to_var)
         }
       None => adj[edge.from_var] = [edge.to_var]
@@ -65,11 +65,11 @@ pub fn analyze_cycles(func : @ast.TsFunc) -> CycleInfo {
 
   // Initialize all nodes as white
   for entry in adj {
-    if not(white.contains(entry.0)) {
+    if !white.contains(entry.0) {
       white.push(entry.0)
     }
     for neighbor in entry.1 {
-      if not(white.contains(neighbor)) {
+      if !white.contains(neighbor) {
         white.push(neighbor)
       }
     }
@@ -77,7 +77,7 @@ pub fn analyze_cycles(func : @ast.TsFunc) -> CycleInfo {
 
   // DFS from each unvisited node
   for start in white {
-    if not(black.contains(start)) && not(gray.contains(start)) {
+    if !black.contains(start) && !gray.contains(start) {
       dfs_find_cycles(start, adj, gray, black, info)
     }
   }
@@ -107,7 +107,7 @@ fn dfs_find_cycles(
             }
             if in_cycle {
               cycle_vars.push(v)
-              if not(info.cyclic_vars.contains(v)) {
+              if !info.cyclic_vars.contains(v) {
                 info.cyclic_vars.push(v)
               }
             }
@@ -125,7 +125,7 @@ fn dfs_find_cycles(
             variables: cycle_vars,
             edges: cycle_edges,
           })
-        } else if not(black.contains(neighbor)) {
+        } else if !black.contains(neighbor) {
           dfs_find_cycles(neighbor, adj, gray, black, info)
         }
       }

--- a/src/analysis/errors.mbt
+++ b/src/analysis/errors.mbt
@@ -5,7 +5,7 @@
 pub(all) enum AnalysisResult[T] {
   Ok(T, Array[AnalysisError]) // value and warnings
   Err(Array[AnalysisError]) // errors
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// Check if result is successful.

--- a/src/analysis/generator_analysis.mbt
+++ b/src/analysis/generator_analysis.mbt
@@ -38,7 +38,7 @@ pub struct GeneratorAnalysis {
 ///|
 /// Analyze a generator function for AOT compilation.
 pub fn analyze_generator(func : @ast.TsFunc) -> GeneratorAnalysis {
-  if not(func.is_generator) {
+  if !func.is_generator {
     return {
       yield_points: [],
       persisted_vars: [],

--- a/src/analysis/inline.mbt
+++ b/src/analysis/inline.mbt
@@ -6,7 +6,7 @@ pub(all) enum InlineRecommendation {
   Inline // Should be inlined
   MaybeInline // Could be inlined if called few times
   NoInline // Should not be inlined
-} derive(Show, Eq)
+} derive(Eq, Debug)
 
 ///|
 /// Information about a function's inlining suitability.
@@ -53,7 +53,7 @@ pub fn analyze_inline(func : @ast.TsFunc, call_count : Int) -> InlineInfo {
     NoInline
   } else if stmt_count <= inline_stmt_threshold &&
     expr_count <= inline_expr_threshold &&
-    not(has_loops) {
+    !has_loops {
     Inline
   } else if stmt_count <= maybe_inline_stmt_threshold && call_count <= 2 {
     MaybeInline

--- a/src/analysis/leak_detect.mbt
+++ b/src/analysis/leak_detect.mbt
@@ -84,11 +84,11 @@ pub fn analyze_leaks(func : @ast.TsFunc) -> LeakAnalysis {
 
   // Check 2: Variables that escape but aren't tracked
   for name in aliases.escaped {
-    if not(liveness.captured_vars.contains(name)) {
+    if !liveness.captured_vars.contains(name) {
       // Escaped but not in captured list - may indicate tracking issue
       match liveness.lifetimes.get(name) {
         Some(lifetime) =>
-          if not(lifetime.escapes) {
+          if !lifetime.escapes {
             result.leaks.push({
               kind: EscapedWithoutTracking(name),
               message: "Variable '" +
@@ -219,7 +219,7 @@ fn find_accumulating_in_expr(
           @ast.TsExpr::Var(name) =>
             // Check if this variable is defined outside the loop
             // For now, just report it
-            if not(results.iter().any(fn(p) { p.0 == name })) {
+            if !results.iter().any(fn(p) { p.0 == name }) {
               results.push((name, idx))
             }
           _ => ()
@@ -233,7 +233,7 @@ fn find_accumulating_in_expr(
             match recv {
               @ast.TsExpr::Var(recv_name) =>
                 if recv_name == name {
-                  if not(results.iter().any(fn(p) { p.0 == name })) {
+                  if !results.iter().any(fn(p) { p.0 == name }) {
                     results.push((name, idx))
                   }
                 }
@@ -248,7 +248,7 @@ fn find_accumulating_in_expr(
                 match inner {
                   @ast.TsExpr::Var(spread_name) =>
                     if spread_name == name {
-                      if not(results.iter().any(fn(p) { p.0 == name })) {
+                      if !results.iter().any(fn(p) { p.0 == name }) {
                         results.push((name, idx))
                       }
                     }

--- a/src/analysis/liveness.mbt
+++ b/src/analysis/liveness.mbt
@@ -471,11 +471,11 @@ fn find_captured_in_expr(
   match expr {
     @ast.TsExpr::Var(name) =>
       // If variable is not a local parameter, it's captured from outer scope
-      if not(local_params.contains(name)) {
+      if !local_params.contains(name) {
         match info.lifetimes.get(name) {
           Some(lifetime) => {
             lifetime.is_captured = true
-            if not(info.captured_vars.contains(name)) {
+            if !info.captured_vars.contains(name) {
               info.captured_vars.push(name)
             }
           }

--- a/src/analysis/loop_invariant.mbt
+++ b/src/analysis/loop_invariant.mbt
@@ -50,23 +50,20 @@ pub fn analyze_loop_invariants(
 /// Collect variables that are modified in a statement.
 fn collect_modified_vars(stmt : @ast.TsStmt, vars : Array[String]) -> Unit {
   match stmt {
-    @ast.TsStmt::Assign(name, _) =>
-      if not(vars.contains(name)) {
-        vars.push(name)
-      }
+    @ast.TsStmt::Assign(name, _) => if !vars.contains(name) { vars.push(name) }
     @ast.TsStmt::Var(binding, _, _)
     | @ast.TsStmt::Let(binding, _, _)
     | @ast.TsStmt::Const(binding, _, _) => {
       let names : Array[String] = []
       collect_binding_names(binding, names)
       for name in names {
-        if not(vars.contains(name)) {
+        if !vars.contains(name) {
           vars.push(name)
         }
       }
     }
     @ast.TsStmt::CompoundAssign(name, _, _) =>
-      if not(vars.contains(name)) {
+      if !vars.contains(name) {
         vars.push(name)
       }
     @ast.TsStmt::Expr(e) => collect_modified_vars_in_expr(e, vars)
@@ -114,15 +111,12 @@ fn collect_modified_vars_in_expr(
 ) -> Unit {
   match expr {
     @ast.TsExpr::AssignExpr(name, _) =>
-      if not(vars.contains(name)) {
+      if !vars.contains(name) {
         vars.push(name)
       }
     @ast.TsExpr::CompoundAssignExpr(target, _, _) =>
       match target {
-        @ast.TsExpr::Var(name) =>
-          if not(vars.contains(name)) {
-            vars.push(name)
-          }
+        @ast.TsExpr::Var(name) => if !vars.contains(name) { vars.push(name) }
         _ => ()
       }
     @ast.TsExpr::UnaryOp(op, operand) =>
@@ -133,7 +127,7 @@ fn collect_modified_vars_in_expr(
         | @ast.TsUnaryOp::PostDec =>
           match operand {
             @ast.TsExpr::Var(name) =>
-              if not(vars.contains(name)) {
+              if !vars.contains(name) {
                 vars.push(name)
               }
             _ => ()
@@ -273,7 +267,7 @@ fn is_loop_invariant(expr : @ast.TsExpr, modified : Array[String]) -> Bool {
     | @ast.TsExpr::NullLit
     | @ast.TsExpr::ArrayHole => true
     // Variable is invariant if not modified
-    @ast.TsExpr::Var(name) => not(modified.contains(name))
+    @ast.TsExpr::Var(name) => !modified.contains(name)
     // Binary op is invariant if both operands are
     @ast.TsExpr::BinOp(_, left, right) =>
       is_loop_invariant(left, modified) && is_loop_invariant(right, modified)
@@ -318,7 +312,7 @@ fn is_loop_invariant(expr : @ast.TsExpr, modified : Array[String]) -> Bool {
 /// Collect variable dependencies of an expression.
 fn collect_var_deps(expr : @ast.TsExpr, deps : Array[String]) -> Unit {
   match expr {
-    @ast.TsExpr::Var(name) => if not(deps.contains(name)) { deps.push(name) }
+    @ast.TsExpr::Var(name) => if !deps.contains(name) { deps.push(name) }
     @ast.TsExpr::BinOp(_, left, right) => {
       collect_var_deps(left, deps)
       collect_var_deps(right, deps)

--- a/src/analysis/moon.pkg
+++ b/src/analysis/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "moonbitlang/core/debug",
   "mizchi/ts/ast" @ast,
   "mizchi/ts/parser" @parser,
 }

--- a/src/analysis/pkg.generated.mbti
+++ b/src/analysis/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "mizchi/ts/analysis"
 
 import {
   "mizchi/ts/ast",
+  "moonbitlang/core/debug",
 }
 
 // Values
@@ -255,7 +256,7 @@ pub(all) struct AnalysisError {
   kind : AnalysisErrorKind
   message : String
   loc : SourceLoc
-}
+} derive(@debug.Debug)
 pub impl Show for AnalysisError
 
 pub(all) enum AnalysisErrorKind {
@@ -264,18 +265,17 @@ pub(all) enum AnalysisErrorKind {
   TypeError
   UnsupportedFeature
   Warning
-}
-pub impl Eq for AnalysisErrorKind
+} derive(Eq, @debug.Debug)
 pub impl Show for AnalysisErrorKind
 
 pub(all) enum AnalysisResult[T] {
   Ok(T, Array[AnalysisError])
   Err(Array[AnalysisError])
-}
+} derive(@debug.Debug)
 pub fn[T] AnalysisResult::get_errors(Self[T]) -> Array[AnalysisError]
 pub fn[T] AnalysisResult::is_ok(Self[T]) -> Bool
 pub fn[T] AnalysisResult::unwrap(Self[T]) -> T
-pub impl[T : Show] Show for AnalysisResult[T]
+pub impl[T : @debug.Debug] Show for AnalysisResult[T]
 
 pub(all) struct BasicBlock {
   id : Int
@@ -293,7 +293,7 @@ pub(all) struct BindingInfo {
   type_ : @ast.TsType
   is_initialized : Bool
   loc : SourceLoc
-}
+} derive(@debug.Debug)
 pub impl Show for BindingInfo
 
 pub(all) struct CFG {
@@ -343,9 +343,8 @@ pub(all) enum ConstValue {
   Null
   Undefined
   NotConst
-}
+} derive(Eq, @debug.Debug)
 pub fn ConstValue::is_const(Self) -> Bool
-pub impl Eq for ConstValue
 pub impl Show for ConstValue
 
 pub(all) struct ConstraintSolver {
@@ -371,8 +370,7 @@ pub(all) enum DeclKind {
   Param
   Function
   CatchParam
-}
-pub impl Eq for DeclKind
+} derive(Eq, @debug.Debug)
 pub impl Show for DeclKind
 
 pub(all) struct DropAnalysis {
@@ -429,8 +427,7 @@ pub(all) enum InlineRecommendation {
   Inline
   MaybeInline
   NoInline
-}
-pub impl Eq for InlineRecommendation
+} derive(Eq, @debug.Debug)
 pub impl Show for InlineRecommendation
 
 pub(all) struct LeakAnalysis {
@@ -529,7 +526,7 @@ pub(all) enum RefOp {
   Incref(String)
   Decref(String)
   Move(String)
-}
+} derive(@debug.Debug)
 pub impl Show for RefOp
 
 pub(all) struct RefPoint {
@@ -562,8 +559,7 @@ pub(all) enum ScopeKind {
   Catch
   With
   ForLoop
-}
-pub impl Eq for ScopeKind
+} derive(Eq, @debug.Debug)
 pub impl Show for ScopeKind
 
 pub(all) enum SideEffect {
@@ -573,18 +569,16 @@ pub(all) enum SideEffect {
   IO
   Throws
   Unknown
-}
-pub impl Eq for SideEffect
+} derive(Eq, @debug.Debug)
 pub impl Show for SideEffect
 
 pub(all) struct SourceLoc {
   offset : Int
   line : Int
   column : Int
-}
+} derive(Eq, @debug.Debug)
 pub fn SourceLoc::from_offset(String, Int) -> Self
 pub fn SourceLoc::unknown() -> Self
-pub impl Eq for SourceLoc
 pub impl Show for SourceLoc
 
 pub(all) struct SymbolRef {
@@ -592,7 +586,7 @@ pub(all) struct SymbolRef {
   kind : UseKind
   in_closure : Bool
   scope_depth : Int
-}
+} derive(@debug.Debug)
 pub impl Show for SymbolRef
 
 pub(all) struct SymbolTable {
@@ -680,7 +674,7 @@ pub(all) struct UsageInfo {
   references : Array[SymbolRef]
   mut drop_points : Array[SourceLoc]
   mut last_use : SourceLoc?
-}
+} derive(@debug.Debug)
 pub fn UsageInfo::can_drop_at_last_use(Self) -> Bool
 pub fn UsageInfo::is_affine(Self) -> Bool
 pub fn UsageInfo::is_linear(Self) -> Bool
@@ -692,8 +686,7 @@ pub(all) enum UseKind {
   Read
   Write
   ReadWrite
-}
-pub impl Eq for UseKind
+} derive(Eq, @debug.Debug)
 pub impl Show for UseKind
 
 pub(all) struct UsePoint {

--- a/src/analysis/purity.mbt
+++ b/src/analysis/purity.mbt
@@ -9,7 +9,7 @@ pub(all) enum SideEffect {
   IO // Console, network, etc.
   Throws // May throw exception
   Unknown // Cannot determine
-} derive(Show, Eq)
+} derive(Eq, Debug)
 
 ///|
 /// Purity information for a function.
@@ -290,23 +290,23 @@ fn combine_purity(a : PurityInfo, b : PurityInfo) -> PurityInfo {
   }
   let effects : Array[SideEffect] = []
   for e in a.effects {
-    if not(effects.contains(e)) {
+    if !effects.contains(e) {
       effects.push(e)
     }
   }
   for e in b.effects {
-    if not(effects.contains(e)) {
+    if !effects.contains(e) {
       effects.push(e)
     }
   }
   let impure_calls : Array[String] = []
   for c in a.impure_calls {
-    if not(impure_calls.contains(c)) {
+    if !impure_calls.contains(c) {
       impure_calls.push(c)
     }
   }
   for c in b.impure_calls {
-    if not(impure_calls.contains(c)) {
+    if !impure_calls.contains(c) {
       impure_calls.push(c)
     }
   }

--- a/src/analysis/refcount.mbt
+++ b/src/analysis/refcount.mbt
@@ -6,7 +6,7 @@ pub(all) enum RefOp {
   Incref(String) // Increment reference count
   Decref(String) // Decrement reference count
   Move(String) // Transfer ownership (no ref change)
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// A reference operation at a specific point.
@@ -125,7 +125,7 @@ fn analyze_stmt_refcount(
         @ast.TsExpr::Var(name) =>
           // Returning transfers ownership - mark as moved
           if is_rc_var(name, info, type_info) {
-            if not(info.moved_vars.contains(name)) {
+            if !info.moved_vars.contains(name) {
               info.moved_vars.push(name)
             }
             info.ops.push({ stmt_index: idx, op: Move(name), is_before: false })
@@ -141,7 +141,7 @@ fn analyze_stmt_refcount(
   for var_name in get_drop_vars(liveness, idx) {
     if is_rc_var(var_name, info, type_info) {
       // Don't decref if already moved
-      if not(info.moved_vars.contains(var_name)) {
+      if !info.moved_vars.contains(var_name) {
         // Check if this is the last alias
         if is_unique(aliases, var_name) {
           info.ops.push({

--- a/src/analysis/scope.mbt
+++ b/src/analysis/scope.mbt
@@ -441,11 +441,11 @@ fn analyze_stmt_bindings(ctx : AnalysisCtx, stmt : @ast.TsStmt) -> Unit {
     }
     @ast.TsStmt::Label(_, inner_stmt) => analyze_stmt_bindings(ctx, inner_stmt)
     @ast.TsStmt::Break(label) =>
-      if not(ctx.in_loop) && not(ctx.in_switch) && label is None {
+      if !ctx.in_loop && !ctx.in_switch && label is None {
         ctx.add_error(SyntaxError, "Illegal break statement", 0)
       }
     @ast.TsStmt::Continue(label) =>
-      if not(ctx.in_loop) && label is None {
+      if !ctx.in_loop && label is None {
         ctx.add_error(SyntaxError, "Illegal continue statement", 0)
       }
     @ast.TsStmt::Empty | @ast.TsStmt::Debugger => ()

--- a/src/analysis/show_impls.mbt
+++ b/src/analysis/show_impls.mbt
@@ -1,0 +1,77 @@
+///|
+using @debug {trait Debug}
+
+///|
+fn[T : Debug] write_debug_show(logger : &Logger, value : T) -> Unit {
+  logger.write_string(@debug.to_string(value))
+}
+
+///|
+pub impl Show for RefOp with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for SideEffect with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl[T : Debug] Show for AnalysisResult[T] with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for SourceLoc with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for DeclKind with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for BindingInfo with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for ScopeKind with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for AnalysisError with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for AnalysisErrorKind with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for UseKind with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for SymbolRef with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for UsageInfo with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for ConstValue with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for InlineRecommendation with output(self, logger) {
+  write_debug_show(logger, self)
+}

--- a/src/analysis/type_check.mbt
+++ b/src/analysis/type_check.mbt
@@ -147,7 +147,7 @@ fn type_check_function(ctx : FlowTypeCtx, func : @ast.TsFunc) -> @ast.TypedFunc 
     func.return_type != @ast.TsType::Any {
     let inferred_return = ctx.get_return_type()
     if inferred_return != @ast.TsType::Void &&
-      not(is_assignable(inferred_return, func.return_type)) {
+      !is_assignable(inferred_return, func.return_type) {
       ctx.add_constraint(
         Assignable(inferred_return, func.return_type, SourceLoc::unknown()),
       )
@@ -287,8 +287,8 @@ fn type_check_stmt(
           Some(test_e) => {
             let case_type = infer_expr_flow(ctx, test_e)
             // Check case type is compatible
-            if not(is_assignable(case_type, disc_type)) &&
-              not(is_assignable(disc_type, case_type)) {
+            if !is_assignable(case_type, disc_type) &&
+              !is_assignable(disc_type, case_type) {
               ctx.add_constraint(
                 Equal(case_type, disc_type, SourceLoc::unknown()),
               )
@@ -522,7 +522,7 @@ fn infer_expr_flow(ctx : FlowTypeCtx, expr : @ast.TsExpr) -> @ast.TsType {
             let arg_type = infer_expr_flow(ctx, args[i])
             if i < param_types.length() {
               let param_type = param_types[i]
-              if not(is_assignable(arg_type, param_type)) {
+              if !is_assignable(arg_type, param_type) {
                 ctx.add_constraint(
                   Assignable(arg_type, param_type, SourceLoc::unknown()),
                 )
@@ -548,7 +548,7 @@ fn infer_expr_flow(ctx : FlowTypeCtx, expr : @ast.TsExpr) -> @ast.TsType {
             let arg_type = infer_expr_flow(ctx, args[i])
             if i < param_types.length() {
               let param_type = param_types[i]
-              if not(is_assignable(arg_type, param_type)) {
+              if !is_assignable(arg_type, param_type) {
                 ctx.add_constraint(
                   Assignable(arg_type, param_type, SourceLoc::unknown()),
                 )
@@ -577,7 +577,7 @@ fn infer_expr_flow(ctx : FlowTypeCtx, expr : @ast.TsExpr) -> @ast.TsType {
             let arg_type = infer_expr_flow(ctx, args[i])
             if i < param_types.length() {
               let param_type = param_types[i]
-              if not(is_assignable(arg_type, param_type)) {
+              if !is_assignable(arg_type, param_type) {
                 ctx.add_constraint(
                   Assignable(arg_type, param_type, SourceLoc::unknown()),
                 )

--- a/src/analysis/type_constraints.mbt
+++ b/src/analysis/type_constraints.mbt
@@ -168,7 +168,7 @@ pub fn is_assignable(a : @ast.TsType, b : @ast.TsType) -> Bool {
         return false
       }
       for i = 0; i < params_a.length(); i = i + 1 {
-        if not(is_assignable(params_b[i], params_a[i])) {
+        if !is_assignable(params_b[i], params_a[i]) {
           return false
         }
       }
@@ -180,7 +180,7 @@ pub fn is_assignable(a : @ast.TsType, b : @ast.TsType) -> Bool {
         return false
       }
       for i = 0; i < elems_a.length(); i = i + 1 {
-        if not(is_assignable(elems_a[i], elems_b[i])) {
+        if !is_assignable(elems_a[i], elems_b[i]) {
           return false
         }
       }
@@ -212,7 +212,7 @@ pub fn ConstraintSolver::solve(self : ConstraintSolver) -> Unit {
   for constraint in self.constraints {
     match constraint {
       Assignable(from, to, loc) =>
-        if not(is_assignable(from, to)) {
+        if !is_assignable(from, to) {
           self.errors.push({
             message: "Type is not assignable",
             loc,
@@ -224,7 +224,7 @@ pub fn ConstraintSolver::solve(self : ConstraintSolver) -> Unit {
         // For now, just check against inferred type
         ignore(expected)
       Equal(a, b, loc) =>
-        if a != b && not(is_assignable(a, b)) && not(is_assignable(b, a)) {
+        if a != b && !is_assignable(a, b) && !is_assignable(b, a) {
           self.errors.push({
             message: "Types are not equal",
             loc,

--- a/src/analysis/types.mbt
+++ b/src/analysis/types.mbt
@@ -6,7 +6,7 @@ pub(all) struct SourceLoc {
   offset : Int
   line : Int
   column : Int
-} derive(Show, Eq)
+} derive(Eq, Debug)
 
 ///|
 /// Create SourceLoc from token offset by scanning source string.
@@ -41,7 +41,7 @@ pub(all) enum DeclKind {
   Param
   Function
   CatchParam
-} derive(Show, Eq)
+} derive(Eq, Debug)
 
 ///|
 /// Information about a variable binding in scope.
@@ -51,7 +51,7 @@ pub(all) struct BindingInfo {
   type_ : @ast.TsType
   is_initialized : Bool
   loc : SourceLoc
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// Kind of scope for different contexts.
@@ -63,7 +63,7 @@ pub(all) enum ScopeKind {
   Catch
   With
   ForLoop
-} derive(Show, Eq)
+} derive(Eq, Debug)
 
 ///|
 /// Scope for tracking variable bindings.
@@ -137,7 +137,7 @@ pub fn Scope::find_function_scope(self : Scope) -> Scope? {
 /// Check if a name is defined as uninitialized (TDZ).
 pub fn Scope::is_uninitialized(self : Scope, name : String) -> Bool {
   match self.bindings.get(name) {
-    Some(info) => not(info.is_initialized)
+    Some(info) => !info.is_initialized
     None =>
       match self.parent {
         Some(p) => p.is_uninitialized(name)
@@ -199,7 +199,7 @@ pub(all) struct AnalysisError {
   kind : AnalysisErrorKind
   message : String
   loc : SourceLoc
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// Error kind enumeration.
@@ -209,7 +209,7 @@ pub(all) enum AnalysisErrorKind {
   TypeError
   UnsupportedFeature
   Warning
-} derive(Show, Eq)
+} derive(Eq, Debug)
 
 ///|
 /// Create a new analysis context.
@@ -321,7 +321,7 @@ pub fn AnalysisCtx::lookup_binding(
   match self.current_scope.lookup(name) {
     Some(info) => {
       // Check for TDZ violation
-      if not(info.is_initialized) && (info.kind == Let || info.kind == Const) {
+      if !info.is_initialized && (info.kind == Let || info.kind == Const) {
         self.add_error(
           ReferenceError,
           "Cannot access '\{name}' before initialization",

--- a/src/analysis/usage.mbt
+++ b/src/analysis/usage.mbt
@@ -7,7 +7,7 @@ pub(all) enum UseKind {
   Read // x (read value)
   Write // x = ... (assign)
   ReadWrite // x += 1 (read then write)
-} derive(Show, Eq)
+} derive(Eq, Debug)
 
 ///|
 /// A single reference to a symbol.
@@ -16,7 +16,7 @@ pub(all) struct SymbolRef {
   kind : UseKind
   in_closure : Bool // Is this use inside a nested function/arrow?
   scope_depth : Int // Depth of scope at use site
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// Usage information for a single symbol.
@@ -36,7 +36,7 @@ pub(all) struct UsageInfo {
   mut drop_points : Array[SourceLoc]
   // Last use location (for linear/affine analysis)
   mut last_use : SourceLoc?
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// Create new UsageInfo for a symbol.
@@ -64,13 +64,13 @@ pub fn UsageInfo::new(
 ///|
 /// Check if this symbol is used linearly (exactly once after declaration).
 pub fn UsageInfo::is_linear(self : UsageInfo) -> Bool {
-  self.read_count == 1 && self.write_count == 0 && not(self.is_captured)
+  self.read_count == 1 && self.write_count == 0 && !self.is_captured
 }
 
 ///|
 /// Check if this symbol is affine (at most once after declaration).
 pub fn UsageInfo::is_affine(self : UsageInfo) -> Bool {
-  self.read_count <= 1 && self.write_count == 0 && not(self.is_captured)
+  self.read_count <= 1 && self.write_count == 0 && !self.is_captured
 }
 
 ///|
@@ -82,7 +82,7 @@ pub fn UsageInfo::is_unused(self : UsageInfo) -> Bool {
 ///|
 /// Check if symbol can be dropped immediately after last use.
 pub fn UsageInfo::can_drop_at_last_use(self : UsageInfo) -> Bool {
-  not(self.is_captured) && not(self.is_escaped) && self.last_use is Some(_)
+  !self.is_captured && !self.is_escaped && self.last_use is Some(_)
 }
 
 ///|

--- a/src/aot/aot.mbt
+++ b/src/aot/aot.mbt
@@ -19,7 +19,9 @@ pub struct AOTCompilationResult {
 ///|
 /// Compile all compilable functions in a module to wasm-gc.
 /// Returns both the compiled functions and the functions that couldn't be compiled.
-pub fn compile_module_aot(mod : @ast.TsModule) -> AOTCompilationResult {
+pub fn experimental_compile_module_aot(
+  mod : @ast.TsModule,
+) -> AOTCompilationResult {
   let compiled : Array[AOTCompiledFunction] = []
   let uncompiled : Array[@ast.TsFunc] = []
   // Find compilable functions
@@ -41,7 +43,7 @@ pub fn compile_module_aot(mod : @ast.TsModule) -> AOTCompilationResult {
   }
   // Add non-compilable functions to uncompiled
   for func in mod.funcs {
-    if not(compilable_names.contains(func.name)) {
+    if !compilable_names.contains(func.name) {
       uncompiled.push(func)
     }
   }
@@ -55,7 +57,7 @@ fn compile_single_function(func : @ast.TsFunc) -> (Bytes, UInt)? {
   // Create a minimal module with just this function
   let mod : @ast.TsModule = { funcs: [func], interfaces: [], imports: [] }
   try {
-    let wasm_module = @codegen.compile_module_gc(mod)
+    let wasm_module = @codegen.experimental_compile_module_gc(mod)
     // Encode the module to bytes
     let encoded = @encode.encode(wasm_module)
     // The function index is 0 since it's the only function
@@ -67,13 +69,13 @@ fn compile_single_function(func : @ast.TsFunc) -> (Bytes, UInt)? {
 
 ///|
 /// Check if a function is compilable to wasm-gc.
-pub fn is_function_compilable(func : @ast.TsFunc) -> Bool {
+pub fn experimental_is_function_compilable(func : @ast.TsFunc) -> Bool {
   @analysis.can_compile_to_wasm(func).is_compilable()
 }
 
 ///|
 /// Get compilation info for a module (useful for debugging).
-pub fn get_compilation_info(
+pub fn experimental_get_compilation_info(
   mod : @ast.TsModule,
 ) -> (Int, Int, Array[String], Array[String]) {
   let compilable : Array[String] = []

--- a/src/aot/aot_runtime.mbt
+++ b/src/aot/aot_runtime.mbt
@@ -127,7 +127,7 @@ pub suberror AOTError {
 
 ///|
 /// Compile a module to a single wasm module with all compilable functions.
-pub fn compile_module_to_wasm(
+pub fn experimental_compile_module_to_wasm(
   mod : @ast.TsModule,
 ) -> AOTCompiledModule raise AOTError {
   // Get all compilable functions
@@ -146,7 +146,7 @@ pub fn compile_module_to_wasm(
     imports: mod.imports,
   }
   // Compile to wasm-gc
-  let wasm_module = @codegen.compile_module_gc(compile_mod) catch {
+  let wasm_module = @codegen.experimental_compile_module_gc(compile_mod) catch {
     e => raise AOTError::CodeGenError(e.to_string())
   }
   // Encode to bytes
@@ -168,7 +168,9 @@ pub fn compile_module_to_wasm(
 
 ///|
 /// Create an AOT runtime from a TypeScript module.
-pub fn create_aot_runtime(mod : @ast.TsModule) -> AOTRuntime raise AOTError {
-  let compiled = compile_module_to_wasm(mod)
+pub fn experimental_create_aot_runtime(
+  mod : @ast.TsModule,
+) -> AOTRuntime raise AOTError {
+  let compiled = experimental_compile_module_to_wasm(mod)
   AOTRuntime::new(compiled)
 }

--- a/src/aot/aot_wbtest.mbt
+++ b/src/aot/aot_wbtest.mbt
@@ -1,14 +1,14 @@
 // Tests for AOT compilation.
 
 ///|
-test "compile_module_aot: simple pure function" {
+test "experimental_compile_module_aot: simple pure function" {
   let src =
     #|export function add(a: number, b: number): number {
     #|  return a + b;
     #|}
   let parser = @parser.Parser::from_source(src)
   let mod = parser.parse_module()
-  let result = compile_module_aot(mod)
+  let result = experimental_compile_module_aot(mod)
   // Should compile successfully
   assert_eq(result.compiled_functions.length(), 1)
   assert_eq(result.uncompiled_functions.length(), 0)
@@ -18,7 +18,7 @@ test "compile_module_aot: simple pure function" {
 }
 
 ///|
-test "compile_module_aot: multiple functions" {
+test "experimental_compile_module_aot: multiple functions" {
   let src =
     #|export function add(a: number, b: number): number {
     #|  return a + b;
@@ -28,21 +28,21 @@ test "compile_module_aot: multiple functions" {
     #|}
   let parser = @parser.Parser::from_source(src)
   let mod = parser.parse_module()
-  let result = compile_module_aot(mod)
+  let result = experimental_compile_module_aot(mod)
   // Both should compile
   assert_eq(result.compiled_functions.length(), 2)
   assert_eq(result.uncompiled_functions.length(), 0)
 }
 
 ///|
-test "get_compilation_info" {
+test "experimental_get_compilation_info" {
   let src =
     #|export function pure(x: number): number {
     #|  return x * 2;
     #|}
   let parser = @parser.Parser::from_source(src)
   let mod = parser.parse_module()
-  let (compilable_count, not_compilable_count, compilable, not_compilable) = get_compilation_info(
+  let (compilable_count, not_compilable_count, compilable, not_compilable) = experimental_get_compilation_info(
     mod,
   )
   assert_eq(compilable_count, 1)
@@ -52,7 +52,7 @@ test "get_compilation_info" {
 }
 
 ///|
-test "is_function_compilable" {
+test "experimental_is_function_compilable" {
   // Create a simple pure function
   let pure_func : @ast.TsFunc = {
     name: "test",
@@ -62,7 +62,7 @@ test "is_function_compilable" {
     is_generator: false,
     is_async: false,
   }
-  assert_true(is_function_compilable(pure_func))
+  assert_true(experimental_is_function_compilable(pure_func))
   // Create an async function
   let async_func : @ast.TsFunc = {
     name: "async_test",
@@ -72,18 +72,18 @@ test "is_function_compilable" {
     is_generator: false,
     is_async: true,
   }
-  assert_false(is_function_compilable(async_func))
+  assert_false(experimental_is_function_compilable(async_func))
 }
 
 ///|
-test "compile_module_to_wasm" {
+test "experimental_compile_module_to_wasm" {
   let src =
     #|export function add(a: number, b: number): number {
     #|  return a + b;
     #|}
   let parser = @parser.Parser::from_source(src)
   let mod = parser.parse_module()
-  let compiled = compile_module_to_wasm(mod)
+  let compiled = experimental_compile_module_to_wasm(mod)
   assert_eq(compiled.functions.length(), 1)
   assert_true(compiled.wasm_bytes.length() > 0)
 }
@@ -96,7 +96,7 @@ test "AOTRuntime::call simple function" {
     #|}
   let parser = @parser.Parser::from_source(src)
   let mod = parser.parse_module()
-  let runtime = create_aot_runtime(mod)
+  let runtime = experimental_create_aot_runtime(mod)
   assert_true(runtime.has_function("double"))
   // Call the compiled function
   let result = runtime.call("double", [21.0])
@@ -111,7 +111,7 @@ test "AOTRuntime::call add function" {
     #|}
   let parser = @parser.Parser::from_source(src)
   let mod = parser.parse_module()
-  let runtime = create_aot_runtime(mod)
+  let runtime = experimental_create_aot_runtime(mod)
   let result = runtime.call("add", [10.0, 32.0])
   assert_eq(result, 42.0)
 }

--- a/src/aot/pkg.generated.mbti
+++ b/src/aot/pkg.generated.mbti
@@ -7,15 +7,15 @@ import {
 }
 
 // Values
-pub fn compile_module_aot(@ast.TsModule) -> AOTCompilationResult
+pub fn experimental_compile_module_aot(@ast.TsModule) -> AOTCompilationResult
 
-pub fn compile_module_to_wasm(@ast.TsModule) -> AOTCompiledModule raise AOTError
+pub fn experimental_compile_module_to_wasm(@ast.TsModule) -> AOTCompiledModule raise AOTError
 
-pub fn create_aot_runtime(@ast.TsModule) -> AOTRuntime raise AOTError
+pub fn experimental_create_aot_runtime(@ast.TsModule) -> AOTRuntime raise AOTError
 
-pub fn get_compilation_info(@ast.TsModule) -> (Int, Int, Array[String], Array[String])
+pub fn experimental_get_compilation_info(@ast.TsModule) -> (Int, Int, Array[String], Array[String])
 
-pub fn is_function_compilable(@ast.TsFunc) -> Bool
+pub fn experimental_is_function_compilable(@ast.TsFunc) -> Bool
 
 // Errors
 pub suberror AOTError {

--- a/src/aot_fixtures_wbtest.mbt
+++ b/src/aot_fixtures_wbtest.mbt
@@ -186,7 +186,10 @@ test "closure codegen for fixtures/aot/closure_readonly.ts" {
   ]
   let outer_scope : Array[String] = ["x"]
   let ctx = @codegen.ClosureCodegenCtx::new(0U)
-  match @codegen.compile_arrow_func(arrow_params, body, outer_scope, ctx) {
+  match
+    @codegen.experimental_compile_arrow_func(
+      arrow_params, body, outer_scope, ctx,
+    ) {
     Some(code) => {
       assert_true(code.env_struct_type is Some(_))
       assert_eq(code.capture_names.length(), 1)
@@ -233,7 +236,7 @@ test "closure codegen for fixtures/aot/closure_mutable.ts" {
     ],
   }
   let params : Array[@ast.TsParam] = []
-  let lifted_info = @codegen.analyze_lifted_vars(block, [])
+  let lifted_info = @codegen.experimental_analyze_lifted_vars(block, [])
 
   // count should be lifted with mutable flag
   assert_eq(lifted_info.lifted_vars.length(), 1)
@@ -241,7 +244,7 @@ test "closure codegen for fixtures/aot/closure_mutable.ts" {
   assert_eq(lifted_info.is_mutated.get("count"), Some(true))
 
   // Generate code with environment sharing
-  let result = @codegen.compile_func_body_with_env(
+  let result = @codegen.experimental_compile_func_body_with_env(
     block, params, lifted_info, 0U,
   )
   assert_true(result.env_struct_type is Some(_))
@@ -269,7 +272,7 @@ test "generator codegen for fixtures/aot/generator.ts - range" {
   println("Generator yield points: \{analysis.yield_points.length()}")
 
   // Compile generator
-  match @codegen.compile_generator_func(func, 0U) {
+  match @codegen.experimental_compile_generator_func(func, 0U) {
     Some(code) =>
       println(
         "Generated range() next function: \{code.next_func_code.body.instrs.length()} instructions",

--- a/src/ast/moon.pkg
+++ b/src/ast/moon.pkg
@@ -1,2 +1,3 @@
 import {
+  "moonbitlang/core/debug",
 }

--- a/src/ast/pkg.generated.mbti
+++ b/src/ast/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "mizchi/ts/ast"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 
 // Errors
@@ -9,13 +13,13 @@ package "mizchi/ts/ast"
 pub(all) struct TsArrayBinding {
   items : Array[TsBindingElem?]
   rest : TsBinding?
-}
+} derive(@debug.Debug)
 pub impl Show for TsArrayBinding
 
 pub(all) enum TsArrowBody {
   ArrowExpr(TsExpr)
   ArrowBlock(TsBlock)
-}
+} derive(@debug.Debug)
 pub impl Show for TsArrowBody
 
 pub(all) enum TsBinOp {
@@ -44,8 +48,7 @@ pub(all) enum TsBinOp {
   And
   Or
   Coalesce
-}
-pub impl Eq for TsBinOp
+} derive(Eq, @debug.Debug)
 pub impl Show for TsBinOp
 
 pub(all) enum TsBinding {
@@ -53,18 +56,18 @@ pub(all) enum TsBinding {
   Array(TsArrayBinding)
   Object(TsObjectBinding)
   Target(TsExpr)
-}
+} derive(@debug.Debug)
 pub impl Show for TsBinding
 
 pub(all) struct TsBindingElem {
   binding : TsBinding
   default : TsExpr?
-}
+} derive(@debug.Debug)
 pub impl Show for TsBindingElem
 
 pub(all) struct TsBlock {
   stmts : Array[TsStmt]
-}
+} derive(@debug.Debug)
 pub impl Show for TsBlock
 
 pub(all) enum TsCompoundOp {
@@ -83,14 +86,13 @@ pub(all) enum TsCompoundOp {
   AndAssign
   OrAssign
   CoalesceAssign
-}
-pub impl Eq for TsCompoundOp
+} derive(Eq, @debug.Debug)
 pub impl Show for TsCompoundOp
 
 pub(all) struct TsExportSpec {
   local_name : String
   export_name : String
-}
+} derive(@debug.Debug)
 pub impl Show for TsExportSpec
 
 pub(all) enum TsExpr {
@@ -131,7 +133,7 @@ pub(all) enum TsExpr {
   ImportMeta
   TaggedTemplate(TsExpr, Array[String], Array[String], Array[TsExpr])
   TemplateLiteral(Array[String], Array[TsExpr])
-}
+} derive(@debug.Debug)
 pub impl Show for TsExpr
 
 pub(all) enum TsForOfKind {
@@ -139,8 +141,7 @@ pub(all) enum TsForOfKind {
   Let
   Const
   Assign
-}
-pub impl Eq for TsForOfKind
+} derive(Eq, @debug.Debug)
 pub impl Show for TsForOfKind
 
 pub(all) struct TsFunc {
@@ -150,7 +151,7 @@ pub(all) struct TsFunc {
   body : TsBlock
   is_generator : Bool
   is_async : Bool
-}
+} derive(@debug.Debug)
 pub impl Show for TsFunc
 
 pub(all) struct TsImport {
@@ -158,7 +159,7 @@ pub(all) struct TsImport {
   module_ : String
   params : Array[(String, TsType)]
   return_type : TsType
-}
+} derive(@debug.Debug)
 pub impl Show for TsImport
 
 pub(all) struct TsImportDecl {
@@ -168,20 +169,20 @@ pub(all) struct TsImportDecl {
   named_bindings : Array[(String, String)]
   side_effect_only : Bool
   type_only : Bool
-}
+} derive(@debug.Debug)
 pub impl Show for TsImportDecl
 
 pub(all) struct TsInterface {
   name : String
   fields : Array[(String, TsType)]
-}
+} derive(@debug.Debug)
 pub impl Show for TsInterface
 
 pub(all) struct TsModule {
   funcs : Array[TsFunc]
   interfaces : Array[TsInterface]
   imports : Array[TsImport]
-}
+} derive(@debug.Debug)
 pub impl Show for TsModule
 
 pub(all) struct TsModuleBlock {
@@ -189,13 +190,13 @@ pub(all) struct TsModuleBlock {
   imports : Array[TsImportDecl]
   exports : Array[TsExportSpec]
   reexports : Array[TsReExportSpec]
-}
+} derive(@debug.Debug)
 pub impl Show for TsModuleBlock
 
 pub(all) struct TsObjectBinding {
   props : Array[TsObjectBindingProp]
   rest : String?
-}
+} derive(@debug.Debug)
 pub impl Show for TsObjectBinding
 
 pub(all) struct TsObjectBindingProp {
@@ -203,7 +204,7 @@ pub(all) struct TsObjectBindingProp {
   key_expr : TsExpr?
   binding : TsBinding
   default : TsExpr?
-}
+} derive(@debug.Debug)
 pub impl Show for TsObjectBindingProp
 
 pub(all) struct TsParam {
@@ -212,20 +213,20 @@ pub(all) struct TsParam {
   is_rest : Bool
   type_ : TsType
   default : TsExpr?
-}
+} derive(@debug.Debug)
 pub impl Show for TsParam
 
 pub(all) enum TsReExportKind {
   Named(Array[(String, String)])
   All
   Namespace(String)
-}
+} derive(@debug.Debug)
 pub impl Show for TsReExportKind
 
 pub(all) struct TsReExportSpec {
   module_spec : String
   kind : TsReExportKind
-}
+} derive(@debug.Debug)
 pub impl Show for TsReExportSpec
 
 pub(all) enum TsStmt {
@@ -255,13 +256,13 @@ pub(all) enum TsStmt {
   Block(TsBlock)
   Break(String?)
   Continue(String?)
-}
+} derive(@debug.Debug)
 pub impl Show for TsStmt
 
 pub(all) struct TsSwitchCase {
   test_expr : TsExpr?
   body : TsBlock
-}
+} derive(@debug.Debug)
 pub impl Show for TsSwitchCase
 
 pub(all) enum TsType {
@@ -285,8 +286,7 @@ pub(all) enum TsType {
   Union(Array[TsType])
   Intersection(Array[TsType])
   Named(String)
-}
-pub impl Eq for TsType
+} derive(Eq, @debug.Debug)
 pub impl Show for TsType
 
 pub(all) enum TsUnaryOp {
@@ -301,30 +301,29 @@ pub(all) enum TsUnaryOp {
   PreDec
   PostInc
   PostDec
-}
-pub impl Eq for TsUnaryOp
+} derive(Eq, @debug.Debug)
 pub impl Show for TsUnaryOp
 
 pub(all) struct TypedExpr {
   expr : TsExpr
   type_ : TsType
-}
+} derive(@debug.Debug)
 pub impl Show for TypedExpr
 
 pub(all) struct TypedFunc {
   func : TsFunc
   locals : Array[(String, TsType)]
-}
+} derive(@debug.Debug)
 pub impl Show for TypedFunc
 
 pub(all) struct TypedModule {
   funcs : Array[TypedFunc]
-}
+} derive(@debug.Debug)
 pub impl Show for TypedModule
 
 pub(all) struct TypedStmt {
   stmt : TsStmt
-}
+} derive(@debug.Debug)
 pub impl Show for TypedStmt
 
 // Type aliases

--- a/src/ast/show_impls.mbt
+++ b/src/ast/show_impls.mbt
@@ -1,0 +1,152 @@
+///|
+using @debug {trait Debug}
+
+///|
+fn[T : Debug] write_debug_show(logger : &Logger, value : T) -> Unit {
+  logger.write_string(@debug.to_string(value))
+}
+
+///|
+pub impl Show for TsType with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsExpr with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsArrowBody with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsBinOp with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsUnaryOp with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsCompoundOp with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsForOfKind with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsStmt with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsBlock with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsSwitchCase with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsParam with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsBinding with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsBindingElem with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsArrayBinding with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsObjectBindingProp with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsObjectBinding with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsFunc with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsInterface with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsImport with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsModule with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsImportDecl with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsExportSpec with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsReExportKind with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsReExportSpec with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TsModuleBlock with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TypedExpr with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TypedStmt with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TypedFunc with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TypedModule with output(self, logger) {
+  write_debug_show(logger, self)
+}

--- a/src/ast/types.mbt
+++ b/src/ast/types.mbt
@@ -29,7 +29,7 @@ pub(all) enum TsType {
   Intersection(Array[TsType]) // A & B
   // Type reference
   Named(String)
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 // / typedexpression
@@ -130,14 +130,14 @@ pub(all) enum TsExpr {
   // untagged template literal: `string ${expr} string`
   // strings (cooked), expressions
   TemplateLiteral(Array[String], Array[TsExpr])
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / function
 pub(all) enum TsArrowBody {
   ArrowExpr(TsExpr) // () => expr
   ArrowBlock(TsBlock) // () => { ... }
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / binaryoperator
@@ -171,7 +171,7 @@ pub(all) enum TsBinOp {
   And // &&
   Or // ||
   Coalesce // ??
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 // / unaryoperator
@@ -187,7 +187,7 @@ pub(all) enum TsUnaryOp {
   PreDec // --x
   PostInc // x++
   PostDec // x--
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 // / compoundassignmentoperator
@@ -208,7 +208,7 @@ pub(all) enum TsCompoundOp {
   AndAssign // &&=
   OrAssign // ||=
   CoalesceAssign // ??=
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 // / for...of binding kind
@@ -217,7 +217,7 @@ pub(all) enum TsForOfKind {
   Let
   Const
   Assign
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 // / statement
@@ -267,19 +267,19 @@ pub(all) enum TsStmt {
   // break/continue
   Break(String?)
   Continue(String?)
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / block (statementarray)
 pub(all) struct TsBlock {
   stmts : Array[TsStmt]
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub(all) struct TsSwitchCase {
   test_expr : TsExpr?
   body : TsBlock
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / functionparameter
@@ -289,7 +289,7 @@ pub(all) struct TsParam {
   is_rest : Bool
   type_ : TsType
   default : TsExpr? // ()
-} derive(Show)
+} derive(Debug)
 
 ///|
 // /
@@ -298,19 +298,19 @@ pub(all) enum TsBinding {
   Array(TsArrayBinding)
   Object(TsObjectBinding)
   Target(TsExpr)
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub(all) struct TsBindingElem {
   binding : TsBinding
   default : TsExpr?
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub(all) struct TsArrayBinding {
   items : Array[TsBindingElem?]
   rest : TsBinding?
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub(all) struct TsObjectBindingProp {
@@ -318,13 +318,13 @@ pub(all) struct TsObjectBindingProp {
   key_expr : TsExpr?
   binding : TsBinding
   default : TsExpr?
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub(all) struct TsObjectBinding {
   props : Array[TsObjectBindingProp]
   rest : String?
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / functiondefine
@@ -335,14 +335,14 @@ pub(all) struct TsFunc {
   body : TsBlock
   is_generator : Bool
   is_async : Bool
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / interface (structtype)
 pub(all) struct TsInterface {
   name : String
   fields : Array[(String, TsType)] // (fieldName, type)
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / externalfunctionimport
@@ -351,7 +351,7 @@ pub(all) struct TsImport {
   module_ : String // import (: "env")
   params : Array[(String, TsType)] // parameter (name, type)
   return_type : TsType // return valuetype
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / ()
@@ -359,7 +359,7 @@ pub(all) struct TsModule {
   funcs : Array[TsFunc]
   interfaces : Array[TsInterface]
   imports : Array[TsImport] // externalimport
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / module import declaration
@@ -370,14 +370,14 @@ pub(all) struct TsImportDecl {
   named_bindings : Array[(String, String)] // imported, local
   side_effect_only : Bool
   type_only : Bool
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / module export specifier
 pub(all) struct TsExportSpec {
   local_name : String
   export_name : String
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / module re-export kind
@@ -385,14 +385,14 @@ pub(all) enum TsReExportKind {
   Named(Array[(String, String)]) // imported, exported
   All
   Namespace(String) // export * as name from "mod"
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / module re-export specifier
 pub(all) struct TsReExportSpec {
   module_spec : String
   kind : TsReExportKind
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / module block with import/export metadata
@@ -401,7 +401,7 @@ pub(all) struct TsModuleBlock {
   imports : Array[TsImportDecl]
   exports : Array[TsExportSpec]
   reexports : Array[TsReExportSpec]
-} derive(Show)
+} derive(Debug)
 
 // ============================================
 // Typed AST (type-resolved)
@@ -412,14 +412,14 @@ pub(all) struct TsModuleBlock {
 pub(all) struct TypedExpr {
   expr : TsExpr
   type_ : TsType
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / typedstatement
 pub(all) struct TypedStmt {
   stmt : TsStmt
   // add
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / typedfunction
@@ -427,10 +427,10 @@ pub(all) struct TypedFunc {
   func : TsFunc
   // variabletype
   locals : Array[(String, TsType)]
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / typed
 pub(all) struct TypedModule {
   funcs : Array[TypedFunc]
-} derive(Show)
+} derive(Debug)

--- a/src/codegen/closure_codegen.mbt
+++ b/src/codegen/closure_codegen.mbt
@@ -36,7 +36,7 @@ pub fn LiftedVarsInfo::empty() -> LiftedVarsInfo {
 ///|
 /// Analyze a function body to find variables that need to be lifted.
 /// Returns info about which variables are captured by closures.
-pub fn analyze_lifted_vars(
+pub fn experimental_analyze_lifted_vars(
   block : @ast.TsBlock,
   params : Array[String],
 ) -> LiftedVarsInfo {
@@ -52,7 +52,7 @@ pub fn analyze_lifted_vars(
     outer_scope.push(p)
   }
   for l in locals {
-    if not(outer_scope.contains(l)) {
+    if !outer_scope.contains(l) {
       outer_scope.push(l)
     }
   }
@@ -137,10 +137,7 @@ fn collect_binding_names_for_lift(
   names : Array[String],
 ) -> Unit {
   match binding {
-    @ast.TsBinding::Ident(name) =>
-      if not(names.contains(name)) {
-        names.push(name)
-      }
+    @ast.TsBinding::Ident(name) => if !names.contains(name) { names.push(name) }
     @ast.TsBinding::Array(arr) => {
       for item in arr.items {
         match item {
@@ -159,7 +156,7 @@ fn collect_binding_names_for_lift(
       }
       match obj.rest {
         Some(rest_name) =>
-          if not(names.contains(rest_name)) {
+          if !names.contains(rest_name) {
             names.push(rest_name)
           }
         None => ()
@@ -396,7 +393,7 @@ fn ClosureCodegenCtx::gen_name(
 
 ///|
 /// Compile an arrow function to wasm-gc.
-pub fn compile_arrow_func(
+pub fn experimental_compile_arrow_func(
   params : Array[@ast.TsParam],
   body : @ast.TsArrowBody,
   outer_scope : Array[String],
@@ -404,7 +401,7 @@ pub fn compile_arrow_func(
 ) -> ClosureWasmCode? {
   // Analyze the closure
   let info = @analysis.analyze_arrow_func(params, body, outer_scope)
-  if not(info.compilable) {
+  if !info.compilable {
     return None
   }
 
@@ -467,14 +464,14 @@ pub fn compile_arrow_func(
 
 ///|
 /// Compile a function expression to wasm-gc.
-pub fn compile_func_expr(
+pub fn experimental_compile_func_expr(
   func : @ast.TsFunc,
   outer_scope : Array[String],
   ctx : ClosureCodegenCtx,
 ) -> ClosureWasmCode? {
   // Analyze the closure
   let info = @analysis.analyze_func_expr(func, outer_scope)
-  if not(info.compilable) {
+  if !info.compilable {
     return None
   }
 
@@ -659,7 +656,7 @@ fn generate_closure_block(
         let names : Array[String] = []
         collect_binding_names_simple(binding, names)
         for name in names {
-          if not(local_var_indices.contains(name)) {
+          if !local_var_indices.contains(name) {
             local_var_indices[name] = next_local
             locals.push(@core.ValType::F64)
             next_local += 1
@@ -1077,7 +1074,7 @@ pub struct FuncWithEnvCode {
 /// Compile a function body with environment sharing for closures.
 /// This handles the case where closures modify captured variables
 /// and the outer function needs to see those modifications.
-pub fn compile_func_body_with_env(
+pub fn experimental_compile_func_body_with_env(
   block : @ast.TsBlock,
   params : Array[@ast.TsParam],
   lifted_info : LiftedVarsInfo,
@@ -1210,8 +1207,8 @@ fn generate_body_with_env(
         collect_binding_names_simple(binding, names)
         for name in names {
           // Don't assign local index to lifted vars
-          if not(lifted_info.lifted_vars.contains(name)) &&
-            not(local_var_indices.contains(name)) {
+          if !lifted_info.lifted_vars.contains(name) &&
+            !local_var_indices.contains(name) {
             local_var_indices[name] = next_local
             locals.push(@core.ValType::F64)
             next_local += 1

--- a/src/codegen/codegen.mbt
+++ b/src/codegen/codegen.mbt
@@ -4,7 +4,7 @@
 // / codegenerror
 pub suberror CodeGenError {
   CodeGenError(String)
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / string (snapshot)
@@ -4452,7 +4452,7 @@ fn compile_function(
 
 ///|
 // /
-pub fn compile_module(
+pub fn experimental_compile_module(
   module_ : @ast.TsModule,
 ) -> @core.Module raise CodeGenError {
   // importcompute
@@ -4600,7 +4600,7 @@ pub fn compile_module(
 ///|
 /// Compile module using wasm-gc types instead of linear memory.
 /// Arrays are represented as GC arrays, no linear memory allocation.
-pub fn compile_module_gc(
+pub fn experimental_compile_module_gc(
   module_ : @ast.TsModule,
 ) -> @core.Module raise CodeGenError {
   // Import count
@@ -4713,7 +4713,7 @@ pub fn compile_module_gc(
           })
         }
         for v in analysis.persisted_vars {
-          if not(v.is_param) {
+          if !v.is_param {
             gen_fields.push({
               storage: @core.StorageType::Val(@core.ValType::F64),
               mutable: true,
@@ -4752,7 +4752,9 @@ pub fn compile_module_gc(
     match generator_struct_types.get(func.name) {
       Some(struct_type_idx) => {
         // Compile generator: produces create() and next() functions
-        let gen_code = compile_generator_func(func, struct_type_idx)
+        let gen_code = experimental_compile_generator_func(
+          func, struct_type_idx,
+        )
         match gen_code {
           Some(gc) => {
             // Add create function
@@ -5003,7 +5005,7 @@ fn compile_typed_function(
 ///|
 /// Compile a TypedModule to WebAssembly.
 /// Uses pre-analyzed type information for better optimization.
-pub fn compile_typed_module(
+pub fn experimental_compile_typed_module(
   typed_module : @ast.TypedModule,
   original_module : @ast.TsModule,
 ) -> @core.Module raise CodeGenError {
@@ -5142,7 +5144,9 @@ pub fn compile_typed_module(
 
 ///|
 /// Analyze and compile source code in one step.
-pub fn analyze_and_compile(source : String) -> @core.Module raise CodeGenError {
+pub fn experimental_analyze_and_compile(
+  source : String,
+) -> @core.Module raise CodeGenError {
   let parser = @parser.Parser::from_source(source)
   let module_ = parser.parse_module() catch {
     @parser.ParseError(msg) => raise CodeGenError(msg)
@@ -5162,7 +5166,7 @@ pub fn analyze_and_compile(source : String) -> @core.Module raise CodeGenError {
         raise CodeGenError("Analysis failed with unknown error")
       }
     @analysis.AnalysisResult::Ok(typed_module, _) =>
-      compile_typed_module(typed_module, module_)
+      experimental_compile_typed_module(typed_module, module_)
   }
 }
 
@@ -5184,11 +5188,13 @@ fn string_to_bytes(s : String) -> Bytes {
 // / error ( + codegen)
 pub suberror CompileError {
   CompileError(String)
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / TypeScript Wasm
-pub fn compile_to_wasm(source : String) -> Bytes raise CompileError {
+pub fn experimental_compile_to_wasm(
+  source : String,
+) -> Bytes raise CompileError {
   let parser = @parser.Parser::from_source(source)
   let ts_module = parser.parse_module() catch {
     @parser.ParseError::ParseError(msg) =>
@@ -5196,7 +5202,7 @@ pub fn compile_to_wasm(source : String) -> Bytes raise CompileError {
   }
 
   // codegen
-  let wasm_module = compile_module(ts_module) catch {
+  let wasm_module = experimental_compile_module(ts_module) catch {
     CodeGenError(msg) => raise CompileError("CodeGen error: \{msg}")
   }
 
@@ -5209,13 +5215,13 @@ pub fn compile_to_wasm(source : String) -> Bytes raise CompileError {
 
 ///|
 // / TypeScript wasm5 Module generate
-pub fn compile(source : String) -> @core.Module raise CompileError {
+pub fn experimental_compile(source : String) -> @core.Module raise CompileError {
   let parser = @parser.Parser::from_source(source)
   let ts_module = parser.parse_module() catch {
     @parser.ParseError::ParseError(msg) =>
       raise CompileError("Parse error: \{msg}")
   }
-  compile_module(ts_module) catch {
+  experimental_compile_module(ts_module) catch {
     CodeGenError(msg) => raise CompileError("CodeGen error: \{msg}")
   }
 }

--- a/src/codegen/codegen_wbtest.mbt
+++ b/src/codegen/codegen_wbtest.mbt
@@ -2,12 +2,94 @@
 // Uses WasmtimeCli by default for faster execution in CI
 
 ///|
-test "compile_to_wasm: generates valid wasm binary" {
+fn compile_to_wasm(source : String) -> Bytes raise CompileError {
+  experimental_compile_to_wasm(source)
+}
+
+///|
+fn compile(source : String) -> @core.Module raise CompileError {
+  experimental_compile(source)
+}
+
+///|
+fn compile_module(ts_module : @ast.TsModule) -> @core.Module raise CodeGenError {
+  experimental_compile_module(ts_module)
+}
+
+///|
+fn compile_module_gc(
+  ts_module : @ast.TsModule,
+) -> @core.Module raise CodeGenError {
+  experimental_compile_module_gc(ts_module)
+}
+
+///|
+fn analyze_and_compile(source : String) -> @core.Module raise CodeGenError {
+  experimental_analyze_and_compile(source)
+}
+
+///|
+fn transform_to_state_machine(
+  func : @ast.TsFunc,
+  analysis : @analysis.GeneratorAnalysis,
+) -> GenStateMachine {
+  experimental_transform_to_state_machine(func, analysis)
+}
+
+///|
+fn compile_generator(
+  sm : GenStateMachine,
+  state_struct_type_idx : UInt,
+) -> GeneratorWasmCode {
+  experimental_compile_generator(sm, state_struct_type_idx)
+}
+
+///|
+fn compile_arrow_func(
+  params : Array[@ast.TsParam],
+  body : @ast.TsArrowBody,
+  outer_scope : Array[String],
+  ctx : ClosureCodegenCtx,
+) -> ClosureWasmCode? {
+  experimental_compile_arrow_func(params, body, outer_scope, ctx)
+}
+
+///|
+fn compile_func_expr(
+  func : @ast.TsFunc,
+  outer_scope : Array[String],
+  ctx : ClosureCodegenCtx,
+) -> ClosureWasmCode? {
+  experimental_compile_func_expr(func, outer_scope, ctx)
+}
+
+///|
+fn analyze_lifted_vars(
+  block : @ast.TsBlock,
+  params : Array[String],
+) -> LiftedVarsInfo {
+  experimental_analyze_lifted_vars(block, params)
+}
+
+///|
+fn compile_func_body_with_env(
+  block : @ast.TsBlock,
+  params : Array[@ast.TsParam],
+  lifted_info : LiftedVarsInfo,
+  env_type_idx : UInt,
+) -> FuncWithEnvCode {
+  experimental_compile_func_body_with_env(
+    block, params, lifted_info, env_type_idx,
+  )
+}
+
+///|
+test "experimental_compile_to_wasm: generates valid wasm binary" {
   let src =
     #|function add(a: number, b: number): number {
     #|  return a + b;
     #|}
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
 
   // Wasm magic numbercheck: 0x00 0x61 0x73 0x6D (= "\0asm")
   assert_eq(wasm[0], b'\x00')
@@ -24,7 +106,7 @@ test "compile_to_wasm: generates valid wasm binary" {
 }
 
 ///|
-test "compile_to_wasm: factorial" {
+test "experimental_compile_to_wasm: factorial" {
   let src =
     #|function factorial(n: number): number {
     #|  if (n <= 1) {
@@ -32,23 +114,23 @@ test "compile_to_wasm: factorial" {
     #|  }
     #|  return n * factorial(n - 1);
     #|}
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   assert_eq(wasm[0], b'\x00')
   assert_eq(wasm[1], b'\x61')
   assert_run_f64(wasm, "factorial", [5.0], 120.0)
 }
 
 ///|
-test "compile: convenience function" {
+test "experimental_compile: convenience function" {
   let src =
     #|function double(x: number): number {
     #|  return x * 2;
     #|}
-  let wasm_module = compile(src)
+  let wasm_module = experimental_compile(src)
   assert_eq(wasm_module.funcs.length(), 1)
   assert_eq(wasm_module.exports.length(), 1)
   assert_eq(wasm_module.codes.length(), 1)
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   assert_run_f64(wasm, "double", [21.0], 42.0)
 }
 
@@ -58,7 +140,7 @@ test "codegen: constant function" {
     #|function answer(): number {
     #|  return 42;
     #|}
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   assert_run_f64(wasm, "answer", [], 42.0)
 }
 
@@ -68,7 +150,7 @@ test "codegen: add function" {
     #|function add(a: number, b: number): number {
     #|  return a + b;
     #|}
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   assert_run_f64(wasm, "add", [3.0, 5.0], 8.0)
 }
 
@@ -78,7 +160,7 @@ test "codegen: arithmetic" {
     #|function calc(a: number, b: number): number {
     #|  return (a + b) * (a - b);
     #|}
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   // (5 + 3) * (5 - 3) = 8 * 2 = 16
   assert_run_f64(wasm, "calc", [5.0, 3.0], 16.0)
 }
@@ -91,7 +173,7 @@ test "codegen: local variable" {
     #|  let y: number = 20;
     #|  return x + y;
     #|}
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   assert_run_f64(wasm, "test", [], 30.0)
 }
 
@@ -105,7 +187,7 @@ test "codegen: if-else" {
     #|    return b;
     #|  }
     #|}
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   assert_run_f64(wasm, "max", [10.0, 5.0], 10.0)
   assert_run_f64(wasm, "max", [3.0, 7.0], 7.0)
 }
@@ -119,7 +201,7 @@ test "codegen: recursive factorial" {
     #|  }
     #|  return n * factorial(n - 1);
     #|}
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   assert_run_f64(wasm, "factorial", [5.0], 120.0)
 }
 
@@ -135,7 +217,7 @@ test "codegen: while loop" {
     #|  }
     #|  return total;
     #|}
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   // sum(10) = 1+2+...+10 = 55
   assert_run_f64(wasm, "sum", [10.0], 55.0)
 }
@@ -149,7 +231,7 @@ test "codegen: multiple functions" {
     #|function quadruple(x: number): number {
     #|  return double(double(x));
     #|}
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   assert_run_f64(wasm, "quadruple", [5.0], 20.0)
 }
 
@@ -165,7 +247,7 @@ test "codegen: int type operations" {
     #|  }
     #|  return total;
     #|}
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   // sum_int(10) = 1+2+...+10 = 55
   assert_run_i32(wasm, "sum_int", [10.0], 55)
 }
@@ -179,7 +261,7 @@ test "codegen: int factorial" {
     #|  }
     #|  return n * factorial_int(n - 1);
     #|}
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   assert_run_i32(wasm, "factorial_int", [5.0], 120)
 }
 
@@ -190,7 +272,7 @@ test "codegen: array literal and access" {
     #|  let arr: number[] = [1.0, 2.0, 3.0];
     #|  return arr[0] + arr[1] + arr[2];
     #|}
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   assert_run_f64(wasm, "sum_array", [], 6.0)
 }
 
@@ -201,7 +283,7 @@ test "codegen: array with new" {
     #|  let arr: int[] = new Array<int>(5);
     #|  return arr.length;
     #|}
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   assert_run_i32(wasm, "array_length", [], 5)
 }
 
@@ -215,7 +297,7 @@ test "codegen: array assignment" {
     #|  arr[2] = 30;
     #|  return arr[0] + arr[1] + arr[2];
     #|}
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   assert_run_i32(wasm, "array_set", [], 60)
 }
 
@@ -232,7 +314,7 @@ test "codegen: struct creation and field access" {
     #|  p.y = 20.0;
     #|  return p.x + p.y;
     #|}
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   assert_run_f64(wasm, "createPoint", [], 30.0)
 }
 
@@ -247,7 +329,7 @@ test "codegen: struct with int fields" {
     #|  c.count = 42;
     #|  return c.count;
     #|}
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   assert_run_i32(wasm, "testCounter", [], 42)
 }
 
@@ -262,7 +344,7 @@ test "codegen: object literal with computed key" {
     #|  let p: Point = { ["x"]: a, y: b };
     #|  return p.x + p.y;
     #|}
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   assert_run_i32(wasm, "makePoint", [2.0, 5.0], 7)
 }
 
@@ -1310,7 +1392,7 @@ test "generator_codegen: try-catch generates TryTable wasm" {
 }
 
 ///|
-test "compile_aot_group: generator with helper functions" {
+test "experimental_compile_aot_group: generator with helper functions" {
   let src =
     #|function double(x) { return x * 2; }
     #|function triple(x) { return x * 3; }
@@ -1324,14 +1406,14 @@ test "compile_aot_group: generator with helper functions" {
   let groups = @analysis.find_aot_groups(ts_module, graph)
   assert_eq(groups.length(), 1)
   let group = groups[0]
-  match compile_aot_group(group, ts_module, 0U) {
+  match experimental_compile_aot_group(group, ts_module, 0U) {
     Some(code) => assert_eq(code.funcs.length(), 4)
     None => assert_true(false)
   }
 }
 
 ///|
-test "compile_aot_group: helper function calls in generator" {
+test "experimental_compile_aot_group: helper function calls in generator" {
   let src =
     #|function add(a, b) { return a + b; }
     #|function* sum(n) {
@@ -1350,7 +1432,7 @@ test "compile_aot_group: helper function calls in generator" {
   assert_eq(groups.length(), 1)
   let group = groups[0]
   assert_false(group.external_calls.contains("add"))
-  match compile_aot_group(group, ts_module, 0U) {
+  match experimental_compile_aot_group(group, ts_module, 0U) {
     Some(code) => {
       assert_eq(code.funcs.length(), 3)
       match code.func_map.get("add") {
@@ -1365,7 +1447,7 @@ test "compile_aot_group: helper function calls in generator" {
 // ============ Closure codegen tests ============
 
 ///|
-test "compile_arrow_func: no captures" {
+test "experimental_compile_arrow_func: no captures" {
   let params : Array[@ast.TsParam] = [
     {
       name: "x",

--- a/src/codegen/generator_codegen.mbt
+++ b/src/codegen/generator_codegen.mbt
@@ -4,25 +4,25 @@
 ///|
 /// Compile a generator function to wasm-gc.
 /// Returns None if the function is not a generator or cannot be AOT compiled.
-pub fn compile_generator_func(
+pub fn experimental_compile_generator_func(
   func : @ast.TsFunc,
   state_struct_type_idx : UInt,
 ) -> GeneratorWasmCode? {
-  if not(func.is_generator) {
+  if !func.is_generator {
     return None
   }
 
   // Analyze the generator
   let analysis = @analysis.analyze_generator(func)
-  if not(analysis.compilable) {
+  if !analysis.compilable {
     return None
   }
 
   // Transform to state machine IR
-  let sm = transform_to_state_machine(func, analysis)
+  let sm = experimental_transform_to_state_machine(func, analysis)
 
   // Compile to wasm-gc
-  Some(compile_generator(sm, state_struct_type_idx))
+  Some(experimental_compile_generator(sm, state_struct_type_idx))
 }
 
 ///|
@@ -43,7 +43,7 @@ pub struct GeneratorWasmCode {
 ///|
 /// Compile a generator state machine to wasm-gc instructions.
 /// Uses br_table for efficient state dispatch.
-pub fn compile_generator(
+pub fn experimental_compile_generator(
   sm : GenStateMachine,
   state_struct_type_idx : UInt,
 ) -> GeneratorWasmCode {
@@ -166,7 +166,7 @@ fn generate_next_instrs_br_table(
 
 ///|
 /// Compile a generator with if-else chain dispatch (for debugging).
-pub fn compile_generator_if_else(
+pub fn experimental_compile_generator_if_else(
   sm : GenStateMachine,
   state_struct_type_idx : UInt,
 ) -> GeneratorWasmCode {
@@ -818,7 +818,7 @@ pub struct AOTGroupCode {
 ///|
 /// Compile an AOT group to wasm.
 /// All functions in the group are compiled together, allowing internal calls.
-pub fn compile_aot_group(
+pub fn experimental_compile_aot_group(
   group : @analysis.AOTGroup,
   ts_module : @ast.TsModule,
   base_type_idx : UInt,
@@ -856,10 +856,10 @@ pub fn compile_aot_group(
         if func.is_generator {
           // Compile generator
           let analysis = @analysis.analyze_generator(func)
-          if not(analysis.compilable) {
+          if !analysis.compilable {
             return None
           }
-          let sm = transform_to_state_machine(func, analysis)
+          let sm = experimental_transform_to_state_machine(func, analysis)
 
           // State struct type
           let state_struct_type_idx = type_idx
@@ -920,7 +920,7 @@ fn compile_generator_with_calls(
   // For now, use the basic compilation
   // TODO: Replace Call expressions with wasm call instructions using func_map
   let _ = func_map
-  compile_generator(sm, state_struct_type_idx)
+  experimental_compile_generator(sm, state_struct_type_idx)
 }
 
 ///|
@@ -974,12 +974,10 @@ fn compile_helper_body(
 
   // Default return
   if instrs.length() == 0 ||
-    not(
-      match instrs[instrs.length() - 1] {
-        @core.Instr::Return => true
-        _ => false
-      },
-    ) {
+    !(match instrs[instrs.length() - 1] {
+      @core.Instr::Return => true
+      _ => false
+    }) {
     instrs.push(@core.Instr::F64Const(0.0))
   }
   instrs

--- a/src/codegen/generator_ir.mbt
+++ b/src/codegen/generator_ir.mbt
@@ -16,13 +16,13 @@ pub struct GenStateMachine {
   initial_state : Int
   /// Done state index
   done_state : Int
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// A variable in the generator state struct.
 pub struct GenVar {
   name : String
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// A state in the generator state machine.
@@ -33,7 +33,7 @@ pub struct GenState {
   label : String
   /// Instructions to execute in this state
   body : Array[GenInstr]
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// Instructions in the generator state machine IR.
@@ -56,7 +56,7 @@ pub enum GenInstr {
   TryCatch(Array[GenInstr], String?, Array[GenInstr], Array[GenInstr]?)
   /// Throw exception with value
   Throw(GenExpr)
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// Expressions in the generator IR (simplified from AST).
@@ -93,7 +93,7 @@ pub enum GenExpr {
   Cond(GenExpr, GenExpr, GenExpr)
   /// Raw AST expression (fallback for complex cases)
   Raw(@ast.TsExpr)
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// Binary operators in generator IR.
@@ -118,7 +118,7 @@ pub enum GenBinOp {
   Shr
   Ushr
   Other(@ast.TsBinOp)
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// Unary operators in generator IR.
@@ -128,11 +128,11 @@ pub enum GenUnaryOp {
   BitNot
   TypeOf
   Other(@ast.TsUnaryOp)
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// Transform a generator function and its analysis into state machine IR.
-pub fn transform_to_state_machine(
+pub fn experimental_transform_to_state_machine(
   func : @ast.TsFunc,
   analysis : @analysis.GeneratorAnalysis,
 ) -> GenStateMachine {
@@ -145,7 +145,7 @@ pub fn transform_to_state_machine(
   // Build locals from analysis
   let locals : Array[GenVar] = []
   for v in analysis.persisted_vars {
-    if not(v.is_param) {
+    if !v.is_param {
       locals.push({ name: v.name })
     }
   }

--- a/src/codegen/moon.pkg
+++ b/src/codegen/moon.pkg
@@ -1,4 +1,6 @@
 import {
+  "moonbitlang/core/debug",
+  "moonbitlang/core/string",
   "mizchi/wasmx/core" @core,
   "mizchi/wasmx/encode" @encode,
   "mizchi/ts/ast" @ast,

--- a/src/codegen/pkg.generated.mbti
+++ b/src/codegen/pkg.generated.mbti
@@ -5,48 +5,49 @@ import {
   "mizchi/ts/analysis",
   "mizchi/ts/ast",
   "mizchi/wasmx/core",
+  "moonbitlang/core/debug",
 }
 
 // Values
-pub fn analyze_and_compile(String) -> @core.Module raise CodeGenError
+pub fn experimental_analyze_and_compile(String) -> @core.Module raise CodeGenError
 
-pub fn analyze_lifted_vars(@ast.TsBlock, Array[String]) -> LiftedVarsInfo
+pub fn experimental_analyze_lifted_vars(@ast.TsBlock, Array[String]) -> LiftedVarsInfo
 
-pub fn compile(String) -> @core.Module raise CompileError
+pub fn experimental_compile(String) -> @core.Module raise CompileError
 
-pub fn compile_aot_group(@analysis.AOTGroup, @ast.TsModule, UInt) -> AOTGroupCode?
+pub fn experimental_compile_aot_group(@analysis.AOTGroup, @ast.TsModule, UInt) -> AOTGroupCode?
 
-pub fn compile_arrow_func(Array[@ast.TsParam], @ast.TsArrowBody, Array[String], ClosureCodegenCtx) -> ClosureWasmCode?
+pub fn experimental_compile_arrow_func(Array[@ast.TsParam], @ast.TsArrowBody, Array[String], ClosureCodegenCtx) -> ClosureWasmCode?
 
-pub fn compile_func_body_with_env(@ast.TsBlock, Array[@ast.TsParam], LiftedVarsInfo, UInt) -> FuncWithEnvCode
+pub fn experimental_compile_func_body_with_env(@ast.TsBlock, Array[@ast.TsParam], LiftedVarsInfo, UInt) -> FuncWithEnvCode
 
-pub fn compile_func_expr(@ast.TsFunc, Array[String], ClosureCodegenCtx) -> ClosureWasmCode?
+pub fn experimental_compile_func_expr(@ast.TsFunc, Array[String], ClosureCodegenCtx) -> ClosureWasmCode?
 
-pub fn compile_generator(GenStateMachine, UInt) -> GeneratorWasmCode
+pub fn experimental_compile_generator(GenStateMachine, UInt) -> GeneratorWasmCode
 
-pub fn compile_generator_func(@ast.TsFunc, UInt) -> GeneratorWasmCode?
+pub fn experimental_compile_generator_func(@ast.TsFunc, UInt) -> GeneratorWasmCode?
 
-pub fn compile_generator_if_else(GenStateMachine, UInt) -> GeneratorWasmCode
+pub fn experimental_compile_generator_if_else(GenStateMachine, UInt) -> GeneratorWasmCode
 
-pub fn compile_module(@ast.TsModule) -> @core.Module raise CodeGenError
+pub fn experimental_compile_module(@ast.TsModule) -> @core.Module raise CodeGenError
 
-pub fn compile_module_gc(@ast.TsModule) -> @core.Module raise CodeGenError
+pub fn experimental_compile_module_gc(@ast.TsModule) -> @core.Module raise CodeGenError
 
-pub fn compile_to_wasm(String) -> Bytes raise CompileError
+pub fn experimental_compile_to_wasm(String) -> Bytes raise CompileError
 
-pub fn compile_typed_module(@ast.TypedModule, @ast.TsModule) -> @core.Module raise CodeGenError
+pub fn experimental_compile_typed_module(@ast.TypedModule, @ast.TsModule) -> @core.Module raise CodeGenError
 
-pub fn transform_to_state_machine(@ast.TsFunc, @analysis.GeneratorAnalysis) -> GenStateMachine
+pub fn experimental_transform_to_state_machine(@ast.TsFunc, @analysis.GeneratorAnalysis) -> GenStateMachine
 
 // Errors
 pub suberror CodeGenError {
   CodeGenError(String)
-}
+} derive(@debug.Debug)
 pub impl Show for CodeGenError
 
 pub suberror CompileError {
   CompileError(String)
-}
+} derive(@debug.Debug)
 pub impl Show for CompileError
 
 // Types and methods
@@ -102,7 +103,7 @@ pub enum GenBinOp {
   Shr
   Ushr
   Other(@ast.TsBinOp)
-}
+} derive(@debug.Debug)
 pub impl Show for GenBinOp
 
 pub enum GenExpr {
@@ -122,7 +123,7 @@ pub enum GenExpr {
   ObjectLit(Array[(String, GenExpr)])
   Cond(GenExpr, GenExpr, GenExpr)
   Raw(@ast.TsExpr)
-}
+} derive(@debug.Debug)
 pub impl Show for GenExpr
 
 pub enum GenInstr {
@@ -135,14 +136,14 @@ pub enum GenInstr {
   Nop
   TryCatch(Array[GenInstr], String?, Array[GenInstr], Array[GenInstr]?)
   Throw(GenExpr)
-}
+} derive(@debug.Debug)
 pub impl Show for GenInstr
 
 pub struct GenState {
   id : Int
   label : String
   body : Array[GenInstr]
-}
+} derive(@debug.Debug)
 pub impl Show for GenState
 
 pub struct GenStateMachine {
@@ -152,7 +153,7 @@ pub struct GenStateMachine {
   states : Array[GenState]
   initial_state : Int
   done_state : Int
-}
+} derive(@debug.Debug)
 pub fn GenStateMachine::debug_string(Self) -> String
 pub impl Show for GenStateMachine
 
@@ -162,12 +163,12 @@ pub enum GenUnaryOp {
   BitNot
   TypeOf
   Other(@ast.TsUnaryOp)
-}
+} derive(@debug.Debug)
 pub impl Show for GenUnaryOp
 
 pub struct GenVar {
   name : String
-}
+} derive(@debug.Debug)
 pub impl Show for GenVar
 
 pub struct GeneratorWasmCode {

--- a/src/codegen/runner_wasmtime_wbtest.mbt
+++ b/src/codegen/runner_wasmtime_wbtest.mbt
@@ -93,7 +93,7 @@ pub fn run_with_wasmtime(
 
   // Try to parse as number
   try {
-    let v = @strconv.parse_double(result_str)
+    let v = @string.parse_double(result_str)
     RunResult::F64(v)
   } catch {
     _ =>
@@ -103,7 +103,7 @@ pub fn run_with_wasmtime(
       } else {
         // Try parsing as int
         try {
-          let i = @strconv.parse_int(result_str)
+          let i = @string.parse_int(result_str)
           RunResult::I32(i)
         } catch {
           _ => RunResult::Error("Cannot parse result: \{result_str}")

--- a/src/codegen/runner_wbtest.mbt
+++ b/src/codegen/runner_wbtest.mbt
@@ -152,7 +152,7 @@ test "runner: basic wasmx test" {
     #|  return a + b;
     #|}
 
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   assert_run_f64(wasm, "add", [3.0, 5.0], 8.0)
 
   clear_runner()
@@ -167,7 +167,7 @@ test "runner: basic wasmtime test" {
     #|  return a + b;
     #|}
 
-  let wasm = compile_to_wasm(src)
+  let wasm = experimental_compile_to_wasm(src)
   match run_wasm(wasm, "add", [3.0, 5.0]) {
     RunResult::F64(v) => assert_eq(v, 8.0)
     RunResult::Error(e) =>

--- a/src/codegen/show_impls.mbt
+++ b/src/codegen/show_impls.mbt
@@ -1,0 +1,52 @@
+///|
+using @debug {trait Debug}
+
+///|
+fn[T : Debug] write_debug_show(logger : &Logger, value : T) -> Unit {
+  logger.write_string(@debug.to_string(value))
+}
+
+///|
+pub impl Show for CodeGenError with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for CompileError with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for GenStateMachine with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for GenVar with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for GenState with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for GenInstr with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for GenExpr with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for GenBinOp with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for GenUnaryOp with output(self, logger) {
+  write_debug_show(logger, self)
+}

--- a/src/lib/string.mbt
+++ b/src/lib/string.mbt
@@ -64,17 +64,13 @@ pub fn trim_string(s : String, mode : String) -> String {
       end = end - 1
     }
   }
-  s[start:end].to_string() catch {
-    _ => ""
-  }
+  s[start:end].to_string()
 }
 
 ///|
 pub fn string_char_at(s : String, idx : Int) -> String {
   if idx >= 0 && idx < s.length() {
-    s[idx:idx + 1].to_string() catch {
-      _ => ""
-    }
+    s[idx:idx + 1].to_string()
   } else {
     ""
   }
@@ -127,7 +123,7 @@ pub fn string_index_of(s : String, search : String, start_idx : Int) -> Int {
   let end_idx = s.length() - search_len + 1
   let mut i = start
   while i < end_idx {
-    if (s[i:i + search_len].to_string() catch { _ => "" }) == search {
+    if s[i:i + search_len].to_string() == search {
       return i
     }
     i = i + 1
@@ -153,7 +149,7 @@ pub fn string_last_index_of(s : String, search : String, pos : Int) -> Int {
     i = 0
   }
   while i >= 0 {
-    if (s[i:i + search_len].to_string() catch { _ => "" }) == search {
+    if s[i:i + search_len].to_string() == search {
       return i
     }
     if i == 0 {
@@ -181,7 +177,7 @@ pub fn string_starts_with(s : String, search : String, pos : Int) -> Bool {
   } else if p + search_len > s.length() {
     false
   } else {
-    (s[p:p + search_len].to_string() catch { _ => "" }) == search
+    s[p:p + search_len].to_string() == search
   }
 }
 
@@ -201,7 +197,7 @@ pub fn string_ends_with(s : String, search : String, end_pos : Int) -> Bool {
     false
   } else {
     let start = ep - search_len
-    (s[start:ep].to_string() catch { _ => "" }) == search
+    s[start:ep].to_string() == search
   }
 }
 
@@ -214,7 +210,7 @@ pub fn string_at(s : String, idx : Int) -> String? {
   if i < 0 || i >= s.length() {
     None
   } else {
-    Some(s[i:i + 1].to_string() catch { _ => "" })
+    Some(s[i:i + 1].to_string())
   }
 }
 
@@ -244,9 +240,7 @@ pub fn string_slice(s : String, start : Int, end : Int) -> String {
   if st >= en {
     ""
   } else {
-    s[st:en].to_string() catch {
-      _ => ""
-    }
+    s[st:en].to_string()
   }
 }
 
@@ -272,9 +266,7 @@ pub fn string_substring(s : String, start : Int, end : Int) -> String {
     st = en
     en = tmp
   }
-  s[st:en].to_string() catch {
-    _ => ""
-  }
+  s[st:en].to_string()
 }
 
 ///|
@@ -297,7 +289,7 @@ pub fn string_pad_start(
       sb.write_string(pad)
       filled = filled + pad.length()
     } else {
-      sb.write_string(pad[0:remaining].to_string() catch { _ => "" })
+      sb.write_string(pad[0:remaining].to_string())
       filled = fill_len
     }
   }
@@ -322,7 +314,7 @@ pub fn string_pad_end(s : String, target_len : Int, pad_str : String) -> String 
       sb.write_string(pad)
       filled = filled + pad.length()
     } else {
-      sb.write_string(pad[0:remaining].to_string() catch { _ => "" })
+      sb.write_string(pad[0:remaining].to_string())
       filled = fill_len
     }
   }

--- a/src/main.mbt
+++ b/src/main.mbt
@@ -15,14 +15,14 @@ async fn main_async() -> Unit {
       let file_path = args[2]
       run_ts_file(file_path)
     }
-    "emit-gc" => {
+    "experimental-emit-gc" => {
       if args.length() < 3 {
         println("Error: no file specified")
         return
       }
       let file_path = args[2]
       let output_path = if args.length() >= 4 { args[3] } else { "out.wasm" }
-      emit_wasm_gc(file_path, output_path)
+      experimental_emit_wasm_gc(file_path, output_path)
     }
     "test262" => {
       if args.length() < 3 {
@@ -32,13 +32,13 @@ async fn main_async() -> Unit {
       let test_path = args[2]
       run_test262(test_path)
     }
-    "analyze" | "aot-check" => {
+    "experimental-analyze" | "experimental-aot-check" => {
       if args.length() < 3 {
         println("Error: no file specified")
         return
       }
       let file_path = args[2]
-      analyze_aot(file_path)
+      experimental_analyze_aot(file_path)
     }
     "emit-moonbit-decl" => {
       if args.length() < 3 {
@@ -66,18 +66,22 @@ fn print_usage() -> Unit {
   println("Usage: wasm5-ts <command> [args...]")
   println("")
   println("Commands:")
-  println("  run <file>           Run a TypeScript/JavaScript file")
-  println("  emit-gc <file> [out] Emit wasm-gc binary (default: out.wasm)")
-  println("  test262 <path>       Run test262 tests (file or directory)")
-  println("  analyze <file>       Analyze AOT compilability of functions")
-  println("  aot-check <file>     Alias for analyze")
-  println(
-    "  emit-moonbit-decl <file> [out] Emit MoonBit declare stubs from TypeScript declarations",
-  )
+  for line in command_help_lines() {
+    println(line)
+  }
 }
 
 ///|
-async fn analyze_aot(file_path : String) -> Unit {
+fn command_help_lines() -> Array[String] {
+  [
+    "  run <file>           Run a TypeScript/JavaScript file", "  experimental-emit-gc <file> [out] Emit experimental wasm-gc binary (default: out.wasm)",
+    "  test262 <path>       Run test262 tests (file or directory)", "  experimental-analyze <file> Analyze experimental AOT compilability of functions",
+    "  experimental-aot-check <file> Alias for experimental-analyze", "  emit-moonbit-decl <file> [out] Emit MoonBit declare stubs from TypeScript declarations",
+  ]
+}
+
+///|
+async fn experimental_analyze_aot(file_path : String) -> Unit {
   let content = @fs.read_file(file_path).text() catch {
     e => {
       println("Error reading file: \{e}")
@@ -170,7 +174,10 @@ fn string_to_bytes(s : String) -> Bytes {
 }
 
 ///|
-async fn emit_wasm_gc(file_path : String, output_path : String) -> Unit {
+async fn experimental_emit_wasm_gc(
+  file_path : String,
+  output_path : String,
+) -> Unit {
   let content = @fs.read_file(file_path).text() catch {
     e => {
       println("Error reading file: \{e}")
@@ -184,7 +191,7 @@ async fn emit_wasm_gc(file_path : String, output_path : String) -> Unit {
       return
     }
   }
-  let wasm_module = @codegen.compile_module_gc(ts_module) catch {
+  let wasm_module = @codegen.experimental_compile_module_gc(ts_module) catch {
     e => {
       println("CodeGen error: \{e}")
       return
@@ -308,7 +315,7 @@ fn normalize_path(path : String) -> String {
 ///|
 fn dirname(path : String) -> String {
   match path.rev_find("/") {
-    Some(idx) => path[:idx].to_string() catch { _ => "." }
+    Some(idx) => path[:idx].to_string()
     None => "."
   }
 }
@@ -639,12 +646,8 @@ fn parse_bracket_list(line : String) -> Array[String] {
     (Some(s), Some(e)) => if e <= s { return [] }
     _ => return []
   }
-  let inner = try {
-    match (start, end_) {
-      (Some(s), Some(e)) => line[s + 1:e].to_string()
-      _ => ""
-    }
-  } catch {
+  let inner = match (start, end_) {
+    (Some(s), Some(e)) => line[s + 1:e].to_string()
     _ => ""
   }
   let items = inner.split(",")
@@ -657,9 +660,7 @@ fn parse_bracket_list(line : String) -> Array[String] {
     let stripped = if trimmed.length() >= 2 &&
       trimmed.has_prefix("\"") &&
       trimmed.has_suffix("\"") {
-      trimmed[1:trimmed.length() - 1].to_string() catch {
-        _ => trimmed
-      }
+      trimmed[1:trimmed.length() - 1].to_string()
     } else {
       trimmed
     }
@@ -678,9 +679,9 @@ fn parse_test262_meta(content : String) -> Test262Meta {
   let mut meta_block = ""
   match content.find("/*---") {
     Some(start) => {
-      let rest = content[start + 5:].to_string() catch { _ => "" }
+      let rest = content[start + 5:].to_string()
       match rest.find("---*/") {
-        Some(end_) => meta_block = rest[:end_].to_string() catch { _ => "" }
+        Some(end_) => meta_block = rest[:end_].to_string()
         None => ()
       }
     }
@@ -697,19 +698,17 @@ fn parse_test262_meta(content : String) -> Test262Meta {
       if trimmed.length() == 0 {
         continue
       }
-      if not(trimmed.has_prefix("//")) {
+      if !trimmed.has_prefix("//") {
         break
       }
-      let body = trimmed[2:].trim().to_string() catch { _ => "" }
+      let body = trimmed[2:].trim().to_string()
       lines.push(body)
     }
   }
   for raw in lines {
     let line = raw.trim().to_string()
     let body = if line.has_prefix("*") {
-      line[1:].trim().to_string() catch {
-        _ => line
-      }
+      line[1:].trim().to_string()
     } else {
       line
     }
@@ -724,12 +723,12 @@ fn parse_test262_meta(content : String) -> Test262Meta {
     } else if body.has_prefix("negative:") {
       negative = true
     } else if body.has_prefix("phase:") {
-      let value = body[6:].trim().to_string() catch { _ => "" }
+      let value = body[6:].trim().to_string()
       if value.length() > 0 {
         negative_phase = Some(value)
       }
     } else if body.has_prefix("type:") {
-      let value = body[5:].trim().to_string() catch { _ => "" }
+      let value = body[5:].trim().to_string()
       if value.length() > 0 {
         negative_type = Some(value)
       }
@@ -1362,7 +1361,7 @@ fn split_patterns(patterns : Array[String]) -> (Array[String], Array[String]) {
   let excludes : Array[String] = []
   for pat in patterns {
     if pat.has_prefix("!") {
-      let sub = pat[1:].to_string() catch { _ => "" }
+      let sub = pat[1:].to_string()
       if sub.length() > 0 {
         excludes.push(sub)
       }
@@ -1511,7 +1510,7 @@ async fn run_test262(test_path : String) -> Unit {
           let base = "test262/test"
           collect_test_files(base, candidates)
           for path in candidates {
-            if matches_any(includes, path) && not(matches_any(excludes, path)) {
+            if matches_any(includes, path) && !matches_any(excludes, path) {
               files.push(path)
             }
           }
@@ -1590,7 +1589,7 @@ async fn run_test262(test_path : String) -> Unit {
           }
         }
       }
-      if not(has_error) {
+      if !has_error {
         let module_cache : Array[(String, @runtime.JSValue)] = []
         result = eval_module(interp, path, module_cache, source=content) catch {
           e => {
@@ -1620,7 +1619,7 @@ async fn run_test262(test_path : String) -> Unit {
           }
         }
       }
-      if not(has_error) {
+      if !has_error {
         let wrapped = wrap_test_source(source)
         result = interp.run(wrapped) catch {
           e => {

--- a/src/main.mbt
+++ b/src/main.mbt
@@ -40,6 +40,15 @@ async fn main_async() -> Unit {
       let file_path = args[2]
       analyze_aot(file_path)
     }
+    "emit-moonbit-decl" => {
+      if args.length() < 3 {
+        println("Error: no file specified")
+        return
+      }
+      let file_path = args[2]
+      let output_path = if args.length() >= 4 { Some(args[3]) } else { None }
+      emit_moonbit_decl(file_path, output_path)
+    }
     _ => {
       println("Unknown command: \{command}")
       print_usage()
@@ -62,6 +71,9 @@ fn print_usage() -> Unit {
   println("  test262 <path>       Run test262 tests (file or directory)")
   println("  analyze <file>       Analyze AOT compilability of functions")
   println("  aot-check <file>     Alias for analyze")
+  println(
+    "  emit-moonbit-decl <file> [out] Emit MoonBit declare stubs from TypeScript declarations",
+  )
 }
 
 ///|
@@ -118,6 +130,43 @@ async fn analyze_aot(file_path : String) -> Unit {
       println("  - \{name}: \{reason}")
     }
   }
+}
+
+///|
+async fn emit_moonbit_decl(file_path : String, output_path : String?) -> Unit {
+  let content = @fs.read_file(file_path).text() catch {
+    e => {
+      println("Error reading file: \{e}")
+      return
+    }
+  }
+  let emitted = @parser.emit_moonbit_decl_from_source(content) catch {
+    e => {
+      println("Parse error: \{e}")
+      return
+    }
+  }
+  match output_path {
+    Some(path) => {
+      let _ = @fs.write_file(path, string_to_bytes(emitted), create=0o644) catch {
+        e => {
+          println("Write error: \{e}")
+          return
+        }
+      }
+      println("Wrote MoonBit declarations to \{path}")
+    }
+    None => println(emitted)
+  }
+}
+
+///|
+fn string_to_bytes(s : String) -> Bytes {
+  let arr : Array[Byte] = []
+  for i = 0; i < s.length(); i = i + 1 {
+    arr.push((s[i].to_int() & 0xFF).to_byte())
+  }
+  Bytes::from_array(arr)
 }
 
 ///|

--- a/src/main_wbtest.mbt
+++ b/src/main_wbtest.mbt
@@ -1,0 +1,30 @@
+///|
+test "command_help_lines hides unstable wasm commands behind experimental names" {
+  let lines = command_help_lines()
+  assert_true(
+    lines.contains(
+      "  experimental-emit-gc <file> [out] Emit experimental wasm-gc binary (default: out.wasm)",
+    ),
+  )
+  assert_true(
+    lines.contains(
+      "  experimental-analyze <file> Analyze experimental AOT compilability of functions",
+    ),
+  )
+  assert_true(
+    lines.contains(
+      "  experimental-aot-check <file> Alias for experimental-analyze",
+    ),
+  )
+  assert_false(
+    lines.contains(
+      "  emit-gc <file> [out] Emit wasm-gc binary (default: out.wasm)",
+    ),
+  )
+  assert_false(
+    lines.contains(
+      "  analyze <file>       Analyze AOT compilability of functions",
+    ),
+  )
+  assert_false(lines.contains("  aot-check <file>     Alias for analyze"))
+}

--- a/src/moon.pkg
+++ b/src/moon.pkg
@@ -11,12 +11,6 @@ import {
   "mizchi/ts/analysis" @analysis,
 }
 
-import {
-  "moonbitlang/core/bench",
-  "mizchi/ts/parser" @parser,
-  "mizchi/ts/aot" @aot,
-} for "test"
-
 options(
   is_main: true,
 )

--- a/src/parser/lexer.mbt
+++ b/src/parser/lexer.mbt
@@ -121,7 +121,7 @@ pub enum TokenKind {
   Declare // declare (externalimport)
   Null // null
   Eof
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 // /
@@ -129,7 +129,7 @@ pub struct Token {
   kind : TokenKind
   pos : Int // position
   has_newline_before : Bool // true if there was a newline before this token
-} derive(Show)
+} derive(Debug)
 
 ///|
 fn write_codepoint(buf : StringBuilder, code : Int) -> Unit {
@@ -149,7 +149,7 @@ pub struct Lexer {
   mut pending : Array[Token]
   mut pending_index : Int
   mut newline_before_next : Bool // Set when whitespace skipping encounters a newline
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / 161( advance )
@@ -445,7 +445,7 @@ fn Lexer::scan_number(self : Lexer) -> TokenKind {
             None => break
           }
         }
-        if not(has_digit) {
+        if !has_digit {
           value = 0
         }
         let mut is_bigint = false
@@ -482,7 +482,7 @@ fn Lexer::scan_number(self : Lexer) -> TokenKind {
             _ => break
           }
         }
-        if not(has_digit) {
+        if !has_digit {
           value = 0
         }
         let mut is_bigint = false
@@ -549,7 +549,7 @@ fn Lexer::scan_number(self : Lexer) -> TokenKind {
             _ => break
           }
         }
-        if not(has_digit) {
+        if !has_digit {
           value = 0
         }
         let mut is_bigint = false
@@ -613,10 +613,10 @@ fn Lexer::scan_number(self : Lexer) -> TokenKind {
         } else if c == '_' {
           has_sep = true
           let _ = self.advance()
-        } else if c == '.' && not(has_dot) && not(has_exp) {
+        } else if c == '.' && !has_dot && !has_exp {
           has_dot = true
           let _ = self.advance()
-        } else if (c == 'e' || c == 'E') && not(has_exp) {
+        } else if (c == 'e' || c == 'E') && !has_exp {
           has_exp = true
           let _ = self.advance()
           match self.peek() {
@@ -637,13 +637,9 @@ fn Lexer::scan_number(self : Lexer) -> TokenKind {
   }
   let raw = if is_bigint {
     let end = if self.pos > start { self.pos - 1 } else { self.pos }
-    self.src[start:end].to_string() catch {
-      _ => ""
-    }
+    self.src[start:end].to_string()
   } else {
-    self.src[start:self.pos].to_string() catch {
-      _ => ""
-    }
+    self.src[start:self.pos].to_string()
   }
   let s = if has_sep {
     let cleaned = StringBuilder::new()
@@ -662,7 +658,7 @@ fn Lexer::scan_number(self : Lexer) -> TokenKind {
   } else if has_dot || has_exp {
     // Double
     try {
-      let d = @strconv.parse_double(s)
+      let d = @string.parse_double(s)
       Number(d)
     } catch {
       // Overflow to Infinity for very large numbers
@@ -673,7 +669,7 @@ fn Lexer::scan_number(self : Lexer) -> TokenKind {
     // JavaScript numbers are IEEE 754 doubles which can represent integers up to 2^53
     // MoonBit Int is 32-bit signed, so max is 2147483647
     try {
-      let d = @strconv.parse_double(s)
+      let d = @string.parse_double(s)
       // Check if the value fits in 32-bit signed integer
       if d >= -2147483648.0 && d <= 2147483647.0 && d == d.trunc() {
         Int(d.to_int())
@@ -1152,9 +1148,7 @@ fn Lexer::scan_template_expr_source(self : Lexer) -> String {
     }
   }
   let end = if self.pos > 0 { self.pos - 1 } else { 0 }
-  self.src[start:end].to_string() catch {
-    _ => ""
-  }
+  self.src[start:end].to_string()
 }
 
 ///|
@@ -1644,7 +1638,7 @@ fn Lexer::scan_regex(self : Lexer) -> TokenKind {
         } else if c == ']' {
           in_class = false
         }
-        if c == '/' && not(in_class) {
+        if c == '/' && !in_class {
           break
         }
         buf.write_char(c)
@@ -1699,7 +1693,7 @@ pub fn Lexer::next_token(self : Lexer) -> Token {
       self.pending = []
       self.pending_index = 0
     }
-    self.allow_regex = not(token_can_end_expr(tok.kind))
+    self.allow_regex = !token_can_end_expr(tok.kind)
     return tok
   }
   self.skip_whitespace()
@@ -2039,7 +2033,7 @@ pub fn Lexer::next_token(self : Lexer) -> Token {
         }
         _ => Eof // statement
       }
-      self.allow_regex = not(token_can_end_expr(kind))
+      self.allow_regex = !token_can_end_expr(kind)
       { kind, pos, has_newline_before: has_newline }
     }
   }

--- a/src/parser/moon.pkg
+++ b/src/parser/moon.pkg
@@ -1,4 +1,6 @@
 import {
+  "moonbitlang/core/debug",
+  "moonbitlang/core/string",
   "moonbitlang/core/strconv",
   "mizchi/ts/ast" @ast,
 }

--- a/src/parser/parser_binding.mbt
+++ b/src/parser/parser_binding.mbt
@@ -181,7 +181,7 @@ fn Parser::parse_binding_array(
   let _ = self.expect(LBracket)
   let items : Array[@ast.TsBindingElem?] = []
   let mut rest : @ast.TsBinding? = None
-  while not(self.check(RBracket)) {
+  while !self.check(RBracket) {
     if self.match_(Ellipsis) {
       let rest_binding = self.parse_binding_pattern()
       rest = Some(rest_binding)
@@ -268,7 +268,7 @@ fn Parser::parse_binding_object(
   let _ = self.expect(LBrace)
   let props : Array[@ast.TsObjectBindingProp] = []
   let mut rest : String? = None
-  if not(self.check(RBrace)) {
+  if !self.check(RBrace) {
     while true {
       if self.match_(Ellipsis) {
         let name = self.parse_binding_ident()
@@ -368,7 +368,7 @@ fn Parser::parse_assignment_binding_array(
   let _ = self.expect(LBracket)
   let items : Array[@ast.TsBindingElem?] = []
   let mut rest : @ast.TsBinding? = None
-  while not(self.check(RBracket)) {
+  while !self.check(RBracket) {
     if self.match_(Ellipsis) {
       let rest_binding = self.parse_assignment_binding_pattern()
       rest = Some(rest_binding)
@@ -402,7 +402,7 @@ fn Parser::parse_assignment_binding_object(
   let _ = self.expect(LBrace)
   let props : Array[@ast.TsObjectBindingProp] = []
   let mut rest : String? = None
-  if not(self.check(RBrace)) {
+  if !self.check(RBrace) {
     while true {
       if self.match_(Ellipsis) {
         let name = self.parse_binding_ident()

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -40,7 +40,7 @@ fn has_instance_private_elements(elements : Array[ClassElement]) -> Bool {
     match element {
       Field(is_static, Name(name), _) | Method(is_static, Name(name), _, _) =>
         // Check for instance (non-static) private members
-        if not(is_static) && (name.has_prefix("#") || name.contains("__#")) {
+        if !is_static && (name.has_prefix("#") || name.contains("__#")) {
           return true
         }
       _ => ()
@@ -154,14 +154,14 @@ fn Parser::inject_instance_field_assigns(
   if base is Some(_) {
     for stmt in func.body.stmts {
       new_stmts.push(stmt)
-      if not(inserted) && self.is_super_call_stmt(stmt) {
+      if !inserted && self.is_super_call_stmt(stmt) {
         for assign in assigns {
           new_stmts.push(assign)
         }
         inserted = true
       }
     }
-    if not(inserted) {
+    if !inserted {
       let combined : Array[@ast.TsStmt] = []
       for assign in assigns {
         combined.push(assign)
@@ -199,7 +199,7 @@ fn Parser::parse_class_body(
   self.in_strict = true
   let mut ctor : @ast.TsFunc? = None
   let elements : Array[ClassElement] = []
-  while not(self.check(RBrace)) && not(self.check(Eof)) {
+  while !self.check(RBrace) && !self.check(Eof) {
     if self.match_(Semicolon) {
       continue
     }
@@ -274,7 +274,7 @@ fn Parser::parse_class_body(
         is_generator,
         is_async: is_async_method,
       }
-      if accessor_kind is None && key is Name("constructor") && not(is_static) {
+      if accessor_kind is None && key is Name("constructor") && !is_static {
         ctor = Some(func)
       } else {
         elements.push(Method(is_static, key, accessor_kind, func))
@@ -380,7 +380,7 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
   for idx, element in elements {
     match element {
       Field(is_static, key, init_opt) =>
-        if not(is_static) {
+        if !is_static {
           let init = match init_opt {
             Some(expr) => expr
             None => @ast.TsExpr::Var("undefined")
@@ -787,7 +787,7 @@ fn Parser::parse_class_decl(self : Parser) -> @ast.TsStmt raise ParseError {
   for idx, element in elements {
     match element {
       Field(is_static, key, init_opt) =>
-        if not(is_static) {
+        if !is_static {
           let init = match init_opt {
             Some(expr) => expr
             None => @ast.TsExpr::Var("undefined")

--- a/src/parser/parser_core.mbt
+++ b/src/parser/parser_core.mbt
@@ -4,7 +4,7 @@
 // / error
 pub(all) suberror ParseError {
   ParseError(String)
-} derive(Show)
+} derive(Debug)
 
 ///|
 // /
@@ -22,7 +22,7 @@ pub struct Parser {
   src : String
   mut class_id : Int // for private field brand generation
   mut current_class_brand : String? // brand ID of current class being parsed
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / create

--- a/src/parser/parser_expr.mbt
+++ b/src/parser/parser_expr.mbt
@@ -702,7 +702,7 @@ fn Parser::parse_call(self : Parser) -> @ast.TsExpr raise ParseError {
 // / argument
 fn Parser::parse_args(self : Parser) -> Array[@ast.TsExpr] raise ParseError {
   let args : Array[@ast.TsExpr] = []
-  if not(self.check(RParen)) {
+  if !self.check(RParen) {
     if self.match_ellipsis() {
       args.push(Spread(self.parse_assignment()))
     } else {
@@ -803,14 +803,14 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
     Ident(name) =>
       if name == "async" &&
         self.peek_at(1).kind == Function &&
-        not(self.has_line_terminator_after()) {
+        !self.has_line_terminator_after() {
         let _ = self.advance()
         self.in_async = true
         let func = self.parse_function_expr()
         self.in_async = false
         @ast.TsExpr::FuncExpr(func)
       } else if name == "async" &&
-        not(self.has_line_terminator_after()) &&
+        !self.has_line_terminator_after() &&
         self.is_async_arrow_function() {
         // async arrow function: async (params) => body or async x => body
         let _ = self.advance()
@@ -936,7 +936,7 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
       // arrayliteral: [1, 2, 3]
       let _ = self.advance()
       let elements : Array[@ast.TsExpr] = []
-      while not(self.check(RBracket)) {
+      while !self.check(RBracket) {
         if self.match_ellipsis() {
           elements.push(Spread(self.parse_assignment()))
           if self.match_(Comma) {
@@ -1172,7 +1172,7 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
       let fields : Array[(String, @ast.TsExpr)] = []
       let mut spread_idx = 0
       let mut computed_idx = 0
-      if not(self.check(RBrace)) {
+      if !self.check(RBrace) {
         if self.match_ellipsis() {
           let spread_expr = self.parse_assignment()
           fields.push(("@@spread:" + spread_idx.to_string(), spread_expr))
@@ -1248,10 +1248,10 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
           let mut prop_key = key
           let value = if is_ident_key &&
             (prop_key == "get" || prop_key == "set") &&
-            not(self.check(Colon)) &&
-            not(self.check(LParen)) &&
-            not(self.check(Comma)) &&
-            not(self.check(RBrace)) {
+            !self.check(Colon) &&
+            !self.check(LParen) &&
+            !self.check(Comma) &&
+            !self.check(RBrace) {
             let mut acc_computed_key : @ast.TsExpr? = None
             let acc_key = if self.match_(LBracket) {
               let key_expr = self.parse_assignment()
@@ -1466,10 +1466,10 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
           let mut prop_key = key
           let value = if is_ident_key &&
             (prop_key == "get" || prop_key == "set") &&
-            not(self.check(Colon)) &&
-            not(self.check(LParen)) &&
-            not(self.check(Comma)) &&
-            not(self.check(RBrace)) {
+            !self.check(Colon) &&
+            !self.check(LParen) &&
+            !self.check(Comma) &&
+            !self.check(RBrace) {
             let mut acc_computed_key : @ast.TsExpr? = None
             let acc_key = if self.match_(LBracket) {
               let key_expr = self.parse_assignment()
@@ -1659,7 +1659,7 @@ fn Parser::is_async_arrow_function(self : Parser) -> Bool {
     let _ = self.advance() // consume 'async'
     let _ = self.advance() // consume '('
     let mut paren_depth = 1
-    while paren_depth > 0 && not(self.check(Eof)) {
+    while paren_depth > 0 && !self.check(Eof) {
       match self.peek().kind {
         LParen => paren_depth += 1
         RParen => paren_depth -= 1
@@ -1672,7 +1672,7 @@ fn Parser::is_async_arrow_function(self : Parser) -> Bool {
         self.check(Colon) &&
         ({
           // Skip type annotation: (): ReturnType =>
-          while not(self.check(Arrow)) && not(self.check(Eof)) {
+          while !self.check(Arrow) && !self.check(Eof) {
             let _ = self.advance()
           }
           self.check(Arrow)

--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -28,7 +28,7 @@ fn Parser::parse_param(self : Parser) -> @ast.TsParam raise ParseError {
 // / parameter
 fn Parser::parse_params(self : Parser) -> Array[@ast.TsParam] raise ParseError {
   let params : Array[@ast.TsParam] = []
-  if not(self.check(RParen)) {
+  if !self.check(RParen) {
     params.push(self.parse_param())
     while self.match_(Comma) {
       if self.check(RParen) {
@@ -40,7 +40,7 @@ fn Parser::parse_params(self : Parser) -> Array[@ast.TsParam] raise ParseError {
   // Check for duplicate parameter names
   // In strict mode or with non-simple parameters (default, rest, destructuring),
   // duplicate names are forbidden
-  let has_default = params.iter().any(fn(p) { not(p.default is None) })
+  let has_default = params.iter().any(fn(p) { !(p.default is None) })
   let has_rest = params.iter().any(fn(p) { p.is_rest })
   let has_destructuring = params
     .iter()
@@ -50,7 +50,7 @@ fn Parser::parse_params(self : Parser) -> Array[@ast.TsParam] raise ParseError {
         _ => false
       }
     })
-  let is_simple = not(has_default) && not(has_rest) && not(has_destructuring)
+  let is_simple = !has_default && !has_rest && !has_destructuring
   // Collect all bound names
   let all_names : Array[String] = []
   for param in params {
@@ -64,7 +64,7 @@ fn Parser::parse_params(self : Parser) -> Array[@ast.TsParam] raise ParseError {
   for name in all_names {
     if seen.contains(name) {
       // In strict mode or with non-simple params, duplicates are errors
-      if self.in_strict || not(is_simple) {
+      if self.in_strict || !is_simple {
         raise ParseError("Duplicate parameter name '\{name}' not allowed")
       }
     }
@@ -194,12 +194,12 @@ fn Parser::parse_function_expr(self : Parser) -> @ast.TsFunc raise ParseError {
 ///|
 /// Skip generic type parameters <T, U extends Foo, V = Default>
 fn Parser::skip_type_params(self : Parser) -> Unit {
-  if not(self.check(Lt)) {
+  if !self.check(Lt) {
     return
   }
   let _ = self.advance() // consume <
   let mut depth = 1
-  while depth > 0 && not(self.check(Eof)) {
+  while depth > 0 && !self.check(Eof) {
     match self.peek().kind {
       Lt => {
         depth += 1
@@ -229,12 +229,12 @@ fn Parser::skip_type_params(self : Parser) -> Unit {
 ///|
 /// Skip extends clause: extends Foo, Bar<T>
 fn Parser::skip_extends_clause(self : Parser) -> Unit {
-  if not(self.check(Extends)) {
+  if !self.check(Extends) {
     return
   }
   let _ = self.advance() // consume extends
   // Parse comma-separated type references until { or EOF
-  while not(self.check(LBrace)) && not(self.check(Eof)) {
+  while !self.check(LBrace) && !self.check(Eof) {
     match self.peek().kind {
       Comma => {
         let _ = self.advance()
@@ -262,7 +262,7 @@ pub fn Parser::parse_interface(
   self.skip_extends_clause()
   let _ = self.expect(LBrace)
   let fields : Array[(String, @ast.TsType)] = []
-  while not(self.check(RBrace)) && not(self.check(Eof)) {
+  while !self.check(RBrace) && !self.check(Eof) {
     // Skip readonly modifier
     if self.check(Ident("readonly")) {
       let _ = self.advance()
@@ -285,7 +285,7 @@ pub fn Parser::parse_interface(
       LBracket => {
         let _ = self.advance()
         // Skip until ]
-        while not(self.check(RBracket)) && not(self.check(Eof)) {
+        while !self.check(RBracket) && !self.check(Eof) {
           let _ = self.advance()
         }
         let _ = self.expect(RBracket)
@@ -454,7 +454,7 @@ pub fn Parser::parse_interface(
       let _ = self.advance()
       // Skip parameters
       let mut paren_depth = 1
-      while paren_depth > 0 && not(self.check(Eof)) {
+      while paren_depth > 0 && !self.check(Eof) {
         match self.peek().kind {
           LParen => {
             paren_depth += 1
@@ -501,7 +501,7 @@ fn Parser::skip_until_semicolon(self : Parser) -> Unit {
   let mut brace_depth = 0
   let mut bracket_depth = 0
   let mut paren_depth = 0
-  while not(self.check(Eof)) {
+  while !self.check(Eof) {
     match self.peek().kind {
       Semicolon => {
         if brace_depth == 0 && bracket_depth == 0 && paren_depth == 0 {
@@ -548,7 +548,7 @@ fn Parser::skip_type_alias(self : Parser) -> Unit {
   // Skip until semicolon, handling nested braces and angle brackets
   let mut brace_depth = 0
   let mut angle_depth = 0
-  while not(self.check(Eof)) {
+  while !self.check(Eof) {
     match self.peek().kind {
       LBrace => {
         brace_depth += 1
@@ -597,9 +597,7 @@ fn Parser::skip_type_alias(self : Parser) -> Unit {
 /// Skip declaration block (namespace, module, class, enum, etc.)
 fn Parser::skip_declaration_block(self : Parser) -> Unit {
   // Skip until we find { or ;
-  while not(self.check(LBrace)) &&
-        not(self.check(Semicolon)) &&
-        not(self.check(Eof)) {
+  while !self.check(LBrace) && !self.check(Semicolon) && !self.check(Eof) {
     let _ = self.advance()
   }
   if self.check(Semicolon) {
@@ -609,7 +607,7 @@ fn Parser::skip_declaration_block(self : Parser) -> Unit {
   if self.check(LBrace) {
     let _ = self.advance()
     let mut depth = 1
-    while depth > 0 && not(self.check(Eof)) {
+    while depth > 0 && !self.check(Eof) {
       match self.peek().kind {
         LBrace => {
           depth += 1
@@ -647,7 +645,7 @@ pub fn Parser::parse_declare_function(
   // parameter
   let _ = self.expect(LParen)
   let params : Array[(String, @ast.TsType)] = []
-  while not(self.check(RParen)) && not(self.check(Eof)) {
+  while !self.check(RParen) && !self.check(Eof) {
     // Handle rest parameter: ...name
     let _ = self.match_ellipsis()
     // Handle parameter name (can be identifier, keyword, or destructuring pattern)
@@ -715,7 +713,7 @@ pub fn Parser::parse_declare_function(
         }
         let _ = self.advance()
         let mut depth = 1
-        while depth > 0 && not(self.check(Eof)) {
+        while depth > 0 && !self.check(Eof) {
           if self.peek().kind == open_tok {
             depth += 1
           } else if self.peek().kind == close_tok {

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -19,7 +19,7 @@ fn Parser::expect_from(self : Parser) -> Unit raise ParseError {
 
 ///|
 fn Parser::parse_import_specifiers(self : Parser) -> Unit raise ParseError {
-  while not(self.check(RBrace)) {
+  while !self.check(RBrace) {
     let _ = self.parse_binding_ident()
     if self.match_(As) || self.match_ident("as") {
       let _ = self.parse_binding_ident()
@@ -46,7 +46,7 @@ fn Parser::parse_named_imports(
   self : Parser,
 ) -> Array[(String, String)] raise ParseError {
   let items : Array[(String, String)] = []
-  while not(self.check(RBrace)) {
+  while !self.check(RBrace) {
     let imported = self.parse_binding_ident()
     let local_name = if self.match_(As) || self.match_ident("as") {
       self.parse_binding_ident()
@@ -70,7 +70,7 @@ fn Parser::parse_named_exports(
   self : Parser,
 ) -> Array[(String, String)] raise ParseError {
   let items : Array[(String, String)] = []
-  while not(self.check(RBrace)) {
+  while !self.check(RBrace) {
     let local_name = self.parse_binding_ident()
     let export_name = if self.match_(As) || self.match_ident("as") {
       self.parse_binding_ident()
@@ -164,7 +164,7 @@ fn Parser::parse_import_decl(
   let mut default_binding : String? = None
   let mut namespace_binding : String? = None
   let named_bindings : Array[(String, String)] = []
-  if not(self.check(Star)) && not(self.check(LBrace)) {
+  if !self.check(Star) && !self.check(LBrace) {
     default_binding = Some(self.parse_binding_ident())
     if self.match_(Comma) {
       // continue to namespace/named
@@ -183,7 +183,7 @@ fn Parser::parse_import_decl(
     }
   }
   if self.match_(Star) {
-    if not(self.match_(As) || self.match_ident("as")) {
+    if !(self.match_(As) || self.match_ident("as")) {
       raise ParseError("Expected 'as' in import namespace")
     }
     namespace_binding = Some(self.parse_binding_ident())
@@ -349,7 +349,7 @@ fn Parser::parse_import_stmt(self : Parser) -> Unit raise ParseError {
     _ => ()
   }
   if self.match_(Star) {
-    if not(self.match_(As) || self.match_ident("as")) {
+    if !(self.match_(As) || self.match_ident("as")) {
       raise ParseError("Expected 'as' in import namespace")
     }
     let _ = self.parse_binding_ident()
@@ -466,7 +466,7 @@ pub fn Parser::parse_module(self : Parser) -> @ast.TsModule raise ParseError {
   let funcs : Array[@ast.TsFunc] = []
   let interfaces : Array[@ast.TsInterface] = []
   let imports : Array[@ast.TsImport] = []
-  while not(self.check(Eof)) {
+  while !self.check(Eof) {
     if self.check(Function) {
       funcs.push(self.parse_function())
     } else if self.check(Interface) {
@@ -530,7 +530,7 @@ pub fn Parser::parse_module_block(
   let imports : Array[@ast.TsImportDecl] = []
   let exports : Array[@ast.TsExportSpec] = []
   let reexports : Array[@ast.TsReExportSpec] = []
-  while not(self.check(Eof)) {
+  while !self.check(Eof) {
     if self.check(Import) {
       imports.push(self.parse_import_decl())
       continue
@@ -593,7 +593,7 @@ pub fn parse_block_from_source(
 ) -> @ast.TsBlock raise ParseError {
   let parser = Parser::from_source(source)
   let stmts : Array[@ast.TsStmt] = []
-  while not(parser.check(Eof)) {
+  while !parser.check(Eof) {
     stmts.push(parser.parse_stmt())
   }
   { stmts, }
@@ -613,7 +613,7 @@ pub fn parse_block_from_source_strict(
     trimmed.has_prefix("'use strict';")
   let parser = Parser::new_with_strict(tokens, inherit_strict || source_strict)
   let stmts : Array[@ast.TsStmt] = []
-  while not(parser.check(Eof)) {
+  while !parser.check(Eof) {
     stmts.push(parser.parse_stmt())
   }
   { stmts, }

--- a/src/parser/parser_moonbit.mbt
+++ b/src/parser/parser_moonbit.mbt
@@ -1,0 +1,181 @@
+///|
+priv struct MoonBitDeclState {
+  declared_interface_names : Array[String]
+  referenced_type_names : Array[String]
+  mut needs_jsvalue : Bool
+}
+
+///|
+fn is_ascii_letter(c : Char) -> Bool {
+  (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+///|
+fn is_ascii_digit(c : Char) -> Bool {
+  c >= '0' && c <= '9'
+}
+
+///|
+fn sanitize_identifier(name : String, fallback : String) -> String {
+  let mut result = ""
+  for c in name {
+    if is_ascii_letter(c) || is_ascii_digit(c) || c == '_' {
+      result += c.to_string()
+    } else {
+      result += "_"
+    }
+  }
+  if result == "" {
+    result = fallback
+  }
+  let first = result[0].unsafe_to_char()
+  if is_ascii_digit(first) {
+    result = "_" + result
+  }
+  match result {
+    "as"
+    | "break"
+    | "catch"
+    | "const"
+    | "continue"
+    | "else"
+    | "fn"
+    | "for"
+    | "if"
+    | "in"
+    | "let"
+    | "match"
+    | "pub"
+    | "return"
+    | "struct"
+    | "test"
+    | "trait"
+    | "type"
+    | "typealias"
+    | "while" => result + "_"
+    _ => result
+  }
+}
+
+///|
+fn mark_referenced_type(state : MoonBitDeclState, name : String) -> Unit {
+  if name == "Array" || name == "ReadonlyArray" {
+    return
+  }
+  if state.declared_interface_names.contains(name) {
+    return
+  }
+  if state.referenced_type_names.contains(name) {
+    return
+  }
+  state.referenced_type_names.push(name)
+}
+
+///|
+fn moonbit_type_name(state : MoonBitDeclState, type_ : @ast.TsType) -> String {
+  match type_ {
+    Number => "Double"
+    Int => "Int"
+    Boolean => "Bool"
+    String_ => "String"
+    Void => "Unit"
+    Array(inner) => "Array[" + moonbit_type_name(state, inner) + "]"
+    Named("Array") | Named("ReadonlyArray") => {
+      state.needs_jsvalue = true
+      "Array[JSValue]"
+    }
+    Named(name) => {
+      mark_referenced_type(state, name)
+      sanitize_identifier(name, "OpaqueType")
+    }
+    _ => {
+      state.needs_jsvalue = true
+      "JSValue"
+    }
+  }
+}
+
+///|
+fn interface_decl_to_moonbit(
+  state : MoonBitDeclState,
+  iface : @ast.TsInterface,
+) -> String {
+  let lines : Array[String] = ["///|", "/// TS interface \{iface.name}"]
+  for field in iface.fields {
+    let (name, type_) = field
+    let moonbit_type = moonbit_type_name(state, type_)
+    lines.push("/// \{name} : \{moonbit_type}")
+  }
+  let type_name = sanitize_identifier(iface.name, "OpaqueType")
+  lines.push("declare pub type \{type_name}")
+  lines.join("\n")
+}
+
+///|
+fn import_decl_to_moonbit(
+  state : MoonBitDeclState,
+  import_ : @ast.TsImport,
+) -> String {
+  let params : Array[String] = []
+  for item in import_.params {
+    let (name, type_) = item
+    let param_name = sanitize_identifier(name, "arg")
+    let param_type = moonbit_type_name(state, type_)
+    params.push("\{param_name} : \{param_type}")
+  }
+  let return_type = moonbit_type_name(state, import_.return_type)
+  let fn_name = sanitize_identifier(import_.name, "generated_fn")
+  let params_str = params.join(", ")
+  "///|\ndeclare pub fn \{fn_name}(\{params_str}) -> \{return_type}"
+}
+
+///|
+pub fn emit_moonbit_decl(module_ : @ast.TsModule) -> String {
+  let declared_interface_names : Array[String] = []
+  for iface in module_.interfaces {
+    declared_interface_names.push(iface.name)
+  }
+  let state : MoonBitDeclState = {
+    declared_interface_names,
+    referenced_type_names: [],
+    needs_jsvalue: false,
+  }
+  let interface_sections : Array[String] = []
+  for iface in module_.interfaces {
+    interface_sections.push(interface_decl_to_moonbit(state, iface))
+  }
+  let import_sections : Array[String] = []
+  for import_ in module_.imports {
+    import_sections.push(import_decl_to_moonbit(state, import_))
+  }
+  let sections : Array[String] = [
+    "///|\n/// Generated from TypeScript declarations by mizchi/ts/parser.\n/// Complex or unsupported TypeScript types are widened to JSValue.",
+  ]
+  if state.needs_jsvalue {
+    sections.push("///|\ndeclare pub type JSValue")
+  }
+  for section in interface_sections {
+    sections.push(section)
+  }
+  let referenced : Array[String] = []
+  for name in state.referenced_type_names {
+    referenced.push(sanitize_identifier(name, "OpaqueType"))
+  }
+  referenced.sort()
+  for name in referenced {
+    sections.push("///|\ndeclare pub type \{name}")
+  }
+  for section in import_sections {
+    sections.push(section)
+  }
+  sections.join("\n\n")
+}
+
+///|
+pub fn emit_moonbit_decl_from_source(
+  source : String,
+) -> String raise ParseError {
+  let parser = Parser::from_source(source)
+  let module_ = parser.parse_module()
+  emit_moonbit_decl(module_)
+}

--- a/src/parser/parser_moonbit_wbtest.mbt
+++ b/src/parser/parser_moonbit_wbtest.mbt
@@ -1,0 +1,75 @@
+///|
+test "parser: emit MoonBit declarations from interface and declare function" {
+  let src =
+    #|interface Point {
+    #|  x: number;
+    #|  y: number;
+    #|}
+    #|
+    #|declare function draw(point: Point, labels: string[]): void;
+  let actual = emit_moonbit_decl_from_source(src) catch {
+    e => {
+      fail("Parse error: \{e}")
+      return
+    }
+  }
+  let expected =
+    #|///|
+    #|/// Generated from TypeScript declarations by mizchi/ts/parser.
+    #|/// Complex or unsupported TypeScript types are widened to JSValue.
+    #|
+    #|///|
+    #|/// TS interface Point
+    #|/// x : Double
+    #|/// y : Double
+    #|declare pub type Point
+    #|
+    #|///|
+    #|declare pub fn draw(point : Point, labels : Array[String]) -> Unit
+  assert_eq(actual, expected)
+}
+
+///|
+test "parser: emit MoonBit declarations widens unsupported types" {
+  let src =
+    #|declare function later(
+    #|  callback: (value: number) => void,
+    #|  promise: Promise<string>,
+    #|): Promise<number>;
+  let actual = emit_moonbit_decl_from_source(src) catch {
+    e => {
+      fail("Parse error: \{e}")
+      return
+    }
+  }
+  let expected =
+    #|///|
+    #|/// Generated from TypeScript declarations by mizchi/ts/parser.
+    #|/// Complex or unsupported TypeScript types are widened to JSValue.
+    #|
+    #|///|
+    #|declare pub type JSValue
+    #|
+    #|///|
+    #|declare pub type Promise
+    #|
+    #|///|
+    #|declare pub fn later(callback : JSValue, promise : Promise) -> Promise
+  assert_eq(actual, expected)
+}
+
+///|
+test "parser: emit MoonBit declarations sanitizes parameter names" {
+  let src = "declare function useKeywords(in: string, type: number): void;"
+  let actual = emit_moonbit_decl_from_source(src) catch {
+    e => {
+      fail("Parse error: \{e}")
+      return
+    }
+  }
+  assert_true(
+    actual.contains(
+      "declare pub fn useKeywords(in_ : String, type_ : Double) -> Unit",
+    ),
+  )
+}

--- a/src/parser/parser_stmt.mbt
+++ b/src/parser/parser_stmt.mbt
@@ -35,7 +35,7 @@ pub fn Parser::parse_stmt(self : Parser) -> @ast.TsStmt raise ParseError {
     For => self.parse_for()
     Try => self.parse_try()
     Ident("async") if self.peek_at(1).kind == Function &&
-      not(self.has_line_terminator_after()) => {
+      !self.has_line_terminator_after() => {
       let _ = self.advance()
       self.in_async = true
       let func = self.parse_function()
@@ -66,12 +66,12 @@ pub fn Parser::parse_stmt(self : Parser) -> @ast.TsStmt raise ParseError {
       // Check if break is inside iteration or switch (or has valid label)
       match label {
         None =>
-          if not(self.in_iteration) && not(self.in_switch) {
+          if !self.in_iteration && !self.in_switch {
             raise ParseError("Illegal break statement")
           }
         Some(name) =>
           // Check if label exists
-          if not(self.labels.contains(name)) {
+          if !self.labels.contains(name) {
             raise ParseError("Undefined label '\{name}'")
           }
       }
@@ -96,12 +96,12 @@ pub fn Parser::parse_stmt(self : Parser) -> @ast.TsStmt raise ParseError {
       // Check if continue is inside iteration (or has valid label for an iteration)
       match label {
         None =>
-          if not(self.in_iteration) {
+          if !self.in_iteration {
             raise ParseError("Illegal continue statement")
           }
         Some(name) =>
           // Check if label exists (should be an iteration label for continue)
-          if not(self.labels.contains(name)) {
+          if !self.labels.contains(name) {
             raise ParseError("Undefined label '\{name}'")
           }
       }
@@ -131,7 +131,7 @@ pub fn Parser::parse_stmt(self : Parser) -> @ast.TsStmt raise ParseError {
       Label(name, stmt)
     }
     // yield as label identifier in non-strict mode
-    Yield if not(self.in_strict) && self.peek_at(1).kind == Colon => {
+    Yield if !self.in_strict && self.peek_at(1).kind == Colon => {
       let _ = self.advance()
       let name = "yield"
       let _ = self.expect(Colon)
@@ -182,7 +182,7 @@ fn Parser::parse_var_like(
 // / return statement
 fn Parser::parse_return(self : Parser) -> @ast.TsStmt raise ParseError {
   // Check if return is inside a function
-  if not(self.in_function) {
+  if !self.in_function {
     raise ParseError("Illegal return statement")
   }
   let _ = self.expect(Return)
@@ -303,7 +303,7 @@ fn Parser::parse_switch(self : Parser) -> @ast.TsStmt raise ParseError {
   let prev_switch = self.in_switch
   self.in_switch = true
   let cases : Array[@ast.TsSwitchCase] = []
-  while not(self.check(RBrace)) {
+  while !self.check(RBrace) {
     let case_test : @ast.TsExpr? = if self.match_(Case) {
       Some(self.parse_expr())
     } else if self.match_(Default) {
@@ -313,9 +313,7 @@ fn Parser::parse_switch(self : Parser) -> @ast.TsStmt raise ParseError {
     }
     let _ = self.expect(Colon)
     let stmts : Array[@ast.TsStmt] = []
-    while not(self.check(Case)) &&
-          not(self.check(Default)) &&
-          not(self.check(RBrace)) {
+    while !self.check(Case) && !self.check(Default) && !self.check(RBrace) {
       stmts.push(self.parse_stmt())
     }
     cases.push({ test_expr: case_test, body: { stmts, } })
@@ -384,7 +382,7 @@ fn Parser::parse_for(self : Parser) -> @ast.TsStmt raise ParseError {
   let _ = self.expect(LParen)
 
   // for...of check: for (var/let/const x of arr)
-  if (self.check(Let) && not(self.is_let_for_in_head_ident())) ||
+  if (self.check(Let) && !self.is_let_for_in_head_ident()) ||
     self.check(Const) ||
     self.check(Var) {
     let kind = match self.advance().kind {
@@ -811,7 +809,7 @@ pub fn Parser::parse_block(self : Parser) -> @ast.TsBlock raise ParseError {
   let stmts : Array[@ast.TsStmt] = []
   let prev_strict = self.in_strict
   let mut in_directive = true
-  while not(self.check(RBrace)) && not(self.check(Eof)) {
+  while !self.check(RBrace) && !self.check(Eof) {
     let stmt = self.parse_stmt()
     if in_directive {
       match stmt {
@@ -863,7 +861,7 @@ fn Parser::is_let_for_in_head_ident(self : Parser) -> Bool {
   if self.in_strict {
     return false
   }
-  if not(self.check(Let)) {
+  if !self.check(Let) {
     return false
   }
   match self.peek_at(1).kind {
@@ -891,16 +889,16 @@ fn Parser::is_disallowed_lexical_stmt_start(
   allow_function : Bool,
 ) -> Bool {
   match self.peek().kind {
-    Let => not(self.is_let_identifier_expr_start())
+    Let => !self.is_let_identifier_expr_start()
     Const | Class => true
     Function =>
       if self.peek_at(1).kind == Star {
         true
       } else {
-        not(allow_function) || self.in_strict
+        !allow_function || self.in_strict
       }
     Ident("async") if self.peek_at(1).kind == Function &&
-      not(self.has_line_terminator_after()) => true
+      !self.has_line_terminator_after() => true
     _ => false
   }
 }

--- a/src/parser/parser_type.mbt
+++ b/src/parser/parser_type.mbt
@@ -199,7 +199,7 @@ fn Parser::parse_postfix_type(
     }
     // Indexed access type: T[K] - skip it
     let mut bracket_depth = 1
-    while bracket_depth > 0 && not(self.check(Eof)) {
+    while bracket_depth > 0 && !self.check(Eof) {
       match self.peek().kind {
         LBracket => {
           bracket_depth += 1
@@ -250,7 +250,7 @@ fn Parser::parse_type(self : Parser) -> @ast.TsType raise ParseError {
 fn Parser::skip_object_type(self : Parser) -> Unit {
   let _ = self.advance() // consume {
   let mut depth = 1
-  while depth > 0 && not(self.check(Eof)) {
+  while depth > 0 && !self.check(Eof) {
     match self.peek().kind {
       LBrace => {
         depth += 1
@@ -272,7 +272,7 @@ fn Parser::skip_object_type(self : Parser) -> Unit {
 fn Parser::skip_bracket_type(self : Parser) -> Unit {
   let _ = self.advance() // consume [
   let mut depth = 1
-  while depth > 0 && not(self.check(Eof)) {
+  while depth > 0 && !self.check(Eof) {
     match self.peek().kind {
       LBracket => {
         depth += 1
@@ -294,7 +294,7 @@ fn Parser::skip_bracket_type(self : Parser) -> Unit {
 fn Parser::skip_paren_type(self : Parser) -> Unit raise ParseError {
   let _ = self.advance() // consume (
   let mut depth = 1
-  while depth > 0 && not(self.check(Eof)) {
+  while depth > 0 && !self.check(Eof) {
     match self.peek().kind {
       LParen => {
         depth += 1
@@ -337,12 +337,12 @@ fn Parser::skip_typeof_operand(self : Parser) -> Unit {
 ///|
 /// Skip type arguments: <T, U>
 fn Parser::skip_type_args(self : Parser) -> Unit {
-  if not(self.check(Lt)) {
+  if !self.check(Lt) {
     return
   }
   let _ = self.advance() // consume <
   let mut depth = 1
-  while depth > 0 && not(self.check(Eof)) {
+  while depth > 0 && !self.check(Eof) {
     match self.peek().kind {
       Lt => {
         depth += 1

--- a/src/parser/parser_type.mbt
+++ b/src/parser/parser_type.mbt
@@ -45,6 +45,10 @@ fn Parser::parse_primary_type(self : Parser) -> @ast.TsType raise ParseError {
       let _ = self.advance()
       Void
     }
+    Template(_, _, _) => {
+      let _ = self.advance()
+      String_
+    }
     // Literal types: "foo", 1, true, false
     Str(_) => {
       let _ = self.advance()

--- a/src/parser/parser_typescript_wbtest.mbt
+++ b/src/parser/parser_typescript_wbtest.mbt
@@ -118,6 +118,7 @@ async test "parser: parse TypeScript lib d.ts files" {
     for item in failures {
       println(item)
     }
+    fail("Expected all TypeScript lib files to parse")
   }
 }
 

--- a/src/parser/parser_typescript_wbtest.mbt
+++ b/src/parser/parser_typescript_wbtest.mbt
@@ -364,7 +364,7 @@ async test "parser: compare es5 interface fields" {
       ]
       let missing : Array[String] = []
       for name in expected {
-        if not(fields.contains(name)) {
+        if !fields.contains(name) {
           missing.push(name)
         }
       }

--- a/src/parser/parser_wbtest.mbt
+++ b/src/parser/parser_wbtest.mbt
@@ -631,6 +631,31 @@ test "parser: parse string type" {
 }
 
 ///|
+test "parser: parse template literal type" {
+  let parser = Parser::from_source("`section-${string}`")
+  let t = parser.parse_type()
+  match t {
+    String_ => ()
+    _ => fail("expected String_ for template literal type, got \{t}")
+  }
+}
+
+///|
+test "parser: parse interface method with template literal return type" {
+  let src =
+    #|interface Crypto {
+    #|  randomUUID(): `${string}-${string}-${string}-${string}-${string}`;
+    #|}
+  let parser = Parser::from_source(src)
+  let iface = parser.parse_interface()
+  assert_eq(iface.name, "Crypto")
+  assert_eq(iface.fields.length(), 1)
+  let (name, type_) = iface.fields[0]
+  assert_eq(name, "randomUUID")
+  assert_eq(type_, String_)
+}
+
+///|
 test "parser: parse let with string" {
   let parser = Parser::from_source("let s: string = \"hello\";")
   let stmt = parser.parse_stmt()

--- a/src/parser/pkg.generated.mbti
+++ b/src/parser/pkg.generated.mbti
@@ -6,6 +6,10 @@ import {
 }
 
 // Values
+pub fn emit_moonbit_decl(@ast.TsModule) -> String
+
+pub fn emit_moonbit_decl_from_source(String) -> String raise ParseError
+
 pub fn parse_block_from_source(String) -> @ast.TsBlock raise ParseError
 
 pub fn parse_block_from_source_strict(String, Bool) -> @ast.TsBlock raise ParseError
@@ -19,8 +23,7 @@ pub fn parse_module_block_from_source(String) -> @ast.TsModuleBlock raise ParseE
 // Errors
 pub(all) suberror ParseError {
   ParseError(String)
-}
-pub impl Show for ParseError
+} derive(Show)
 
 // Types and methods
 pub struct Lexer {
@@ -30,11 +33,10 @@ pub struct Lexer {
   mut pending : Array[Token]
   mut pending_index : Int
   mut newline_before_next : Bool
-}
+} derive(Show)
 pub fn Lexer::new(String) -> Self
 pub fn Lexer::next_token(Self) -> Token
 pub fn Lexer::tokenize(Self) -> Array[Token]
-pub impl Show for Lexer
 
 pub struct Parser {
   tokens : Array[Token]
@@ -50,7 +52,7 @@ pub struct Parser {
   src : String
   mut class_id : Int
   mut current_class_brand : String?
-}
+} derive(Show)
 pub fn Parser::from_source(String) -> Self
 pub fn Parser::new(Array[Token]) -> Self
 pub fn Parser::new_with_strict(Array[Token], Bool) -> Self
@@ -62,14 +64,12 @@ pub fn Parser::parse_interface(Self) -> @ast.TsInterface raise ParseError
 pub fn Parser::parse_module(Self) -> @ast.TsModule raise ParseError
 pub fn Parser::parse_module_block(Self) -> @ast.TsModuleBlock raise ParseError
 pub fn Parser::parse_stmt(Self) -> @ast.TsStmt raise ParseError
-pub impl Show for Parser
 
 pub struct Token {
   kind : TokenKind
   pos : Int
   has_newline_before : Bool
-}
-pub impl Show for Token
+} derive(Show)
 
 pub enum TokenKind {
   Number(Double)
@@ -182,9 +182,7 @@ pub enum TokenKind {
   Declare
   Null
   Eof
-}
-pub impl Eq for TokenKind
-pub impl Show for TokenKind
+} derive(Eq, Show)
 
 // Type aliases
 

--- a/src/parser/pkg.generated.mbti
+++ b/src/parser/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "mizchi/ts/parser"
 
 import {
   "mizchi/ts/ast",
+  "moonbitlang/core/debug",
 }
 
 // Values
@@ -23,7 +24,8 @@ pub fn parse_module_block_from_source(String) -> @ast.TsModuleBlock raise ParseE
 // Errors
 pub(all) suberror ParseError {
   ParseError(String)
-} derive(Show)
+} derive(@debug.Debug)
+pub impl Show for ParseError
 
 // Types and methods
 pub struct Lexer {
@@ -33,10 +35,11 @@ pub struct Lexer {
   mut pending : Array[Token]
   mut pending_index : Int
   mut newline_before_next : Bool
-} derive(Show)
+} derive(@debug.Debug)
 pub fn Lexer::new(String) -> Self
 pub fn Lexer::next_token(Self) -> Token
 pub fn Lexer::tokenize(Self) -> Array[Token]
+pub impl Show for Lexer
 
 pub struct Parser {
   tokens : Array[Token]
@@ -52,7 +55,7 @@ pub struct Parser {
   src : String
   mut class_id : Int
   mut current_class_brand : String?
-} derive(Show)
+} derive(@debug.Debug)
 pub fn Parser::from_source(String) -> Self
 pub fn Parser::new(Array[Token]) -> Self
 pub fn Parser::new_with_strict(Array[Token], Bool) -> Self
@@ -64,12 +67,14 @@ pub fn Parser::parse_interface(Self) -> @ast.TsInterface raise ParseError
 pub fn Parser::parse_module(Self) -> @ast.TsModule raise ParseError
 pub fn Parser::parse_module_block(Self) -> @ast.TsModuleBlock raise ParseError
 pub fn Parser::parse_stmt(Self) -> @ast.TsStmt raise ParseError
+pub impl Show for Parser
 
 pub struct Token {
   kind : TokenKind
   pos : Int
   has_newline_before : Bool
-} derive(Show)
+} derive(@debug.Debug)
+pub impl Show for Token
 
 pub enum TokenKind {
   Number(Double)
@@ -182,7 +187,8 @@ pub enum TokenKind {
   Declare
   Null
   Eof
-} derive(Eq, Show)
+} derive(Eq, @debug.Debug)
+pub impl Show for TokenKind
 
 // Type aliases
 

--- a/src/parser/show_impls.mbt
+++ b/src/parser/show_impls.mbt
@@ -1,0 +1,32 @@
+///|
+using @debug {trait Debug}
+
+///|
+fn[T : Debug] write_debug_show(logger : &Logger, value : T) -> Unit {
+  logger.write_string(@debug.to_string(value))
+}
+
+///|
+pub impl Show for ParseError with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for Parser with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TokenKind with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for Token with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for Lexer with output(self, logger) {
+  write_debug_show(logger, self)
+}

--- a/src/perf/bench_test.mbt
+++ b/src/perf/bench_test.mbt
@@ -678,7 +678,7 @@ test "bench AOT compile add" (b : @bench.T) {
   let module_ = try! parser.parse_module()
   b.bench(
     () => {
-      let _ = try! @aot.compile_module_to_wasm(module_)
+      let _ = try! @aot.experimental_compile_module_to_wasm(module_)
     },
     name="aot.compile.add",
     count=20,
@@ -689,7 +689,7 @@ test "bench AOT compile add" (b : @bench.T) {
 test "bench AOT call add" (b : @bench.T) {
   let parser = @parser.Parser::from_source(aot_add_src)
   let module_ = try! parser.parse_module()
-  let runtime = try! @aot.create_aot_runtime(module_)
+  let runtime = try! @aot.experimental_create_aot_runtime(module_)
   b.bench(
     () => {
       let _ = try! runtime.call("add", [10.0, 32.0])
@@ -715,7 +715,7 @@ test "bench AOT compile loop" (b : @bench.T) {
   let module_ = try! parser.parse_module()
   b.bench(
     () => {
-      let _ = try! @aot.compile_module_to_wasm(module_)
+      let _ = try! @aot.experimental_compile_module_to_wasm(module_)
     },
     name="aot.compile.loop",
     count=10,
@@ -726,7 +726,7 @@ test "bench AOT compile loop" (b : @bench.T) {
 test "bench AOT call loop(1000)" (b : @bench.T) {
   let parser = @parser.Parser::from_source(aot_loop_src)
   let module_ = try! parser.parse_module()
-  let runtime = try! @aot.create_aot_runtime(module_)
+  let runtime = try! @aot.experimental_create_aot_runtime(module_)
   b.bench(
     () => {
       let _ = try! runtime.call("sum", [1000.0])
@@ -770,7 +770,7 @@ test "bench AOT compile fib" (b : @bench.T) {
   let module_ = try! parser.parse_module()
   b.bench(
     () => {
-      let _ = try! @aot.compile_module_to_wasm(module_)
+      let _ = try! @aot.experimental_compile_module_to_wasm(module_)
     },
     name="aot.compile.fib",
     count=10,
@@ -781,7 +781,7 @@ test "bench AOT compile fib" (b : @bench.T) {
 test "bench AOT call fib(20)" (b : @bench.T) {
   let parser = @parser.Parser::from_source(aot_fib_src)
   let module_ = try! parser.parse_module()
-  let runtime = try! @aot.create_aot_runtime(module_)
+  let runtime = try! @aot.experimental_create_aot_runtime(module_)
   b.bench(
     () => {
       let _ = try! runtime.call("fib", [20.0])
@@ -814,7 +814,7 @@ test "bench interpreter vs AOT loop(10000)" (b : @bench.T) {
   // AOT version
   let parser = @parser.Parser::from_source(aot_loop_src)
   let module_ = try! parser.parse_module()
-  let runtime = try! @aot.create_aot_runtime(module_)
+  let runtime = try! @aot.experimental_create_aot_runtime(module_)
   b.bench(
     () => {
       let _ = try! runtime.call("sum", [10000.0])
@@ -836,7 +836,7 @@ let aot_math_src : String =
 test "bench AOT call math.sqrt" (b : @bench.T) {
   let parser = @parser.Parser::from_source(aot_math_src)
   let module_ = try! parser.parse_module()
-  let runtime = try! @aot.create_aot_runtime(module_)
+  let runtime = try! @aot.experimental_create_aot_runtime(module_)
   b.bench(
     () => {
       let _ = try! runtime.call("distance", [0.0, 0.0, 3.0, 4.0])

--- a/src/perf/moon.pkg
+++ b/src/perf/moon.pkg
@@ -1,0 +1,6 @@
+import {
+  "moonbitlang/core/bench",
+  "mizchi/ts/parser" @parser,
+  "mizchi/ts/runtime" @runtime,
+  "mizchi/ts/aot" @aot,
+} for "test"

--- a/src/perf/pkg.generated.mbti
+++ b/src/perf/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "mizchi/ts/perf"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/runtime/builtins_collection.mbt
+++ b/src/runtime/builtins_collection.mbt
@@ -307,7 +307,7 @@ fn JSInterpreter::weakmap_get_entry(
   key : JSValue,
 ) -> JSValue {
   let _ = self
-  if not(is_weak_key(key)) {
+  if !is_weak_key(key) {
     return Undefined
   }
   let key_id = get_weak_key_id(key)
@@ -337,7 +337,7 @@ fn JSInterpreter::weakmap_set_entry(
   value : JSValue,
 ) -> JSValue {
   let _ = self
-  if not(is_weak_key(key)) {
+  if !is_weak_key(key) {
     return Undefined
   }
   let key_id = get_weak_key_id(key)
@@ -379,7 +379,7 @@ fn JSInterpreter::weakmap_has_entry(
   key : JSValue,
 ) -> Bool {
   let _ = self
-  if not(is_weak_key(key)) {
+  if !is_weak_key(key) {
     return false
   }
   let key_id = get_weak_key_id(key)
@@ -408,7 +408,7 @@ fn JSInterpreter::weakmap_delete_entry(
   key : JSValue,
 ) -> Bool {
   let _ = self
-  if not(is_weak_key(key)) {
+  if !is_weak_key(key) {
     return false
   }
   let key_id = get_weak_key_id(key)
@@ -443,7 +443,7 @@ fn JSInterpreter::weakset_add_entry(
   value : JSValue,
 ) -> JSValue {
   let _ = self
-  if not(is_weak_key(value)) {
+  if !is_weak_key(value) {
     return ws_obj
   }
   let val_id = get_weak_key_id(value)
@@ -471,7 +471,7 @@ fn JSInterpreter::weakset_has_entry(
   value : JSValue,
 ) -> Bool {
   let _ = self
-  if not(is_weak_key(value)) {
+  if !is_weak_key(value) {
     return false
   }
   let val_id = get_weak_key_id(value)
@@ -496,7 +496,7 @@ fn JSInterpreter::weakset_delete_entry(
   value : JSValue,
 ) -> Bool {
   let _ = self
-  if not(is_weak_key(value)) {
+  if !is_weak_key(value) {
     return false
   }
   let val_id = get_weak_key_id(value)
@@ -529,7 +529,7 @@ fn JSInterpreter::fr_register(
   unregister_token : JSValue,
 ) -> Unit {
   let _ = self
-  if not(is_weak_key(target)) {
+  if !is_weak_key(target) {
     return
   }
   let target_id = get_weak_key_id(target)
@@ -558,7 +558,7 @@ fn JSInterpreter::fr_unregister(
   unregister_token : JSValue,
 ) -> Bool {
   let _ = self
-  if not(is_weak_key(unregister_token)) {
+  if !is_weak_key(unregister_token) {
     return false
   }
   let token_id = get_weak_key_id(unregister_token)

--- a/src/runtime/builtins_iterator.mbt
+++ b/src/runtime/builtins_iterator.mbt
@@ -84,14 +84,14 @@ fn JSInterpreter::string_iterator_next(
       idx + 1 < s.length() {
       let cu2 = s[idx + 1]
       if cu2.is_trailing_surrogate() {
-        let str = s[idx:idx + 2].to_string() catch { _ => "" }
+        let str = s[idx:idx + 2].to_string()
         (idx + 2, str)
       } else {
-        let str = s[idx:idx + 1].to_string() catch { _ => "" }
+        let str = s[idx:idx + 1].to_string()
         (idx + 1, str)
       }
     } else {
-      let str = s[idx:idx + 1].to_string() catch { _ => "" }
+      let str = s[idx:idx + 1].to_string()
       (idx + 1, str)
     }
     let _ = js_set_prop(this_arg, "__iter_index", Number(next_idx.to_double()))

--- a/src/runtime/builtins_object.mbt
+++ b/src/runtime/builtins_object.mbt
@@ -109,7 +109,7 @@ fn JSInterpreter::call_object_native(
                 false,
               )
             } else {
-              let idx = @strconv.parse_int(key) catch { _ => -1 }
+              let idx = @string.parse_int(key) catch { _ => -1 }
               if idx >= 0 && idx < arr.items.length() && arr.present[idx] {
                 self.make_data_descriptor(arr.items[idx], true, true, true)
               } else {
@@ -146,13 +146,9 @@ fn JSInterpreter::call_object_native(
                 false,
               )
             } else {
-              let idx = @strconv.parse_int(key) catch { _ => -1 }
+              let idx = @string.parse_int(key) catch { _ => -1 }
               if idx >= 0 && idx < s.length() {
-                let ch = JSValue::String(
-                  s[idx:idx + 1].to_string() catch {
-                    _ => ""
-                  },
-                )
+                let ch = JSValue::String(s[idx:idx + 1].to_string())
                 self.make_data_descriptor(ch, false, true, false)
               } else {
                 Undefined
@@ -284,7 +280,7 @@ fn JSInterpreter::call_object_native(
             if key == "length" {
               Bool(true)
             } else {
-              let idx = @strconv.parse_int(key) catch { _ => -1 }
+              let idx = @string.parse_int(key) catch { _ => -1 }
               if idx >= 0 && idx < arr.items.length() && arr.present[idx] {
                 Bool(true)
               } else {
@@ -302,7 +298,7 @@ fn JSInterpreter::call_object_native(
             if key == "length" {
               Bool(true)
             } else {
-              let idx = @strconv.parse_int(key) catch { _ => -1 }
+              let idx = @string.parse_int(key) catch { _ => -1 }
               Bool(idx >= 0 && idx < s.length())
             }
           _ => Bool(false)
@@ -517,13 +513,13 @@ fn JSInterpreter::object_get_own_property_names(
   match target {
     Function(closure) =>
       for prop in closure.props {
-        if not(prop.key.has_prefix("Symbol(")) {
+        if !prop.key.has_prefix("Symbol(") {
           names.push(String(prop.key))
         }
       }
     Object(map) =>
       for prop in map.props {
-        if not(prop.key.has_prefix("Symbol(")) {
+        if !prop.key.has_prefix("Symbol(") {
           names.push(String(prop.key))
         }
       }
@@ -534,7 +530,7 @@ fn JSInterpreter::object_get_own_property_names(
         }
       }
       for prop in arr.props {
-        if not(prop.key.has_prefix("Symbol(")) {
+        if !prop.key.has_prefix("Symbol(") {
           names.push(String(prop.key))
         }
       }
@@ -558,7 +554,7 @@ fn JSInterpreter::object_get_own_property_names(
                 break
               }
             }
-            valid && not(has_leading_zero)
+            valid && !has_leading_zero
           })
         if is_index {
           let mut n = 0

--- a/src/runtime/builtins_typedarray.mbt
+++ b/src/runtime/builtins_typedarray.mbt
@@ -6,7 +6,7 @@ pub struct JSByteBuffer {
   id : Int
   data : Array[Byte]
   mut detached : Bool
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// ByteBuffer ID generator
@@ -45,7 +45,7 @@ pub enum TypedArrayKind {
   Float64Array
   BigInt64Array
   BigUint64Array
-} derive(Show, Eq)
+} derive(Eq, Debug)
 
 ///|
 /// Get bytes per element for TypedArray type
@@ -84,7 +84,7 @@ pub struct TypedArrayData {
   byte_offset : Int
   byte_length : Int
   length : Int
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// Global storage for ByteBuffers (referenced by ID from Objects)
@@ -697,7 +697,7 @@ fn JSInterpreter::create_typedarray(
             if byte_offset < 0 || byte_offset > buffer_byte_length {
               return self.set_error_kind("RangeError", "Invalid byte offset")
             }
-            let length = if args.length() > 2 && not(args[2].is_undefined()) {
+            let length = if args.length() > 2 && !args[2].is_undefined() {
               let len = args[2].to_number().to_int()
               if len < 0 {
                 return self.set_error_kind(
@@ -982,7 +982,7 @@ fn JSInterpreter::typedarray_set(
                       break
                     }
                   }
-                  if not(valid) {
+                  if !valid {
                     return self.set_error_kind(
                       "SyntaxError", "Cannot convert to BigInt",
                     )
@@ -1034,7 +1034,7 @@ fn JSInterpreter::typedarray_subarray(
       } else {
         0
       }
-      let end_arg = if args.length() > 1 && not(args[1].is_undefined()) {
+      let end_arg = if args.length() > 1 && !args[1].is_undefined() {
         args[1].to_number().to_int()
       } else {
         length
@@ -1103,7 +1103,7 @@ fn JSInterpreter::typedarray_slice(
       } else {
         0
       }
-      let end_arg = if args.length() > 1 && not(args[1].is_undefined()) {
+      let end_arg = if args.length() > 1 && !args[1].is_undefined() {
         args[1].to_number().to_int()
       } else {
         length
@@ -1195,7 +1195,7 @@ fn JSInterpreter::typedarray_fill(
       } else {
         0
       }
-      let end_arg = if args.length() > 2 && not(args[2].is_undefined()) {
+      let end_arg = if args.length() > 2 && !args[2].is_undefined() {
         args[2].to_number().to_int()
       } else {
         length
@@ -1306,7 +1306,7 @@ fn JSInterpreter::typedarray_copy_within(
         0
       }
       // Coerce end to integer (with error handling)
-      let end_arg = if args.length() > 2 && not(args[2].is_undefined()) {
+      let end_arg = if args.length() > 2 && !args[2].is_undefined() {
         match self.to_integer_or_error(args[2]) {
           Some(n) => n
           None => return self.error_or_undefined()
@@ -1638,7 +1638,7 @@ fn JSInterpreter::typedarray_every(
           Number(i.to_double()),
           this_arg,
         ])
-        if not(result.to_boolean()) {
+        if !result.to_boolean() {
           return Bool(false)
         }
       }
@@ -1886,7 +1886,7 @@ fn JSInterpreter::typedarray_join(
 ) -> JSValue {
   match get_typedarray_data(this_arg) {
     Some(data) => {
-      let sep = if args.length() > 0 && not(args[0].is_undefined()) {
+      let sep = if args.length() > 0 && !args[0].is_undefined() {
         args[0].to_js_string()
       } else {
         ","
@@ -2164,7 +2164,7 @@ fn JSInterpreter::create_dataview(
     return self.set_error_kind("TypeError", "DataView requires ArrayBuffer")
   }
   let buffer = args[0]
-  if not(is_arraybuffer(buffer)) {
+  if !is_arraybuffer(buffer) {
     return self.set_error_kind(
       "TypeError", "First argument must be an ArrayBuffer",
     )
@@ -2183,7 +2183,7 @@ fn JSInterpreter::create_dataview(
       if byte_offset < 0 || byte_offset > buffer_byte_length {
         return self.set_error_kind("RangeError", "Invalid byte offset")
       }
-      let byte_length = if args.length() > 2 && not(args[2].is_undefined()) {
+      let byte_length = if args.length() > 2 && !args[2].is_undefined() {
         let len = args[2].to_number().to_int()
         if len < 0 || byte_offset + len > buffer_byte_length {
           return self.set_error_kind("RangeError", "Invalid byte length")
@@ -2214,7 +2214,7 @@ fn JSInterpreter::dataview_get(
   args : Array[JSValue],
   type_name : String,
 ) -> JSValue {
-  if not(is_dataview(this_arg)) {
+  if !is_dataview(this_arg) {
     return self.set_error_kind("TypeError", "Not a DataView")
   }
   let buf_id = match js_get_prop(this_arg, "__dv_buffer_id") {
@@ -2310,7 +2310,7 @@ fn JSInterpreter::dataview_set(
   args : Array[JSValue],
   type_name : String,
 ) -> JSValue {
-  if not(is_dataview(this_arg)) {
+  if !is_dataview(this_arg) {
     return self.set_error_kind("TypeError", "Not a DataView")
   }
   let buf_id = match js_get_prop(this_arg, "__dv_buffer_id") {

--- a/src/runtime/interpreter_aot_gen.mbt
+++ b/src/runtime/interpreter_aot_gen.mbt
@@ -121,12 +121,12 @@ fn try_build_aot_state_machine(
   func : @ast.TsFunc,
   args : Array[JSValue],
 ) -> (AOTGenStateMachine, Array[Double])? {
-  if not(func.is_generator) {
+  if !func.is_generator {
     return None
   }
 
   // Check if the generator body is simple enough for AOT
-  if not(is_simple_generator_body(func.body)) {
+  if !is_simple_generator_body(func.body) {
     return None
   }
 
@@ -186,7 +186,7 @@ fn is_simple_generator_body(block : @ast.TsBlock) -> Bool {
     return false
   }
   for stmt in block.stmts {
-    if not(is_simple_stmt(stmt)) {
+    if !is_simple_stmt(stmt) {
       return false
     }
   }
@@ -307,7 +307,7 @@ fn is_simple_stmt(stmt : @ast.TsStmt) -> Bool {
     @ast.TsStmt::Assign(_, expr) => is_simple_expr(expr)
     @ast.TsStmt::CompoundAssign(_, _, expr) => is_simple_expr(expr)
     @ast.TsStmt::If(cond, then_block, else_block) => {
-      if not(is_simple_expr(cond)) || not(is_simple_generator_body(then_block)) {
+      if !is_simple_expr(cond) || !is_simple_generator_body(then_block) {
         return false
       }
       match else_block {
@@ -321,15 +321,15 @@ fn is_simple_stmt(stmt : @ast.TsStmt) -> Bool {
       is_simple_expr(cond) && is_simple_generator_body(body)
     @ast.TsStmt::For(init, cond, update, body) => {
       match init {
-        Some(s) => if not(is_simple_stmt(s)) { return false }
+        Some(s) => if !is_simple_stmt(s) { return false }
         None => ()
       }
       match cond {
-        Some(e) => if not(is_simple_expr(e)) { return false }
+        Some(e) => if !is_simple_expr(e) { return false }
         None => ()
       }
       match update {
-        Some(s) => if not(is_simple_stmt(s)) { return false }
+        Some(s) => if !is_simple_stmt(s) { return false }
         None => ()
       }
       is_simple_generator_body(body)
@@ -400,7 +400,7 @@ fn collect_local_names_stmt(
     @ast.TsStmt::Var(@ast.TsBinding::Ident(name), _, _)
     | @ast.TsStmt::Let(@ast.TsBinding::Ident(name), _, _)
     | @ast.TsStmt::Const(@ast.TsBinding::Ident(name), _, _) =>
-      if not(params.contains(name)) && not(locals.contains(name)) {
+      if !params.contains(name) && !locals.contains(name) {
         locals.push(name)
       }
     @ast.TsStmt::If(_, then_block, else_block) => {
@@ -699,7 +699,7 @@ fn js_to_f64(val : JSValue) -> Double {
     Bool(b) => if b { 1.0 } else { 0.0 }
     Undefined | Null => 0.0
     String(s) =>
-      @strconv.parse_double(s) catch {
+      @string.parse_double(s) catch {
         _ => 0.0 / 0.0 // NaN
       }
     _ => 0.0 / 0.0 // NaN for non-numeric types

--- a/src/runtime/interpreter_binding.mbt
+++ b/src/runtime/interpreter_binding.mbt
@@ -36,7 +36,7 @@ fn JSInterpreter::maybe_set_function_name(
   }
   match value {
     Function(_) =>
-      if not(self.has_own_prop(value, "name")) {
+      if !self.has_own_prop(value, "name") {
         self.set_function_name(value, name)
       } else {
         match js_get_prop(value, "name") {
@@ -51,7 +51,7 @@ fn JSInterpreter::maybe_set_function_name(
       match js_get_prop(value, "__class_name") {
         String(class_name) =>
           if class_name.length() > 0 {
-            if not(self.has_own_prop(value, "name")) {
+            if !self.has_own_prop(value, "name") {
               let _ = js_set_prop(value, "name", String(class_name))
             }
           } else {
@@ -60,7 +60,7 @@ fn JSInterpreter::maybe_set_function_name(
               Bool(b) => b
               _ => false
             }
-            if not(has_name_prop) && not(self.has_own_prop(value, "name")) {
+            if !has_name_prop && !self.has_own_prop(value, "name") {
               let _ = js_set_prop(value, "name", String(name))
             }
           }
@@ -180,7 +180,7 @@ fn JSInterpreter::assign_ident(
     let _ = self.set_error_kind("TypeError", "Assignment to constant variable")
     return
   }
-  if not(env.set(name, value)) {
+  if !env.set(name, value) {
     if env.has("__strict__") {
       let _ = self.set_error_kind("ReferenceError", name + " is not defined")
     } else {
@@ -436,14 +436,14 @@ fn JSInterpreter::assign_array_pattern_gen(
                 @ast.TsBinding::Target(target_expr) =>
                   self.eval_assignment_target_gen(target_expr, env, prepared => {
                     if self.peek_error() is Some(_) {
-                      if not(done) {
+                      if !done {
                         self.iterator_close_on_error(iterator)
                       }
                       self.pop_active_iterator()
                       GenValue::Value(Undefined)
                     } else {
                       let rest_items : Array[JSValue] = []
-                      while not(done) {
+                      while !done {
                         let val = next_value()
                         if done {
                           break
@@ -460,7 +460,7 @@ fn JSInterpreter::assign_array_pattern_gen(
                         let rest_val = js_array_from(rest_items)
                         self.assign_prepared_target(prepared, rest_val, env)
                         if self.peek_error() is Some(_) {
-                          if not(done) {
+                          if !done {
                             self.iterator_close_on_error(iterator)
                           }
                           self.pop_active_iterator()
@@ -474,7 +474,7 @@ fn JSInterpreter::assign_array_pattern_gen(
                   })
                 _ => {
                   let rest_items : Array[JSValue] = []
-                  while not(done) {
+                  while !done {
                     let val = next_value()
                     if done {
                       break
@@ -493,7 +493,7 @@ fn JSInterpreter::assign_array_pattern_gen(
                       self.assign_pattern_gen(rest_binding, rest_val, env),
                       _unused => {
                         if self.peek_error() is Some(_) {
-                          if not(done) {
+                          if !done {
                             self.iterator_close_on_error(iterator)
                           }
                           self.pop_active_iterator()
@@ -511,7 +511,7 @@ fn JSInterpreter::assign_array_pattern_gen(
         } else {
           match pattern.items[index] {
             None => {
-              if not(done) {
+              if !done {
                 let _ = next_value()
               }
               process_index(index + 1)
@@ -543,7 +543,7 @@ fn JSInterpreter::assign_array_pattern_gen(
                 }
                 gen_bind(self.assign_pattern_gen(elem.binding, v, env), _unused => {
                   if self.peek_error() is Some(_) {
-                    if not(done) {
+                    if !done {
                       self.iterator_close_on_error(iterator)
                     }
                     self.pop_active_iterator()
@@ -616,10 +616,10 @@ fn JSInterpreter::assign_object_pattern_gen(
           match value {
             Object(map) =>
               for prop in map.props {
-                if not(prop.enumerable) {
+                if !prop.enumerable {
                   continue
                 }
-                if not(contains_key(used_keys, prop.key)) {
+                if !contains_key(used_keys, prop.key) {
                   let val = self.eval_prop_value(JSValue::Object(map), prop)
                   let _ = js_set_prop(rest_obj, prop.key, val)
                 }
@@ -627,13 +627,13 @@ fn JSInterpreter::assign_object_pattern_gen(
             Array(arr) => {
               for i, item in arr.items {
                 let key = i.to_string()
-                if not(contains_key(used_keys, key)) && arr.present[i] {
+                if !contains_key(used_keys, key) && arr.present[i] {
                   let _ = js_set_prop(rest_obj, key, item)
                 }
               }
               for prop in arr.props {
-                if not(contains_key(used_keys, prop.key)) {
-                  if not(prop.enumerable) {
+                if !contains_key(used_keys, prop.key) {
+                  if !prop.enumerable {
                     continue
                   }
                   let val = self.eval_prop_value(JSValue::Array(arr), prop)
@@ -643,8 +643,8 @@ fn JSInterpreter::assign_object_pattern_gen(
             }
             Function(closure) =>
               for prop in closure.props {
-                if not(contains_key(used_keys, prop.key)) {
-                  if not(prop.enumerable) {
+                if !contains_key(used_keys, prop.key) {
+                  if !prop.enumerable {
                     continue
                   }
                   let val = self.eval_prop_value(
@@ -737,7 +737,7 @@ fn JSInterpreter::bind_array_pattern(
       }
       for item in pattern.items {
         match item {
-          None => if not(done) { let _ = next_value() }
+          None => if !done { let _ = next_value() }
           Some(elem) => {
             let mut val = if done { JSValue::Undefined } else { next_value() }
             let mut used_default = false
@@ -765,7 +765,7 @@ fn JSInterpreter::bind_array_pattern(
         None => ()
         Some(rest_binding) => {
           let rest_items : Array[JSValue] = []
-          while not(done) {
+          while !done {
             let val = next_value()
             if done {
               break
@@ -776,7 +776,7 @@ fn JSInterpreter::bind_array_pattern(
           self.bind_pattern(rest_binding, rest_val, env)
         }
       }
-      if not(done) {
+      if !done {
         let _ = self.generator_return(gen_id, Undefined)
       }
     }
@@ -804,7 +804,7 @@ fn JSInterpreter::bind_array_pattern(
           for item in pattern.items {
             match item {
               None => {
-                if not(done) {
+                if !done {
                   let _ = next_value()
                 }
                 match self.peek_error() {
@@ -842,7 +842,7 @@ fn JSInterpreter::bind_array_pattern(
                 self.bind_pattern(elem.binding, val, env)
                 match self.peek_error() {
                   Some(_) => {
-                    if not(done) {
+                    if !done {
                       self.iterator_close(iterator)
                     }
                     return
@@ -856,7 +856,7 @@ fn JSInterpreter::bind_array_pattern(
             None => ()
             Some(rest_binding) => {
               let rest_items : Array[JSValue] = []
-              while not(done) {
+              while !done {
                 let val = next_value()
                 match self.peek_error() {
                   Some(_) => return
@@ -871,7 +871,7 @@ fn JSInterpreter::bind_array_pattern(
               self.bind_pattern(rest_binding, rest_val, env)
               match self.peek_error() {
                 Some(_) => {
-                  if not(done) {
+                  if !done {
                     self.iterator_close(iterator)
                   }
                   return
@@ -880,7 +880,7 @@ fn JSInterpreter::bind_array_pattern(
               }
             }
           }
-          if not(done) {
+          if !done {
             self.iterator_close(iterator)
             match self.peek_error() {
               Some(_) => return
@@ -933,7 +933,7 @@ fn JSInterpreter::init_array_pattern(
       }
       for item in pattern.items {
         match item {
-          None => if not(done) { let _ = next_value() }
+          None => if !done { let _ = next_value() }
           Some(elem) => {
             let mut val = if done { JSValue::Undefined } else { next_value() }
             let mut used_default = false
@@ -961,7 +961,7 @@ fn JSInterpreter::init_array_pattern(
         None => ()
         Some(rest_binding) => {
           let rest_items : Array[JSValue] = []
-          while not(done) {
+          while !done {
             let val = next_value()
             if done {
               break
@@ -972,7 +972,7 @@ fn JSInterpreter::init_array_pattern(
           self.init_pattern(rest_binding, rest_val, env, is_const)
         }
       }
-      if not(done) {
+      if !done {
         let _ = self.generator_return(gen_id, Undefined)
       }
     }
@@ -1000,7 +1000,7 @@ fn JSInterpreter::init_array_pattern(
           for item in pattern.items {
             match item {
               None => {
-                if not(done) {
+                if !done {
                   let _ = next_value()
                 }
                 match self.peek_error() {
@@ -1038,7 +1038,7 @@ fn JSInterpreter::init_array_pattern(
                 self.init_pattern(elem.binding, val, env, is_const)
                 match self.peek_error() {
                   Some(_) => {
-                    if not(done) {
+                    if !done {
                       self.iterator_close(iterator)
                     }
                     return
@@ -1052,7 +1052,7 @@ fn JSInterpreter::init_array_pattern(
             None => ()
             Some(rest_binding) => {
               let rest_items : Array[JSValue] = []
-              while not(done) {
+              while !done {
                 let val = next_value()
                 match self.peek_error() {
                   Some(_) => return
@@ -1067,7 +1067,7 @@ fn JSInterpreter::init_array_pattern(
               self.init_pattern(rest_binding, rest_val, env, is_const)
               match self.peek_error() {
                 Some(_) => {
-                  if not(done) {
+                  if !done {
                     self.iterator_close(iterator)
                   }
                   return
@@ -1076,7 +1076,7 @@ fn JSInterpreter::init_array_pattern(
               }
             }
           }
-          if not(done) {
+          if !done {
             self.iterator_close(iterator)
             match self.peek_error() {
               Some(_) => return
@@ -1128,7 +1128,7 @@ fn JSInterpreter::assign_array_pattern(
       }
       for item in pattern.items {
         match item {
-          None => if not(done) { let _ = next_value() }
+          None => if !done { let _ = next_value() }
           Some(elem) => {
             let mut val = if done { JSValue::Undefined } else { next_value() }
             let mut used_default = false
@@ -1156,7 +1156,7 @@ fn JSInterpreter::assign_array_pattern(
         None => ()
         Some(rest_binding) => {
           let rest_items : Array[JSValue] = []
-          while not(done) {
+          while !done {
             let val = next_value()
             if done {
               break
@@ -1192,7 +1192,7 @@ fn JSInterpreter::assign_array_pattern(
           for item in pattern.items {
             match item {
               None => {
-                if not(done) {
+                if !done {
                   let _ = next_value()
                 }
                 match self.peek_error() {
@@ -1230,7 +1230,7 @@ fn JSInterpreter::assign_array_pattern(
                 self.assign_pattern(elem.binding, val, env)
                 match self.peek_error() {
                   Some(_) => {
-                    if not(done) {
+                    if !done {
                       self.iterator_close_on_error(iterator)
                     }
                     return
@@ -1249,7 +1249,7 @@ fn JSInterpreter::assign_array_pattern(
                     target_expr, env,
                   )
                   if self.peek_error() is Some(_) {
-                    if not(done) {
+                    if !done {
                       self.iterator_close_on_error(iterator)
                     }
                     return
@@ -1257,7 +1257,7 @@ fn JSInterpreter::assign_array_pattern(
                   match prepared {
                     Some(target) => {
                       let rest_items : Array[JSValue] = []
-                      while not(done) {
+                      while !done {
                         let val = next_value()
                         match self.peek_error() {
                           Some(_) => return
@@ -1272,7 +1272,7 @@ fn JSInterpreter::assign_array_pattern(
                       self.assign_prepared_target(target, rest_val, env)
                       match self.peek_error() {
                         Some(_) => {
-                          if not(done) {
+                          if !done {
                             self.iterator_close_on_error(iterator)
                           }
                           return
@@ -1281,7 +1281,7 @@ fn JSInterpreter::assign_array_pattern(
                       }
                     }
                     None => {
-                      if not(done) {
+                      if !done {
                         self.iterator_close_on_error(iterator)
                       }
                       return
@@ -1290,7 +1290,7 @@ fn JSInterpreter::assign_array_pattern(
                 }
                 _ => {
                   let rest_items : Array[JSValue] = []
-                  while not(done) {
+                  while !done {
                     let val = next_value()
                     match self.peek_error() {
                       Some(_) => return
@@ -1305,7 +1305,7 @@ fn JSInterpreter::assign_array_pattern(
                   self.assign_pattern(rest_binding, rest_val, env)
                   match self.peek_error() {
                     Some(_) => {
-                      if not(done) {
+                      if !done {
                         self.iterator_close_on_error(iterator)
                       }
                       return
@@ -1378,10 +1378,10 @@ fn JSInterpreter::bind_object_pattern(
       match value {
         Object(map) =>
           for prop in map.props {
-            if not(prop.enumerable) {
+            if !prop.enumerable {
               continue
             }
-            if not(contains_key(used_keys, prop.key)) {
+            if !contains_key(used_keys, prop.key) {
               let val = self.eval_prop_value(JSValue::Object(map), prop)
               let _ = js_set_prop(rest_obj, prop.key, val)
             }
@@ -1389,13 +1389,13 @@ fn JSInterpreter::bind_object_pattern(
         Array(arr) => {
           for i, item in arr.items {
             let key = i.to_string()
-            if not(contains_key(used_keys, key)) && arr.present[i] {
+            if !contains_key(used_keys, key) && arr.present[i] {
               let _ = js_set_prop(rest_obj, key, item)
             }
           }
           for prop in arr.props {
-            if not(contains_key(used_keys, prop.key)) {
-              if not(prop.enumerable) {
+            if !contains_key(used_keys, prop.key) {
+              if !prop.enumerable {
                 continue
               }
               let val = self.eval_prop_value(JSValue::Array(arr), prop)
@@ -1405,8 +1405,8 @@ fn JSInterpreter::bind_object_pattern(
         }
         Function(closure) =>
           for prop in closure.props {
-            if not(contains_key(used_keys, prop.key)) {
-              if not(prop.enumerable) {
+            if !contains_key(used_keys, prop.key) {
+              if !prop.enumerable {
                 continue
               }
               let val = self.eval_prop_value(JSValue::Function(closure), prop)
@@ -1470,10 +1470,10 @@ fn JSInterpreter::init_object_pattern(
       match value {
         Object(map) =>
           for prop in map.props {
-            if not(prop.enumerable) {
+            if !prop.enumerable {
               continue
             }
-            if not(contains_key(used_keys, prop.key)) {
+            if !contains_key(used_keys, prop.key) {
               let val = self.eval_prop_value(JSValue::Object(map), prop)
               let _ = js_set_prop(rest_obj, prop.key, val)
             }
@@ -1481,13 +1481,13 @@ fn JSInterpreter::init_object_pattern(
         Array(arr) => {
           for i, item in arr.items {
             let key = i.to_string()
-            if not(contains_key(used_keys, key)) && arr.present[i] {
+            if !contains_key(used_keys, key) && arr.present[i] {
               let _ = js_set_prop(rest_obj, key, item)
             }
           }
           for prop in arr.props {
-            if not(contains_key(used_keys, prop.key)) {
-              if not(prop.enumerable) {
+            if !contains_key(used_keys, prop.key) {
+              if !prop.enumerable {
                 continue
               }
               let val = self.eval_prop_value(JSValue::Array(arr), prop)
@@ -1497,8 +1497,8 @@ fn JSInterpreter::init_object_pattern(
         }
         Function(closure) =>
           for prop in closure.props {
-            if not(contains_key(used_keys, prop.key)) {
-              if not(prop.enumerable) {
+            if !contains_key(used_keys, prop.key) {
+              if !prop.enumerable {
                 continue
               }
               let val = self.eval_prop_value(JSValue::Function(closure), prop)
@@ -1561,10 +1561,10 @@ fn JSInterpreter::assign_object_pattern(
       match value {
         Object(map) =>
           for prop in map.props {
-            if not(prop.enumerable) {
+            if !prop.enumerable {
               continue
             }
-            if not(contains_key(used_keys, prop.key)) {
+            if !contains_key(used_keys, prop.key) {
               let val = self.eval_prop_value(JSValue::Object(map), prop)
               let _ = js_set_prop(rest_obj, prop.key, val)
             }
@@ -1572,13 +1572,13 @@ fn JSInterpreter::assign_object_pattern(
         Array(arr) => {
           for i, item in arr.items {
             let key = i.to_string()
-            if not(contains_key(used_keys, key)) && arr.present[i] {
+            if !contains_key(used_keys, key) && arr.present[i] {
               let _ = js_set_prop(rest_obj, key, item)
             }
           }
           for prop in arr.props {
-            if not(contains_key(used_keys, prop.key)) {
-              if not(prop.enumerable) {
+            if !contains_key(used_keys, prop.key) {
+              if !prop.enumerable {
                 continue
               }
               let val = self.eval_prop_value(JSValue::Array(arr), prop)
@@ -1588,8 +1588,8 @@ fn JSInterpreter::assign_object_pattern(
         }
         Function(closure) =>
           for prop in closure.props {
-            if not(contains_key(used_keys, prop.key)) {
-              if not(prop.enumerable) {
+            if !contains_key(used_keys, prop.key) {
+              if !prop.enumerable {
                 continue
               }
               let val = self.eval_prop_value(JSValue::Function(closure), prop)

--- a/src/runtime/interpreter_builtins.mbt
+++ b/src/runtime/interpreter_builtins.mbt
@@ -2408,7 +2408,7 @@ fn JSInterpreter::array_like_method(
         let key = i.to_string()
         let has_prop = js_has_prop(receiver, key)
         let use_string = match str_value {
-          Some(s) => not(has_prop) && i >= 0 && i < s.length()
+          Some(s) => !has_prop && i >= 0 && i < s.length()
           None => false
         }
         if has_prop {
@@ -2416,7 +2416,7 @@ fn JSInterpreter::array_like_method(
           parts.push(value.to_js_string())
         } else if use_string {
           match str_value {
-            Some(s) => parts.push(s[i:i + 1].to_string() catch { _ => "" })
+            Some(s) => parts.push(s[i:i + 1].to_string())
             None => parts.push("")
           }
         } else {
@@ -2445,17 +2445,17 @@ fn JSInterpreter::array_like_method(
         let key = i.to_string()
         let has_prop = js_has_prop(receiver, key)
         let use_string = match str_value {
-          Some(s) => not(has_prop) && i >= 0 && i < s.length()
+          Some(s) => !has_prop && i >= 0 && i < s.length()
           None => false
         }
-        if not(has_prop) && not(use_string) {
+        if !has_prop && !use_string {
           continue
         }
         let value = if has_prop {
           self.get_prop_value(receiver, key)
         } else {
           match str_value {
-            Some(s) => String(s[i:i + 1].to_string() catch { _ => "" })
+            Some(s) => String(s[i:i + 1].to_string())
             None => Undefined
           }
         }
@@ -2487,7 +2487,7 @@ fn JSInterpreter::array_like_method(
         let key = i.to_string()
         let has_prop = js_has_prop(receiver, key)
         let use_string = match str_value {
-          Some(s) => not(has_prop) && i >= 0 && i < s.length()
+          Some(s) => !has_prop && i >= 0 && i < s.length()
           None => false
         }
         if has_prop || use_string {
@@ -2495,7 +2495,7 @@ fn JSInterpreter::array_like_method(
             self.get_prop_value(receiver, key)
           } else {
             match str_value {
-              Some(s) => String(s[i:i + 1].to_string() catch { _ => "" })
+              Some(s) => String(s[i:i + 1].to_string())
               None => Undefined
             }
           }
@@ -2531,7 +2531,7 @@ fn JSInterpreter::array_like_method(
         } else {
           match str_value {
             Some(s) if i >= 0 && i < s.length() =>
-              String(s[i:i + 1].to_string() catch { _ => "" })
+              String(s[i:i + 1].to_string())
             _ => Undefined
           }
         }
@@ -2548,7 +2548,7 @@ fn JSInterpreter::array_like_method(
         )
       } else {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return self.set_error_kind(
             "TypeError", "Array.prototype.map requires a callback",
           )
@@ -2563,7 +2563,7 @@ fn JSInterpreter::array_like_method(
               let key = i.to_string()
               let has_prop = js_has_prop(receiver, key)
               let use_string = match str_value {
-                Some(s) => not(has_prop) && i >= 0 && i < s.length()
+                Some(s) => !has_prop && i >= 0 && i < s.length()
                 None => false
               }
               if has_prop || use_string {
@@ -2571,7 +2571,7 @@ fn JSInterpreter::array_like_method(
                   self.get_prop_value(receiver, key)
                 } else {
                   match str_value {
-                    Some(s) => String(s[i:i + 1].to_string() catch { _ => "" })
+                    Some(s) => String(s[i:i + 1].to_string())
                     None => Undefined
                   }
                 }
@@ -2598,7 +2598,7 @@ fn JSInterpreter::array_like_method(
         )
       } else {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return self.set_error_kind(
             "TypeError", "Array.prototype.filter requires a callback",
           )
@@ -2610,7 +2610,7 @@ fn JSInterpreter::array_like_method(
           let key = i.to_string()
           let has_prop = js_has_prop(receiver, key)
           let use_string = match str_value {
-            Some(s) => not(has_prop) && i >= 0 && i < s.length()
+            Some(s) => !has_prop && i >= 0 && i < s.length()
             None => false
           }
           if has_prop || use_string {
@@ -2618,7 +2618,7 @@ fn JSInterpreter::array_like_method(
               self.get_prop_value(receiver, key)
             } else {
               match str_value {
-                Some(s) => String(s[i:i + 1].to_string() catch { _ => "" })
+                Some(s) => String(s[i:i + 1].to_string())
                 None => Undefined
               }
             }
@@ -2639,7 +2639,7 @@ fn JSInterpreter::array_like_method(
         )
       } else {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return self.set_error_kind(
             "TypeError", "Array.prototype.reduce requires a callback",
           )
@@ -2655,7 +2655,7 @@ fn JSInterpreter::array_like_method(
             let key = i.to_string()
             let has_prop = js_has_prop(receiver, key)
             let use_string = match str_value {
-              Some(s) => not(has_prop) && i >= 0 && i < s.length()
+              Some(s) => !has_prop && i >= 0 && i < s.length()
               None => false
             }
             if has_prop || use_string {
@@ -2663,7 +2663,7 @@ fn JSInterpreter::array_like_method(
                 self.get_prop_value(receiver, key)
               } else {
                 match str_value {
-                  Some(s) => String(s[i:i + 1].to_string() catch { _ => "" })
+                  Some(s) => String(s[i:i + 1].to_string())
                   None => Undefined
                 }
               }
@@ -2673,7 +2673,7 @@ fn JSInterpreter::array_like_method(
             }
             i += 1
           }
-          if not(found) {
+          if !found {
             return self.set_error_kind(
               "TypeError", "Reduce of empty array with no initial value",
             )
@@ -2683,7 +2683,7 @@ fn JSInterpreter::array_like_method(
           let key = i.to_string()
           let has_prop = js_has_prop(receiver, key)
           let use_string = match str_value {
-            Some(s) => not(has_prop) && i >= 0 && i < s.length()
+            Some(s) => !has_prop && i >= 0 && i < s.length()
             None => false
           }
           if has_prop || use_string {
@@ -2691,7 +2691,7 @@ fn JSInterpreter::array_like_method(
               self.get_prop_value(receiver, key)
             } else {
               match str_value {
-                Some(s) => String(s[i:i + 1].to_string() catch { _ => "" })
+                Some(s) => String(s[i:i + 1].to_string())
                 None => Undefined
               }
             }
@@ -2714,7 +2714,7 @@ fn JSInterpreter::array_like_method(
         )
       } else {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return self.set_error_kind(
             "TypeError", "Array.prototype.reduceRight requires a callback",
           )
@@ -2730,7 +2730,7 @@ fn JSInterpreter::array_like_method(
             let key = i.to_string()
             let has_prop = js_has_prop(receiver, key)
             let use_string = match str_value {
-              Some(s) => not(has_prop) && i >= 0 && i < s.length()
+              Some(s) => !has_prop && i >= 0 && i < s.length()
               None => false
             }
             if has_prop || use_string {
@@ -2738,7 +2738,7 @@ fn JSInterpreter::array_like_method(
                 self.get_prop_value(receiver, key)
               } else {
                 match str_value {
-                  Some(s) => String(s[i:i + 1].to_string() catch { _ => "" })
+                  Some(s) => String(s[i:i + 1].to_string())
                   None => Undefined
                 }
               }
@@ -2751,7 +2751,7 @@ fn JSInterpreter::array_like_method(
             }
             i = i - 1
           }
-          if not(found) {
+          if !found {
             return self.set_error_kind(
               "TypeError", "Reduce of empty array with no initial value",
             )
@@ -2761,7 +2761,7 @@ fn JSInterpreter::array_like_method(
           let key = i.to_string()
           let has_prop = js_has_prop(receiver, key)
           let use_string = match str_value {
-            Some(s) => not(has_prop) && i >= 0 && i < s.length()
+            Some(s) => !has_prop && i >= 0 && i < s.length()
             None => false
           }
           if has_prop || use_string {
@@ -2769,7 +2769,7 @@ fn JSInterpreter::array_like_method(
               self.get_prop_value(receiver, key)
             } else {
               match str_value {
-                Some(s) => String(s[i:i + 1].to_string() catch { _ => "" })
+                Some(s) => String(s[i:i + 1].to_string())
                 None => Undefined
               }
             }
@@ -2795,7 +2795,7 @@ fn JSInterpreter::array_like_method(
         )
       } else {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return self.set_error_kind(
             "TypeError", "Array.prototype.forEach requires a callback",
           )
@@ -2806,7 +2806,7 @@ fn JSInterpreter::array_like_method(
           let key = i.to_string()
           let has_prop = js_has_prop(receiver, key)
           let use_string = match str_value {
-            Some(s) => not(has_prop) && i >= 0 && i < s.length()
+            Some(s) => !has_prop && i >= 0 && i < s.length()
             None => false
           }
           if has_prop || use_string {
@@ -2814,7 +2814,7 @@ fn JSInterpreter::array_like_method(
               self.get_prop_value(receiver, key)
             } else {
               match str_value {
-                Some(s) => String(s[i:i + 1].to_string() catch { _ => "" })
+                Some(s) => String(s[i:i + 1].to_string())
                 None => Undefined
               }
             }
@@ -2832,7 +2832,7 @@ fn JSInterpreter::array_like_method(
         )
       } else {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return self.set_error_kind(
             "TypeError", "Array.prototype.every requires a callback",
           )
@@ -2843,7 +2843,7 @@ fn JSInterpreter::array_like_method(
           let key = i.to_string()
           let has_prop = js_has_prop(receiver, key)
           let use_string = match str_value {
-            Some(s) => not(has_prop) && i >= 0 && i < s.length()
+            Some(s) => !has_prop && i >= 0 && i < s.length()
             None => false
           }
           if has_prop || use_string {
@@ -2851,13 +2851,13 @@ fn JSInterpreter::array_like_method(
               self.get_prop_value(receiver, key)
             } else {
               match str_value {
-                Some(s) => String(s[i:i + 1].to_string() catch { _ => "" })
+                Some(s) => String(s[i:i + 1].to_string())
                 None => Undefined
               }
             }
             let args_array = [value, Number(i.to_double()), receiver]
             let ok = self.call_function(callback, this_arg, args_array)
-            if not(ok.to_boolean()) {
+            if !ok.to_boolean() {
               return Bool(false)
             }
           }
@@ -2872,7 +2872,7 @@ fn JSInterpreter::array_like_method(
         )
       } else {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return self.set_error_kind(
             "TypeError", "Array.prototype.some requires a callback",
           )
@@ -2883,7 +2883,7 @@ fn JSInterpreter::array_like_method(
           let key = i.to_string()
           let has_prop = js_has_prop(receiver, key)
           let use_string = match str_value {
-            Some(s) => not(has_prop) && i >= 0 && i < s.length()
+            Some(s) => !has_prop && i >= 0 && i < s.length()
             None => false
           }
           if has_prop || use_string {
@@ -2891,7 +2891,7 @@ fn JSInterpreter::array_like_method(
               self.get_prop_value(receiver, key)
             } else {
               match str_value {
-                Some(s) => String(s[i:i + 1].to_string() catch { _ => "" })
+                Some(s) => String(s[i:i + 1].to_string())
                 None => Undefined
               }
             }
@@ -2908,7 +2908,7 @@ fn JSInterpreter::array_like_method(
     "find" =>
       if args.length() > 0 {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return Undefined
         }
         let this_arg = if args.length() > 1 { args[1] } else { Undefined }
@@ -2917,7 +2917,7 @@ fn JSInterpreter::array_like_method(
           let key = i.to_string()
           let has_prop = js_has_prop(receiver, key)
           let use_string = match str_value {
-            Some(s) => not(has_prop) && i >= 0 && i < s.length()
+            Some(s) => !has_prop && i >= 0 && i < s.length()
             None => false
           }
           if has_prop || use_string {
@@ -2925,7 +2925,7 @@ fn JSInterpreter::array_like_method(
               self.get_prop_value(receiver, key)
             } else {
               match str_value {
-                Some(s) => String(s[i:i + 1].to_string() catch { _ => "" })
+                Some(s) => String(s[i:i + 1].to_string())
                 None => Undefined
               }
             }
@@ -2945,7 +2945,7 @@ fn JSInterpreter::array_like_method(
     "findIndex" =>
       if args.length() > 0 {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return Number(-1.0)
         }
         let this_arg = if args.length() > 1 { args[1] } else { Undefined }
@@ -2954,7 +2954,7 @@ fn JSInterpreter::array_like_method(
           let key = i.to_string()
           let has_prop = js_has_prop(receiver, key)
           let use_string = match str_value {
-            Some(s) => not(has_prop) && i >= 0 && i < s.length()
+            Some(s) => !has_prop && i >= 0 && i < s.length()
             None => false
           }
           if has_prop || use_string {
@@ -2962,7 +2962,7 @@ fn JSInterpreter::array_like_method(
               self.get_prop_value(receiver, key)
             } else {
               match str_value {
-                Some(s) => String(s[i:i + 1].to_string() catch { _ => "" })
+                Some(s) => String(s[i:i + 1].to_string())
                 None => Undefined
               }
             }
@@ -2982,7 +2982,7 @@ fn JSInterpreter::array_like_method(
     "findLast" =>
       if args.length() > 0 {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return Undefined
         }
         let this_arg = if args.length() > 1 { args[1] } else { Undefined }
@@ -2991,7 +2991,7 @@ fn JSInterpreter::array_like_method(
           let key = i.to_string()
           let has_prop = js_has_prop(receiver, key)
           let use_string = match str_value {
-            Some(s) => not(has_prop) && i >= 0 && i < s.length()
+            Some(s) => !has_prop && i >= 0 && i < s.length()
             None => false
           }
           if has_prop || use_string {
@@ -2999,7 +2999,7 @@ fn JSInterpreter::array_like_method(
               self.get_prop_value(receiver, key)
             } else {
               match str_value {
-                Some(s) => String(s[i:i + 1].to_string() catch { _ => "" })
+                Some(s) => String(s[i:i + 1].to_string())
                 None => Undefined
               }
             }
@@ -3022,7 +3022,7 @@ fn JSInterpreter::array_like_method(
     "findLastIndex" =>
       if args.length() > 0 {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return Number(-1.0)
         }
         let this_arg = if args.length() > 1 { args[1] } else { Undefined }
@@ -3031,7 +3031,7 @@ fn JSInterpreter::array_like_method(
           let key = i.to_string()
           let has_prop = js_has_prop(receiver, key)
           let use_string = match str_value {
-            Some(s) => not(has_prop) && i >= 0 && i < s.length()
+            Some(s) => !has_prop && i >= 0 && i < s.length()
             None => false
           }
           if has_prop || use_string {
@@ -3039,7 +3039,7 @@ fn JSInterpreter::array_like_method(
               self.get_prop_value(receiver, key)
             } else {
               match str_value {
-                Some(s) => String(s[i:i + 1].to_string() catch { _ => "" })
+                Some(s) => String(s[i:i + 1].to_string())
                 None => Undefined
               }
             }
@@ -3170,7 +3170,7 @@ fn JSInterpreter::array_like_method(
             let key = i.to_string()
             let has_prop = js_has_prop(receiver, key)
             let use_string = match str_value {
-              Some(s) => not(has_prop) && i >= 0 && i < s.length()
+              Some(s) => !has_prop && i >= 0 && i < s.length()
               None => false
             }
             if has_prop || use_string {
@@ -3178,7 +3178,7 @@ fn JSInterpreter::array_like_method(
                 self.get_prop_value(receiver, key)
               } else {
                 match str_value {
-                  Some(s) => String(s[i:i + 1].to_string() catch { _ => "" })
+                  Some(s) => String(s[i:i + 1].to_string())
                   None => Undefined
                 }
               }
@@ -3278,7 +3278,7 @@ fn JSInterpreter::array_like_method(
         let key = i.to_string()
         let has_prop = js_has_prop(receiver, key)
         let use_string = match str_value {
-          Some(s) => not(has_prop) && i >= 0 && i < s.length()
+          Some(s) => !has_prop && i >= 0 && i < s.length()
           None => false
         }
         if has_prop || use_string {
@@ -3286,7 +3286,7 @@ fn JSInterpreter::array_like_method(
             self.get_prop_value(receiver, key)
           } else {
             match str_value {
-              Some(s) => String(s[i:i + 1].to_string() catch { _ => "" })
+              Some(s) => String(s[i:i + 1].to_string())
               None => Undefined
             }
           }
@@ -3321,7 +3321,7 @@ fn JSInterpreter::array_like_method(
         } else {
           match str_value {
             Some(s) if idx >= 0 && idx < s.length() =>
-              String(s[idx:idx + 1].to_string() catch { _ => "" })
+              String(s[idx:idx + 1].to_string())
             _ => Undefined
           }
         }
@@ -3503,7 +3503,7 @@ fn JSInterpreter::lookup_own_prop(
           set: None,
         })
       } else {
-        let idx = @strconv.parse_int(key) catch { _ => -1 }
+        let idx = @string.parse_int(key) catch { _ => -1 }
         if idx >= 0 && idx < arr.items.length() && arr.present[idx] {
           Some({
             key,
@@ -3535,9 +3535,9 @@ fn JSInterpreter::lookup_own_prop(
           set: None,
         })
       } else {
-        let idx = @strconv.parse_int(key) catch { _ => -1 }
+        let idx = @string.parse_int(key) catch { _ => -1 }
         if idx >= 0 && idx < s.length() {
-          let ch = JSValue::String(s[idx:idx + 1].to_string() catch { _ => "" })
+          let ch = JSValue::String(s[idx:idx + 1].to_string())
           Some({
             key,
             value: ch,
@@ -3591,7 +3591,7 @@ fn JSInterpreter::define_property(
     Object(_) | Function(_) => true
     _ => false
   }
-  if not(is_obj) {
+  if !is_obj {
     return self.set_error_kind(
       "TypeError", "Property description must be an object",
     )
@@ -3645,10 +3645,10 @@ fn JSInterpreter::define_property(
         None => Undefined
       }
     }
-    if not(get_val.is_undefined()) && not(self.is_callable(get_val)) {
+    if !get_val.is_undefined() && !self.is_callable(get_val) {
       return self.set_error_kind("TypeError", "Getter must be callable")
     }
-    if not(set_val.is_undefined()) && not(self.is_callable(set_val)) {
+    if !set_val.is_undefined() && !self.is_callable(set_val) {
       return self.set_error_kind("TypeError", "Setter must be callable")
     }
     let getter = match get_val {
@@ -3695,9 +3695,9 @@ fn JSInterpreter::call_native(
   args : Array[JSValue],
 ) -> JSValue {
   if name.has_prefix("Array.prototype") {
-    let mut method_name = (name[15:] catch { _ => "" }).to_string()
+    let mut method_name = name[15:].to_string()
     if method_name.has_prefix(".") {
-      method_name = (method_name[1:] catch { _ => "" }).to_string()
+      method_name = method_name[1:].to_string()
     }
     if method_name == "[@@iterator]" {
       method_name = "@@iterator"
@@ -3721,9 +3721,9 @@ fn JSInterpreter::call_native(
     }
   }
   if name.has_prefix("String.prototype") {
-    let mut method_name = (name[16:] catch { _ => "" }).to_string()
+    let mut method_name = name[16:].to_string()
     if method_name.has_prefix(".") {
-      method_name = (method_name[1:] catch { _ => "" }).to_string()
+      method_name = method_name[1:].to_string()
     }
     if method_name == "[@@iterator]" {
       method_name = "@@iterator"
@@ -3809,7 +3809,7 @@ fn JSInterpreter::call_native(
       }
     }
     "Promise.prototype.then" => {
-      if not(self.is_promise(this_arg)) {
+      if !self.is_promise(this_arg) {
         return self.set_error_kind(
           "TypeError", "Promise.prototype.then called on non-Promise",
         )
@@ -3848,7 +3848,7 @@ fn JSInterpreter::call_native(
         Some(err) => return err
         None => ()
       }
-      if not(self.is_callable(then_method)) {
+      if !self.is_callable(then_method) {
         return self.set_error_kind(
           "TypeError", "Promise.prototype.catch called on non-callable then",
         )
@@ -3871,12 +3871,12 @@ fn JSInterpreter::call_native(
         Some(err) => return err
         None => ()
       }
-      if not(self.is_callable(then_method)) {
+      if !self.is_callable(then_method) {
         return self.set_error_kind(
           "TypeError", "Promise.prototype.finally called on non-callable then",
         )
       }
-      if not(self.is_callable(on_finally)) {
+      if !self.is_callable(on_finally) {
         return self.call_function(then_method, this_arg, [
           on_finally, on_finally,
         ])
@@ -3918,7 +3918,7 @@ fn JSInterpreter::call_native(
       }
       match this_arg {
         Object(_) | Function(_) =>
-          if not(self.is_constructor(this_arg)) {
+          if !self.is_constructor(this_arg) {
             self.set_error_kind(
               "TypeError", "Promise.try called on non-constructor",
             )
@@ -3996,7 +3996,7 @@ fn JSInterpreter::call_native(
         Object(_) | Function(_) | Array(_) => {
           let cur_resolve = js_get_prop(cap, "resolve")
           let cur_reject = js_get_prop(cap, "reject")
-          if not(cur_resolve.is_undefined()) || not(cur_reject.is_undefined()) {
+          if !cur_resolve.is_undefined() || !cur_reject.is_undefined() {
             return self.set_error_kind(
               "TypeError", "Promise capability already initialized",
             )
@@ -4309,7 +4309,7 @@ fn JSInterpreter::call_native(
     }
     "queueMicrotask" => {
       let callback = if args.length() > 0 { args[0] } else { Undefined }
-      if not(self.is_callable(callback)) {
+      if !self.is_callable(callback) {
         return self.set_error_kind(
           "TypeError", "queueMicrotask callback is not callable",
         )
@@ -4454,8 +4454,7 @@ fn JSInterpreter::call_native(
         return if n > 0.0 { String("Infinity") } else { String("-Infinity") }
       }
       // Get fraction digits argument
-      let frac_digits : Int? = if args.length() > 0 &&
-        not(args[0].is_undefined()) {
+      let frac_digits : Int? = if args.length() > 0 && !args[0].is_undefined() {
         let d = self.to_number_value(args[0]).to_int()
         if d < 0 || d > 100 {
           let _ = self.set_error_kind(
@@ -4481,7 +4480,7 @@ fn JSInterpreter::call_native(
     "Number.isFinite" =>
       if args.length() > 0 {
         match args[0] {
-          Number(n) => Bool(not(n.is_nan()) && not(n.is_inf()))
+          Number(n) => Bool(!n.is_nan() && !n.is_inf())
           _ => Bool(false)
         }
       } else {
@@ -4535,12 +4534,10 @@ fn JSInterpreter::call_native(
       } else if trimmed.length() >= 2 &&
         trimmed.has_prefix("\"") &&
         trimmed.has_suffix("\"") {
-        let inner = trimmed[1:trimmed.length() - 1].to_string() catch {
-          _ => ""
-        }
+        let inner = trimmed[1:trimmed.length() - 1].to_string()
         String(self.json_unescape(inner))
       } else {
-        let num = @strconv.parse_double(trimmed) catch {
+        let num = @string.parse_double(trimmed) catch {
           _ => return self.set_error_kind("SyntaxError", "Invalid JSON")
         }
         Number(num)
@@ -4696,7 +4693,7 @@ fn JSInterpreter::call_native(
       }
     "Function.call" => {
       let target = this_arg
-      if not(self.is_callable(target)) {
+      if !self.is_callable(target) {
         return self.set_error_kind(
           "TypeError", "Function.prototype.call called on non-callable",
         )
@@ -4710,7 +4707,7 @@ fn JSInterpreter::call_native(
     }
     "Function.apply" => {
       let target = this_arg
-      if not(self.is_callable(target)) {
+      if !self.is_callable(target) {
         return self.set_error_kind(
           "TypeError", "Function.prototype.apply called on non-callable",
         )
@@ -4730,7 +4727,7 @@ fn JSInterpreter::call_native(
     }
     "Function.bind" => {
       let target = this_arg
-      if not(self.is_callable(target)) {
+      if !self.is_callable(target) {
         return self.set_error_kind(
           "TypeError", "Function.prototype.bind called on non-callable",
         )
@@ -4810,7 +4807,7 @@ fn JSInterpreter::call_native(
         return Undefined
       }
       let array_like = args[0]
-      let has_map_fn = args.length() > 1 && not(args[0 + 1].is_undefined())
+      let has_map_fn = args.length() > 1 && !args[0 + 1].is_undefined()
       let map_fn_val = if has_map_fn { args[0 + 1] } else { Undefined }
       let this_arg_for_map = if args.length() > 2 { args[2] } else { Undefined }
       // Handle different types of arrayLike
@@ -5533,7 +5530,7 @@ fn JSInterpreter::call_native(
         String(s) =>
           if s.has_prefix("@@global:") {
             // Extract key from "@@global:key"
-            String(s[9:].to_string() catch { _ => "" })
+            String(s[9:].to_string())
           } else if s.has_prefix("Symbol(") || s.has_prefix("@@") {
             // Non-global symbol
             Undefined
@@ -5549,10 +5546,10 @@ fn JSInterpreter::call_native(
         String(s) =>
           if s.has_prefix("@@global:") {
             // Global symbol - description is the key
-            String(s[9:].to_string() catch { _ => "" })
+            String(s[9:].to_string())
           } else if s.has_prefix("@@") {
             // Well-known symbol - description is "Symbol." + name
-            String("Symbol." + (s[2:].to_string() catch { _ => "" }))
+            String("Symbol." + s[2:].to_string())
           } else if s.has_prefix("Symbol([empty])") {
             // Symbol("") - empty string description
             String("")
@@ -5568,7 +5565,7 @@ fn JSInterpreter::call_native(
               }
             }
             if end_idx > 7 {
-              String(s[7:end_idx].to_string() catch { _ => "" })
+              String(s[7:end_idx].to_string())
             } else if end_idx == 7 {
               // Symbol()#id - no description
               Undefined
@@ -5590,12 +5587,10 @@ fn JSInterpreter::call_native(
         String(s) =>
           if s.has_prefix("@@global:") {
             // Global symbol - format as Symbol(key)
-            String("Symbol(" + (s[9:].to_string() catch { _ => "" }) + ")")
+            String("Symbol(" + s[9:].to_string() + ")")
           } else if s.has_prefix("@@") {
             // Well-known symbol - format as Symbol(Symbol.name)
-            String(
-              "Symbol(Symbol." + (s[2:].to_string() catch { _ => "" }) + ")",
-            )
+            String("Symbol(Symbol." + s[2:].to_string() + ")")
           } else if s.has_prefix("Symbol([empty])") {
             // Symbol("") - empty string description -> "Symbol()"
             String("Symbol()")
@@ -5610,7 +5605,7 @@ fn JSInterpreter::call_native(
               }
             }
             if hash_idx > 0 {
-              String(s[:hash_idx].to_string() catch { _ => s })
+              String(s[:hash_idx].to_string())
             } else {
               String(s)
             }
@@ -5947,7 +5942,7 @@ fn JSInterpreter::call_native(
       }
     }
     "RegExp.prototype.exec" => {
-      if not(is_regexp(this_arg)) {
+      if !is_regexp(this_arg) {
         return self.set_error_kind(
           "TypeError", "RegExp.prototype.exec called on non-RegExp",
         )
@@ -5981,7 +5976,7 @@ fn JSInterpreter::call_native(
       }
     }
     "RegExp.prototype.compile" => {
-      if not(is_regexp(this_arg)) {
+      if !is_regexp(this_arg) {
         return self.set_error_kind(
           "TypeError", "RegExp.prototype.compile called on non-RegExp",
         )
@@ -6018,7 +6013,7 @@ fn JSInterpreter::call_native(
       this_arg
     }
     "RegExp.prototype.test" => {
-      if not(is_regexp(this_arg)) {
+      if !is_regexp(this_arg) {
         return self.set_error_kind(
           "TypeError", "RegExp.prototype.test called on non-RegExp",
         )
@@ -6292,7 +6287,7 @@ fn JSInterpreter::call_native(
     }
     "isFinite" => {
       let num = if args.length() > 0 { args[0].to_number() } else { 0.0 / 0.0 }
-      Bool(not(num.is_nan()) && not(num.is_inf()) && not(num.is_neg_inf()))
+      Bool(!num.is_nan() && !num.is_inf() && !num.is_neg_inf())
     }
     "parseInt" => {
       let input_str = if args.length() > 0 {
@@ -6315,7 +6310,7 @@ fn JSInterpreter::call_native(
       let (actual_str, actual_radix) : (String, Int) = if radix == 16 ||
         radix == 0 {
         if trimmed.has_prefix("0x") || trimmed.has_prefix("0X") {
-          ((trimmed[2:] catch { _ => trimmed }).to_string(), 16)
+          (trimmed[2:].to_string(), 16)
         } else {
           (trimmed, if radix == 0 { 10 } else { radix })
         }
@@ -6325,10 +6320,10 @@ fn JSInterpreter::call_native(
       if actual_radix < 2 || actual_radix > 36 {
         Number(0.0 / 0.0) // NaN
       } else {
-        let result : Int = @strconv.parse_int(actual_str, base=actual_radix) catch {
+        let result : Int = @string.parse_int(actual_str, base=actual_radix) catch {
           _ =>
             // Try without base if it fails
-            @strconv.parse_int(actual_str) catch {
+            @string.parse_int(actual_str) catch {
               _ => 0
             }
         }
@@ -6346,7 +6341,7 @@ fn JSInterpreter::call_native(
         "NaN"
       }
       let trimmed = input_str.trim_start().to_string()
-      let result : Double = @strconv.parse_double(trimmed) catch {
+      let result : Double = @string.parse_double(trimmed) catch {
         _ => 0.0 / 0.0 // NaN
       }
       Number(result)
@@ -6542,7 +6537,7 @@ fn JSInterpreter::call_native(
         return Undefined
       }
       let callback = args[0]
-      let constructors = if args.length() > 1 && not(args[1].is_undefined()) {
+      let constructors = if args.length() > 1 && !args[1].is_undefined() {
         args[1]
       } else {
         self.global_env.get("typedArrayConstructors")
@@ -6830,7 +6825,7 @@ fn JSInterpreter::call_native(
       // Register with VM GC
       vm_gc_register_weak_map(wm_obj)
       // Initialize from iterable if provided
-      if args.length() > 0 && not(args[0].is_nullish()) {
+      if args.length() > 0 && !args[0].is_nullish() {
         let iterable = args[0]
         let iter_fn = js_get_prop(iterable, "@@iterator")
         match iter_fn {
@@ -6888,7 +6883,7 @@ fn JSInterpreter::call_native(
       // Register with VM GC
       vm_gc_register_weak_set(ws_obj)
       // Initialize from iterable if provided
-      if args.length() > 0 && not(args[0].is_nullish()) {
+      if args.length() > 0 && !args[0].is_nullish() {
         let iterable = args[0]
         let iter_fn = js_get_prop(iterable, "@@iterator")
         match iter_fn {
@@ -7105,7 +7100,7 @@ fn JSInterpreter::call_native(
               "TypeError", "Cannot transfer a detached ArrayBuffer",
             )
           }
-          let new_length_f = if args.length() > 0 && not(args[0].is_undefined()) {
+          let new_length_f = if args.length() > 0 && !args[0].is_undefined() {
             let n = args[0].to_number()
             if n.is_nan() {
               0.0
@@ -7164,7 +7159,7 @@ fn JSInterpreter::call_native(
               "TypeError", "Cannot transfer a detached ArrayBuffer",
             )
           }
-          let new_length_f = if args.length() > 0 && not(args[0].is_undefined()) {
+          let new_length_f = if args.length() > 0 && !args[0].is_undefined() {
             let n = args[0].to_number()
             if n.is_nan() {
               0.0
@@ -7227,7 +7222,7 @@ fn JSInterpreter::call_native(
           } else {
             0
           }
-          let end_arg = if args.length() > 1 && not(args[1].is_undefined()) {
+          let end_arg = if args.length() > 1 && !args[1].is_undefined() {
             args[1].to_number().to_int()
           } else {
             byte_length

--- a/src/runtime/interpreter_eval.mbt
+++ b/src/runtime/interpreter_eval.mbt
@@ -534,7 +534,7 @@ pub fn JSInterpreter::eval_expr(
               }
               // In strict mode, deleting non-configurable property throws TypeError
               let result = js_delete_prop(obj, prop)
-              if not(result) && env.has("__strict__") {
+              if !result && env.has("__strict__") {
                 let _ = self.set_error_kind(
                   "TypeError",
                   "Cannot delete property '\{prop}' of #<Object>",
@@ -577,7 +577,7 @@ pub fn JSInterpreter::eval_expr(
               }
               // In strict mode, deleting non-configurable property throws TypeError
               let result = js_delete_prop(obj, key)
-              if not(result) && env.has("__strict__") {
+              if !result && env.has("__strict__") {
                 let _ = self.set_error_kind(
                   "TypeError",
                   "Cannot delete property '\{key}' of #<Object>",
@@ -1003,7 +1003,7 @@ pub fn JSInterpreter::eval_expr(
           }
         } else if key.has_prefix("@@get:") || key.has_prefix("@@set:") {
           let is_get = key.has_prefix("@@get:")
-          let raw_key = (key[6:] catch { _ => "" }).to_string()
+          let raw_key = key[6:].to_string()
           // Check if this is a computed accessor key
           let (real_key, func_val) = if raw_key.has_prefix("@@computed:") {
             match val_expr {
@@ -1158,7 +1158,7 @@ pub fn JSInterpreter::eval_expr(
         @ast.TsExpr::Var(name) => {
           // Check if variable exists before reading
           let global_obj = self.global_env.get("globalThis")
-          if not(env.has(name)) && not(js_has_prop(global_obj, name)) {
+          if !env.has(name) && !js_has_prop(global_obj, name) {
             let _ = self.set_error_kind(
               "ReferenceError",
               name + " is not defined",
@@ -1182,7 +1182,7 @@ pub fn JSInterpreter::eval_expr(
                 current
               }
             @ast.TsCompoundOp::OrAssign =>
-              if not(current.to_boolean()) {
+              if !current.to_boolean() {
                 let val = self.eval_expr(right, env)
                 self.assign_ident(name, val, env)
                 val
@@ -1221,7 +1221,7 @@ pub fn JSInterpreter::eval_expr(
                 current
               }
             @ast.TsCompoundOp::OrAssign =>
-              if not(current.to_boolean()) {
+              if !current.to_boolean() {
                 let val = self.eval_expr(right, env)
                 self.set_prop_value(obj, prop, val, strict=is_strict)
                 val
@@ -1299,7 +1299,7 @@ pub fn JSInterpreter::eval_expr(
                 current
               }
             @ast.TsCompoundOp::OrAssign =>
-              if not(current.to_boolean()) {
+              if !current.to_boolean() {
                 let val = self.eval_expr(right, env)
                 match obj {
                   Array(_) | Object(_) | Function(_) =>
@@ -1542,7 +1542,7 @@ fn JSInterpreter::eval_expr_gen(
   expr : @ast.TsExpr,
   env : JSEnv,
 ) -> GenValue {
-  if not(expr_has_yield(expr)) {
+  if !expr_has_yield(expr) {
     return GenValue::Value(self.eval_expr(expr, env))
   }
   match expr {
@@ -2232,7 +2232,7 @@ fn JSInterpreter::exec_while_for_eval(
       Some(err) => return (Some(err), Undefined)
       None => ()
     }
-    if not(cond_val.to_boolean()) {
+    if !cond_val.to_boolean() {
       return (None, v)
     }
     // Create a new block scope for the loop body (ES6 block scoping)
@@ -2327,7 +2327,7 @@ fn JSInterpreter::exec_do_while_for_eval(
       Some(err) => return (Some(err), Undefined)
       None => ()
     }
-    if not(cond_val.to_boolean()) {
+    if !cond_val.to_boolean() {
       return (None, v)
     }
   }
@@ -2367,7 +2367,7 @@ fn JSInterpreter::exec_for_for_eval(
           Some(err) => return (Some(err), Undefined)
           None => ()
         }
-        if not(cond_val.to_boolean()) {
+        if !cond_val.to_boolean() {
           return (None, v)
         }
       }
@@ -2439,7 +2439,7 @@ fn JSInterpreter::exec_while_for_eval_labeled(
       Some(err) => return (Some(err), Undefined)
       None => ()
     }
-    if not(cond_val.to_boolean()) {
+    if !cond_val.to_boolean() {
       return (None, v)
     }
     // Create a new block scope for the loop body (ES6 block scoping)
@@ -2551,7 +2551,7 @@ fn JSInterpreter::exec_do_while_for_eval_labeled(
       Some(err) => return (Some(err), Undefined)
       None => ()
     }
-    if not(cond_val.to_boolean()) {
+    if !cond_val.to_boolean() {
       return (None, v)
     }
   }
@@ -2593,7 +2593,7 @@ fn JSInterpreter::exec_for_for_eval_labeled(
           Some(err) => return (Some(err), Undefined)
           None => ()
         }
-        if not(cond_val.to_boolean()) {
+        if !cond_val.to_boolean() {
           return (None, v)
         }
       }
@@ -2952,7 +2952,7 @@ fn JSInterpreter::apply_for_of_binding(
     @ast.TsForOfKind::Var =>
       match binding {
         @ast.TsBinding::Ident(name) =>
-          if not(env.set(name, value)) {
+          if !env.set(name, value) {
             env.define_var(name, value)
           }
         _ => self.bind_pattern(binding, value, env)
@@ -2975,7 +2975,7 @@ fn JSInterpreter::collect_for_in_keys(
     seen : Array[String],
     key : String,
   ) -> Unit {
-    if not(contains_key(seen, key)) {
+    if !contains_key(seen, key) {
       keys.push(key)
       seen.push(key)
     }
@@ -3119,7 +3119,7 @@ fn JSInterpreter::exec_do_while_loop(
       Some(err) => return Some(err)
       None => ()
     }
-    if not(cond_val.to_boolean()) {
+    if !cond_val.to_boolean() {
       break
     }
   }
@@ -3488,7 +3488,7 @@ fn JSInterpreter::exec_for_of_loop(
               Some(err) => return Some(err)
               None => ()
             }
-            let char_str = s[idx:idx + 1].to_string() catch { _ => "" }
+            let char_str = s[idx:idx + 1].to_string()
 
             // ES6: Create per-iteration environment for let/const
             let iter_env = create_iter_env(
@@ -3910,7 +3910,7 @@ pub fn JSInterpreter::exec_stmt(
     @ast.TsStmt::CompoundAssign(name, op, val_expr) => {
       // Check if variable exists before reading
       let global_obj = self.global_env.get("globalThis")
-      if not(env.has(name)) && not(js_has_prop(global_obj, name)) {
+      if !env.has(name) && !js_has_prop(global_obj, name) {
         let _ = self.set_error_kind("ReferenceError", name + " is not defined")
         return Some(Undefined)
       }
@@ -3934,7 +3934,7 @@ pub fn JSInterpreter::exec_stmt(
           }
         @ast.TsCompoundOp::OrAssign =>
           // x ||= y: only assign if x is falsy
-          if not(current.to_boolean()) {
+          if !current.to_boolean() {
             let val = self.eval_expr(val_expr, env)
             match self.peek_error() {
               Some(err) => return Some(err)
@@ -3992,7 +3992,7 @@ pub fn JSInterpreter::exec_stmt(
         None => ()
       }
       if prop.has_prefix("@@define:") {
-        let real_key = (prop[9:] catch { _ => "" }).to_string()
+        let real_key = prop[9:].to_string()
         // ES6 14.5.14: It is a Syntax Error if PropName of ClassElement is "prototype"
         // Check if this is a static method named "prototype" on a function/class
         if real_key == "prototype" {
@@ -4034,7 +4034,7 @@ pub fn JSInterpreter::exec_stmt(
         }
 
         let is_get = prop.has_prefix("@@get:")
-        let real_key = (prop[6:] catch { _ => "" }).to_string()
+        let real_key = prop[6:].to_string()
         // ES6 14.5.14: It is a Syntax Error if PropName of ClassElement is "prototype"
         // Check if this is a static accessor named "prototype" on a function/class
         if real_key == "prototype" {
@@ -4131,7 +4131,7 @@ fn JSInterpreter::hoist_stmt(
       let names : Array[String] = []
       collect_binding_names(binding, names)
       for name in names {
-        if not(env.has(name)) {
+        if !env.has(name) {
           env.define_var(name, Undefined)
           match env.parent {
             None => {
@@ -4153,7 +4153,7 @@ fn JSInterpreter::hoist_stmt(
         _ => false
       }
       for name in names {
-        if not(env.has_local(name)) {
+        if !env.has_local(name) {
           env.define_uninitialized(name, is_const)
           match env.parent {
             None => {
@@ -4198,7 +4198,7 @@ fn JSInterpreter::hoist_stmt(
         collect_binding_names(binding, names)
         let is_const = kind == @ast.TsForOfKind::Const
         for name in names {
-          if not(env.has(name)) {
+          if !env.has(name) {
             match kind {
               @ast.TsForOfKind::Var => env.define_var(name, Undefined)
               @ast.TsForOfKind::Let | @ast.TsForOfKind::Const =>
@@ -4224,7 +4224,7 @@ fn JSInterpreter::hoist_stmt(
         collect_binding_names(binding, names)
         let is_const = kind == @ast.TsForOfKind::Const
         for name in names {
-          if not(env.has(name)) {
+          if !env.has(name) {
             match kind {
               @ast.TsForOfKind::Var => env.define_var(name, Undefined)
               @ast.TsForOfKind::Let | @ast.TsForOfKind::Const =>
@@ -4249,7 +4249,7 @@ fn JSInterpreter::hoist_stmt(
         collect_binding_names(binding, names)
         let is_const = kind == @ast.TsForOfKind::Const
         for name in names {
-          if not(env.has(name)) {
+          if !env.has(name) {
             match kind {
               @ast.TsForOfKind::Var => env.define_var(name, Undefined)
               @ast.TsForOfKind::Let | @ast.TsForOfKind::Const =>
@@ -4308,7 +4308,7 @@ fn JSInterpreter::hoist_block_var_only(
         let names : Array[String] = []
         collect_binding_names(binding, names)
         for name in names {
-          if not(env.has(name)) {
+          if !env.has(name) {
             env.define_var(name, Undefined)
           }
         }
@@ -4334,7 +4334,7 @@ fn JSInterpreter::hoist_block_lexical(
         collect_binding_names(binding, names)
         for name in names {
           // Always create local binding for let (shadowing is intended)
-          if not(env.has_local(name)) {
+          if !env.has_local(name) {
             env.define_uninitialized(name, false)
           }
         }
@@ -4344,7 +4344,7 @@ fn JSInterpreter::hoist_block_lexical(
         collect_binding_names(binding, names)
         for name in names {
           // Always create local binding for const (shadowing is intended)
-          if not(env.has_local(name)) {
+          if !env.has_local(name) {
             env.define_uninitialized(name, true)
           }
         }
@@ -4389,7 +4389,7 @@ fn apply_cached_lexical_names(
 ) -> Unit {
   for pair in names {
     let (name, is_const) = pair
-    if not(env.has_local(name)) {
+    if !env.has_local(name) {
       env.define_uninitialized(name, is_const)
     }
   }
@@ -4420,7 +4420,7 @@ fn JSInterpreter::hoist_var_stmt_to_local(
       collect_binding_names(binding, names)
       for name in names {
         // Always define locally, even if parent has same name
-        if not(env.has_local(name)) {
+        if !env.has_local(name) {
           env.define_var(name, Undefined)
         }
       }
@@ -4704,7 +4704,7 @@ pub fn JSInterpreter::call_function(
       if closure.is_strict {
         call_env.define_var("__strict__", Bool(true))
       }
-      if not(closure.is_arrow) {
+      if !closure.is_arrow {
         if closure.is_strict {
           call_env.define_var("this", this_arg)
         } else {
@@ -4805,7 +4805,7 @@ pub fn JSInterpreter::call_function(
             _ => ()
           }
           let result = if name == "Promise" {
-            if not(new_target.is_undefined()) {
+            if !new_target.is_undefined() {
               self.promise_construct_with_instance(this_arg, args)
             } else {
               self.call_native(name, this_arg, args)

--- a/src/runtime/interpreter_init.mbt
+++ b/src/runtime/interpreter_init.mbt
@@ -119,12 +119,7 @@ fn extract_function_name(native_name : String) -> String {
   }
   // Handle prototype[...] patterns
   match native_name.find("[") {
-    Some(bracket_idx) =>
-      try {
-        return native_name[bracket_idx:].to_string()
-      } catch {
-        _ => ()
-      }
+    Some(bracket_idx) => return native_name[bracket_idx:].to_string()
     None => ()
   }
   // Handle "Foo.bar" -> "bar" (find last dot)
@@ -135,11 +130,7 @@ fn extract_function_name(native_name : String) -> String {
     }
   }
   if last_dot >= 0 {
-    try {
-      return native_name[last_dot + 1:].to_string()
-    } catch {
-      _ => ()
-    }
+    return native_name[last_dot + 1:].to_string()
   }
   native_name
 }

--- a/src/runtime/interpreter_iter_eval.mbt
+++ b/src/runtime/interpreter_iter_eval.mbt
@@ -286,7 +286,7 @@ fn JSInterpreter::get_iterator(
           match self.peek_error() {
             Some(_) => None
             None =>
-              if not(self.is_callable(next_method)) {
+              if !self.is_callable(next_method) {
                 let _ = self.set_error_kind(
                   "TypeError", "Iterator next is not callable",
                 )
@@ -1025,7 +1025,7 @@ fn JSInterpreter::exec_for_loop_iter_gen(
     Some(c) => self.eval_expr(c, env).to_boolean()
     None => true
   }
-  if not(cond_val) {
+  if !cond_val {
     return GenSignal::Continue
   }
   // Execute body
@@ -1112,7 +1112,7 @@ fn JSInterpreter::exec_while_loop_gen(
     None => ()
   }
   // Check condition
-  if not(self.eval_expr(cond, env).to_boolean()) {
+  if !self.eval_expr(cond, env).to_boolean() {
     return GenSignal::Continue
   }
   // Execute body

--- a/src/runtime/interpreter_iterator.mbt
+++ b/src/runtime/interpreter_iterator.mbt
@@ -91,7 +91,7 @@ fn JSInterpreter::ensure_iterator_object_with_next(
     }
     _ => ()
   }
-  if not(self.is_callable(iter_method)) {
+  if !self.is_callable(iter_method) {
     let _ = self.set_error_kind(
       "TypeError", "Iterator @@iterator is not callable",
     )
@@ -116,7 +116,7 @@ fn JSInterpreter::ensure_iterator_object_with_next(
     Some(_) => return None
     None => ()
   }
-  if not(self.is_callable(next_method)) {
+  if !self.is_callable(next_method) {
     let _ = self.set_error_kind("TypeError", "Iterator next is not callable")
     return None
   }
@@ -247,7 +247,7 @@ pub fn JSInterpreter::iterator_from(
   match iter_method {
     Undefined | Null => ()
     _ => {
-      if not(self.is_callable(iter_method)) {
+      if !self.is_callable(iter_method) {
         return self.set_error_kind(
           "TypeError", "Iterator.from @@iterator is not callable",
         )
@@ -271,7 +271,7 @@ pub fn JSInterpreter::iterator_from(
     Some(err) => return err
     None => ()
   }
-  if not(self.is_callable(next_method)) {
+  if !self.is_callable(next_method) {
     return self.set_error_kind("TypeError", "Iterator next is not callable")
   }
   if self.ordinary_has_instance(ctor, iterator) {
@@ -289,7 +289,7 @@ pub fn JSInterpreter::iterator_map(
   args : Array[JSValue],
 ) -> JSValue {
   let mapper = if args.length() > 0 { args[0] } else { Undefined }
-  if not(self.is_callable(mapper)) {
+  if !self.is_callable(mapper) {
     return self.set_error_kind("TypeError", "mapper is not callable")
   }
   let (iter, next_method) = match
@@ -312,7 +312,7 @@ pub fn JSInterpreter::iterator_filter(
   args : Array[JSValue],
 ) -> JSValue {
   let predicate = if args.length() > 0 { args[0] } else { Undefined }
-  if not(self.is_callable(predicate)) {
+  if !self.is_callable(predicate) {
     return self.set_error_kind("TypeError", "predicate is not callable")
   }
   let (iter, next_method) = match
@@ -383,7 +383,7 @@ pub fn JSInterpreter::iterator_flat_map(
   args : Array[JSValue],
 ) -> JSValue {
   let mapper = if args.length() > 0 { args[0] } else { Undefined }
-  if not(self.is_callable(mapper)) {
+  if !self.is_callable(mapper) {
     return self.set_error_kind("TypeError", "mapper is not callable")
   }
   let (iter, next_method) = match
@@ -407,7 +407,7 @@ pub fn JSInterpreter::iterator_for_each(
   args : Array[JSValue],
 ) -> JSValue {
   let callback = if args.length() > 0 { args[0] } else { Undefined }
-  if not(self.is_callable(callback)) {
+  if !self.is_callable(callback) {
     self.iterator_close(this_arg)
     return self.set_error_kind("TypeError", "callback is not callable")
   }
@@ -477,7 +477,7 @@ pub fn JSInterpreter::iterator_reduce(
   args : Array[JSValue],
 ) -> JSValue {
   let reducer = if args.length() > 0 { args[0] } else { Undefined }
-  if not(self.is_callable(reducer)) {
+  if !self.is_callable(reducer) {
     self.iterator_close(this_arg)
     return self.set_error_kind("TypeError", "reducer is not callable")
   }
@@ -499,7 +499,7 @@ pub fn JSInterpreter::iterator_reduce(
     }
     let done = self.get_prop_value(result, "done").to_boolean()
     if done {
-      if not(has_acc) {
+      if !has_acc {
         return self.set_error_kind(
           "TypeError", "Reduce of empty iterator with no initial value",
         )
@@ -507,7 +507,7 @@ pub fn JSInterpreter::iterator_reduce(
       return acc
     }
     let value = self.get_prop_value(result, "value")
-    if not(has_acc) {
+    if !has_acc {
       acc = value
       has_acc = true
       idx += 1
@@ -538,7 +538,7 @@ pub fn JSInterpreter::iterator_every(
   args : Array[JSValue],
 ) -> JSValue {
   let predicate = if args.length() > 0 { args[0] } else { Undefined }
-  if not(self.is_callable(predicate)) {
+  if !self.is_callable(predicate) {
     self.iterator_close(this_arg)
     return self.set_error_kind("TypeError", "predicate is not callable")
   }
@@ -569,7 +569,7 @@ pub fn JSInterpreter::iterator_every(
       }
       None => ()
     }
-    if not(passed.to_boolean()) {
+    if !passed.to_boolean() {
       self.iterator_close(iter)
       return Bool(false)
     }
@@ -585,7 +585,7 @@ pub fn JSInterpreter::iterator_some(
   args : Array[JSValue],
 ) -> JSValue {
   let predicate = if args.length() > 0 { args[0] } else { Undefined }
-  if not(self.is_callable(predicate)) {
+  if !self.is_callable(predicate) {
     self.iterator_close(this_arg)
     return self.set_error_kind("TypeError", "predicate is not callable")
   }
@@ -632,7 +632,7 @@ pub fn JSInterpreter::iterator_find(
   args : Array[JSValue],
 ) -> JSValue {
   let predicate = if args.length() > 0 { args[0] } else { Undefined }
-  if not(self.is_callable(predicate)) {
+  if !self.is_callable(predicate) {
     self.iterator_close(this_arg)
     return self.set_error_kind("TypeError", "predicate is not callable")
   }

--- a/src/runtime/interpreter_methods.mbt
+++ b/src/runtime/interpreter_methods.mbt
@@ -255,7 +255,7 @@ fn JSInterpreter::string_method(
         let end_idx = s.length() - search_len + 1
         let mut i = start_idx
         while i < end_idx && idx == -1 {
-          if (s[i:i + search_len].to_string() catch { _ => "" }) == search_str {
+          if s[i:i + search_len].to_string() == search_str {
             idx = i
           }
           i = i + 1
@@ -290,7 +290,7 @@ fn JSInterpreter::string_method(
         i = 0
       }
       while i >= 0 {
-        if (s[i:i + search_len].to_string() catch { _ => "" }) == search_str {
+        if s[i:i + search_len].to_string() == search_str {
           idx = i
           break
         }
@@ -329,8 +329,8 @@ fn JSInterpreter::string_method(
         let end_idx = s.length() - search_len + 1
         let mut i = start_idx
         let mut found = false
-        while i < end_idx && not(found) {
-          if (s[i:i + search_len].to_string() catch { _ => "" }) == search_str {
+        while i < end_idx && !found {
+          if s[i:i + search_len].to_string() == search_str {
             found = true
           }
           i = i + 1
@@ -363,9 +363,7 @@ fn JSInterpreter::string_method(
       } else if pos + search_len > s.length() {
         Bool(false)
       } else {
-        Bool(
-          (s[pos:pos + search_len].to_string() catch { _ => "" }) == search_str,
-        )
+        Bool(s[pos:pos + search_len].to_string() == search_str)
       }
     }
     "endsWith" => {
@@ -397,7 +395,7 @@ fn JSInterpreter::string_method(
         Bool(false)
       } else {
         let start = end_pos - search_len
-        Bool((s[start:end_pos].to_string() catch { _ => "" }) == search_str)
+        Bool(s[start:end_pos].to_string() == search_str)
       }
     }
     "at" => {
@@ -412,13 +410,13 @@ fn JSInterpreter::string_method(
       if idx < 0 || idx >= s.length() {
         Undefined
       } else {
-        String(s[idx:idx + 1].to_string() catch { _ => "" })
+        String(s[idx:idx + 1].to_string())
       }
     }
     "split" => {
       let sep_val = if args.length() > 0 { args[0] } else { Undefined }
       let mut sep_string : String? = None
-      if not(is_regexp(sep_val)) {
+      if !is_regexp(sep_val) {
         match sep_val {
           Undefined => ()
           _ => sep_string = Some(self.to_string_value(sep_val))
@@ -470,7 +468,7 @@ fn JSInterpreter::string_method(
             if limit >= 0 && result.length() >= limit {
               break
             }
-            result.push(String(s[i:i + 1].to_string() catch { _ => "" }))
+            result.push(String(s[i:i + 1].to_string()))
           }
         }
         return js_array_from(result)
@@ -485,8 +483,8 @@ fn JSInterpreter::string_method(
         let mut pos = start
         if start + sep_len <= s.length() {
           let end_idx = s.length() - sep_len + 1
-          while pos < end_idx && not(found) {
-            if (s[pos:pos + sep_len].to_string() catch { _ => "" }) == sep {
+          while pos < end_idx && !found {
+            if s[pos:pos + sep_len].to_string() == sep {
               found = true
             } else {
               pos = pos + 1
@@ -494,10 +492,10 @@ fn JSInterpreter::string_method(
           }
         }
         if found {
-          result.push(String(s[start:pos].to_string() catch { _ => "" }))
+          result.push(String(s[start:pos].to_string()))
           start = pos + sep_len
         } else {
-          result.push(String(s[start:s.length()].to_string() catch { _ => "" }))
+          result.push(String(s[start:s.length()].to_string()))
           break
         }
       }
@@ -595,7 +593,7 @@ fn JSInterpreter::string_method(
       if end < start {
         end = start
       }
-      String(s[start:end].to_string() catch { _ => "" })
+      String(s[start:end].to_string())
     }
     "substr" => {
       let len = s.length()
@@ -648,7 +646,7 @@ fn JSInterpreter::string_method(
       if end > len {
         end = len
       }
-      String(s[start:end].to_string() catch { _ => "" })
+      String(s[start:end].to_string())
     }
     "substring" => {
       let mut start = if args.length() > 0 {
@@ -678,7 +676,7 @@ fn JSInterpreter::string_method(
       if end > s.length() {
         end = s.length()
       }
-      String(s[start:end].to_string() catch { _ => "" })
+      String(s[start:end].to_string())
     }
     "toUpperCase" => String(s.to_upper())
     "toLowerCase" => String(s.to_lower())
@@ -761,7 +759,7 @@ fn JSInterpreter::string_method(
             pad_str = pad_str + pad
           }
           if pad_str.length() > needed {
-            pad_str = pad_str[:needed].to_string() catch { _ => pad_str }
+            pad_str = pad_str[:needed].to_string()
           }
         }
         String(pad_str + s)
@@ -786,7 +784,7 @@ fn JSInterpreter::string_method(
             pad_str = pad_str + pad
           }
           if pad_str.length() > needed {
-            pad_str = pad_str[:needed].to_string() catch { _ => pad_str }
+            pad_str = pad_str[:needed].to_string()
           }
         }
         String(s + pad_str)
@@ -997,7 +995,7 @@ fn JSInterpreter::array_method(
       }
       for i in start_idx..<len {
         let key = i.to_string()
-        if not(js_has_prop(arr_val, key)) {
+        if !js_has_prop(arr_val, key) {
           continue
         }
         let value = self.get_prop_value(arr_val, key)
@@ -1069,7 +1067,7 @@ fn JSInterpreter::array_method(
         )
       } else {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return self.set_error_kind(
             "TypeError", "Array.prototype.map requires a callback",
           )
@@ -1108,7 +1106,7 @@ fn JSInterpreter::array_method(
         )
       } else {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return self.set_error_kind(
             "TypeError", "Array.prototype.filter requires a callback",
           )
@@ -1139,7 +1137,7 @@ fn JSInterpreter::array_method(
         )
       } else {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return self.set_error_kind(
             "TypeError", "Array.prototype.reduce requires a callback",
           )
@@ -1160,7 +1158,7 @@ fn JSInterpreter::array_method(
             }
             i += 1
           }
-          if not(found) {
+          if !found {
             return self.set_error_kind(
               "TypeError", "Reduce of empty array with no initial value",
             )
@@ -1191,7 +1189,7 @@ fn JSInterpreter::array_method(
         )
       } else {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return self.set_error_kind(
             "TypeError", "Array.prototype.reduceRight requires a callback",
           )
@@ -1215,7 +1213,7 @@ fn JSInterpreter::array_method(
             }
             i = i - 1
           }
-          if not(found) {
+          if !found {
             return self.set_error_kind(
               "TypeError", "Reduce of empty array with no initial value",
             )
@@ -1249,7 +1247,7 @@ fn JSInterpreter::array_method(
         )
       } else {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return self.set_error_kind(
             "TypeError", "Array.prototype.forEach requires a callback",
           )
@@ -1275,7 +1273,7 @@ fn JSInterpreter::array_method(
         )
       } else {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return self.set_error_kind(
             "TypeError", "Array.prototype.every requires a callback",
           )
@@ -1289,7 +1287,7 @@ fn JSInterpreter::array_method(
             args_array[0] = arr.items[i]
             args_array[1] = Number(i.to_double())
             let ok = self.call_function(callback, this_arg, args_array)
-            if not(ok.to_boolean()) {
+            if !ok.to_boolean() {
               return Bool(false)
             }
           }
@@ -1304,7 +1302,7 @@ fn JSInterpreter::array_method(
         )
       } else {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return self.set_error_kind(
             "TypeError", "Array.prototype.some requires a callback",
           )
@@ -1847,7 +1845,7 @@ fn JSInterpreter::array_method(
     "flatMap" =>
       if args.length() > 0 {
         let callback = args[0]
-        if not(self.is_callable(callback)) {
+        if !self.is_callable(callback) {
           return self.set_error_kind(
             "TypeError", "Array.prototype.flatMap requires a callback",
           )

--- a/src/runtime/interpreter_promise.mbt
+++ b/src/runtime/interpreter_promise.mbt
@@ -481,7 +481,7 @@ fn JSInterpreter::promise_construct(
   args : Array[JSValue],
 ) -> JSValue {
   let executor = if args.length() > 0 { args[0] } else { Undefined }
-  if not(self.is_callable(executor)) {
+  if !self.is_callable(executor) {
     return self.set_error_kind(
       "TypeError", "Promise resolver is not a function",
     )
@@ -508,7 +508,7 @@ fn JSInterpreter::promise_construct_with_instance(
   args : Array[JSValue],
 ) -> JSValue {
   let executor = if args.length() > 0 { args[0] } else { Undefined }
-  if not(self.is_callable(executor)) {
+  if !self.is_callable(executor) {
     return self.set_error_kind(
       "TypeError", "Promise resolver is not a function",
     )
@@ -536,7 +536,7 @@ fn JSInterpreter::promise_new_capability(
   self : JSInterpreter,
   ctor : JSValue,
 ) -> (JSValue, JSValue, JSValue) {
-  if not(self.is_constructor(ctor)) {
+  if !self.is_constructor(ctor) {
     let _ = self.set_error_kind("TypeError", "not a constructor")
     return (Undefined, Undefined, Undefined)
   }
@@ -553,7 +553,7 @@ fn JSInterpreter::promise_new_capability(
   }
   let resolve = js_get_prop(cap, "resolve")
   let reject = js_get_prop(cap, "reject")
-  if not(self.is_callable(resolve)) || not(self.is_callable(reject)) {
+  if !self.is_callable(resolve) || !self.is_callable(reject) {
     let _ = self.set_error_kind(
       "TypeError", "Promise capability is not callable",
     )
@@ -656,7 +656,7 @@ fn JSInterpreter::promise_try(
     Some(err) => return err
     None => ()
   }
-  if not(self.is_callable(callback)) {
+  if !self.is_callable(callback) {
     let err = self.set_error_kind(
       "TypeError", "Promise.try callback is not callable",
     )
@@ -734,7 +734,7 @@ fn JSInterpreter::promise_all_with_ctor(
     Some(err) => return err
     None => ()
   }
-  if not(self.is_callable(promise_resolve)) {
+  if !self.is_callable(promise_resolve) {
     return self.set_error_kind("TypeError", "Promise.resolve is not callable")
   }
   let iterator = match self.get_iterator(iter) {
@@ -837,7 +837,7 @@ fn JSInterpreter::promise_all_with_ctor(
       }
       None => ()
     }
-    if not(self.is_callable(then_method)) {
+    if !self.is_callable(then_method) {
       let err = self.set_error_kind(
         "TypeError", "Promise resolve is not callable",
       )
@@ -876,7 +876,7 @@ fn JSInterpreter::promise_race_with_ctor(
     Some(err) => return err
     None => ()
   }
-  if not(self.is_callable(promise_resolve)) {
+  if !self.is_callable(promise_resolve) {
     return self.set_error_kind("TypeError", "Promise.resolve is not callable")
   }
   let iterator = match self.get_iterator(iter) {
@@ -929,7 +929,7 @@ fn JSInterpreter::promise_race_with_ctor(
       }
       None => ()
     }
-    if not(self.is_callable(then_method)) {
+    if !self.is_callable(then_method) {
       let err = self.set_error_kind(
         "TypeError", "Promise resolve is not callable",
       )
@@ -987,7 +987,7 @@ fn JSInterpreter::promise_any_with_ctor(
     Some(err) => return err
     None => ()
   }
-  if not(self.is_callable(promise_resolve)) {
+  if !self.is_callable(promise_resolve) {
     return self.set_error_kind("TypeError", "Promise.resolve is not callable")
   }
   let iterator = match self.get_iterator(iter) {
@@ -1073,7 +1073,7 @@ fn JSInterpreter::promise_any_with_ctor(
       }
       None => ()
     }
-    if not(self.is_callable(then_method)) {
+    if !self.is_callable(then_method) {
       let err = self.set_error_kind(
         "TypeError", "Promise resolve is not callable",
       )
@@ -1180,7 +1180,7 @@ pub fn JSInterpreter::await_promise(
   value : JSValue,
 ) -> JSValue {
   // If value is not a Promise, wrap it in resolved Promise semantics (return as-is)
-  if not(self.is_promise(value)) {
+  if !self.is_promise(value) {
     return value
   }
 

--- a/src/runtime/interpreter_props.mbt
+++ b/src/runtime/interpreter_props.mbt
@@ -44,7 +44,7 @@ fn extract_private_name(key : String) -> String {
   let mut idx = 0
   while idx < len - 2 {
     if key[idx] == '_' && key[idx + 1] == '_' && key[idx + 2] == '#' {
-      return key[idx + 2:].to_string() catch { _ => key }
+      return key[idx + 2:].to_string()
     }
     idx += 1
   }
@@ -160,7 +160,7 @@ fn extract_private_brand(key : String) -> String? {
       while idx < len - 2 {
         if key[idx] == '_' && key[idx + 1] == '_' && key[idx + 2] == '#' {
           // Brand is everything before "__#"
-          let brand = key[:idx].to_string() catch { _ => "" }
+          let brand = key[:idx].to_string()
           return Some(brand)
         }
         idx += 1
@@ -197,9 +197,7 @@ fn JSInterpreter::check_private_brand(
           }
           idx += 1
         }
-        key[idx + 2:].to_string() catch {
-          _ => key
-        }
+        key[idx + 2:].to_string()
       } else {
         key
       }
@@ -290,7 +288,7 @@ fn JSInterpreter::get_proxy_trap(
   match trap {
     Undefined | Null => None
     _ =>
-      if not(self.is_callable(trap)) {
+      if !self.is_callable(trap) {
         let _ = self.set_error_kind("TypeError", "Proxy trap is not callable")
         None
       } else {
@@ -518,7 +516,7 @@ fn JSInterpreter::set_prop_value(
   // Check private field brand before access
   match extract_private_brand(key) {
     Some(brand) => {
-      if not(self.check_private_brand(obj, brand, key)) {
+      if !self.check_private_brand(obj, brand, key) {
         return
       }
       // PrivateSet throws TypeError when:
@@ -571,7 +569,7 @@ fn JSInterpreter::set_prop_value(
               return
             }
             None =>
-              if not(prop.writable) {
+              if !prop.writable {
                 if strict {
                   let _ = self.set_error_kind(
                     "TypeError",
@@ -590,9 +588,9 @@ fn JSInterpreter::set_prop_value(
       // Check if this is a TypedArray index access
       match get_typedarray_data(obj) {
         Some(data) => {
-          let idx = @strconv.parse_int(key) catch { _ => -1 }
+          let idx = @string.parse_int(key) catch { _ => -1 }
           if idx >= 0 {
-            if idx < data.length && not(data.buffer.detached) {
+            if idx < data.length && !data.buffer.detached {
               typedarray_set_element_jsvalue(data, idx, value)
             }
             return
@@ -608,7 +606,7 @@ fn JSInterpreter::set_prop_value(
               return
             }
             None =>
-              if not(prop.writable) {
+              if !prop.writable {
                 if strict {
                   let _ = self.set_error_kind(
                     "TypeError",
@@ -633,7 +631,7 @@ fn JSInterpreter::set_prop_value(
               return
             }
             None =>
-              if not(prop.writable) {
+              if !prop.writable {
                 if strict {
                   let _ = self.set_error_kind(
                     "TypeError",
@@ -651,7 +649,7 @@ fn JSInterpreter::set_prop_value(
     _ => ()
   }
   // Check if object is non-extensible and we're adding a new property
-  if strict && not(self.has_own_prop(obj, key)) {
+  if strict && !self.has_own_prop(obj, key) {
     match js_get_prop(obj, "__non_extensible") {
       Bool(true) => {
         let _ = self.set_error_kind(
@@ -681,7 +679,7 @@ fn JSInterpreter::get_prop_value_with_receiver(
   // Check private field brand before access
   match extract_private_brand(key) {
     Some(brand) =>
-      if not(self.check_private_brand(receiver, brand, key)) {
+      if !self.check_private_brand(receiver, brand, key) {
         return Undefined
       }
     None => ()
@@ -735,9 +733,9 @@ fn JSInterpreter::get_prop_value_with_receiver(
       // Check if this is a TypedArray index access
       match get_typedarray_data(target) {
         Some(data) => {
-          let idx = @strconv.parse_int(key) catch { _ => -1 }
+          let idx = @string.parse_int(key) catch { _ => -1 }
           if idx >= 0 {
-            if idx < data.length && not(data.buffer.detached) {
+            if idx < data.length && !data.buffer.detached {
               return typedarray_get_element_jsvalue(data, idx)
             }
             return Undefined
@@ -759,7 +757,7 @@ fn JSInterpreter::get_prop_value_with_receiver(
       if key == "length" {
         Number(arr.length.to_double())
       } else {
-        let idx = @strconv.parse_int(key) catch { _ => -1 }
+        let idx = @string.parse_int(key) catch { _ => -1 }
         if idx >= 0 && idx < arr.items.length() && arr.present[idx] {
           arr.items[idx]
         } else {
@@ -790,9 +788,9 @@ fn JSInterpreter::get_prop_value_with_receiver(
       } else if key == "length" {
         Number(s.length().to_double())
       } else {
-        let idx = @strconv.parse_int(key) catch { _ => -1 }
+        let idx = @string.parse_int(key) catch { _ => -1 }
         if idx >= 0 && idx < s.length() {
-          String(s[idx:idx + 1].to_string() catch { _ => "" })
+          String(s[idx:idx + 1].to_string())
         } else {
           // Look up on String.prototype
           let string_ctor = self.global_env.get("String")
@@ -861,7 +859,7 @@ fn JSInterpreter::has_own_prop(
       if key == "length" {
         true
       } else {
-        let idx = @strconv.parse_int(key) catch { _ => -1 }
+        let idx = @string.parse_int(key) catch { _ => -1 }
         if idx >= 0 && idx < arr.items.length() && arr.present[idx] {
           true
         } else {
@@ -879,7 +877,7 @@ fn JSInterpreter::has_own_prop(
       if key == "length" {
         true
       } else {
-        let idx = @strconv.parse_int(key) catch { _ => -1 }
+        let idx = @string.parse_int(key) catch { _ => -1 }
         idx >= 0 && idx < s.length()
       }
     _ => false
@@ -914,7 +912,7 @@ fn JSInterpreter::is_enumerable(
       if key == "length" {
         false
       } else {
-        let idx = @strconv.parse_int(key) catch { _ => -1 }
+        let idx = @string.parse_int(key) catch { _ => -1 }
         if idx >= 0 && idx < arr.items.length() {
           true
         } else {
@@ -932,7 +930,7 @@ fn JSInterpreter::is_enumerable(
       if key == "length" {
         false
       } else {
-        let idx = @strconv.parse_int(key) catch { _ => -1 }
+        let idx = @string.parse_int(key) catch { _ => -1 }
         idx >= 0 && idx < s.length()
       }
     _ => false
@@ -954,7 +952,7 @@ fn JSInterpreter::ordinary_has_instance(
       }
     _ => ctor
   }
-  if not(self.is_callable(target)) {
+  if !self.is_callable(target) {
     return false
   }
   match obj {
@@ -985,7 +983,7 @@ fn JSInterpreter::construct_with(
   new_target : JSValue,
   args : Array[JSValue],
 ) -> JSValue {
-  if not(self.is_constructor(ctor)) || not(self.is_constructor(new_target)) {
+  if !self.is_constructor(ctor) || !self.is_constructor(new_target) {
     return self.set_error_kind("TypeError", "not a constructor")
   }
   match ctor {
@@ -993,7 +991,7 @@ fn JSInterpreter::construct_with(
       match closure.body {
         Native(name) if name == "Promise" => {
           let executor = if args.length() > 0 { args[0] } else { Undefined }
-          if not(self.is_callable(executor)) {
+          if !self.is_callable(executor) {
             return self.set_error_kind(
               "TypeError", "Promise resolver is not a function",
             )
@@ -1154,7 +1152,7 @@ fn JSInterpreter::to_string_value(
           }
           _ => return res.to_js_string()
         }
-      } else if not(to_prim.is_undefined()) {
+      } else if !to_prim.is_undefined() {
         let _ = self.set_error_kind(
           "TypeError", "Cannot convert object to primitive value",
         )

--- a/src/runtime/interpreter_run.mbt
+++ b/src/runtime/interpreter_run.mbt
@@ -39,7 +39,7 @@ pub fn JSInterpreter::run_module(
     Function(closure) =>
       match closure.body {
         Ast(func_def) => {
-          if closure.is_strict && not(self.global_env.has("__strict__")) {
+          if closure.is_strict && !self.global_env.has("__strict__") {
             self.global_env.define_var("__strict__", Bool(true))
           }
           self.hoist_block(func_def.body, self.global_env)

--- a/src/runtime/jsvalue_env.mbt
+++ b/src/runtime/jsvalue_env.mbt
@@ -7,14 +7,14 @@ pub struct JSBinding {
   mut value : JSValue
   mut is_const : Bool
   mut is_uninitialized : Bool
-} derive(Show)
+} derive(Debug)
 
 ///|
 // /
 pub struct JSEnv {
   parent : JSEnv?
   bindings : Array[JSBinding]
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / create

--- a/src/runtime/jsvalue_function.mbt
+++ b/src/runtime/jsvalue_function.mbt
@@ -13,7 +13,7 @@ pub struct JSClosure {
   is_async : Bool
   props : Array[JSProp]
   mut object_proto : JSValue?
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// Compiled wasm function representation for AOT compilation.
@@ -22,10 +22,10 @@ pub struct CompiledFunc {
   ast : @ast.TsFunc // Original AST for fallback
   wasm_bytes : Bytes // Compiled wasm-gc module
   func_index : UInt // Function index in the wasm module
-}
+} derive(Debug)
 
 ///|
-impl Show for CompiledFunc with output(self, logger) {
+pub impl Show for CompiledFunc with output(self, logger) {
   logger.write_string("CompiledFunc(\{self.name}, index=\{self.func_index})")
 }
 
@@ -79,7 +79,7 @@ pub enum JSFuncBody {
   Native(String) // Built-in native function
   Bound(JSValue, JSValue, Array[JSValue]) // target, thisArg, bound args
   Compiled(CompiledFunc) // AOT compiled to wasm-gc
-} derive(Show)
+} derive(Debug)
 
 // === ID generator (object/function/array identity) ===
 

--- a/src/runtime/jsvalue_object.mbt
+++ b/src/runtime/jsvalue_object.mbt
@@ -10,7 +10,7 @@ pub struct JSProp {
   configurable : Bool
   get : JSValue?
   set : JSValue?
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / objectproperty
@@ -18,7 +18,7 @@ pub struct JSPropMap {
   id : Int
   props : Array[JSProp]
   mut prototype : JSValue?
-} derive(Show)
+} derive(Debug)
 
 ///|
 // / array
@@ -29,7 +29,7 @@ pub struct JSArray {
   props : Array[JSProp]
   mut length : Int
   mut prototype : JSValue?
-} derive(Show)
+} derive(Debug)
 
 ///|
 const MAX_DENSE_ARRAY_LENGTH : Int = 1000000
@@ -73,7 +73,7 @@ pub fn JSValue::to_number(self : JSValue) -> Double {
         0.0
       } else {
         // TODO:
-        @strconv.parse_double(s) catch {
+        @string.parse_double(s) catch {
           _ => js_nan
         }
       }
@@ -174,9 +174,9 @@ pub fn js_get_prop(obj : JSValue, key : String) -> JSValue {
       // Check if this is a TypedArray index access
       match get_typedarray_data(obj) {
         Some(data) => {
-          let idx = @strconv.parse_int(key) catch { _ => -1 }
+          let idx = @string.parse_int(key) catch { _ => -1 }
           if idx >= 0 {
-            if idx < data.length && not(data.buffer.detached) {
+            if idx < data.length && !data.buffer.detached {
               return typedarray_get_element_jsvalue(data, idx)
             }
             return Undefined
@@ -229,7 +229,7 @@ pub fn js_get_prop(obj : JSValue, key : String) -> JSValue {
           None => Undefined
         }
       } else {
-        let idx = @strconv.parse_int(key) catch { _ => -1 }
+        let idx = @string.parse_int(key) catch { _ => -1 }
         if idx >= 0 && idx < arr.items.length() && arr.present[idx] {
           arr.items[idx]
         } else {
@@ -275,7 +275,7 @@ pub fn js_get_prop(obj : JSValue, key : String) -> JSValue {
       if key == "length" {
         Number(s.length().to_double())
       } else {
-        let idx = @strconv.parse_int(key) catch { _ => -1 }
+        let idx = @string.parse_int(key) catch { _ => -1 }
         if idx >= 0 && idx < s.length() {
           // TODO: charAt
           Undefined
@@ -314,7 +314,7 @@ pub fn js_set_prop(obj : JSValue, key : String, value : JSValue) -> JSValue {
           if prop.get is Some(_) || prop.set is Some(_) {
             return value
           }
-          if not(prop.writable) {
+          if !prop.writable {
             return prop.value
           }
           closure.props[i] = {
@@ -361,9 +361,9 @@ pub fn js_set_prop(obj : JSValue, key : String, value : JSValue) -> JSValue {
       // Check if this is a TypedArray index access
       match get_typedarray_data(obj) {
         Some(data) => {
-          let idx = @strconv.parse_int(key) catch { _ => -1 }
+          let idx = @string.parse_int(key) catch { _ => -1 }
           if idx >= 0 {
-            if idx < data.length && not(data.buffer.detached) {
+            if idx < data.length && !data.buffer.detached {
               typedarray_set_element_jsvalue(data, idx, value)
             }
             return value
@@ -377,7 +377,7 @@ pub fn js_set_prop(obj : JSValue, key : String, value : JSValue) -> JSValue {
           if prop.get is Some(_) || prop.set is Some(_) {
             return value
           }
-          if not(prop.writable) {
+          if !prop.writable {
             return prop.value
           }
           map.props[i] = {
@@ -440,7 +440,7 @@ pub fn js_set_prop(obj : JSValue, key : String, value : JSValue) -> JSValue {
         }
         return value
       }
-      let idx = @strconv.parse_int(key) catch { _ => -1 }
+      let idx = @string.parse_int(key) catch { _ => -1 }
       if idx >= 0 {
         if idx < MAX_DENSE_ARRAY_LENGTH {
           // array
@@ -457,7 +457,7 @@ pub fn js_set_prop(obj : JSValue, key : String, value : JSValue) -> JSValue {
               if prop.get is Some(_) || prop.set is Some(_) {
                 return value
               }
-              if not(prop.writable) {
+              if !prop.writable {
                 return prop.value
               }
               arr.props[i] = {
@@ -473,7 +473,7 @@ pub fn js_set_prop(obj : JSValue, key : String, value : JSValue) -> JSValue {
               break
             }
           }
-          if not(replaced) {
+          if !replaced {
             arr.props.push({
               key,
               value,
@@ -495,7 +495,7 @@ pub fn js_set_prop(obj : JSValue, key : String, value : JSValue) -> JSValue {
             if prop.get is Some(_) || prop.set is Some(_) {
               return value
             }
-            if not(prop.writable) {
+            if !prop.writable {
               return prop.value
             }
             arr.props[i] = {
@@ -534,7 +534,7 @@ pub fn js_delete_prop(obj : JSValue, key : String) -> Bool {
       let mut i = 0
       while i < closure.props.length() {
         if closure.props[i].key == key {
-          if not(closure.props[i].configurable) {
+          if !closure.props[i].configurable {
             return false
           }
           let _ = closure.props.remove(i)
@@ -548,7 +548,7 @@ pub fn js_delete_prop(obj : JSValue, key : String) -> Bool {
       let mut i = 0
       while i < map.props.length() {
         if map.props[i].key == key {
-          if not(map.props[i].configurable) {
+          if !map.props[i].configurable {
             return false
           }
           let _ = map.props.remove(i)
@@ -562,14 +562,14 @@ pub fn js_delete_prop(obj : JSValue, key : String) -> Bool {
       if key == "length" {
         false
       } else {
-        let idx = @strconv.parse_int(key) catch { _ => -1 }
+        let idx = @string.parse_int(key) catch { _ => -1 }
         if idx >= 0 && idx < arr.items.length() {
           arr.present[idx] = false
         } else {
           let mut i = 0
           while i < arr.props.length() {
             if arr.props[i].key == key {
-              if not(arr.props[i].configurable) {
+              if !arr.props[i].configurable {
                 return false
               }
               let _ = arr.props.remove(i)
@@ -666,7 +666,7 @@ pub fn js_define_data_prop(
         }
         return value
       }
-      let idx = @strconv.parse_int(key) catch { _ => -1 }
+      let idx = @string.parse_int(key) catch { _ => -1 }
       if idx >= 0 {
         if idx < MAX_DENSE_ARRAY_LENGTH {
           while arr.items.length() <= idx {
@@ -692,7 +692,7 @@ pub fn js_define_data_prop(
               break
             }
           }
-          if not(replaced) {
+          if !replaced {
             arr.props.push({
               key,
               value,
@@ -806,7 +806,7 @@ pub fn js_define_accessor_prop(
       if key == "length" {
         return Undefined
       }
-      let idx = @strconv.parse_int(key) catch { _ => -1 }
+      let idx = @string.parse_int(key) catch { _ => -1 }
       if idx >= 0 {
         let mut replaced = false
         for i, prop in arr.props {
@@ -824,7 +824,7 @@ pub fn js_define_accessor_prop(
             break
           }
         }
-        if not(replaced) {
+        if !replaced {
           arr.props.push({
             key,
             value: Undefined,

--- a/src/runtime/jsvalue_value.mbt
+++ b/src/runtime/jsvalue_value.mbt
@@ -14,7 +14,7 @@ pub enum JSTag {
   Array // 6
   Function // 7
   BigInt // 8
-} derive(Show, Eq)
+} derive(Eq, Debug)
 
 ///|
 // / JSTag i32 conversion
@@ -65,7 +65,7 @@ pub enum JSValue {
   BreakSignal(String?)
   ContinueSignal(String?)
   Empty // ECMAScript empty completion value (distinct from undefined)
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub fn JSValue::tag(self : JSValue) -> JSTag {
@@ -192,9 +192,9 @@ pub fn JSValue::to_boolean(self : JSValue) -> Bool {
     Undefined => false
     Null => false
     Bool(b) => b
-    Number(n) => n != 0.0 && not(n.is_nan())
+    Number(n) => n != 0.0 && !n.is_nan()
     String(s) => s.length() > 0
-    BigInt(n) => not(n.is_zero())
+    BigInt(n) => !n.is_zero()
     Object(map) => {
       for prop in map.props {
         if prop.key == "__class" {
@@ -230,7 +230,7 @@ let js_nan : Double = 0.0 / 0.0
 // / Strip the internal ID suffix from symbol strings for display
 pub fn strip_symbol_id(s : String) -> String {
   // Find the last # and strip the ID suffix
-  if not(s.has_prefix("Symbol(")) || not(s.contains("#")) {
+  if !s.has_prefix("Symbol(") || !s.contains("#") {
     return s
   }
   let mut last_hash_idx = -1
@@ -409,7 +409,7 @@ pub fn js_pos(val : JSValue) -> JSValue {
 ///|
 // / NOT
 pub fn js_not(val : JSValue) -> JSValue {
-  Bool(not(val.to_boolean()))
+  Bool(!val.to_boolean())
 }
 
 ///|
@@ -485,12 +485,10 @@ pub fn js_strict_eq(left : JSValue, right : JSValue) -> JSValue {
 // / (!==)
 pub fn js_strict_ne(left : JSValue, right : JSValue) -> JSValue {
   Bool(
-    not(
-      match js_strict_eq(left, right) {
-        Bool(b) => b
-        _ => false
-      },
-    ),
+    !(match js_strict_eq(left, right) {
+      Bool(b) => b
+      _ => false
+    }),
   )
 }
 
@@ -589,12 +587,10 @@ pub fn js_eq(left : JSValue, right : JSValue) -> JSValue {
 // / (!=)
 pub fn js_ne(left : JSValue, right : JSValue) -> JSValue {
   Bool(
-    not(
-      match js_eq(left, right) {
-        Bool(b) => b
-        _ => false
-      },
-    ),
+    !(match js_eq(left, right) {
+      Bool(b) => b
+      _ => false
+    }),
   )
 }
 
@@ -711,7 +707,7 @@ pub fn js_has_prop(obj : JSValue, key : String) -> Bool {
       if key == "length" {
         true
       } else {
-        let idx = @strconv.parse_int(key) catch { _ => -1 }
+        let idx = @string.parse_int(key) catch { _ => -1 }
         if idx >= 0 && idx < arr.items.length() && arr.present[idx] {
           true
         } else {
@@ -736,7 +732,7 @@ pub fn js_has_prop(obj : JSValue, key : String) -> Bool {
       if key == "length" {
         true
       } else {
-        let idx = @strconv.parse_int(key) catch { _ => -1 }
+        let idx = @string.parse_int(key) catch { _ => -1 }
         idx >= 0 && idx < s.length()
       }
     _ => false

--- a/src/runtime/moon.pkg
+++ b/src/runtime/moon.pkg
@@ -1,5 +1,7 @@
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/core/math",
+  "moonbitlang/core/string",
   "moonbitlang/core/strconv",
   "moonbitlang/regexp",
   "mizchi/ts/ast" @ast,

--- a/src/runtime/perceus_gc.mbt
+++ b/src/runtime/perceus_gc.mbt
@@ -74,7 +74,7 @@ pub fn perceus_register_object(obj_id : Int) -> Unit {
 ///|
 /// Mark an object as escaped (it was returned or assigned to outer scope)
 pub fn perceus_mark_escaped(obj_id : Int) -> Unit {
-  if not(perceus_state.escaped_objects.contains(obj_id)) {
+  if !perceus_state.escaped_objects.contains(obj_id) {
     perceus_state.escaped_objects.push(obj_id)
   }
 }
@@ -98,7 +98,7 @@ pub fn perceus_leave_scope() -> Array[Int] {
   // Find objects that haven't escaped
   let to_cleanup : Array[Int] = []
   for obj_id in scope.object_ids {
-    if not(perceus_has_escaped(obj_id)) {
+    if !perceus_has_escaped(obj_id) {
       to_cleanup.push(obj_id)
     }
   }
@@ -106,7 +106,7 @@ pub fn perceus_leave_scope() -> Array[Int] {
   let remaining_scopes : Array[(Int, Int)] = []
   for pair in perceus_state.object_scopes {
     let (obj_id, _scope_id) = pair
-    if not(to_cleanup.contains(obj_id)) {
+    if !to_cleanup.contains(obj_id) {
       remaining_scopes.push(pair)
     }
   }

--- a/src/runtime/pkg.generated.mbti
+++ b/src/runtime/pkg.generated.mbti
@@ -5,6 +5,7 @@ import {
   "mizchi/ts/ast",
   "mizchi/ts/parser",
   "moonbitlang/core/bigint",
+  "moonbitlang/core/debug",
 }
 
 // Values
@@ -308,8 +309,9 @@ pub struct CompiledFunc {
   ast : @ast.TsFunc
   wasm_bytes : Bytes
   func_index : UInt
-}
+} derive(@debug.Debug)
 pub fn CompiledFunc::new(String, @ast.TsFunc, Bytes, UInt) -> Self
+pub impl Show for CompiledFunc
 
 pub struct GCStats {
   mut objects_created : Int
@@ -334,7 +336,7 @@ pub struct JSArray {
   props : Array[JSProp]
   mut length : Int
   mut prototype : JSValue?
-}
+} derive(@debug.Debug)
 pub impl Show for JSArray
 
 pub struct JSBinding {
@@ -342,14 +344,14 @@ pub struct JSBinding {
   mut value : JSValue
   mut is_const : Bool
   mut is_uninitialized : Bool
-}
+} derive(@debug.Debug)
 pub impl Show for JSBinding
 
 pub struct JSByteBuffer {
   id : Int
   data : Array[Byte]
   mut detached : Bool
-}
+} derive(@debug.Debug)
 pub impl Show for JSByteBuffer
 
 pub struct JSClosure {
@@ -363,13 +365,13 @@ pub struct JSClosure {
   is_async : Bool
   props : Array[JSProp]
   mut object_proto : JSValue?
-}
+} derive(@debug.Debug)
 pub impl Show for JSClosure
 
 pub struct JSEnv {
   parent : JSEnv?
   bindings : Array[JSBinding]
-}
+} derive(@debug.Debug)
 pub fn JSEnv::define_const(Self, String, JSValue) -> Unit
 pub fn JSEnv::define_uninitialized(Self, String, Bool) -> Unit
 pub fn JSEnv::define_var(Self, String, JSValue) -> Unit
@@ -388,7 +390,7 @@ pub enum JSFuncBody {
   Native(String)
   Bound(JSValue, JSValue, Array[JSValue])
   Compiled(CompiledFunc)
-}
+} derive(@debug.Debug)
 pub impl Show for JSFuncBody
 
 pub(all) struct JSGeneratorState {
@@ -454,14 +456,14 @@ pub struct JSProp {
   configurable : Bool
   get : JSValue?
   set : JSValue?
-}
+} derive(@debug.Debug)
 pub impl Show for JSProp
 
 pub struct JSPropMap {
   id : Int
   props : Array[JSProp]
   mut prototype : JSValue?
-}
+} derive(@debug.Debug)
 pub impl Show for JSPropMap
 
 pub enum JSTag {
@@ -474,10 +476,9 @@ pub enum JSTag {
   Array
   Function
   BigInt
-}
+} derive(Eq, @debug.Debug)
 pub fn JSTag::from_i32(Int) -> Self
 pub fn JSTag::to_i32(Self) -> Int
-pub impl Eq for JSTag
 pub impl Show for JSTag
 
 pub enum JSValue {
@@ -493,7 +494,7 @@ pub enum JSValue {
   BreakSignal(String?)
   ContinueSignal(String?)
   Empty
-}
+} derive(@debug.Debug)
 pub fn JSValue::is_array(Self) -> Bool
 pub fn JSValue::is_bigint(Self) -> Bool
 pub fn JSValue::is_bool(Self) -> Bool
@@ -529,7 +530,7 @@ pub struct TypedArrayData {
   byte_offset : Int
   byte_length : Int
   length : Int
-}
+} derive(@debug.Debug)
 pub impl Show for TypedArrayData
 
 pub enum TypedArrayKind {
@@ -544,11 +545,10 @@ pub enum TypedArrayKind {
   Float64Array
   BigInt64Array
   BigUint64Array
-}
+} derive(Eq, @debug.Debug)
 pub fn TypedArrayKind::bytes_per_element(Self) -> Int
 pub fn TypedArrayKind::is_bigint_type(Self) -> Bool
 pub fn TypedArrayKind::type_name(Self) -> String
-pub impl Eq for TypedArrayKind
 pub impl Show for TypedArrayKind
 
 // Type aliases

--- a/src/runtime/regexp.mbt
+++ b/src/runtime/regexp.mbt
@@ -196,7 +196,7 @@ fn regexp_split_simple(
       if limit >= 0 && result.length() >= limit {
         break
       }
-      result.push(String(input[i:i + 1].to_string() catch { _ => "" }))
+      result.push(String(input[i:i + 1].to_string()))
     }
     return result
   }
@@ -213,19 +213,11 @@ fn regexp_split_simple(
         }
         match regexp_exec_with_re(re, input, last_index) {
           None => {
-            result.push(
-              String(
-                input[last_index:input.length()].to_string() catch {
-                  _ => ""
-                },
-              ),
-            )
+            result.push(String(input[last_index:input.length()].to_string()))
             break
           }
           Some((_result, start, end)) => {
-            result.push(
-              String(input[last_index:start].to_string() catch { _ => "" }),
-            )
+            result.push(String(input[last_index:start].to_string()))
             let next = if end == last_index { end + 1 } else { end }
             last_index = next
             if last_index > input.length() {
@@ -266,11 +258,11 @@ fn regexp_match_simple(
     None => Null
     Some(re) => {
       let mut last_index = 0
-      if not(global) {
+      if !global {
         match regexp_exec_with_re(re, input, 0) {
           None => return Null
           Some((_result, start, end)) => {
-            matches.push(String(input[start:end].to_string() catch { _ => "" }))
+            matches.push(String(input[start:end].to_string()))
             return js_array_from(matches)
           }
         }
@@ -279,7 +271,7 @@ fn regexp_match_simple(
         match regexp_exec_with_re(re, input, last_index) {
           None => break
           Some((_result, start, end)) => {
-            matches.push(String(input[start:end].to_string() catch { _ => "" }))
+            matches.push(String(input[start:end].to_string()))
             let next = if end == last_index { end + 1 } else { end }
             last_index = next
           }
@@ -307,14 +299,13 @@ fn regexp_replace_simple(
     Some(re) => {
       let mut out = ""
       let mut last_index = 0
-      if not(global) {
+      if !global {
         match regexp_exec_with_re(re, input, 0) {
           None => return input
           Some((_result, start, end)) => {
-            out = out + (input[0:start].to_string() catch { _ => "" })
+            out = out + input[0:start].to_string()
             out = out + replace_with
-            out = out +
-              (input[end:input.length()].to_string() catch { _ => "" })
+            out = out + input[end:input.length()].to_string()
             return out
           }
         }
@@ -322,12 +313,11 @@ fn regexp_replace_simple(
       while last_index <= input.length() {
         match regexp_exec_with_re(re, input, last_index) {
           None => {
-            out = out +
-              (input[last_index:input.length()].to_string() catch { _ => "" })
+            out = out + input[last_index:input.length()].to_string()
             break
           }
           Some((_result, start, end)) => {
-            out = out + (input[last_index:start].to_string() catch { _ => "" })
+            out = out + input[last_index:start].to_string()
             out = out + replace_with
             let next = if end == last_index { end + 1 } else { end }
             last_index = next

--- a/src/runtime/show_impls.mbt
+++ b/src/runtime/show_impls.mbt
@@ -1,0 +1,67 @@
+///|
+using @debug {trait Debug}
+
+///|
+fn[T : Debug] write_debug_show(logger : &Logger, value : T) -> Unit {
+  logger.write_string(@debug.to_string(value))
+}
+
+///|
+pub impl Show for JSTag with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for JSValue with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for JSByteBuffer with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TypedArrayKind with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for TypedArrayData with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for JSProp with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for JSPropMap with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for JSArray with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for JSBinding with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for JSEnv with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for JSClosure with output(self, logger) {
+  write_debug_show(logger, self)
+}
+
+///|
+pub impl Show for JSFuncBody with output(self, logger) {
+  write_debug_show(logger, self)
+}

--- a/src/runtime/test262_assert.mbt
+++ b/src/runtime/test262_assert.mbt
@@ -182,7 +182,7 @@ pub fn compare_array(
   while i < len1 {
     let elem1 = get_arraylike_element(actual, i)
     let elem2 = get_arraylike_element(expected, i)
-    if not(is_same_value(elem1, elem2)) {
+    if !is_same_value(elem1, elem2) {
       return Failure(
         prefix +
         "Arrays differ at index " +


### PR DESCRIPTION
## Summary
- improve the parser-only TypeScript declaration flow for MoonBit stub generation
- isolate incomplete wasm/AOT surfaces behind `experimental_*` names in the CLI and public APIs
- clean up MoonBit deprecations and warning-producing patterns, including benchmark package layout

## Why
The parser and semantics path is being pushed toward higher-fidelity `.d.ts` generation and future glue-code generation. At the same time, the current wasm codegen surface is still not stable enough to present as a normal API. This change separates those concerns and gets CI back to a warning-free baseline.

## What changed
- add parser-side handling needed for parser-only declaration emission, including template literal type parsing fallback and MoonBit declaration emitting entrypoints
- rename wasm/AOT-facing commands and exported APIs to `experimental_*`
- replace deprecated MoonBit patterns (`not`, `@strconv.parse_*`, `derive(Show)` usage) and add explicit `Show` impl shims where needed
- remove `unused_try` warnings and move benchmark definitions into `src/perf`

## Validation
- `moon check --target native`
- `moon test --target native src/main_wbtest.mbt`
- `moon test --target native src/runtime/interpreter_wbtest.mbt`
- `moon info --package mizchi/ts`
- `moon info --package mizchi/ts/perf`
