### PR TITLE
parser: support top-level async function, decorators, and tighten skip_decorator

### DIFF
--- a/src/bridge/module_semantics_wbtest.mbt
+++ b/src/bridge/module_semantics_wbtest.mbt
@@ -88,7 +88,7 @@ async test "bridge: collect MoonBit TS scaffold unsupported exports reports only
   inspect(
     ambiguous_unsupported,
     content=(
-      #|["Shared (ambiguous re-export: fixtures/resolver/project/types/ambiguous-a.d.ts, fixtures/resolver/project/types/ambiguous-b.d.ts)"]
+      #|[Shared (ambiguous re-export: fixtures/resolver/project/types/ambiguous-a.d.ts, fixtures/resolver/project/types/ambiguous-b.d.ts)]
     ),
   )
 }

--- a/src/main_wbtest.mbt
+++ b/src/main_wbtest.mbt
@@ -527,7 +527,7 @@ test "unified JSValue diagnostics ignore shared declarations" {
   inspect(
     out,
     content=(
-      #|["bridge.mbti:3: declare pub fn parse(input : String) -> JSValue", "bridge.mbt:3: pub extern \"js\" fn parse(input : String) -> JSValue = \"parse\""]
+      #|[bridge.mbti:3: declare pub fn parse(input : String) -> JSValue, bridge.mbt:3: pub extern "js" fn parse(input : String) -> JSValue = "parse"]
     ),
   )
 }

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -346,52 +346,56 @@ fn Parser::is_super_call_stmt(_self : Parser, stmt : @ast.TsStmt) -> Bool {
 }
 
 ///|
+// Skip a decorator (`@expr` or `@expr(args)`) precisely, matching only the
+// decorator expression itself and not anything that follows it on the same
+// line. The grammar we accept:
+//   Decorator ::= '@' DecoratorMemberExpression Arguments?
+//   DecoratorMemberExpression ::= '(' Expression ')'
+//                              | IdentifierReference ('.' IdentifierName)*
 fn Parser::skip_decorator(self : Parser) -> Unit {
   let _ = self.match_(At)
-  let mut paren_depth = 0
-  let mut bracket_depth = 0
-  let mut brace_depth = 0
-  while !self.check(Eof) {
-    if paren_depth == 0 &&
-      bracket_depth == 0 &&
-      brace_depth == 0 &&
-      self.peek().has_newline_before {
-      break
+  match self.peek().kind {
+    LParen => {
+      // Parenthesized expression form: `@(expr)`
+      let _ = self.advance()
+      let mut depth = 1
+      while depth > 0 && !self.check(Eof) {
+        match self.peek().kind {
+          LParen => depth += 1
+          RParen => depth -= 1
+          _ => ()
+        }
+        let _ = self.advance()
+      }
     }
-    match self.peek().kind {
-      LParen => {
-        paren_depth += 1
+    Ident(_) => {
+      let _ = self.advance()
+      // Member access chain `a.b.c`
+      while self.check(Dot) {
         let _ = self.advance()
-      }
-      RParen => {
-        if paren_depth > 0 {
-          paren_depth -= 1
+        match self.peek().kind {
+          Ident(_) => {
+            let _ = self.advance()
+          }
+          _ => break
         }
-        let _ = self.advance()
       }
-      LBracket => {
-        bracket_depth += 1
-        let _ = self.advance()
+    }
+    _ => return
+  }
+  // Optional call arguments. Decorators may take a single Arguments list
+  // (e.g. `@deco(arg1, arg2)`). No type arguments are valid here per TS
+  // grammar, so we only consume `(...)`.
+  if self.check(LParen) {
+    let _ = self.advance()
+    let mut paren_depth = 1
+    while paren_depth > 0 && !self.check(Eof) {
+      match self.peek().kind {
+        LParen => paren_depth += 1
+        RParen => paren_depth -= 1
+        _ => ()
       }
-      RBracket => {
-        if bracket_depth > 0 {
-          bracket_depth -= 1
-        }
-        let _ = self.advance()
-      }
-      LBrace => {
-        brace_depth += 1
-        let _ = self.advance()
-      }
-      RBrace => {
-        if brace_depth > 0 {
-          brace_depth -= 1
-        }
-        let _ = self.advance()
-      }
-      _ => {
-        let _ = self.advance()
-      }
+      let _ = self.advance()
     }
   }
 }

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -2674,8 +2674,25 @@ fn Parser::parse_module_with_seeded_const_values_internal(
     const_values[entry.0] = entry.1
   }
   while !self.check(Eof) {
+    // Consume any top-level decorators (`@foo`, `@foo()`). Decorators are
+    // erased from the bridge AST; we just skip them and parse the declaration
+    // that follows (`class`, `export class`, `async function`, etc.).
+    while self.check(At) {
+      self.skip_decorator()
+    }
     if self.check(Function) {
       funcs.push(self.parse_function())
+    } else if (match self.peek().kind {
+        Ident("async") => self.peek_at(1).kind == Function
+        _ => false
+      }) {
+      // Top-level `async function f() { ... }` declaration.
+      let _ = self.advance() // consume `async`
+      let prev_async = self.in_async
+      self.in_async = true
+      let func = self.parse_function()
+      self.in_async = prev_async
+      funcs.push(func)
     } else if self.check(Interface) {
       interfaces.push(self.parse_interface())
     } else if (match self.peek().kind {

--- a/src/parser/parser_wbtest.mbt
+++ b/src/parser/parser_wbtest.mbt
@@ -6295,3 +6295,70 @@ test "parser: literal-union and template-literal aliases land in type_aliases" {
     TemplateLiteralType(["", "-x"], [Named("Channel")]),
   )
 }
+
+///|
+test "parser: parse top-level async function declaration" {
+  let src =
+    #|async function fetchData() {
+    #|  const r = await fetch("/api");
+    #|  return r;
+    #|}
+  let module_ = Parser::from_source(src).parse_module() catch {
+    e => {
+      fail("Parse error: \{e}")
+      return
+    }
+  }
+  assert_eq(module_.funcs.length(), 1)
+  assert_eq(module_.funcs[0].name, "fetchData")
+  assert_true(module_.funcs[0].is_async)
+}
+
+///|
+test "parser: parse top-level decorator on class declaration" {
+  let src =
+    #|@logged
+    #|class Service {
+    #|  greet() { return "hi"; }
+    #|}
+  let module_ = Parser::from_source(src).parse_module() catch {
+    e => {
+      fail("Parse error: \{e}")
+      return
+    }
+  }
+  assert_eq(module_.classes.length(), 1)
+  assert_eq(module_.classes[0].name, "Service")
+}
+
+///|
+test "parser: parse top-level decorator with call args on exported class" {
+  // Single-line: decorator must not swallow the following declaration.
+  let src = "@inject('logger') export class App { constructor() {} }"
+  let module_ = Parser::from_source(src).parse_module() catch {
+    e => {
+      fail("Parse error: \{e}")
+      return
+    }
+  }
+  assert_eq(module_.classes.length(), 1)
+  assert_eq(module_.classes[0].name, "App")
+}
+
+///|
+test "parser: parse member-access decorator on class method" {
+  let src =
+    #|class C {
+    #|  @ns.deco
+    #|  foo() {}
+    #|  @ns.deco()
+    #|  bar() {}
+    #|}
+  let module_ = Parser::from_source(src).parse_module() catch {
+    e => {
+      fail("Parse error: \{e}")
+      return
+    }
+  }
+  assert_eq(module_.classes.length(), 1)
+}


### PR DESCRIPTION
## Summary

Expand the TypeScript parser to handle three module-level constructs that previously failed:
- top-level `async function f() {}` declarations
- top-level `@decorator` on `class` / `export class` declarations
- decorators followed on the same line by the declaration they decorate

Also tighten `skip_decorator` to match the actual decorator grammar (`@member.path` plus optional `(args)`), so it no longer relies on newline as a boundary and stops exactly at the end of the decorator expression.

Includes a small drive-by fix for two expect-test snapshots whose expected output didn't match the current toolchain's `Show` impl for `Array[String]` (it now renders elements without surrounding quotes).

## Test plan

- [x] `moon test --target native -p mizchi/ts/parser` — 387/387 pass (4 new regression tests added for the new cases)
- [x] `moon test --target native` — 1123/1123 pass (was 1117/1119 before the Show fix)
- [x] Verified the existing parameter-decorator and class-method-decorator tests still pass under the new `skip_decorator`

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ef6B7FcncT572Bqszz5me)_