### PR TITLE
parser: handle runtime TS source patterns (export-abstract, !-fields, top-level stmts, namespace bodies)

### DIFF
--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -1908,6 +1908,10 @@ fn Parser::parse_declare_class(
     }
     let member_name = self.parse_declare_class_member_name()
     let _ = self.match_(Question)
+    // Definite-assignment assertion (`foo!: T`) on a class field. Also
+    // tolerate a stray `!` after a method name even though that is not
+    // standard syntax, mirroring how the runtime class parser handles it.
+    let _ = self.match_(Bang)
     let mut local_type_param_bound_len = self.local_type_param_bounds.length()
     let mut method_type_params : Array[String] = []
     let mut method_type_param_bounds : Array[(String, @ast.TsType)] = []

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -427,6 +427,30 @@ fn append_ambient_external_module_exports(
 fn Parser::parse_namespace_decl(
   self : Parser,
 ) -> (@ast.TsValueDecl?, @ast.TsNamespaceDecl?)? raise ParseError {
+  // Historical default: treat the body as ambient. Used by all
+  // declare-context callers (`declare namespace X { ... }` inside `.d.ts`
+  // files) so bodyless declarations like `const foo: T;` parse correctly.
+  self.parse_namespace_decl_with_mode(true)
+}
+
+///|
+fn Parser::parse_namespace_decl_runtime(
+  self : Parser,
+) -> (@ast.TsValueDecl?, @ast.TsNamespaceDecl?)? raise ParseError {
+  // Parse the namespace body as runtime (non-ambient) code. Used by
+  // `namespace X { ... }` / `export namespace X { ... }` at module scope
+  // in real `.ts` source files, whose bodies may contain runtime class
+  // method bodies, expression statements, and so on. Falls back to ambient
+  // parsing if the runtime grammar rejects the body (e.g. for a namespace
+  // whose members are all declare-style signatures).
+  self.parse_namespace_decl_with_mode(false)
+}
+
+///|
+fn Parser::parse_namespace_decl_with_mode(
+  self : Parser,
+  body_is_ambient : Bool,
+) -> (@ast.TsValueDecl?, @ast.TsNamespaceDecl?)? raise ParseError {
   let keyword = match self.peek().kind {
     Ident(name) if name == "namespace" || name == "module" || name == "global" =>
       name
@@ -461,9 +485,28 @@ fn Parser::parse_namespace_decl(
       let body_source = self.parse_declaration_block_source()
       let module_ = if body_source.trim() == "" {
         empty_ts_module()
-      } else {
+      } else if body_is_ambient {
         let parser = Parser::from_source(body_source)
         parser.parse_module_with_seeded_const_values_internal({}, true)
+      } else {
+        // Runtime first, ambient fallback. This lets us parse runtime
+        // namespaces in `.ts` files (with class method bodies) without
+        // breaking .d.ts files that route through here via `parse_export`
+        // helpers.
+        let runtime_parser = Parser::from_source(body_source)
+        match
+          (try?
+            runtime_parser.parse_module_with_seeded_const_values_internal(
+              {}, false,
+            )) {
+          Ok(module_) => module_
+          Err(_) => {
+            let ambient_parser = Parser::from_source(body_source)
+            ambient_parser.parse_module_with_seeded_const_values_internal(
+              {}, true,
+            )
+          }
+        }
       }
       let next_namespace : @ast.TsNamespaceDecl = { name, module_ }
       Some(next_namespace)
@@ -481,6 +524,16 @@ fn Parser::parse_namespace_decl_value(
   self : Parser,
 ) -> @ast.TsValueDecl? raise ParseError {
   match self.parse_namespace_decl() {
+    Some((value, _)) => value
+    None => None
+  }
+}
+
+///|
+fn Parser::parse_namespace_decl_value_runtime(
+  self : Parser,
+) -> @ast.TsValueDecl? raise ParseError {
+  match self.parse_namespace_decl_runtime() {
     Some((value, _)) => value
     None => None
   }
@@ -2195,7 +2248,9 @@ fn Parser::parse_export_decl_for_module(
   }
   match self.peek().kind {
     Ident(name) if name == "namespace" || name == "module" || name == "global" => {
-      match self.parse_namespace_decl_value() {
+      // Non-declare `export namespace X { ... }` — body may contain
+      // runtime class bodies and statements.
+      match self.parse_namespace_decl_value_runtime() {
         Some(value) =>
           exports.push({ local_name: value.name, export_name: value.name })
         None => self.skip_declaration_block()
@@ -2509,7 +2564,17 @@ fn Parser::parse_export_stmt(
   }
   match self.peek().kind {
     Ident(name) if name == "abstract" && self.peek_at(1).kind == Class => {
-      classes.push(self.parse_declare_class_with_optional_abstract())
+      // `export abstract class` at module scope is a runtime class
+      // declaration with a body (methods, definite-assignment fields,
+      // static init blocks, etc.). Route to the same runtime parser used
+      // by the non-export branch; it also tolerates bodyless method
+      // signatures so ambient cases still work.
+      let _ = self.advance() // consume `abstract`
+      let _ = self.parse_class_decl_with_abstract(true)
+      match self.take_last_runtime_class_decl() {
+        Some(class_) => classes.push(class_)
+        None => ()
+      }
       return
     }
     _ => ()
@@ -2605,7 +2670,8 @@ fn Parser::parse_export_stmt(
     _ => false
   }
   if is_namespace_like_export {
-    match self.parse_namespace_decl() {
+    // `export namespace X { ... }` — runtime context.
+    match self.parse_namespace_decl_runtime() {
       Some((value, namespace_)) => {
         match value {
           Some(value) => values.push(value)
@@ -2800,7 +2866,14 @@ fn Parser::parse_module_with_seeded_const_values_internal(
         None => ()
       }
     } else if self.is_namespace_decl_start() {
-      match self.parse_namespace_decl() {
+      // Inherit ambient/runtime mode from the enclosing parser so the body
+      // is parsed under the same context the caller selected.
+      let parse_result = if ambient_decls {
+        self.parse_namespace_decl()
+      } else {
+        self.parse_namespace_decl_runtime()
+      }
+      match parse_result {
         Some((value, namespace_)) => {
           match value {
             Some(value) => values.push(value)
@@ -2830,6 +2903,13 @@ fn Parser::parse_module_with_seeded_const_values_internal(
       } else {
         let _ = self.parse_stmt()
       }
+    } else if !ambient_decls {
+      // Real TS / JS modules can contain ordinary top-level statements:
+      // `if (...) {}`, expression statements (`foo();`), bare blocks
+      // (`{ ... }` used for scoped local types), assignments, etc.
+      // Delegate to the statement parser; it raises a ParseError for
+      // anything genuinely malformed.
+      let _ = self.parse_stmt()
     } else {
       raise ParseError(
         "Expected function, interface, declare, import, or export declaration",

--- a/src/parser/parser_typescript_wbtest.mbt
+++ b/src/parser/parser_typescript_wbtest.mbt
@@ -519,3 +519,65 @@ async test "parser: validate interface structure against TypeScript" {
     }
   }
 }
+
+///|
+async fn collect_ts_source_files(dir : String) -> Array[String] {
+  let kind = @fs.kind(dir, follow_symlink=false) catch {
+    _ => @fs.FileKind::Unknown
+  }
+  if not(kind is @fs.FileKind::Directory) {
+    return []
+  }
+  let entries = @fs.readdir(
+    dir, include_hidden=false, include_special=false, sort=true,
+  ) catch {
+    _ => []
+  }
+  let files : Array[String] = []
+  for name in entries {
+    if name.has_suffix(".ts") && not(name.has_suffix(".d.ts")) {
+      files.push(dir + "/" + name)
+    }
+  }
+  files
+}
+
+///|
+/// Every `.ts` (non-declaration) source file shipped with the upstream
+/// TypeScript compiler/services/server in the pinned submodule must parse
+/// without errors. Acts as a broad regression gate against real-world
+/// runtime TypeScript syntax.
+async test "parser: parse TypeScript compiler/services/server .ts sources" {
+  let dirs = [
+    "typescript/src/compiler",
+    "typescript/src/server",
+    "typescript/src/services",
+    "typescript/src/typingsInstaller",
+    "typescript/src/jsTyping",
+  ]
+  let failures : Array[String] = []
+  let mut total = 0
+  for dir in dirs {
+    let files = collect_ts_source_files(dir)
+    for path in files {
+      total += 1
+      let content = @fs.read_file(path).text() catch {
+        _ => continue
+      }
+      match (try? Parser::from_source(content).parse_module()) {
+        Ok(_) => ()
+        Err(err) => failures.push(path + ": \{err}")
+      }
+    }
+  }
+  if total == 0 {
+    println("skip: no .ts sources found in pinned submodule")
+    return
+  }
+  if failures.length() > 0 {
+    for f in failures {
+      println("FAIL " + f)
+    }
+    fail("\{failures.length()} of \{total} TypeScript .ts files failed to parse")
+  }
+}

--- a/src/parser/parser_wbtest.mbt
+++ b/src/parser/parser_wbtest.mbt
@@ -6362,3 +6362,71 @@ test "parser: parse member-access decorator on class method" {
   }
   assert_eq(module_.classes.length(), 1)
 }
+
+
+///|
+test "parser: export abstract class with definite-assignment field" {
+  let src =
+    #|export abstract class T implements I {
+    #|    protected installer!: P;
+    #|    private projectService!: S;
+    #|    private isReady = false;
+    #|    foo(): number { return 1; }
+    #|}
+  let module_ = Parser::from_source(src).parse_module() catch {
+    e => {
+      fail("Parse error: \{e}")
+      return
+    }
+  }
+  assert_eq(module_.classes.length(), 1)
+  assert_eq(module_.classes[0].name, "T")
+}
+
+///|
+test "parser: top-level if/expression/assignment/block statements" {
+  let cases = [
+    "if (cond()) { setup(); }",
+    "setObjectAllocator(getDefault());",
+    "container.field = computeValue();",
+    "{ type X<T> = T; }",
+  ]
+  for src in cases {
+    let _ = Parser::from_source(src).parse_module() catch {
+      e => {
+        fail("Expected to parse top-level statement, got: \{e} for \{src}")
+        return
+      }
+    }
+
+  }
+}
+
+///|
+test "parser: export namespace with runtime class body" {
+  let src =
+    #|export namespace ScriptSnapshot {
+    #|    class StringScriptSnapshot {
+    #|        constructor(private text: string) {}
+    #|        public getText(start: number, end: number): string {
+    #|            return start === 0 && end === this.text.length
+    #|                ? this.text
+    #|                : this.text.substring(start, end);
+    #|        }
+    #|    }
+    #|    export function fromString(text: string): StringScriptSnapshot {
+    #|        return new StringScriptSnapshot(text);
+    #|    }
+    #|}
+    #|export interface PreProcessed {}
+  let module_ = Parser::from_source(src).parse_module() catch {
+    e => {
+      fail("Parse error: \{e}")
+      return
+    }
+  }
+  assert_eq(module_.namespaces.length(), 1)
+  assert_eq(module_.namespaces[0].name, "ScriptSnapshot")
+  assert_eq(module_.interfaces.length(), 1)
+  assert_eq(module_.interfaces[0].name, "PreProcessed")
+}


### PR DESCRIPTION
## Summary

Surveyed all 92 non-declaration `.ts` files shipped with the pinned TypeScript compiler/services/server. 10 previously failed to parse; this PR brings that to **0/92 failures**. Four root causes addressed:

1. **`export abstract class T { ... }`** was routed to the ambient/declare-class parser, which rejects real method bodies and any subsequent class member after a definite-assignment-asserted field. Now routed to the runtime class parser, which also tolerates bodyless signatures.
2. **The declare-class parser didn't consume a trailing `!`** after a class member name (`protected installer!: P;`). Now `match_(Bang)` is consumed alongside the existing `match_(Question)`.
3. **Module-level decl loop rejected legitimate top-level statements** (`if`, expression statements, assignments, bare blocks used to scope local type aliases) in real `.ts` modules. The loop now falls back to the statement parser outside of ambient contexts.
4. **Namespace bodies were always parsed as ambient**, breaking `export namespace X { class Y { foo() { ... } } }`. Non-declare callers (`export namespace`, top-level `namespace`) now use a runtime body parser with ambient fallback, so .d.ts-style bodyless `const foo: T;` members still parse. Declare-context callers (`declare namespace ts { ... }`) keep ambient-only behavior so semantics like `enum.is_declare` are preserved.

Adds a broad regression test asserting every TypeScript `.ts` source file in the pinned submodule parses cleanly, plus focused tests for each pattern.

## Test plan

- [x] `moon test --target native -p mizchi/ts/parser` — 391/391 pass (4 new regression tests added)
- [x] `moon test --target native` — 1127/1127 pass
- [x] New regression test confirms 92/92 TypeScript `.ts` compiler sources parse

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ef6B7FcncT572Bqszz5me)_