### PR TITLE
checker: JSX coverage — components, generics, spread, key, render props, namespaces

### DIFF
--- a/src/ast/types.mbt
+++ b/src/ast/types.mbt
@@ -189,10 +189,13 @@ pub(all) enum TsExpr {
   //   - the attribute list as `(name, value?)` pairs — `value` is
   //     `None` for boolean attrs (`<Foo bar />`) and string-literal
   //     attrs are wrapped as `StringLit(...)`;
-  //   - the leftover embedded `{expr}` sub-expressions that don't
-  //     belong to a specific attribute (children + spread targets).
+  //   - the children list — one entry per logical child. Each child
+  //     is encoded as a `TsExpr`:
+  //       * `StringLit(text)` for the text segments between tags;
+  //       * the parsed `TsExpr` for `{expr}` blocks;
+  //       * a nested `JsxElement(...)` for inline JSX.
   //
-  // The checker recurses into every embedded expression and (when the
+  // The checker recurses into every child expression and (when the
   // tag resolves to a known component or HTML element) validates the
   // attribute values against the receiving prop / element type.
   JsxElement(String, Array[(String, TsExpr?)], Array[TsExpr])

--- a/src/ast/types.mbt
+++ b/src/ast/types.mbt
@@ -183,14 +183,19 @@ pub(all) enum TsExpr {
   // and at use sites the result type is widened with `undefined`.
   OptionalChain(TsExpr)
 
-  // JSX element / fragment. Stores only the embedded `{expr}` children
-  // parsed from the JSX source. The checker recurses into each child
-  // (`check_call_args_in_expr`) so bad calls / type mismatches inside
-  // JSX braces still surface. The outer element's structural shape
-  // (tag name / attribute names) isn't carried — it'd require a
-  // full JSX-AST design that the current scanner / bridge codegen
-  // doesn't need.
-  JsxElement(Array[TsExpr])
+  // JSX element / fragment. Carries:
+  //   - the tag name (`""` for fragments `<>…</>`; dotted for member
+  //     refs like `<Foo.Bar/>`);
+  //   - the attribute list as `(name, value?)` pairs — `value` is
+  //     `None` for boolean attrs (`<Foo bar />`) and string-literal
+  //     attrs are wrapped as `StringLit(...)`;
+  //   - the leftover embedded `{expr}` sub-expressions that don't
+  //     belong to a specific attribute (children + spread targets).
+  //
+  // The checker recurses into every embedded expression and (when the
+  // tag resolves to a known component or HTML element) validates the
+  // attribute values against the receiving prop / element type.
+  JsxElement(String, Array[(String, TsExpr?)], Array[TsExpr])
 } derive(Debug)
 
 ///|

--- a/src/ast/types.mbt
+++ b/src/ast/types.mbt
@@ -467,6 +467,11 @@ pub(all) struct TsClassMethodDecl {
   params : Array[(String, TsType)]
   return_type : TsType
   is_static : Bool
+  // Method body, when the source supplied one. `None` for ambient class
+  // declarations (`declare class`), abstract methods, and overload
+  // signatures. The expression checker walks the body when present so
+  // method internals get the same coverage as top-level functions.
+  body : TsBlock?
 } derive(Debug)
 
 ///|

--- a/src/ast/types.mbt
+++ b/src/ast/types.mbt
@@ -182,6 +182,15 @@ pub(all) enum TsExpr {
   // shape (`PropAccess` / `MethodCall` / `IndexAccess` / `CallExpr`),
   // and at use sites the result type is widened with `undefined`.
   OptionalChain(TsExpr)
+
+  // JSX element / fragment. Stores only the embedded `{expr}` children
+  // parsed from the JSX source. The checker recurses into each child
+  // (`check_call_args_in_expr`) so bad calls / type mismatches inside
+  // JSX braces still surface. The outer element's structural shape
+  // (tag name / attribute names) isn't carried — it'd require a
+  // full JSX-AST design that the current scanner / bridge codegen
+  // doesn't need.
+  JsxElement(Array[TsExpr])
 } derive(Debug)
 
 ///|

--- a/src/bridge/moonbit_decl.mbt
+++ b/src/bridge/moonbit_decl.mbt
@@ -8486,6 +8486,7 @@ fn clone_class_method_in_scope(
       ),
     ),
     is_static: class_method.is_static,
+    body: class_method.body,
   }
 }
 
@@ -8538,6 +8539,7 @@ fn callable_method_from_func_type(
       class_name, method_name, lowered_return_type,
     ),
     is_static,
+    body: None,
   }
 }
 

--- a/src/bridge/moonbit_js_ffi_wbtest.mbt
+++ b/src/bridge/moonbit_js_ffi_wbtest.mbt
@@ -4987,6 +4987,7 @@ test "bridge: FFI class methods unwrap optional arguments" {
     ],
     return_type: @ast.TsType::Named("This"),
     is_static: false,
+    body: None,
   }
   let actual = ffi_class_method_decl_to_moonbit(state, class_, class_method)
   assert_true(

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -2290,16 +2290,31 @@ fn check_jsx_attrs(
       let name = entry.0
       match entry.1 {
         Some(value) =>
-          match ctx.resolver.lookup_field(raw_props_ty, name) {
-            Some(formal) => {
-              let actual = infer_expr(env, ctx.resolver, value)
-              // JSX inference widens literal types (`"hi"` → `string`,
-              // `1` → `number`) so a single attribute doesn't lock T
-              // to a narrow literal value the user clearly didn't
-              // intend. Matches TS's contextual widening rule.
-              infer_param_bindings(type_params, formal, widen_literal(actual), bindings)
+          if name == "" {
+            // Spread: unify each overlapping field with the props.
+            let spread_ty = infer_expr(env, ctx.resolver, value)
+            let spread_fields = collect_declared_fields(spread_ty, ctx.resolver)
+            for sf in spread_fields {
+              match ctx.resolver.lookup_field(raw_props_ty, sf.0) {
+                Some(formal) =>
+                  infer_param_bindings(
+                    type_params, formal, widen_literal(sf.1), bindings,
+                  )
+                None => ()
+              }
             }
-            None => ()
+          } else {
+            match ctx.resolver.lookup_field(raw_props_ty, name) {
+              Some(formal) => {
+                let actual = infer_expr(env, ctx.resolver, value)
+                // JSX inference widens literal types (`"hi"` → `string`,
+                // `1` → `number`) so a single attribute doesn't lock T
+                // to a narrow literal value the user clearly didn't
+                // intend. Matches TS's contextual widening rule.
+                infer_param_bindings(type_params, formal, widen_literal(actual), bindings)
+              }
+              None => ()
+            }
           }
         None => ()
       }
@@ -2308,26 +2323,51 @@ fn check_jsx_attrs(
   } else {
     raw_props_ty
   }
-  // Per-attribute type check.
+  // Per-attribute type check. Track the fields supplied by `{...spread}`
+  // entries so the missing-required pass below treats them as provided.
+  let spread_provided : Map[String, Bool] = {}
   for entry in attrs {
     let name = entry.0
     match entry.1 {
       Some(value) =>
-        match ctx.resolver.lookup_field(props, name) {
-          Some(declared) =>
-            check_expr_against(
-              env,
-              value,
-              declared,
-              ctx,
-              "<\{tag}> attr `\{name}`",
-            )
-          None =>
-            record(
-              ctx,
-              "<\{tag}> attr `\{name}`",
-              "property `\{name}` does not exist on target type",
-            )
+        if name == "" {
+          // Spread attribute: validate each overlapping field type and
+          // record the names it contributes.
+          let spread_ty = infer_expr(env, ctx.resolver, value)
+          let spread_fields = collect_declared_fields(spread_ty, ctx.resolver)
+          for sf in spread_fields {
+            spread_provided[sf.0] = true
+            match ctx.resolver.lookup_field(props, sf.0) {
+              Some(declared) =>
+                if is_checkable(declared) &&
+                  is_checkable(sf.1) &&
+                  !is_assignable_to(sf.1, declared) {
+                  record(
+                    ctx,
+                    "<\{tag}> spread `\{sf.0}`",
+                    "expected `\{type_display(declared)}` but got `\{type_display(sf.1)}`",
+                  )
+                }
+              None => ()
+            }
+          }
+        } else {
+          match ctx.resolver.lookup_field(props, name) {
+            Some(declared) =>
+              check_expr_against(
+                env,
+                value,
+                declared,
+                ctx,
+                "<\{tag}> attr `\{name}`",
+              )
+            None =>
+              record(
+                ctx,
+                "<\{tag}> attr `\{name}`",
+                "property `\{name}` does not exist on target type",
+              )
+          }
         }
       None =>
         // Boolean attribute (`<Foo bar />`) implies `bar = true`.
@@ -2347,7 +2387,12 @@ fn check_jsx_attrs(
   // child is present.
   let provided : Map[String, Bool] = {}
   for entry in attrs {
-    provided[entry.0] = true
+    if entry.0 != "" {
+      provided[entry.0] = true
+    }
+  }
+  for k in spread_provided.keys() {
+    provided[k] = true
   }
   if children.length() > 0 {
     provided["children"] = true

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -2176,6 +2176,30 @@ fn check_array_lit_against_tuple(
 /// element-shape narrowing yet — but the assignability check still
 /// surfaces obvious mismatches like `children: string` vs a numeric
 /// child.
+///|
+/// Widen a value's literal type to its base — `"hi"` → `string`,
+/// `1` → `number`, `true` → `boolean`. Used by JSX generic inference
+/// so type parameters don't collapse to a too-narrow literal type the
+/// user clearly didn't intend.
+fn widen_literal(t : @ast.TsType) -> @ast.TsType {
+  match t {
+    Literal(_) => @ast.TsType::String_
+    NumberLiteral(_) => @ast.TsType::Number
+    BigIntLiteral(_) => @ast.TsType::BigInt
+    BooleanLiteral(_) => @ast.TsType::Boolean
+    Array(elem) => @ast.TsType::Array(widen_literal(elem))
+    Tuple(items) => {
+      let widened : Array[@ast.TsType] = []
+      for it in items {
+        widened.push(widen_literal(it))
+      }
+      @ast.TsType::Tuple(widened)
+    }
+    _ => t
+  }
+}
+
+///|
 fn synthesize_children_type(
   env : ExprEnv,
   resolver : Resolver,
@@ -2240,13 +2264,49 @@ fn check_jsx_attrs(
   //
   //   function Comp(props: { foo: number }): JSX.Element
   //   function Comp(props: Props): JSX.Element
-  let props_ty : @ast.TsType? = match ctx.resolver.signatures.get(tag) {
+  let raw_props : @ast.TsType? = match ctx.resolver.signatures.get(tag) {
     Some(params) if params.length() == 1 => Some(params[0].type_)
     _ => None
   }
-  let props = match props_ty {
+  let raw_props_ty = match raw_props {
     Some(t) => t
     None => return
+  }
+  // Generic-component inference: when the component declares type
+  // parameters, unify each supplied attribute's value type against the
+  // declared prop's type before per-attribute checks, then substitute
+  // the bindings into the props shape so downstream lookups see the
+  // instantiated form.
+  let type_params = match ctx.resolver.func_type_params.get(tag) {
+    Some(tps) => tps
+    None => []
+  }
+  let props = if type_params.length() > 0 {
+    let bindings : Map[String, @ast.TsType] = {}
+    for tp in type_params {
+      bindings[tp] = @ast.TsType::Any
+    }
+    for entry in attrs {
+      let name = entry.0
+      match entry.1 {
+        Some(value) =>
+          match ctx.resolver.lookup_field(raw_props_ty, name) {
+            Some(formal) => {
+              let actual = infer_expr(env, ctx.resolver, value)
+              // JSX inference widens literal types (`"hi"` → `string`,
+              // `1` → `number`) so a single attribute doesn't lock T
+              // to a narrow literal value the user clearly didn't
+              // intend. Matches TS's contextual widening rule.
+              infer_param_bindings(type_params, formal, widen_literal(actual), bindings)
+            }
+            None => ()
+          }
+        None => ()
+      }
+    }
+    substitute_params(raw_props_ty, bindings)
+  } else {
+    raw_props_ty
   }
   // Per-attribute type check.
   for entry in attrs {

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -1720,6 +1720,11 @@ fn infer_expr(
       let inner_ty = infer_expr(env, resolver, inner)
       narrow_union(inner_ty, @ast.TsType::Undefined)
     }
+    // JSX element / fragment. The value itself is opaque at the type
+    // level (we don't model React's `ReactNode` / `JSX.Element`), so
+    // return `Any`. The embedded `{expr}` sub-expressions are walked
+    // by `check_call_args_in_expr` for diagnostic recursion.
+    JsxElement(_) => @ast.TsType::Any
   }
 }
 
@@ -4343,6 +4348,12 @@ fn check_call_args_in_expr(
       // `x satisfies T` — verify the operand is assignable to `T`.
       check_expr_against(env, inner, ty, ctx, "satisfies")
     }
+    // JSX element / fragment: recurse into each embedded `{expr}`
+    // child so call-site mismatches inside JSX braces are reported.
+    JsxElement(embeds) =>
+      for e in embeds {
+        check_call_args_in_expr(env, e, ctx)
+      }
     _ => ()
   }
 }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -53,28 +53,42 @@ fn Resolver::empty() -> Resolver {
 ///|
 fn Resolver::from_module(module_ : @ast.TsModule) -> Resolver {
   let r = Resolver::empty()
+  Resolver::ingest_module(r, module_, "")
+  r
+}
+
+///|
+/// Register the declarations of `module_` into `r`, prefixing every
+/// name with `prefix` (e.g. `"Layout."`). Recurses into nested
+/// namespaces so `namespace Layout { export function Header(...) }` is
+/// reachable as `Layout.Header` for member-expression JSX tags.
+fn Resolver::ingest_module(
+  r : Resolver,
+  module_ : @ast.TsModule,
+  prefix : String,
+) -> Unit {
   for i in module_.interfaces {
-    r.interfaces[i.name] = i
+    r.interfaces[prefix + i.name] = i
   }
   for c in module_.classes {
-    r.classes[c.name] = c
+    r.classes[prefix + c.name] = c
   }
   for ta in module_.type_aliases {
-    r.type_aliases[ta.name] = ta
+    r.type_aliases[prefix + ta.name] = ta
   }
   for v in module_.values {
-    r.globals[v.name] = v.type_
+    r.globals[prefix + v.name] = v.type_
   }
   for imp in module_.imports {
     let param_types : Array[@ast.TsType] = []
     for p in imp.params {
       param_types.push(p.1)
     }
-    r.globals[imp.name] = @ast.TsType::Func(param_types, imp.return_type)
+    r.globals[prefix + imp.name] = @ast.TsType::Func(param_types, imp.return_type)
     // Also expose type parameters so generic-call inference picks up
     // `declare function f<T>(...)` imports — without this the inference
     // path skipped imports entirely.
-    r.func_type_params[imp.name] = imp.type_params
+    r.func_type_params[prefix + imp.name] = imp.type_params
     // Synthesize a minimal `TsParam` list (names only) so the rich-
     // signature path used by `apply_type_predicate_narrowing` can map
     // the predicate's parameter name to an argument index.
@@ -88,7 +102,7 @@ fn Resolver::from_module(module_ : @ast.TsModule) -> Resolver {
         default: None,
       })
     }
-    r.signatures[imp.name] = synth_params
+    r.signatures[prefix + imp.name] = synth_params
   }
   for f in module_.funcs {
     let param_types : Array[@ast.TsType] = []
@@ -98,11 +112,13 @@ fn Resolver::from_module(module_ : @ast.TsModule) -> Resolver {
     // Async functions expose `Promise<R>` to callers even when the body's
     // declared `return_type` is the un-wrapped `R`.
     let ret = wrap_async_return(f.is_async, f.return_type)
-    r.globals[f.name] = @ast.TsType::Func(param_types, ret)
-    r.signatures[f.name] = f.params
-    r.func_type_params[f.name] = f.type_params
+    r.globals[prefix + f.name] = @ast.TsType::Func(param_types, ret)
+    r.signatures[prefix + f.name] = f.params
+    r.func_type_params[prefix + f.name] = f.type_params
   }
-  r
+  for ns in module_.namespaces {
+    Resolver::ingest_module(r, ns.module_, prefix + ns.name + ".")
+  }
 }
 
 ///|
@@ -2256,9 +2272,10 @@ fn check_jsx_attrs(
       return
     }
   }
-  if tag.contains(".") {
-    return
-  }
+  // Dotted member-expression tags (`<Layout.Header/>`) are resolved
+  // against namespaces ingested with `prefix + name` keys; if the
+  // resolver doesn't have the dotted name registered we fall through
+  // to the standard "no signature" bail later.
   // Resolve the component as a top-level function and pull out its
   // single parameter's type. Component signatures we recognise:
   //

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -1724,7 +1724,7 @@ fn infer_expr(
     // level (we don't model React's `ReactNode` / `JSX.Element`), so
     // return `Any`. The embedded `{expr}` sub-expressions are walked
     // by `check_call_args_in_expr` for diagnostic recursion.
-    JsxElement(_) => @ast.TsType::Any
+    JsxElement(_, _, _) => @ast.TsType::Any
   }
 }
 
@@ -2149,6 +2149,109 @@ fn check_array_lit_against_tuple(
 /// Excess literal fields (not declared on the target) and missing required
 /// fields are reported individually so the diagnostic points at the
 /// specific divergence rather than the whole literal.
+///|
+/// Validate a JSX element's attributes against the receiving component's
+/// props. Recognised receiver shapes:
+///
+///   - lower-case HTML tags (`<div>` etc.) — skipped; we don't model
+///     the global JSX intrinsic table.
+///   - empty tag (fragment `<>…</>`) — skipped.
+///   - dotted tag (`<Foo.Bar/>`) — skipped (member access not modelled).
+///   - a known top-level function whose single parameter is a Props
+///     interface / object type — each attribute is validated against
+///     the corresponding prop's declared type, missing required props
+///     are flagged, and excess props surface as "does not exist on
+///     target type".
+fn check_jsx_attrs(
+  env : ExprEnv,
+  tag : String,
+  attrs : Array[(String, @ast.TsExpr?)],
+  ctx : CheckCtx,
+) -> Unit {
+  if tag == "" {
+    return
+  }
+  // Lower-case HTML element tags — out of scope for now.
+  if tag.length() > 0 {
+    let first = tag[0].to_int().unsafe_to_char()
+    if first >= 'a' && first <= 'z' {
+      return
+    }
+  }
+  if tag.contains(".") {
+    return
+  }
+  // Resolve the component as a top-level function and pull out its
+  // single parameter's type. Component signatures we recognise:
+  //
+  //   function Comp(props: { foo: number }): JSX.Element
+  //   function Comp(props: Props): JSX.Element
+  let props_ty : @ast.TsType? = match ctx.resolver.signatures.get(tag) {
+    Some(params) if params.length() == 1 => Some(params[0].type_)
+    _ => None
+  }
+  let props = match props_ty {
+    Some(t) => t
+    None => return
+  }
+  // Per-attribute type check.
+  for entry in attrs {
+    let name = entry.0
+    match entry.1 {
+      Some(value) =>
+        match ctx.resolver.lookup_field(props, name) {
+          Some(declared) =>
+            check_expr_against(
+              env,
+              value,
+              declared,
+              ctx,
+              "<\{tag}> attr `\{name}`",
+            )
+          None =>
+            record(
+              ctx,
+              "<\{tag}> attr `\{name}`",
+              "property `\{name}` does not exist on target type",
+            )
+        }
+      None =>
+        // Boolean attribute (`<Foo bar />`) implies `bar = true`.
+        match ctx.resolver.lookup_field(props, name) {
+          Some(_) => ()
+          None =>
+            record(
+              ctx,
+              "<\{tag}> attr `\{name}`",
+              "property `\{name}` does not exist on target type",
+            )
+        }
+    }
+  }
+  // Missing-required check.
+  let provided : Map[String, Bool] = {}
+  for entry in attrs {
+    provided[entry.0] = true
+  }
+  let declared_fields = collect_declared_fields(props, ctx.resolver)
+  for d in declared_fields {
+    let n = d.0
+    let ty = d.1
+    if provided.contains(n) {
+      continue
+    }
+    if is_assignable_to(@ast.TsType::Undefined, ty) {
+      continue
+    }
+    record(
+      ctx,
+      "<\{tag}> missing prop `\{n}`",
+      "property `\{n}` is required by `\{type_display(props)}`",
+    )
+  }
+}
+
+///|
 fn check_object_lit_against_target(
   env : ExprEnv,
   entries : Array[(String, @ast.TsExpr)],
@@ -4348,12 +4451,24 @@ fn check_call_args_in_expr(
       // `x satisfies T` — verify the operand is assignable to `T`.
       check_expr_against(env, inner, ty, ctx, "satisfies")
     }
-    // JSX element / fragment: recurse into each embedded `{expr}`
-    // child so call-site mismatches inside JSX braces are reported.
-    JsxElement(embeds) =>
+    // JSX element / fragment: recurse into every attribute value and
+    // child sub-expression so call-site mismatches inside JSX braces
+    // are reported. When the tag resolves to a known component (a
+    // top-level function whose only parameter is a Props interface or
+    // object type), also run per-attribute type checks against the
+    // declared prop types.
+    JsxElement(tag, attrs, embeds) => {
+      check_jsx_attrs(env, tag, attrs, ctx)
+      for entry in attrs {
+        match entry.1 {
+          Some(value) => check_call_args_in_expr(env, value, ctx)
+          None => ()
+        }
+      }
       for e in embeds {
         check_call_args_in_expr(env, e, ctx)
       }
+    }
     _ => ()
   }
 }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -2325,9 +2325,15 @@ fn check_jsx_attrs(
   }
   // Per-attribute type check. Track the fields supplied by `{...spread}`
   // entries so the missing-required pass below treats them as provided.
+  // `key` and `ref` are reserved JSX attributes — React intercepts them
+  // before they reach the component, so they aren't validated against
+  // the declared props.
   let spread_provided : Map[String, Bool] = {}
   for entry in attrs {
     let name = entry.0
+    if name == "key" || name == "ref" {
+      continue
+    }
     match entry.1 {
       Some(value) =>
         if name == "" {

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -4492,5 +4492,41 @@ pub fn check_module_function_bodies(
       all.push(issue)
     }
   }
+  // Class method bodies — when the parser supplied a body, walk it the
+  // same way top-level functions are walked. Synthesise a `TsFunc` so
+  // the existing checker pipeline can run unchanged. The synthetic
+  // function name embeds the class + method names so any reported
+  // issues point at the source location.
+  for cls in module_.classes {
+    for method in cls.methods {
+      match method.body {
+        Some(body) => {
+          let params : Array[@ast.TsParam] = []
+          for p in method.params {
+            params.push({
+              name: p.0,
+              binding: None,
+              is_rest: false,
+              type_: p.1,
+              default: None,
+            })
+          }
+          let synth : @ast.TsFunc = {
+            name: cls.name + "." + method.name,
+            type_params: method.type_params,
+            params,
+            return_type: method.return_type,
+            body,
+            is_generator: false,
+            is_async: false,
+          }
+          for issue in check_function_body_with(synth, resolver) {
+            all.push(issue)
+          }
+        }
+        None => ()
+      }
+    }
+  }
   all
 }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -2162,10 +2162,64 @@ fn check_array_lit_against_tuple(
 ///     the corresponding prop's declared type, missing required props
 ///     are flagged, and excess props surface as "does not exist on
 ///     target type".
+///|
+/// Synthesise a TS type for a JSX element's children list. Used by
+/// `check_jsx_attrs` to validate the synthesised value against the
+/// component's declared `children` prop.
+///
+///   0 children → `Undefined`
+///   1 child   → that child's inferred type
+///   2+ children → `Array<union-of-child-types>`
+///
+/// JSX nested elements infer as `Any` (`JsxElement(_, _, _)` → Any),
+/// so a component declaring `children: SomeElement` won't get strict
+/// element-shape narrowing yet — but the assignability check still
+/// surfaces obvious mismatches like `children: string` vs a numeric
+/// child.
+fn synthesize_children_type(
+  env : ExprEnv,
+  resolver : Resolver,
+  children : Array[@ast.TsExpr],
+) -> @ast.TsType {
+  if children.length() == 0 {
+    return @ast.TsType::Undefined
+  }
+  if children.length() == 1 {
+    return infer_expr(env, resolver, children[0])
+  }
+  let parts : Array[@ast.TsType] = []
+  for c in children {
+    parts.push(infer_expr(env, resolver, c))
+  }
+  // Dedup obviously-identical parts so the synthesised union stays
+  // readable in diagnostics.
+  let dedup : Array[@ast.TsType] = []
+  for p in parts {
+    let mut already = false
+    for existing in dedup {
+      if equivalent(p, existing) {
+        already = true
+        break
+      }
+    }
+    if !already {
+      dedup.push(p)
+    }
+  }
+  let elem = if dedup.length() == 1 {
+    dedup[0]
+  } else {
+    @ast.TsType::Union(dedup)
+  }
+  @ast.TsType::Array(elem)
+}
+
+///|
 fn check_jsx_attrs(
   env : ExprEnv,
   tag : String,
   attrs : Array[(String, @ast.TsExpr?)],
+  children : Array[@ast.TsExpr],
   ctx : CheckCtx,
 ) -> Unit {
   if tag == "" {
@@ -2228,10 +2282,46 @@ fn check_jsx_attrs(
         }
     }
   }
-  // Missing-required check.
+  // Missing-required check. JSX children populate the synthetic
+  // `children` prop, so include it in `provided` when at least one
+  // child is present.
   let provided : Map[String, Bool] = {}
   for entry in attrs {
     provided[entry.0] = true
+  }
+  if children.length() > 0 {
+    provided["children"] = true
+  }
+  // Children-prop type check: when the props shape declares a
+  // `children` field with a non-`Any` type, synthesise the children
+  // value (single child or array union) and validate it.
+  match ctx.resolver.lookup_field(props, "children") {
+    Some(children_ty) =>
+      if is_checkable(children_ty) {
+        let synth = synthesize_children_type(env, ctx.resolver, children)
+        if is_checkable(synth) && !is_assignable_to(synth, children_ty) {
+          record(
+            ctx,
+            "<\{tag}> children",
+            "expected `\{type_display(children_ty)}` but got `\{type_display(synth)}`",
+          )
+        }
+      }
+    None =>
+      if children.length() > 0 {
+        // The component has no `children` prop but the JSX element
+        // supplied some. Mirror TS's "Property 'children' does not
+        // exist" diagnostic.
+        let declared_fields = collect_declared_fields(props, ctx.resolver)
+        let has_children = declared_fields.iter().any(fn(d) { d.0 == "children" })
+        if !has_children && declared_fields.length() > 0 {
+          record(
+            ctx,
+            "<\{tag}> children",
+            "component does not declare a `children` prop",
+          )
+        }
+      }
   }
   let declared_fields = collect_declared_fields(props, ctx.resolver)
   for d in declared_fields {
@@ -4458,7 +4548,7 @@ fn check_call_args_in_expr(
     // object type), also run per-attribute type checks against the
     // declared prop types.
     JsxElement(tag, attrs, children) => {
-      check_jsx_attrs(env, tag, attrs, ctx)
+      check_jsx_attrs(env, tag, attrs, children, ctx)
       for entry in attrs {
         match entry.1 {
           Some(value) => check_call_args_in_expr(env, value, ctx)

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -4673,8 +4673,76 @@ fn check_call_args_in_expr(
       // (text literals walk through as no-op).
       for c in children {
         check_call_args_in_expr(env, c, ctx)
+        // React `key` rule: when a child is `xs.map(fn)` and `fn`
+        // returns a JSX element, that element needs a `key` attr.
+        check_jsx_key_in_map(c, ctx)
       }
     }
+    _ => ()
+  }
+}
+
+///|
+/// React `key`-in-iteration rule: when a JSX child is the result of
+/// `xs.map(fn)` and the callback returns a JSX element, that element
+/// must declare a `key` attribute. The check walks the immediate child
+/// expression and records `<Tag>` missing `key` diagnostics; deeply
+/// nested misses are left to the recursive `check_call_args_in_expr`.
+fn check_jsx_key_in_map(child : @ast.TsExpr, ctx : CheckCtx) -> Unit {
+  match child {
+    MethodCall(_, method, args) =>
+      if method == "map" && args.length() >= 1 {
+        walk_map_callback_for_key(args[0], ctx)
+      }
+    CallExpr(callee, args) =>
+      match callee {
+        PropAccess(_, method) =>
+          if method == "map" && args.length() >= 1 {
+            walk_map_callback_for_key(args[0], ctx)
+          }
+        _ => ()
+      }
+    _ => ()
+  }
+}
+
+///|
+fn walk_map_callback_for_key(callback : @ast.TsExpr, ctx : CheckCtx) -> Unit {
+  match callback {
+    ArrowFunc(_, _, ArrowExpr(body), _) => check_jsx_expr_has_key(body, ctx)
+    ArrowFunc(_, _, ArrowBlock(block), _) =>
+      for stmt in block.stmts {
+        match stmt {
+          Return(Some(e)) => check_jsx_expr_has_key(e, ctx)
+          _ => ()
+        }
+      }
+    _ => ()
+  }
+}
+
+///|
+fn check_jsx_expr_has_key(expr : @ast.TsExpr, ctx : CheckCtx) -> Unit {
+  match expr {
+    JsxElement(tag, attrs, _) =>
+      // Fragments (empty tag) can't take a key in plain JSX form; skip.
+      if tag != "" {
+        let has_key = attrs.iter().any(fn(a) { a.0 == "key" })
+        if !has_key {
+          record(
+            ctx,
+            "<\{tag}> in `.map()`",
+            "missing required `key` prop for list element",
+          )
+        }
+      }
+    // `cond ? <A/> : <B/>` — recurse into both branches.
+    Cond(_, then_e, else_e) => {
+      check_jsx_expr_has_key(then_e, ctx)
+      check_jsx_expr_has_key(else_e, ctx)
+    }
+    // `cond && <A/>`.
+    BinOp(And, _, right) => check_jsx_expr_has_key(right, ctx)
     _ => ()
   }
 }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -4457,7 +4457,7 @@ fn check_call_args_in_expr(
     // top-level function whose only parameter is a Props interface or
     // object type), also run per-attribute type checks against the
     // declared prop types.
-    JsxElement(tag, attrs, embeds) => {
+    JsxElement(tag, attrs, children) => {
       check_jsx_attrs(env, tag, attrs, ctx)
       for entry in attrs {
         match entry.1 {
@@ -4465,8 +4465,13 @@ fn check_call_args_in_expr(
           None => ()
         }
       }
-      for e in embeds {
-        check_call_args_in_expr(env, e, ctx)
+      // Each child entry is a `TsExpr` — text segments are wrapped as
+      // `StringLit(...)`, JSX expressions are parsed expressions, and
+      // nested elements are themselves `JsxElement(...)`. Recursing
+      // through `check_call_args_in_expr` handles all three uniformly
+      // (text literals walk through as no-op).
+      for c in children {
+        check_call_args_in_expr(env, c, ctx)
       }
     }
     _ => ()

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -4054,3 +4054,119 @@ test "expr_check: nested JSX surfaces inner-tag embedded calls" {
   }
   assert_true(found)
 }
+
+// ---------------------------------------------------------------------------
+// Round 39: JSX component prop validation. `<Comp foo={42}>` where
+// `Comp` is declared as `function Comp(props: Props): … {…}` now
+// type-checks attribute values against the corresponding prop types
+// and flags missing required / excess props.
+// ---------------------------------------------------------------------------
+
+///|
+test "expr_check: JSX attribute well-typed passes" {
+  let src =
+    #|interface Props { name: string }
+    #|function Greet(props: Props): void {}
+    #|function comp(): void {
+    #|  const _ = <Greet name="hi"/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: JSX attribute wrong type is flagged" {
+  let src =
+    #|interface Props { name: string }
+    #|function Greet(props: Props): void {}
+    #|function comp(): void {
+    #|  const _ = <Greet name={42}/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.path.contains("<Greet> attr `name`") &&
+      i.message.contains("string") &&
+      i.message.contains("number") {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
+test "expr_check: JSX missing required prop is flagged" {
+  let src =
+    #|interface Props { name: string; age: number }
+    #|function Greet(props: Props): void {}
+    #|function comp(): void {
+    #|  const _ = <Greet name="hi"/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.path.contains("missing prop `age`") {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
+test "expr_check: JSX optional prop can be omitted" {
+  let src =
+    #|interface Props { name: string; age?: number }
+    #|function Greet(props: Props): void {}
+    #|function comp(): void {
+    #|  const _ = <Greet name="hi"/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: JSX excess prop is flagged" {
+  let src =
+    #|interface Props { name: string }
+    #|function Greet(props: Props): void {}
+    #|function comp(): void {
+    #|  const _ = <Greet name="hi" bogus="x"/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.path.contains("<Greet> attr `bogus`") &&
+      i.message.contains("does not exist") {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
+test "expr_check: JSX HTML tag skips prop validation" {
+  // Lower-case tags are HTML intrinsics; we don't have a JSX
+  // intrinsic-element table, so attribute names aren't validated.
+  let src =
+    #|function comp(): void {
+    #|  const _ = <div className="x" anyAttr={42}/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: JSX boolean attribute satisfies a boolean prop" {
+  let src =
+    #|interface Props { disabled?: boolean }
+    #|function Button(props: Props): void {}
+    #|function comp(): void {
+    #|  const _ = <Button disabled/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -4565,6 +4565,41 @@ test "expr_check: JSX in .map() without key flags warning" {
 }
 
 ///|
+test "expr_check: JSX member-expression component resolves via namespace" {
+  // `Layout.Header` is registered as a top-level signature so the JSX
+  // attribute check fires against the inner function's props shape.
+  let src =
+    #|namespace Layout {
+    #|  export function Header(props: { title: string }): void {}
+    #|}
+    #|function comp(): void {
+    #|  const _ = <Layout.Header title="hi"/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: JSX member-expression component flags wrong attr type" {
+  let src =
+    #|namespace Layout {
+    #|  export function Header(props: { title: string }): void {}
+    #|}
+    #|function comp(): void {
+    #|  const _ = <Layout.Header title={1}/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.path.contains("<Layout.Header> attr `title`") {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
 test "expr_check: JSX in .map() with key is silent" {
   let src =
     #|interface Props { value: number }

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -4547,6 +4547,42 @@ test "expr_check: compatible render-prop function child passes" {
 }
 
 ///|
+test "expr_check: JSX in .map() without key flags warning" {
+  let src =
+    #|interface Props { value: number }
+    #|function Item(props: Props): void {}
+    #|function comp(xs: number[]): void {
+    #|  const _ = <ul>{xs.map((n: number) => <Item value={n}/>)}</ul>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.path.contains("<Item> in `.map()`") {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
+test "expr_check: JSX in .map() with key is silent" {
+  let src =
+    #|interface Props { value: number }
+    #|function Item(props: Props): void {}
+    #|function comp(xs: number[]): void {
+    #|  const _ = <ul>{xs.map((n: number) => <Item key={n} value={n}/>)}</ul>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut bad = false
+  for i in check_module_function_bodies(module_) {
+    if i.path.contains("in `.map()`") {
+      bad = true
+    }
+  }
+  assert_false(bad)
+}
+
+///|
 test "expr_check: render-prop child with mismatched arg type flags error" {
   // The callback declares its argument as `string` but the prop expects
   // `(n: number) => string`. The arg-type clash should surface.

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -4170,3 +4170,73 @@ test "expr_check: JSX boolean attribute satisfies a boolean prop" {
   let issues = check_module_function_bodies(module_)
   assert_eq(issues.length(), 0)
 }
+
+// ---------------------------------------------------------------------------
+// Round 40: JSX children are tracked structurally — text, embedded
+// `{expr}` blocks, and nested elements each become a child entry. The
+// checker recurses through all of them.
+// ---------------------------------------------------------------------------
+
+///|
+test "expr_check: JSX text children pass through cleanly" {
+  let src =
+    #|interface Props { name: string }
+    #|function Greet(props: Props): void {}
+    #|function comp(): void {
+    #|  const _ = <Greet name="hi">Hello, world!</Greet>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: bad call inside multi-child JSX surfaces" {
+  let src =
+    #|function takesString(s: string): void {}
+    #|function Box(props: { children?: any }): void {}
+    #|function comp(): void {
+    #|  const _ = <Box>text {takesString(7)} more</Box>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.message.contains("string") && i.message.contains("number") {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
+test "expr_check: deeply nested JSX preserves prop validation" {
+  // Outer Wrap takes no props; inner Greet needs `name: string`.
+  let src =
+    #|function Wrap(props: { children?: any }): void {}
+    #|function Greet(props: { name: string }): void {}
+    #|function comp(): void {
+    #|  const _ = <Wrap><Wrap><Greet name={42}/></Wrap></Wrap>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.path.contains("<Greet> attr `name`") &&
+      i.message.contains("string") &&
+      i.message.contains("number") {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
+test "expr_check: nested HTML inside component children skips inner validation" {
+  let src =
+    #|function Wrap(props: { children?: any }): void {}
+    #|function comp(): void {
+    #|  const _ = <Wrap><div className="x">hello</div></Wrap>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -4526,3 +4526,42 @@ test "expr_check: JSX ref on a component without a ref prop is accepted" {
   let issues = check_module_function_bodies(module_)
   assert_eq(issues.length(), 0)
 }
+
+// ---------------------------------------------------------------------------
+// Round 45: function-as-children (render props). When a component declares
+// `children: (x: T) => U`, the single arrow-function child is synthesised
+// and validated against that callable shape.
+// ---------------------------------------------------------------------------
+
+///|
+test "expr_check: compatible render-prop function child passes" {
+  let src =
+    #|interface Props { children: (n: number) => string }
+    #|function DataLoader(props: Props): void {}
+    #|function comp(): void {
+    #|  const _ = <DataLoader>{(n: number) => "row " + n}</DataLoader>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: render-prop child with mismatched arg type flags error" {
+  // The callback declares its argument as `string` but the prop expects
+  // `(n: number) => string`. The arg-type clash should surface.
+  let src =
+    #|interface Props { children: (n: number) => string }
+    #|function DataLoader(props: Props): void {}
+    #|function comp(): void {
+    #|  const _ = <DataLoader>{(s: string) => s}</DataLoader>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.path.contains("<DataLoader> children") {
+      found = true
+    }
+  }
+  assert_true(found)
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -4494,3 +4494,35 @@ test "expr_check: JSX spread feeds generic component inference" {
   let issues = check_module_function_bodies(module_)
   assert_eq(issues.length(), 0)
 }
+
+// ---------------------------------------------------------------------------
+// Round 44: reserved JSX attributes `key` and `ref`. React intercepts both
+// before they reach the component, so they should be type-checked at the
+// JSX call site but not validated against the declared props shape.
+// ---------------------------------------------------------------------------
+
+///|
+test "expr_check: JSX key on a component without a key prop is accepted" {
+  let src =
+    #|interface Props { value: number }
+    #|function Item(props: Props): void {}
+    #|function comp(): void {
+    #|  const _ = <Item key="row-1" value={1}/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: JSX ref on a component without a ref prop is accepted" {
+  let src =
+    #|interface Props { value: number }
+    #|function Item(props: Props): void {}
+    #|function comp(): void {
+    #|  const _ = <Item ref={null} value={1}/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -4326,3 +4326,78 @@ test "expr_check: JSX children any prop accepts anything" {
   let issues = check_module_function_bodies(module_)
   assert_eq(issues.length(), 0)
 }
+
+// ---------------------------------------------------------------------------
+// Round 42: generic JSX components. `<List<T>/>` instantiates T from the
+// supplied attribute types, mirroring the generic-call inference path
+// used for top-level functions.
+// ---------------------------------------------------------------------------
+
+///|
+test "expr_check: generic component infers T from items attribute" {
+  // T resolves to `number` from `items={[1,2,3]}`, so the synthetic
+  // `select` callback's parameter is also `number`. The component
+  // body itself isn't checked here; we focus on the call site.
+  let src =
+    #|function List<T>(props: { items: T[]; select: (item: T) => void }): void {}
+    #|function comp(): void {
+    #|  const _ = <List items={[1, 2, 3]} select={(n: number) => {}}/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: generic component flags inconsistent T usages" {
+  // T resolves to `number` from `left`; `right={\"x\"}` (string) then
+  // fails against the substituted `T = number` formal.
+  let src =
+    #|function Pair<T>(props: { left: T; right: T }): void {}
+    #|function comp(): void {
+    #|  const _ = <Pair left={1} right="x"/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.path.contains("<Pair> attr `right`") {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
+test "expr_check: generic component picks up T from required attribute" {
+  // T resolves to `string` from `value`; children also `string` after
+  // substitution so the text child is accepted.
+  let src =
+    #|function Wrap<T>(props: { value: T; children: T }): void {}
+    #|function comp(): void {
+    #|  const _ = <Wrap value="hi">other</Wrap>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: generic component children prop checked after substitution" {
+  // T resolves to `number` from `value`, so the `children` prop is
+  // `number` and the string child mismatches.
+  let src =
+    #|function Wrap<T>(props: { value: T; children: T }): void {}
+    #|function comp(): void {
+    #|  const _ = <Wrap value={1}>other</Wrap>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.path.contains("<Wrap> children") &&
+      i.message.contains("number") &&
+      i.message.contains("string") {
+      found = true
+    }
+  }
+  assert_true(found)
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -4401,3 +4401,96 @@ test "expr_check: generic component children prop checked after substitution" {
   }
   assert_true(found)
 }
+
+// ---------------------------------------------------------------------------
+// Round 43: JSX spread attributes. `<Foo {...props}/>` validates the spread
+// expression's fields against the component's prop shape, contributes to the
+// missing-required check, and feeds generic inference like a normal attribute.
+// ---------------------------------------------------------------------------
+
+///|
+test "expr_check: JSX spread of compatible props passes" {
+  let src =
+    #|interface Props { x: number; y: string }
+    #|function Foo(props: Props): void {}
+    #|function comp(): void {
+    #|  const data: Props = { x: 1, y: "hi" };
+    #|  const _ = <Foo {...data}/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: JSX spread of incompatible field flags error" {
+  // `data.x` is a string but `Props.x` is a number — the spread should
+  // flag a per-field mismatch.
+  let src =
+    #|interface Props { x: number; y: string }
+    #|function Foo(props: Props): void {}
+    #|function comp(): void {
+    #|  const data = { x: "no", y: "ok" };
+    #|  const _ = <Foo {...data}/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.path.contains("<Foo> spread `x`") {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
+test "expr_check: JSX spread satisfies missing-required prop" {
+  // The component requires both `x` and `y`; the spread provides them
+  // (no explicit attributes), so no missing-prop diagnostics fire.
+  let src =
+    #|interface Props { x: number; y: string }
+    #|function Foo(props: Props): void {}
+    #|function comp(): void {
+    #|  const data: Props = { x: 1, y: "hi" };
+    #|  const _ = <Foo {...data}/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut bad = false
+  for i in check_module_function_bodies(module_) {
+    if i.path.contains("<Foo> missing prop") {
+      bad = true
+    }
+  }
+  assert_false(bad)
+}
+
+///|
+test "expr_check: JSX spread plus explicit override type-checks" {
+  // `data` supplies `x` and `y`; the explicit `y="bye"` then overrides.
+  // Both forms should pass typing.
+  let src =
+    #|interface Props { x: number; y: string }
+    #|function Foo(props: Props): void {}
+    #|function comp(): void {
+    #|  const data: Props = { x: 1, y: "hi" };
+    #|  const _ = <Foo {...data} y="bye"/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: JSX spread feeds generic component inference" {
+  // T is inferred from the spread's `value: string` field; the explicit
+  // children string then matches `T = string`.
+  let src =
+    #|function Wrap<T>(props: { value: T; children: T }): void {}
+    #|function comp(): void {
+    #|  const data = { value: "hi" };
+    #|  const _ = <Wrap {...data}>other</Wrap>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -4179,8 +4179,10 @@ test "expr_check: JSX boolean attribute satisfies a boolean prop" {
 
 ///|
 test "expr_check: JSX text children pass through cleanly" {
+  // Component declares an optional `children` prop, so the text child
+  // is accepted.
   let src =
-    #|interface Props { name: string }
+    #|interface Props { name: string; children?: any }
     #|function Greet(props: Props): void {}
     #|function comp(): void {
     #|  const _ = <Greet name="hi">Hello, world!</Greet>;
@@ -4235,6 +4237,90 @@ test "expr_check: nested HTML inside component children skips inner validation" 
     #|function Wrap(props: { children?: any }): void {}
     #|function comp(): void {
     #|  const _ = <Wrap><div className="x">hello</div></Wrap>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}
+
+// ---------------------------------------------------------------------------
+// Round 41: JSX children prop type validation. The synthetic
+// `children` value is checked against the receiving component's
+// declared `children` prop type (when one is present).
+// ---------------------------------------------------------------------------
+
+///|
+test "expr_check: JSX children string prop accepts a text child" {
+  let src =
+    #|function Caption(props: { children: string }): void {}
+    #|function comp(): void {
+    #|  const _ = <Caption>Hello!</Caption>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: JSX children string prop rejects a numeric child" {
+  let src =
+    #|function Caption(props: { children: string }): void {}
+    #|function comp(): void {
+    #|  const _ = <Caption>{42}</Caption>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.path.contains("<Caption> children") &&
+      i.message.contains("string") &&
+      i.message.contains("number") {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
+test "expr_check: JSX required children prop flagged when missing" {
+  let src =
+    #|function Caption(props: { children: string }): void {}
+    #|function comp(): void {
+    #|  const _ = <Caption/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.path.contains("missing prop `children`") {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
+test "expr_check: JSX children supplied to component without children prop" {
+  let src =
+    #|function Atom(props: { name: string }): void {}
+    #|function comp(): void {
+    #|  const _ = <Atom name="x">extra</Atom>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.path.contains("<Atom> children") &&
+      i.message.contains("does not declare") {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
+test "expr_check: JSX children any prop accepts anything" {
+  let src =
+    #|function Box(props: { children: any }): void {}
+    #|function comp(): void {
+    #|  const _ = <Box>text and {123} more</Box>;
     #|}
   let module_ = parse_module_or_empty(src)
   let issues = check_module_function_bodies(module_)

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -3893,3 +3893,76 @@ test "expr_check: Omit<T, K> flags excess listed-key field" {
   }
   assert_true(found)
 }
+
+// ---------------------------------------------------------------------------
+// Round 37: class method body checking. Method bodies are now stored on
+// `TsClassMethodDecl.body` and `check_module_function_bodies` walks them
+// alongside top-level functions.
+// ---------------------------------------------------------------------------
+
+///|
+test "expr_check: class method body flags wrong return type" {
+  let src =
+    #|class Greeter {
+    #|  hello(name: string): number {
+    #|    return name;
+    #|  }
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.path.contains("Greeter.hello") &&
+      i.message.contains("number") &&
+      i.message.contains("string") {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
+test "expr_check: class method body with correct return passes" {
+  let src =
+    #|class Greeter {
+    #|  hello(name: string): string {
+    #|    return name;
+    #|  }
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: class method body with bad call site is flagged" {
+  let src =
+    #|function takesString(s: string): void {}
+    #|class C {
+    #|  m(): void {
+    #|    takesString(42);
+    #|  }
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.path.contains("C.m") &&
+      i.message.contains("string") &&
+      i.message.contains("number") {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
+test "expr_check: declare-class method has no body to check" {
+  // Ambient class declarations don't carry a body; the checker
+  // shouldn't crash or invent issues.
+  let src =
+    #|declare class B {
+    #|  hello(name: string): string;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -3966,3 +3966,91 @@ test "expr_check: declare-class method has no body to check" {
   let issues = check_module_function_bodies(module_)
   assert_eq(issues.length(), 0)
 }
+
+// ---------------------------------------------------------------------------
+// Round 38: minimal JSX support. `<Tag attr={expr}>{child}</Tag>` parses
+// into `JsxElement(embedded)` whose payload is the list of `{…}` sub-
+// expressions; the checker recurses into each so call-site mismatches
+// inside JSX braces surface as usual.
+// ---------------------------------------------------------------------------
+
+///|
+test "expr_check: bad call inside JSX brace surfaces" {
+  // `takesString(42)` is wrong; the call sits inside a JSX expression
+  // child but the embedded-expression walker should still flag it.
+  let src =
+    #|function takesString(s: string): void {}
+    #|function comp(): void {
+    #|  const _ = <div>{takesString(42)}</div>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.message.contains("string") && i.message.contains("number") {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
+test "expr_check: bad call inside JSX attribute surfaces" {
+  let src =
+    #|function takesNumber(n: number): void {}
+    #|function comp(): void {
+    #|  const _ = <div className={takesNumber("x")}/>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.message.contains("number") && i.message.contains("string") {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
+test "expr_check: JSX with no embedded calls produces no issues" {
+  let src =
+    #|function comp(): void {
+    #|  const _ = <div className="x">hello</div>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: JSX fragment with embedded expressions" {
+  let src =
+    #|function takesString(s: string): void {}
+    #|function comp(): void {
+    #|  const _ = <>{takesString(99)}</>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.message.contains("string") && i.message.contains("number") {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
+test "expr_check: nested JSX surfaces inner-tag embedded calls" {
+  let src =
+    #|function takesString(s: string): void {}
+    #|function comp(): void {
+    #|  const _ = <div><span>{takesString(7)}</span></div>;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let mut found = false
+  for i in check_module_function_bodies(module_) {
+    if i.message.contains("string") && i.message.contains("number") {
+      found = true
+    }
+  }
+  assert_true(found)
+}

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -103,6 +103,11 @@ fn build_runtime_class_decl(
                 params,
                 return_type: func.return_type,
                 is_static,
+                body: if func.body.stmts.length() == 0 {
+                  None
+                } else {
+                  Some(func.body)
+                },
               })
             }
           }

--- a/src/parser/parser_expr.mbt
+++ b/src/parser/parser_expr.mbt
@@ -343,6 +343,17 @@ fn Parser::parse_assignment(self : Parser) -> @ast.TsExpr raise ParseError {
         let right = self.parse_assignment()
         IndexAssignExpr(obj, index, right)
       }
+      // Destructuring assignment whose LHS slipped past
+      // `is_destructuring_assignment_start` because the spread / element
+      // target wasn't expressible as a simple binding pattern — e.g.
+      // `{ ...super.a } = { ... }`. Consume the `=` and wrap as an
+      // `AssignPattern` with a `Target(...)` binding so the parser can
+      // move on. Downstream passes treat the construct opaquely.
+      ObjectLit(_) | ArrayLit(_) => {
+        let _ = self.advance()
+        let right = self.parse_assignment()
+        AssignPattern(@ast.TsBinding::Target(left), right)
+      }
       _ => left
     }
   } else if self.match_(PlusEq) {

--- a/src/parser/parser_expr.mbt
+++ b/src/parser/parser_expr.mbt
@@ -1050,10 +1050,10 @@ fn Parser::parse_parenthesized_expr(
   if self.peek_at(1).kind == Lt {
     let temp = { ..self, pos: self.pos + 1 }
     if temp.is_jsx_element_start() {
-      temp.skip_jsx_element()
+      let jsx_expr = temp.parse_jsx_element_expr()
       if temp.check(RParen) {
         self.pos = temp.pos + 1
-        return Var("__jsx__")
+        return jsx_expr
       }
     }
   }
@@ -1341,6 +1341,148 @@ fn Parser::scan_type_assertion_source_end(
 }
 
 ///|
+/// Walk a JSX element starting at source position `start` and return
+/// both its end position and the embedded `{expr}` sub-expressions
+/// (attribute values, child expressions, spread targets). The caller
+/// uses the end position to advance the lexer and wraps the embedded
+/// expressions in a `JsxElement(...)` AST node so the checker still
+/// validates calls / type mismatches inside braces.
+fn Parser::scan_jsx_source_end_with_embeds(
+  self : Parser,
+  start : Int,
+) -> (Int, Array[@ast.TsExpr]) {
+  let embeds : Array[@ast.TsExpr] = []
+  let mut i = start
+  let mut depth = 0
+  while i < self.src.length() {
+    let c = self.src[i].to_int().unsafe_to_char()
+    if c == '{' {
+      let end = self.skip_jsx_braces_in_source(i)
+      // Capture the source between `{` and the matching `}` and try to
+      // parse it as a TS expression. Empty braces (`{}`) are ignored.
+      if end > i + 1 {
+        let inner = self.src[i + 1:end - 1].to_string()
+        let trimmed = inner.trim()
+        if trimmed.length() > 0 {
+          // Spread-attribute syntax `{...expr}` and child-spread
+          // `{...arr}` show up as a leading `...`; strip it before
+          // parsing.
+          let payload_str = if trimmed.has_prefix("...") {
+            trimmed[3:].to_string().trim().to_string()
+          } else {
+            trimmed.to_string()
+          }
+          let sub = Parser::from_source_with_jsx(payload_str, self.allow_jsx)
+          match (try? sub.parse_expr()) {
+            Ok(e) => embeds.push(e)
+            Err(_) => ()
+          }
+        }
+      }
+      i = end
+      continue
+    }
+    if c != '<' {
+      i += 1
+      continue
+    }
+    if i + 2 < self.src.length() &&
+      self.src[i + 1].to_int().unsafe_to_char() == '/' &&
+      self.src[i + 2].to_int().unsafe_to_char() == '>' {
+      i += 3
+      if depth > 0 {
+        depth -= 1
+      }
+      if depth == 0 {
+        break
+      }
+      continue
+    }
+    if i + 1 < self.src.length() &&
+      self.src[i + 1].to_int().unsafe_to_char() == '>' {
+      depth += 1
+      i += 2
+      continue
+    }
+    if i + 1 < self.src.length() &&
+      self.src[i + 1].to_int().unsafe_to_char() == '/' {
+      i += 2
+      while i < self.src.length() &&
+            self.src[i].to_int().unsafe_to_char() != '>' {
+        i += 1
+      }
+      if i < self.src.length() {
+        i += 1
+      }
+      if depth > 0 {
+        depth -= 1
+      }
+      if depth == 0 {
+        break
+      }
+      continue
+    }
+    depth += 1
+    i += 1
+    let mut quote : Char? = None
+    while i < self.src.length() {
+      let inner = self.src[i].to_int().unsafe_to_char()
+      match quote {
+        Some(q) => {
+          if inner == '\\' {
+            i += 2
+            continue
+          }
+          if inner == q {
+            quote = None
+          }
+          i += 1
+        }
+        None =>
+          if inner == '"' || inner == '\'' || inner == '`' {
+            quote = Some(inner)
+            i += 1
+          } else if inner == '{' {
+            let end = self.skip_jsx_braces_in_source(i)
+            if end > i + 1 {
+              let inner_src = self.src[i + 1:end - 1].to_string()
+              let trimmed = inner_src.trim()
+              if trimmed.length() > 0 {
+                let payload_str = if trimmed.has_prefix("...") {
+                  trimmed[3:].to_string().trim().to_string()
+                } else {
+                  trimmed.to_string()
+                }
+                let sub = Parser::from_source_with_jsx(payload_str, self.allow_jsx)
+                match (try? sub.parse_expr()) {
+                  Ok(e) => embeds.push(e)
+                  Err(_) => ()
+                }
+              }
+            }
+            i = end
+          } else if inner == '/' &&
+            i + 1 < self.src.length() &&
+            self.src[i + 1].to_int().unsafe_to_char() == '>' {
+            i += 2
+            depth -= 1
+            break
+          } else if inner == '>' {
+            i += 1
+            break
+          } else {
+            i += 1
+          }
+      }
+    }
+    if depth == 0 {
+      break
+    }
+  }
+  (i, embeds)
+}
+
+///|
 fn Parser::scan_jsx_source_end(self : Parser, start : Int) -> Int {
   let mut i = start
   let mut depth = 0
@@ -1436,8 +1578,19 @@ fn Parser::scan_jsx_source_end(self : Parser, start : Int) -> Int {
 
 ///|
 fn Parser::try_skip_parenthesized_jsx_expr(self : Parser) -> Bool {
+  let (ok, _) = self.try_parse_parenthesized_jsx_expr()
+  ok
+}
+
+///|
+/// Same as `try_skip_parenthesized_jsx_expr` but also returns the
+/// embedded `{expr}` sub-expressions extracted from the JSX block.
+/// Caller wraps them in `JsxElement(...)`.
+fn Parser::try_parse_parenthesized_jsx_expr(
+  self : Parser,
+) -> (Bool, Array[@ast.TsExpr]) {
   if self.src.length() == 0 || !self.check(LParen) {
-    return false
+    return (false, [])
   }
   let mut i = self.peek().pos + 1
   while i < self.src.length() {
@@ -1449,9 +1602,9 @@ fn Parser::try_skip_parenthesized_jsx_expr(self : Parser) -> Bool {
     }
   }
   if i >= self.src.length() || self.src[i].to_int().unsafe_to_char() != '<' {
-    return false
+    return (false, [])
   }
-  let jsx_end = self.scan_jsx_source_end(i)
+  let (jsx_end, embeds) = self.scan_jsx_source_end_with_embeds(i)
   let mut j = jsx_end
   while j < self.src.length() {
     let c = self.src[j].to_int().unsafe_to_char()
@@ -1463,9 +1616,9 @@ fn Parser::try_skip_parenthesized_jsx_expr(self : Parser) -> Bool {
   }
   if j < self.src.length() && self.src[j].to_int().unsafe_to_char() == ')' {
     self.advance_to_source_pos(j + 1)
-    return true
+    return (true, embeds)
   }
-  false
+  (false, [])
 }
 
 ///|
@@ -1566,6 +1719,23 @@ fn Parser::skip_jsx_element(self : Parser) -> Unit {
   }
   let i = self.scan_jsx_source_end(self.peek().pos)
   self.advance_to_source_pos(i)
+}
+
+///|
+/// Same as `skip_jsx_element` but returns the embedded `{expr}` sub-
+/// expressions so callers can wrap them in a `JsxElement(...)` AST
+/// node. Call sites that want a real AST should prefer this over
+/// `skip_jsx_element + Var("__jsx__")`.
+fn Parser::parse_jsx_element_expr(
+  self : Parser,
+) -> @ast.TsExpr raise ParseError {
+  if self.src.length() == 0 {
+    self.skip_jsx_element_tokens()
+    return @ast.TsExpr::JsxElement([])
+  }
+  let (end, embeds) = self.scan_jsx_source_end_with_embeds(self.peek().pos)
+  self.advance_to_source_pos(end)
+  @ast.TsExpr::JsxElement(embeds)
 }
 
 ///|
@@ -1829,8 +1999,7 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
       } else if !self.allow_jsx {
         self.parse_angle_bracket_type_assertion()
       } else if self.is_jsx_element_start() {
-        self.skip_jsx_element()
-        Var("__jsx__")
+        self.parse_jsx_element_expr()
       } else {
         raise ParseError("Unexpected token: Lt")
       }
@@ -2064,17 +2233,18 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
       }
       Var(mangled)
     }
-    LParen =>
-      if self.try_skip_parenthesized_jsx_expr() {
-        Var("__jsx__")
+    LParen => {
+      let (paren_jsx, paren_embeds) = self.try_parse_parenthesized_jsx_expr()
+      if paren_jsx {
+        @ast.TsExpr::JsxElement(paren_embeds)
         // functioncheck
       } else if self.peek_at(1).kind == Lt {
         let temp = { ..self, pos: self.pos + 1 }
         if temp.is_jsx_element_start() {
-          temp.skip_jsx_element()
+          let jsx_expr = temp.parse_jsx_element_expr()
           if temp.check(RParen) {
             self.pos = temp.pos + 1
-            Var("__jsx__")
+            jsx_expr
           } else if self.is_arrow_function() {
             // function: (params) => body
             let _ = self.advance() // (
@@ -2223,6 +2393,7 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
         // regularexpression
         self.parse_parenthesized_expr()
       }
+    }
     LBracket => {
       // arrayliteral: [1, 2, 3]
       let _ = self.advance()

--- a/src/parser/parser_expr.mbt
+++ b/src/parser/parser_expr.mbt
@@ -1921,10 +1921,370 @@ fn Parser::parse_jsx_element_expr(
     self.skip_jsx_element_tokens()
     return @ast.TsExpr::JsxElement("", [], [])
   }
-  let (end, tag, attrs, child_embeds) = self
-    .scan_jsx_source_end_with_structure(self.peek().pos)
-  self.advance_to_source_pos(end)
-  @ast.TsExpr::JsxElement(tag, attrs, child_embeds)
+  let start = self.peek().pos
+  match self.parse_jsx_element_at_source(start) {
+    Some((end, element)) => {
+      self.advance_to_source_pos(end)
+      element
+    }
+    None => {
+      // Fallback: structural parse failed — use the legacy flat
+      // scanner so the parser still makes progress.
+      let (end, tag, attrs, child_embeds) = self
+        .scan_jsx_source_end_with_structure(start)
+      self.advance_to_source_pos(end)
+      @ast.TsExpr::JsxElement(tag, attrs, child_embeds)
+    }
+  }
+}
+
+///|
+/// Recursive-descent JSX element parser. Returns `(end_pos, element)`
+/// when parsing succeeds, or `None` if the source at `start` doesn't
+/// open with a recognisable JSX element. Used by
+/// `parse_jsx_element_expr` to assemble a fully structured
+/// `JsxElement` node (tag + attrs + per-child entries) rather than the
+/// flat `embeds` list produced by the legacy scanner.
+fn Parser::parse_jsx_element_at_source(
+  self : Parser,
+  start : Int,
+) -> (Int, @ast.TsExpr)? {
+  if start >= self.src.length() ||
+    self.src[start].to_int().unsafe_to_char() != '<' {
+    return None
+  }
+  // Empty fragment `<>` opener.
+  let after_open = start + 1
+  if after_open < self.src.length() &&
+    self.src[after_open].to_int().unsafe_to_char() == '>' {
+    let body_start = after_open + 1
+    match self.parse_jsx_children(body_start, "") {
+      Some((after_body, children)) => {
+        // Expect `</>` to close.
+        if after_body + 2 < self.src.length() &&
+          self.src[after_body].to_int().unsafe_to_char() == '<' &&
+          self.src[after_body + 1].to_int().unsafe_to_char() == '/' &&
+          self.src[after_body + 2].to_int().unsafe_to_char() == '>' {
+          return Some(
+            (after_body + 3, @ast.TsExpr::JsxElement("", [], children)),
+          )
+        }
+        None
+      }
+      None => None
+    }
+  } else {
+    // Named opener — parse the tag header.
+    let (header_end, tag, attrs, self_close) = self
+      .parse_jsx_opening_header(start)
+    if tag == "" {
+      return None
+    }
+    if self_close {
+      return Some(
+        (header_end, @ast.TsExpr::JsxElement(tag, attrs, [])),
+      )
+    }
+    // Paired element — recurse on children until matching closing tag.
+    match self.parse_jsx_children(header_end, tag) {
+      Some((after_body, children)) => {
+        // Consume `</tag>`.
+        let after_close = self.skip_jsx_closing_tag(after_body, tag)
+        match after_close {
+          Some(end) =>
+            Some((end, @ast.TsExpr::JsxElement(tag, attrs, children)))
+          None => None
+        }
+      }
+      None => None
+    }
+  }
+}
+
+///|
+/// Parse a JSX opening header at `start` — `<Tag attr={…} …>` or
+/// `<Tag …/>`. Returns the position right after the closing `>` /
+/// `/>`, the tag name, the attribute list, and a `self_close` flag
+/// indicating whether the element terminates immediately. An empty
+/// tag name signals a malformed shape that the caller should treat
+/// as a parse failure.
+fn Parser::parse_jsx_opening_header(
+  self : Parser,
+  start : Int,
+) -> (Int, String, Array[(String, @ast.TsExpr?)], Bool) {
+  let attrs : Array[(String, @ast.TsExpr?)] = []
+  let mut i = start
+  if i >= self.src.length() || self.src[i].to_int().unsafe_to_char() != '<' {
+    return (i, "", attrs, false)
+  }
+  i += 1
+  while i < self.src.length() {
+    let c = self.src[i].to_int().unsafe_to_char()
+    if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+      i += 1
+    } else {
+      break
+    }
+  }
+  if i >= self.src.length() {
+    return (i, "", attrs, false)
+  }
+  let first = self.src[i].to_int().unsafe_to_char()
+  if first == '>' || first == '/' {
+    return (i, "", attrs, false)
+  }
+  let name_start = i
+  while i < self.src.length() {
+    let c = self.src[i].to_int().unsafe_to_char()
+    if (c >= 'a' && c <= 'z') ||
+      (c >= 'A' && c <= 'Z') ||
+      (c >= '0' && c <= '9') ||
+      c == '_' ||
+      c == '$' ||
+      c == '.' ||
+      c == '-' {
+      i += 1
+    } else {
+      break
+    }
+  }
+  let tag = self.src[name_start:i].to_string()
+  let mut self_close = false
+  // Attributes.
+  while i < self.src.length() {
+    let c = self.src[i].to_int().unsafe_to_char()
+    if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+      i += 1
+      continue
+    }
+    if c == '>' {
+      i += 1
+      break
+    }
+    if c == '/' &&
+      i + 1 < self.src.length() &&
+      self.src[i + 1].to_int().unsafe_to_char() == '>' {
+      self_close = true
+      i += 2
+      break
+    }
+    if c == '{' {
+      // Spread / standalone attribute. Skip but advance.
+      let end = self.skip_jsx_braces_in_source(i)
+      i = end
+      continue
+    }
+    // Attribute name.
+    let name_start = i
+    while i < self.src.length() {
+      let nc = self.src[i].to_int().unsafe_to_char()
+      if (nc >= 'a' && nc <= 'z') ||
+        (nc >= 'A' && nc <= 'Z') ||
+        (nc >= '0' && nc <= '9') ||
+        nc == '_' ||
+        nc == '$' ||
+        nc == '-' ||
+        nc == ':' {
+        i += 1
+      } else {
+        break
+      }
+    }
+    if i == name_start {
+      break
+    }
+    let attr_name = self.src[name_start:i].to_string()
+    while i < self.src.length() {
+      let wc = self.src[i].to_int().unsafe_to_char()
+      if wc == ' ' || wc == '\t' || wc == '\n' || wc == '\r' {
+        i += 1
+      } else {
+        break
+      }
+    }
+    if i < self.src.length() && self.src[i].to_int().unsafe_to_char() == '=' {
+      i += 1
+      while i < self.src.length() {
+        let wc = self.src[i].to_int().unsafe_to_char()
+        if wc == ' ' || wc == '\t' || wc == '\n' || wc == '\r' {
+          i += 1
+        } else {
+          break
+        }
+      }
+      if i < self.src.length() {
+        let vc = self.src[i].to_int().unsafe_to_char()
+        if vc == '{' {
+          let end = self.skip_jsx_braces_in_source(i)
+          let inner_src = self.src[i + 1:end - 1].to_string()
+          let trimmed = inner_src.trim()
+          if trimmed.length() > 0 {
+            let payload_str = if trimmed.has_prefix("...") {
+              trimmed[3:].to_string().trim().to_string()
+            } else {
+              trimmed.to_string()
+            }
+            let sub = Parser::from_source_with_jsx(payload_str, self.allow_jsx)
+            match (try? sub.parse_expr()) {
+              Ok(e) => attrs.push((attr_name, Some(e)))
+              Err(_) => attrs.push((attr_name, None))
+            }
+          } else {
+            attrs.push((attr_name, None))
+          }
+          i = end
+        } else if vc == '"' || vc == '\'' {
+          let quote = vc
+          let str_start = i + 1
+          i += 1
+          while i < self.src.length() &&
+                self.src[i].to_int().unsafe_to_char() != quote {
+            i += 1
+          }
+          let raw = self.src[str_start:i].to_string()
+          attrs.push((attr_name, Some(@ast.TsExpr::StringLit(raw))))
+          if i < self.src.length() {
+            i += 1
+          }
+        } else {
+          attrs.push((attr_name, None))
+        }
+      } else {
+        attrs.push((attr_name, None))
+      }
+    } else {
+      attrs.push((attr_name, None))
+    }
+  }
+  (i, tag, attrs, self_close)
+}
+
+///|
+/// Parse JSX children starting at `start` until we encounter the
+/// closing tag matching `closing_tag` (or `</>` when `closing_tag` is
+/// empty, indicating a fragment). Returns the position of the closing
+/// `<` and the assembled children list. `None` on malformed input.
+fn Parser::parse_jsx_children(
+  self : Parser,
+  start : Int,
+  closing_tag : String,
+) -> (Int, Array[@ast.TsExpr])? {
+  let children : Array[@ast.TsExpr] = []
+  let mut i = start
+  let mut text_start = i
+  let flush_text = fn(end_idx) {
+    if end_idx > text_start {
+      let raw = self.src[text_start:end_idx].to_string()
+      let trimmed = raw.trim()
+      if trimmed.length() > 0 {
+        children.push(@ast.TsExpr::StringLit(raw))
+      }
+    }
+  }
+  while i < self.src.length() {
+    let c = self.src[i].to_int().unsafe_to_char()
+    if c == '<' {
+      // Closing tag?
+      if i + 1 < self.src.length() &&
+        self.src[i + 1].to_int().unsafe_to_char() == '/' {
+        flush_text(i)
+        return Some((i, children))
+      }
+      // Nested element.
+      flush_text(i)
+      match self.parse_jsx_element_at_source(i) {
+        Some((after, element)) => {
+          children.push(element)
+          i = after
+          text_start = i
+        }
+        None => return None
+      }
+      continue
+    }
+    if c == '{' {
+      flush_text(i)
+      let end = self.skip_jsx_braces_in_source(i)
+      let inner_src = self.src[i + 1:end - 1].to_string()
+      let trimmed = inner_src.trim()
+      if trimmed.length() > 0 {
+        let payload_str = if trimmed.has_prefix("...") {
+          trimmed[3:].to_string().trim().to_string()
+        } else {
+          trimmed.to_string()
+        }
+        let sub = Parser::from_source_with_jsx(payload_str, self.allow_jsx)
+        match (try? sub.parse_expr()) {
+          Ok(e) => children.push(e)
+          Err(_) => ()
+        }
+      }
+      i = end
+      text_start = i
+      continue
+    }
+    i += 1
+  }
+  let _ = closing_tag
+  // Reached EOF without finding a closing tag — malformed.
+  None
+}
+
+///|
+/// Consume `</tag>` starting at position `start`. Returns the position
+/// right after `>` on success, `None` if the source doesn't match.
+fn Parser::skip_jsx_closing_tag(
+  self : Parser,
+  start : Int,
+  tag : String,
+) -> Int? {
+  let mut i = start
+  if i + 1 >= self.src.length() ||
+    self.src[i].to_int().unsafe_to_char() != '<' ||
+    self.src[i + 1].to_int().unsafe_to_char() != '/' {
+    return None
+  }
+  i += 2
+  while i < self.src.length() {
+    let c = self.src[i].to_int().unsafe_to_char()
+    if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+      i += 1
+    } else {
+      break
+    }
+  }
+  let name_start = i
+  while i < self.src.length() {
+    let c = self.src[i].to_int().unsafe_to_char()
+    if (c >= 'a' && c <= 'z') ||
+      (c >= 'A' && c <= 'Z') ||
+      (c >= '0' && c <= '9') ||
+      c == '_' ||
+      c == '$' ||
+      c == '.' ||
+      c == '-' {
+      i += 1
+    } else {
+      break
+    }
+  }
+  let closing_name = self.src[name_start:i].to_string()
+  if closing_name != tag {
+    return None
+  }
+  while i < self.src.length() {
+    let c = self.src[i].to_int().unsafe_to_char()
+    if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+      i += 1
+    } else {
+      break
+    }
+  }
+  if i < self.src.length() && self.src[i].to_int().unsafe_to_char() == '>' {
+    Some(i + 1)
+  } else {
+    None
+  }
 }
 
 ///|

--- a/src/parser/parser_expr.mbt
+++ b/src/parser/parser_expr.mbt
@@ -1342,6 +1342,194 @@ fn Parser::scan_type_assertion_source_end(
 
 ///|
 /// Walk a JSX element starting at source position `start` and return
+/// its end position, the (opening-tag) tag name, the attribute list,
+/// and any remaining embedded `{expr}` sub-expressions from children
+/// / spread positions. Used by `parse_jsx_element_expr` to build a
+/// `JsxElement(tag, attrs, embeds)` AST node.
+fn Parser::scan_jsx_source_end_with_structure(
+  self : Parser,
+  start : Int,
+) -> (Int, String, Array[(String, @ast.TsExpr?)], Array[@ast.TsExpr]) {
+  let (end, embeds) = self.scan_jsx_source_end_with_embeds(start)
+  let (tag, attrs, attr_embed_count) = self.parse_jsx_opening_tag(start)
+  // The first `attr_embed_count` embeds came from attribute values;
+  // the rest are children / spreads.
+  let child_embeds : Array[@ast.TsExpr] = []
+  let mut i = attr_embed_count
+  while i < embeds.length() {
+    child_embeds.push(embeds[i])
+    i = i + 1
+  }
+  (end, tag, attrs, child_embeds)
+}
+
+///|
+/// Parse a JSX opening tag (`<Tag attr="x" foo={bar} {...spread}>` or
+/// `<Tag />` / `</Tag>`) starting at source position `start`. Returns
+/// the tag name, the attribute list, and the count of embedded
+/// `{expr}` values that were consumed inside attribute slots (so the
+/// caller can split the flat embed array into attr vs child halves).
+/// Falls back to empty results when the opening shape is malformed.
+fn Parser::parse_jsx_opening_tag(
+  self : Parser,
+  start : Int,
+) -> (String, Array[(String, @ast.TsExpr?)], Int) {
+  let attrs : Array[(String, @ast.TsExpr?)] = []
+  let mut attr_embeds = 0
+  let mut i = start
+  if i >= self.src.length() || self.src[i].to_int().unsafe_to_char() != '<' {
+    return ("", attrs, 0)
+  }
+  i += 1
+  // Skip whitespace.
+  while i < self.src.length() {
+    let c = self.src[i].to_int().unsafe_to_char()
+    if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+      i += 1
+    } else {
+      break
+    }
+  }
+  // Fragment `<>` / closing-element `</…>` — no name.
+  if i < self.src.length() &&
+    (self.src[i].to_int().unsafe_to_char() == '>' ||
+      self.src[i].to_int().unsafe_to_char() == '/') {
+    return ("", attrs, 0)
+  }
+  // Tag name (identifier with optional `.member.access`).
+  let tag_start = i
+  while i < self.src.length() {
+    let c = self.src[i].to_int().unsafe_to_char()
+    if (c >= 'a' && c <= 'z') ||
+      (c >= 'A' && c <= 'Z') ||
+      (c >= '0' && c <= '9') ||
+      c == '_' ||
+      c == '$' ||
+      c == '.' ||
+      c == '-' {
+      i += 1
+    } else {
+      break
+    }
+  }
+  let tag = self.src[tag_start:i].to_string()
+  // Attributes loop.
+  while i < self.src.length() {
+    let c = self.src[i].to_int().unsafe_to_char()
+    if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+      i += 1
+      continue
+    }
+    if c == '>' || c == '/' || c == '<' {
+      break
+    }
+    // `{...expr}` spread attribute — embed counted; no name pair.
+    if c == '{' {
+      let end = self.skip_jsx_braces_in_source(i)
+      if end > i + 1 {
+        let inner = self.src[i + 1:end - 1].to_string()
+        let trimmed = inner.trim()
+        if trimmed.length() > 0 {
+          attr_embeds = attr_embeds + 1
+        }
+      }
+      i = end
+      continue
+    }
+    // Attribute name.
+    let name_start = i
+    while i < self.src.length() {
+      let nc = self.src[i].to_int().unsafe_to_char()
+      if (nc >= 'a' && nc <= 'z') ||
+        (nc >= 'A' && nc <= 'Z') ||
+        (nc >= '0' && nc <= '9') ||
+        nc == '_' ||
+        nc == '$' ||
+        nc == '-' ||
+        nc == ':' {
+        i += 1
+      } else {
+        break
+      }
+    }
+    if i == name_start {
+      // Couldn't lex a name — break to avoid an infinite loop.
+      break
+    }
+    let attr_name = self.src[name_start:i].to_string()
+    // Skip whitespace.
+    while i < self.src.length() {
+      let wc = self.src[i].to_int().unsafe_to_char()
+      if wc == ' ' || wc == '\t' || wc == '\n' || wc == '\r' {
+        i += 1
+      } else {
+        break
+      }
+    }
+    // Optional value.
+    if i < self.src.length() && self.src[i].to_int().unsafe_to_char() == '=' {
+      i += 1
+      while i < self.src.length() {
+        let wc = self.src[i].to_int().unsafe_to_char()
+        if wc == ' ' || wc == '\t' || wc == '\n' || wc == '\r' {
+          i += 1
+        } else {
+          break
+        }
+      }
+      if i < self.src.length() {
+        let vc = self.src[i].to_int().unsafe_to_char()
+        if vc == '{' {
+          let end = self.skip_jsx_braces_in_source(i)
+          let inner = self.src[i + 1:end - 1].to_string()
+          let trimmed = inner.trim()
+          if trimmed.length() > 0 {
+            let payload_str = if trimmed.has_prefix("...") {
+              trimmed[3:].to_string().trim().to_string()
+            } else {
+              trimmed.to_string()
+            }
+            let sub = Parser::from_source_with_jsx(payload_str, self.allow_jsx)
+            match (try? sub.parse_expr()) {
+              Ok(e) => {
+                attrs.push((attr_name, Some(e)))
+                attr_embeds = attr_embeds + 1
+              }
+              Err(_) => attrs.push((attr_name, None))
+            }
+          } else {
+            attrs.push((attr_name, None))
+          }
+          i = end
+        } else if vc == '"' || vc == '\'' {
+          let quote = vc
+          let str_start = i + 1
+          i += 1
+          while i < self.src.length() &&
+                self.src[i].to_int().unsafe_to_char() != quote {
+            i += 1
+          }
+          let raw = self.src[str_start:i].to_string()
+          attrs.push((attr_name, Some(@ast.TsExpr::StringLit(raw))))
+          if i < self.src.length() {
+            i += 1
+          }
+        } else {
+          attrs.push((attr_name, None))
+        }
+      } else {
+        attrs.push((attr_name, None))
+      }
+    } else {
+      // Boolean attribute.
+      attrs.push((attr_name, None))
+    }
+  }
+  (tag, attrs, attr_embeds)
+}
+
+///|
+/// Walk a JSX element starting at source position `start` and return
 /// both its end position and the embedded `{expr}` sub-expressions
 /// (attribute values, child expressions, spread targets). The caller
 /// uses the end position to advance the lexer and wraps the embedded
@@ -1731,11 +1919,12 @@ fn Parser::parse_jsx_element_expr(
 ) -> @ast.TsExpr raise ParseError {
   if self.src.length() == 0 {
     self.skip_jsx_element_tokens()
-    return @ast.TsExpr::JsxElement([])
+    return @ast.TsExpr::JsxElement("", [], [])
   }
-  let (end, embeds) = self.scan_jsx_source_end_with_embeds(self.peek().pos)
+  let (end, tag, attrs, child_embeds) = self
+    .scan_jsx_source_end_with_structure(self.peek().pos)
   self.advance_to_source_pos(end)
-  @ast.TsExpr::JsxElement(embeds)
+  @ast.TsExpr::JsxElement(tag, attrs, child_embeds)
 }
 
 ///|
@@ -2236,7 +2425,10 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
     LParen => {
       let (paren_jsx, paren_embeds) = self.try_parse_parenthesized_jsx_expr()
       if paren_jsx {
-        @ast.TsExpr::JsxElement(paren_embeds)
+        // Parenthesised-JSX fallback: skip tag / attr extraction since
+        // the existing skipper doesn't preserve start-positions. The
+        // checker still recurses into the embedded sub-expressions.
+        @ast.TsExpr::JsxElement("", [], paren_embeds)
         // functioncheck
       } else if self.peek_at(1).kind == Lt {
         let temp = { ..self, pos: self.pos + 1 }

--- a/src/parser/parser_expr.mbt
+++ b/src/parser/parser_expr.mbt
@@ -2069,8 +2069,20 @@ fn Parser::parse_jsx_opening_header(
       break
     }
     if c == '{' {
-      // Spread / standalone attribute. Skip but advance.
+      // Spread attribute `{...expr}` — capture as ("", Some(expr)).
       let end = self.skip_jsx_braces_in_source(i)
+      if end > i + 1 {
+        let inner_src = self.src[i + 1:end - 1].to_string()
+        let trimmed = inner_src.trim()
+        if trimmed.length() > 0 && trimmed.has_prefix("...") {
+          let payload_str = trimmed[3:].to_string().trim().to_string()
+          let sub = Parser::from_source_with_jsx(payload_str, self.allow_jsx)
+          match (try? sub.parse_expr()) {
+            Ok(e) => attrs.push(("", Some(e)))
+            Err(_) => ()
+          }
+        }
+      }
       i = end
       continue
     }

--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -1079,6 +1079,56 @@ pub fn Parser::parse_interface(
         let _ = self.advance()
         "null"
       }
+      // Additional reserved words allowed as interface field names —
+      // TS accepts every keyword in property-name position.
+      Interface => {
+        let _ = self.advance()
+        "interface"
+      }
+      Class => {
+        let _ = self.advance()
+        "class"
+      }
+      Const => {
+        let _ = self.advance()
+        "const"
+      }
+      Var => {
+        let _ = self.advance()
+        "var"
+      }
+      Let => {
+        let _ = self.advance()
+        "let"
+      }
+      New => {
+        let _ = self.advance()
+        "new"
+      }
+      Try => {
+        let _ = self.advance()
+        "try"
+      }
+      Catch => {
+        let _ = self.advance()
+        "catch"
+      }
+      Throw => {
+        let _ = self.advance()
+        "throw"
+      }
+      Finally => {
+        let _ = self.advance()
+        "finally"
+      }
+      Extends => {
+        let _ = self.advance()
+        "extends"
+      }
+      Function => {
+        let _ = self.advance()
+        "function"
+      }
       k =>
         raise ParseError("Expected field name at \{self.peek().pos}, got \{k}")
     }

--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -2106,6 +2106,10 @@ fn Parser::parse_declare_class(
                   params,
                   return_type,
                   is_static,
+                  // Ambient class declarations (`declare class`) and
+                  // interface-style method signatures don't carry a
+                  // body — leave it as `None`.
+                  body: None,
                 })
               }
           }

--- a/src/parser/parser_stmt.mbt
+++ b/src/parser/parser_stmt.mbt
@@ -948,8 +948,10 @@ fn Parser::is_using_declaration_start(self : Parser) -> Bool {
   if self.peek_at(1).has_newline_before {
     return false
   }
+  // Accept contextual keywords (`of`, `from`, `as`, `async`) as binding
+  // names too — TS allows `using of = ...` etc.
   match self.peek_at(1).kind {
-    Ident(_) | LBrace | LBracket => true
+    Ident(_) | LBrace | LBracket | Of | From | As => true
     _ => false
   }
 }
@@ -972,7 +974,7 @@ fn Parser::is_await_using_declaration_start(self : Parser) -> Bool {
     return false
   }
   match self.peek_at(2).kind {
-    Ident(_) | LBrace | LBracket => true
+    Ident(_) | LBrace | LBracket | Of | From | As => true
     _ => false
   }
 }

--- a/src/parser/parser_typescript_wbtest.mbt
+++ b/src/parser/parser_typescript_wbtest.mbt
@@ -716,10 +716,9 @@ async test "checker: smoke-run against TypeScript conformance test corpus" {
     "conformance corpus: total=\{total} parsed=\{parsed} checked=\{checked}",
   )
   // 70 % parse-success floor leaves room for parser-error-recovery test
-  // cases without masking real regressions. (Most of the parse failures
-  // on this corpus correspond to TS files intentionally exercising
-  // syntax errors — `*Errors.ts`, `*Negative.ts`, etc., or experimental
-  // features like ES2023 `using` declarations.)
+  // cases without masking real regressions. (Almost all of the parse
+  // failures on this corpus correspond to TS files intentionally
+  // exercising syntax errors — `*Errors.ts`, `*Negative.ts`, etc.)
   if parsed * 100 < total * 70 {
     for f in parse_failures {
       println("PARSE FAIL " + f)

--- a/src/parser/parser_wbtest.mbt
+++ b/src/parser/parser_wbtest.mbt
@@ -2053,6 +2053,41 @@ test "parser: `using` followed by newline is still a reference" {
 }
 
 ///|
+test "parser: object literal as destructuring-assignment LHS in static field" {
+  // `{ ...super.a } = { x: 0 }` — the LHS is an object literal that's
+  // re-interpreted as a destructuring assignment target. Our binding
+  // pattern parser doesn't accept complex spread targets, so the
+  // assignment falls through to a generic `AssignPattern` with a
+  // `Target(...)` binding.
+  let src =
+    #|class B { static a: any; }
+    #|class C extends B {
+    #|    static z13 = { ...super.a } = { x: 0 };
+    #|}
+  match (try? Parser::from_source(src).parse_module()) {
+    Ok(_) => ()
+    Err(e) => fail("parse error: \{e}")
+  }
+}
+
+///|
+test "parser: array literal as destructuring-assignment LHS" {
+  // `[a, b] = arr` outside of a destructuring-friendly slot — falls
+  // through to the same generic `AssignPattern(Target(...))` path.
+  let src =
+    #|function f(): void {
+    #|  let z;
+    #|  z = [super.a] = [0];
+    #|}
+  // We don't care about super in a function context; parse only checks
+  // the structural shape.
+  match (try? Parser::from_source(src).parse_module()) {
+    Ok(_) => ()
+    Err(e) => fail("parse error: \{e}")
+  }
+}
+
+///|
 test "parser: parse interface call-signature with type predicate return" {
   let src = "interface I1 { (p1: A): p1 is C; }"
   match (try? Parser::from_source(src).parse_module()) {


### PR DESCRIPTION
## Summary

Twelve focused rounds that grow the TypeScript checker's JSX support
from "parse only" to "structural validation of real React-style
code". Each commit ships its own regression tests; the suite is
green at 1417 / 1417.

### Parser

- Class method bodies retained on `TsClassMethodDecl` so the checker
  can walk them.
- Reserved-word interface fields (`type`, `static`, `interface`, …)
  and object-literal destructuring on the LHS of an assignment.
- JSX scanner builds structured `JsxElement(tag, attrs, children)`
  nodes with attribute values parsed as full `TsExpr`s, including
  spread attributes (`<Foo {...props}/>`) as `("", Some(expr))`
  sentinel entries.

### Checker

- Class method body walking via `check_module_function_bodies`.
- Recurse into JSX braces so call-site checks fire inside attribute
  values and children.
- Component prop validation: per-attribute type-check, missing-
  required, boolean attributes.
- Structural child tracking + `children` prop type-check against a
  synthesised single-child / `Array<union>` shape.
- Generic JSX components — infer `T` from supplied attributes and
  substitute into the props shape before per-attribute checks
  (`widen_literal` keeps the bound from collapsing to a narrow
  literal).
- Spread attributes contribute to per-field type checks, missing-
  required tracking, and generic inference.
- Reserved JSX attrs `key` / `ref` skip per-attribute lookup —
  React intercepts them before they reach the component.
- React `key`-in-iteration rule: JSX returned from `xs.map(fn)`
  must declare a `key` attr (walks `MethodCall`, `CallExpr`,
  ternaries, and `&&`).
- Render-prop function-as-children regression tests for
  `children: (x: T) => U`.
- Member-expression component tags `<Layout.Header/>` resolve
  through ingested namespaces (recursive prefix-walk in
  `Resolver::from_module`).

## Test plan

- [x] `moon check` — 0 errors
- [x] `moon test --target native` — 1417 / 1417 passing
- [x] Conformance corpus — 1841 / 1936 (95.1 %)
- [x] All new behavior covered by per-round wbtests under
      `expr_check_wbtest.mbt`

https://claude.ai/code/session_011Ef6B7FcncT572Bqszz5me

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ef6B7FcncT572Bqszz5me)_