### PR TITLE
emit/mangle real-world fixes + .d.ts quality + sourcemap survives mangle

### DIFF
--- a/bench/hono-real/entry.ts
+++ b/bench/hono-real/entry.ts
@@ -1,0 +1,14 @@
+import { Hono } from "hono";
+
+const app = new Hono();
+
+app.get("/", (c) => c.text("hello"));
+app.get("/users/:id", (c) => c.json({ id: c.req.param("id") }));
+app.post("/users", async (c) => {
+  const body = await c.req.json();
+  return c.json({ ok: true, body });
+});
+app.notFound((c) => c.text("not found", 404));
+app.onError((err, c) => c.text("error: " + err.message, 500));
+
+export default app;

--- a/src/transform/bundle.mbt
+++ b/src/transform/bundle.mbt
@@ -39,8 +39,11 @@ pub(all) struct BundleOptions {
   // module in the bundle.
   with_sourcemap : Bool
   // When `true`, run the identifier-mangling pass on the final
-  // concatenated module block. Source-map positions are skipped in
-  // this mode because the rename pass doesn't carry positions yet.
+  // concatenated module block. `--with-sourcemap` is now compatible
+  // with this path: each combined statement's origin (source-id +
+  // byte offset within that source) is encoded into the position
+  // array, the mangle / treeshake / inline passes preserve it
+  // verbatim, and the emit decodes it for the source-map writer.
   mangle : Bool
   // When `true` (and `mangle == true`), also rename non-reserved
   // property keys via the opt-in property-mangling path.
@@ -355,14 +358,38 @@ pub fn bundle_modules(
   if opts.mangle || opts.treeshake || opts.fold {
     let combined_stmts : Array[@ast.TsStmt] = []
     let combined_type_aliases : Array[@ast.TsTypeAlias] = []
+    // Track each combined-statement's origin so the source-map can
+    // map it back to its module after mangle / treeshake / fold
+    // restructure the AST. Encoding: high 24 bits = source-id (the
+    // module's slot in `sources`), low 8 bits = "" — actually we
+    // pack byte_offset in the high bits and source_id in the low 8
+    // so the existing position-as-int representation survives 1:1
+    // transforms verbatim. `combined_source_count` is the next free
+    // source-id slot.
+    let combined_positions : Array[Int] = []
+    let combined_line_indices : Array[LineIndex] = []
+    let mut combined_source_count = 0
     for path in order {
       let m = match modules.get(path) {
         Some(node) => node
         None => continue
       }
       module_paths.push(path)
-      for s in m.block.stmts {
+      // Allocate a source-id for this module and populate the
+      // top-level sources / sources_content / line-index tables.
+      let source_id = combined_source_count
+      combined_source_count = combined_source_count + 1
+      sources.push(path)
+      sources_content.push(m.source)
+      combined_line_indices.push(LineIndex::new(m.source))
+      let has_positions = m.block.stmt_positions.length() == m.block.stmts.length()
+      for j, s in m.block.stmts {
         combined_stmts.push(s)
+        if has_positions {
+          combined_positions.push(encode_combined_position(m.block.stmt_positions[j], source_id))
+        } else {
+          combined_positions.push(encode_combined_position(0, source_id))
+        }
       }
       for ta in m.type_aliases {
         combined_type_aliases.push(ta)
@@ -370,7 +397,7 @@ pub fn bundle_modules(
     }
     let mut combined : @ast.TsBlock = {
       stmts: combined_stmts,
-      stmt_positions: [],
+      stmt_positions: combined_positions,
     }
     // Type-predicate inline.
     {
@@ -498,7 +525,26 @@ pub fn bundle_modules(
       combined = inline_block(combined)
       combined = peephole_block(combined)
     }
-    for s in combined.stmts {
+    let has_combined_positions = combined.stmt_positions.length() ==
+      combined.stmts.length()
+    for i, s in combined.stmts {
+      // When source-maps are on, decode the per-stmt origin and
+      // switch the emitter's line index to the source the stmt
+      // came from before recording the mapping. Stmts whose origin
+      // was lost (synthesized by a transform) have an out-of-range
+      // source-id and are simply skipped.
+      if opts.with_sourcemap && has_combined_positions {
+        let (offset, source_id) = decode_combined_position(combined.stmt_positions[i])
+        if source_id < combined_line_indices.length() {
+          e.line_index = combined_line_indices[source_id]
+          match e.smap {
+            Some(b) => b.set_current_source(source_id)
+            None => ()
+          }
+          let src_pos = e.line_index.position(offset)
+          e.mark(src_pos)
+        }
+      }
       emit_stmt(e, s)
       e.nl()
     }
@@ -812,4 +858,26 @@ fn emit_import_decl(e : Emitter, decl : @ast.TsImportDecl) -> Unit {
     e.write(" }")
   }
   e.write(";")
+}
+
+///|
+/// Encode a (byte_offset, source_id) pair into a single Int so the
+/// combined-block `stmt_positions` array can carry per-stmt origin
+/// info through every transform pass. Low 8 bits are the source-id
+/// (max 256 distinct sources per bundle); high bits are the byte
+/// offset within that source.
+///
+/// 256 sources is plenty for the synthetic / real-world bundles
+/// the bench drives; when a project hits that wall we can switch
+/// to a wider encoding, but a parallel side-array would be the
+/// cleaner answer at that point.
+fn encode_combined_position(offset : Int, source_id : Int) -> Int {
+  (offset * 256) + (source_id % 256)
+}
+
+///|
+fn decode_combined_position(encoded : Int) -> (Int, Int) {
+  let source_id = encoded % 256
+  let offset = encoded / 256
+  (offset, source_id)
 }

--- a/src/transform/bundle_wbtest.mbt
+++ b/src/transform/bundle_wbtest.mbt
@@ -522,6 +522,49 @@ test "dts: prints conditional + union extends + mapped + indexed access" {
   assert_true(dts.contains("T extends (null | undefined)"))
   assert_true(dts.contains("? never : T"))
   assert_true(dts.contains("{ [P in K]: T[P] }"))
+  // Generic param bounds: `K extends keyof T` should round-trip.
+  assert_true(dts.contains("K extends keyof T"))
+}
+
+///|
+test "dts: optional field round-trips to `x?: T` instead of `T | undefined`" {
+  let src = "export interface Config {\n" +
+    "  host: string;\n" +
+    "  port?: number;\n" +
+    "  tags?: string[];\n" +
+    "}\n"
+  let module_ = @parser.parse_module_from_source_with_const_values(src, {})
+  let dts = emit_entry_dts(module_, ["Config"], {})
+  // Required field still emits with `:`.
+  assert_true(dts.contains("host: string"))
+  // Optional fields use `?:` rather than `: T | undefined`.
+  assert_true(dts.contains("port?: number"))
+  assert_true(dts.contains("tags?: string[]"))
+  assert_false(dts.contains("undefined"))
+}
+
+///|
+test "dts: infer marker prints as `infer T` (not `__tsmbt_infer<T>`)" {
+  let src = "export type R<T> = T extends (...args: any) => infer Ret ? Ret : never;\n"
+  let module_ = @parser.parse_module_from_source_with_const_values(src, {})
+  let dts = emit_entry_dts(module_, ["R"], {})
+  // The parser stores `infer T` as `Applied("__tsmbt_infer", …)` —
+  // emit must render it as the TypeScript keyword form.
+  assert_true(dts.contains("infer Ret"))
+  assert_false(dts.contains("__tsmbt_infer"))
+}
+
+///|
+test "dts: class constructor emits when parser captured it" {
+  let src = "export class Foo {\n" +
+    "  x: number;\n" +
+    "  constructor(x: number, label?: string) { this.x = x; }\n" +
+    "  go(): void { return; }\n" +
+    "}\n"
+  let module_ = @parser.parse_module_from_source_with_const_values(src, {})
+  let dts = emit_entry_dts(module_, ["Foo"], {})
+  assert_true(dts.contains("export class Foo"))
+  assert_true(dts.contains("constructor(x: number, label?: string)"))
 }
 
 ///|

--- a/src/transform/bundle_wbtest.mbt
+++ b/src/transform/bundle_wbtest.mbt
@@ -555,6 +555,42 @@ test "dts: infer marker prints as `infer T` (not `__tsmbt_infer<T>`)" {
 }
 
 ///|
+test "sourcemap: mangle path emits per-stmt mappings via encoded positions" {
+  let files = vfs([
+    ("entry.ts", "import { x } from \"./lib\";\nconst y = x + 1;\nconsole.log(y);\n"),
+    ("lib.ts", "export const x = 41;\n"),
+  ])
+  let opts = BundleOptions::default()
+    .with_treeshake(true)
+    .with_mangle(true)
+    .with_sourcemap(true)
+  match bundle_modules(files, "entry.ts", opts) {
+    Ok(out) =>
+      // The combined-path emit now decodes per-stmt origins and
+      // records source-map mappings. The map must include both
+      // module slots in `sources` and at least one mapping segment
+      // (the `mappings` string isn't empty).
+      match out.sourcemap {
+        Some(sm) => {
+          assert_true(sm.contains("\"entry.ts\""))
+          assert_true(sm.contains("\"lib.ts\""))
+          // mangle path used to drop positions; now `mappings` is
+          // populated.
+          let mappings_pos = sm.find("\"mappings\":\"")
+          let mappings = match mappings_pos {
+            Some(idx) =>
+              sm.substring(start=idx + "\"mappings\":\"".length(), end=sm.length()).to_string()
+            None => ""
+          }
+          assert_true(mappings.length() > 5)
+        }
+        None => fail("expected sourcemap output, got None")
+      }
+    Err(e) => fail("bundle error: \{e}")
+  }
+}
+
+///|
 test "dts: class constructor emits when parser captured it" {
   let src = "export class Foo {\n" +
     "  x: number;\n" +

--- a/src/transform/dts_emit.mbt
+++ b/src/transform/dts_emit.mbt
@@ -121,8 +121,14 @@ fn emit_interface_decl(buf : StringBuilder, i : @ast.TsInterface) -> Unit {
       buf.write_string("readonly ")
     }
     buf.write_string(field.0)
+    // The parser lowers `x?: T` to `x: T | undefined`. Detect that
+    // pattern and round-trip back to `x?: T` for cleaner output.
+    let (is_optional, ty) = unwrap_optional_field_type(field.1)
+    if is_optional {
+      buf.write_string("?")
+    }
     buf.write_string(": ")
-    emit_type(buf, field.1)
+    emit_type(buf, ty)
     buf.write_string(";\n")
   }
   for idx_sig in i.index_signatures {
@@ -139,7 +145,7 @@ fn emit_interface_decl(buf : StringBuilder, i : @ast.TsInterface) -> Unit {
 fn emit_type_alias_decl(buf : StringBuilder, a : @ast.TsTypeAlias) -> Unit {
   buf.write_string("export type ")
   buf.write_string(a.name)
-  emit_type_params(buf, a.type_params)
+  emit_type_params_with_bounds(buf, a.type_params, a.type_param_bounds)
   buf.write_string(" = ")
   emit_type(buf, a.type_)
   buf.write_string(";\n")
@@ -197,6 +203,26 @@ fn emit_class_decl(buf : StringBuilder, c : @ast.TsClassDecl) -> Unit {
     buf.write_string(c.base_names[0])
   }
   buf.write_string(" {\n")
+  // Constructor signature, when the parser captured one.
+  match c.constructor_params {
+    Some(params) => {
+      buf.write_string("  constructor(")
+      for i, p in params {
+        if i > 0 {
+          buf.write_string(", ")
+        }
+        let (is_optional, ty) = unwrap_optional_field_type(p.1)
+        buf.write_string(p.0)
+        if is_optional {
+          buf.write_string("?")
+        }
+        buf.write_string(": ")
+        emit_type(buf, ty)
+      }
+      buf.write_string(");\n")
+    }
+    None => ()
+  }
   for prop in c.properties {
     buf.write_string("  ")
     if prop.is_static {
@@ -206,8 +232,12 @@ fn emit_class_decl(buf : StringBuilder, c : @ast.TsClassDecl) -> Unit {
       buf.write_string("readonly ")
     }
     buf.write_string(prop.name)
+    let (is_optional, ty) = unwrap_optional_field_type(prop.type_)
+    if is_optional {
+      buf.write_string("?")
+    }
     buf.write_string(": ")
-    emit_type(buf, prop.type_)
+    emit_type(buf, ty)
     buf.write_string(";\n")
   }
   for m in c.methods {
@@ -216,18 +246,29 @@ fn emit_class_decl(buf : StringBuilder, c : @ast.TsClassDecl) -> Unit {
       buf.write_string("static ")
     }
     buf.write_string(m.name)
-    emit_type_params(buf, m.type_params)
+    emit_type_params_with_bounds(buf, m.type_params, m.type_param_bounds)
     buf.write_string("(")
     for i, p in m.params {
       if i > 0 {
         buf.write_string(", ")
       }
+      let (is_optional, ty) = unwrap_optional_field_type(p.1)
       buf.write_string(p.0)
+      if is_optional {
+        buf.write_string("?")
+      }
       buf.write_string(": ")
-      emit_type(buf, p.1)
+      emit_type(buf, ty)
     }
     buf.write_string("): ")
     emit_type(buf, m.return_type)
+    buf.write_string(";\n")
+  }
+  for idx_sig in c.index_signatures {
+    buf.write_string("  [k: ")
+    emit_type(buf, idx_sig.0)
+    buf.write_string("]: ")
+    emit_type(buf, idx_sig.1)
     buf.write_string(";\n")
   }
   buf.write_string("}\n")
@@ -246,13 +287,81 @@ fn emit_function_decl(buf : StringBuilder, f : @ast.TsFunc) -> Unit {
     if p.is_rest {
       buf.write_string("...")
     }
+    let (is_optional, ty) = unwrap_optional_field_type(p.type_)
     buf.write_string(p.name)
+    if is_optional && not(p.is_rest) {
+      buf.write_string("?")
+    }
     buf.write_string(": ")
-    emit_type(buf, p.type_)
+    emit_type(buf, ty)
   }
   buf.write_string("): ")
   emit_type(buf, f.return_type)
   buf.write_string(";\n")
+}
+
+///|
+/// When a field / parameter type is `T | undefined`, return
+/// `(true, T)` so the emitter can render it as `x?: T` (the
+/// idiomatic TypeScript shape). For anything else, return
+/// `(false, ty)` unchanged.
+fn unwrap_optional_field_type(ty : @ast.TsType) -> (Bool, @ast.TsType) {
+  match ty {
+    Union(parts) => {
+      // Find an `Undefined` in the union and return the remainder.
+      let mut has_undefined = false
+      let rest : Array[@ast.TsType] = []
+      for p in parts {
+        match p {
+          Undefined => has_undefined = true
+          _ => rest.push(p)
+        }
+      }
+      if not(has_undefined) || rest.length() == 0 {
+        return (false, ty)
+      }
+      if rest.length() == 1 {
+        (true, rest[0])
+      } else {
+        (true, Union(rest))
+      }
+    }
+    _ => (false, ty)
+  }
+}
+
+///|
+/// Variant of `emit_type_params` that also writes per-parameter
+/// `extends Bound` clauses when the binding list carries bounds.
+/// Order in `bounds` mirrors `params`; missing entries mean no
+/// bound was declared.
+fn emit_type_params_with_bounds(
+  buf : StringBuilder,
+  params : Array[String],
+  bounds : Array[(String, @ast.TsType)],
+) -> Unit {
+  if params.length() == 0 {
+    return
+  }
+  let bound_map : Map[String, @ast.TsType] = {}
+  for b in bounds {
+    bound_map[b.0] = b.1
+  }
+  buf.write_string("<")
+  for i, p in params {
+    if i > 0 {
+      buf.write_string(", ")
+    }
+    buf.write_string(p)
+    match bound_map.get(p) {
+      Some(b) => {
+        buf.write_string(" extends ")
+        emit_type(buf, b)
+      }
+      None => ()
+    }
+  }
+  buf.write_string(">")
 }
 
 ///|
@@ -327,23 +436,34 @@ fn emit_type(buf : StringBuilder, ty : @ast.TsType) -> Unit {
       emit_type(buf, inner)
     }
     Object(fields) => {
-      buf.write_string("{ ")
-      for i, f in fields {
-        if i > 0 {
-          buf.write_string("; ")
-        }
-        match f.0 {
-          Literal(name) => buf.write_string(name)
-          _ => {
-            buf.write_string("[k: ")
-            emit_type(buf, f.0)
-            buf.write_string("]")
+      if fields.length() == 0 {
+        buf.write_string("{}")
+      } else {
+        buf.write_string("{ ")
+        for i, f in fields {
+          if i > 0 {
+            buf.write_string("; ")
           }
+          // Track optional even for inline object literal types.
+          let (is_optional, value_ty) = unwrap_optional_field_type(f.1)
+          match f.0 {
+            Literal(name) => {
+              buf.write_string(name)
+              if is_optional {
+                buf.write_string("?")
+              }
+            }
+            _ => {
+              buf.write_string("[k: ")
+              emit_type(buf, f.0)
+              buf.write_string("]")
+            }
+          }
+          buf.write_string(": ")
+          emit_type(buf, value_ty)
         }
-        buf.write_string(": ")
-        emit_type(buf, f.1)
+        buf.write_string(" }")
       }
-      buf.write_string(" }")
     }
     Struct(name, _) => buf.write_string(name)
     Func(params, ret) => {
@@ -404,6 +524,18 @@ fn emit_type(buf : StringBuilder, ty : @ast.TsType) -> Unit {
     }
     Named(name) => buf.write_string(name)
     Applied(name, args) => {
+      // `infer T` and `infer T extends Bound` are stored as the
+      // pseudo-applied form `__tsmbt_infer<…>` so the parser can
+      // round-trip them. Render them with the proper TS keyword.
+      if name == "__tsmbt_infer" && args.length() >= 1 {
+        buf.write_string("infer ")
+        emit_type(buf, args[0])
+        if args.length() >= 2 {
+          buf.write_string(" extends ")
+          emit_type(buf, args[1])
+        }
+        return
+      }
       buf.write_string(name)
       buf.write_string("<")
       for i, a in args {

--- a/src/transform/emit.mbt
+++ b/src/transform/emit.mbt
@@ -1133,9 +1133,27 @@ fn emit_expr_body(e : Emitter, expr : @ast.TsExpr) -> Unit {
     BinOp(op, l, r) => {
       let prec = binop_precedence(op)
       emit_expr(e, l, prec)
-      e.space()
+      // Word operators (`instanceof`, `in`) start with identifier
+      // bytes, so the optional-whitespace `space()` we use for
+      // punctuator ops would produce illegal output like
+      // `xinstanceofy` in minify mode. Force separators on both
+      // sides for word ops; `space()` is still correct for `+`,
+      // `*`, `===` and the rest.
+      let is_word_op = match op {
+        Instanceof | In => true
+        _ => false
+      }
+      if is_word_op {
+        e.write(" ")
+      } else {
+        e.space()
+      }
       e.write(binop_str(op))
-      e.space()
+      if is_word_op {
+        e.write(" ")
+      } else {
+        e.space()
+      }
       // Right-associative ** uses prec, others prec+1 so left chains.
       let right_prec = match op {
         Pow => prec
@@ -1206,15 +1224,25 @@ fn emit_expr_body(e : Emitter, expr : @ast.TsExpr) -> Unit {
           e.space()
         }
         // JSX-runtime lowering encodes object-spread props as a
-        // sentinel `("...", Spread(expr))` entry. Emit those as the
-        // `...expr` shorthand instead of `"...": expr`.
+        // sentinel `("...", Spread(expr))` entry. Some parser paths
+        // emit `("@@spread:N", expr)` for the same purpose. Both
+        // surface as `...expr` shorthand.
         match entry {
           ("...", Spread(inner)) => {
             e.write("...")
             emit_expr(e, inner, 2)
           }
+          (key, _) if key.has_prefix("@@spread:") => {
+            e.write("...")
+            emit_expr(e, entry.1, 2)
+          }
           _ => {
-            e.write(entry.0)
+            // Non-identifier keys (`"Content-Type"`, `"foo bar"`,
+            // numeric-looking, etc.) MUST stay quoted — otherwise
+            // the emitted `{Content-Type: …}` re-parses as binary
+            // minus. Numeric keys can stay unquoted; everything
+            // else needs the quotes.
+            emit_object_key(e, entry.0)
             e.write(":")
             e.space()
             emit_expr(e, entry.1, 2)
@@ -1658,6 +1686,63 @@ fn is_this_type_annotation_param(p : @ast.TsParam) -> Bool {
 /// decide whether to emit a name on a synthesized function
 /// expression. We only need a coarse rejector — the parser handles
 /// the full Unicode case for real source identifiers.
+///|
+/// Emit an object-literal key. Valid JS identifiers and numeric
+/// literals stay unquoted; everything else (`Content-Type`,
+/// `foo bar`, empty string, identifiers that happen to be reserved
+/// words used as keys are still OK unquoted in modern JS) gets
+/// JSON-string quoting so the surrounding object literal stays
+/// parseable.
+fn emit_object_key(e : Emitter, key : String) -> Unit {
+  if is_valid_js_ident(key) || is_numeric_literal_key(key) {
+    e.write(key)
+  } else {
+    e.write("\"")
+    e.write(escape_string_literal(key))
+    e.write("\"")
+  }
+}
+
+///|
+fn is_numeric_literal_key(s : String) -> Bool {
+  if s.length() == 0 {
+    return false
+  }
+  for i = 0; i < s.length(); i = i + 1 {
+    let c = s[i]
+    if not(c >= '0' && c <= '9') {
+      return false
+    }
+  }
+  true
+}
+
+///|
+/// Minimal JSON-style escape for strings emitted as object keys.
+/// Covers backslash, double quote, and the control chars JS doesn't
+/// accept verbatim inside double-quoted strings.
+fn escape_string_literal(s : String) -> String {
+  let buf = StringBuilder::new()
+  for i = 0; i < s.length(); i = i + 1 {
+    let c = s[i]
+    if c == '\\' {
+      buf.write_string("\\\\")
+    } else if c == '"' {
+      buf.write_string("\\\"")
+    } else if c == '\n' {
+      buf.write_string("\\n")
+    } else if c == '\r' {
+      buf.write_string("\\r")
+    } else if c == '\t' {
+      buf.write_string("\\t")
+    } else {
+      buf.write_char(c.to_int().unsafe_to_char())
+    }
+  }
+  buf.to_string()
+}
+
+///|
 fn is_valid_js_ident(s : String) -> Bool {
   if s.length() == 0 {
     return false
@@ -1879,7 +1964,9 @@ fn emit_native_class(
     e.write(decl.name)
   }
   if decl.base_names.length() > 0 {
-    e.space()
+    // `extends` is a word keyword; a forced space, not the
+    // optional one — `classextends` / `nameextends` is invalid.
+    e.write(" ")
     e.write("extends")
     e.sep_after_word('A')
     e.write(decl.base_names[0])

--- a/src/transform/mangle.mbt
+++ b/src/transform/mangle.mbt
@@ -599,6 +599,15 @@ fn ScopeFrame::bind(
   name : String,
   reserved : Map[String, Bool],
 ) -> String {
+  // Idempotency: if this frame already chose a rename for `name`
+  // (e.g. via the function-declaration hoist pre-pass) return it
+  // instead of allocating a fresh short slot. Multiple `bind` calls
+  // for the same name in the same frame would otherwise pick
+  // different shorts and break references.
+  match self.renames.get(name) {
+    Some(existing) => return existing
+    None => ()
+  }
   // Reserved names stay put. They still mark themselves as used so
   // subsequent declarations don't pick a colliding short name.
   if reserved.contains(name) {
@@ -1107,6 +1116,23 @@ fn rename_block_inline_in(
   scope : ScopeFrame,
   reserved : Map[String, Bool],
 ) -> @ast.TsBlock {
+  // Hoist function declarations: in JS, `function f() {}` is
+  // visible from the start of its containing scope, so an earlier
+  // `return f();` should resolve to the SAME rename as the later
+  // declaration. Pre-bind every `<kind>(Ident(name), _, FuncExpr)`
+  // before the recursive walk so the call site and the declaration
+  // both pick up the same short name.
+  for s in block.stmts {
+    match s {
+      Let(@ast.TsBinding::Ident(name), _, @ast.TsExpr::FuncExpr(_))
+      | Const(@ast.TsBinding::Ident(name), _, @ast.TsExpr::FuncExpr(_))
+      | Var(@ast.TsBinding::Ident(name), _, @ast.TsExpr::FuncExpr(_)) =>
+        if not(scope.renames.contains(name)) {
+          let _ = scope.bind(name, reserved)
+        }
+      _ => ()
+    }
+  }
   let stmts : Array[@ast.TsStmt] = []
   for s in block.stmts {
     stmts.push(rename_stmt(s, scope, reserved))


### PR DESCRIPTION
## Summary

Follow-up to #27 covering:

- **Hono real-world bench fixture** (`bench/hono-real/entry.ts`).  Bundling `node_modules/hono` exposed four emit / mangle bugs invisible on the synthetic corpus.
- **Four emit / mangle correctness fixes** found via Hono:
  1. `instanceof` / `in` binary ops emitted without spaces (`xinstanceofy`) — now forced spaces for word operators.
  2. `class extends Base` emitted as `classextends` — forced space.
  3. Object-literal keys with hyphens / special chars unquoted (`{Content-Type: …}`) — new `emit_object_key` quotes anything that isn't a valid JS identifier.
  4. Function declarations not hoisted by the mangler, so `return f(); function f(){}` lost name agreement between the call site and the declaration. New pre-pass binds function-decl names first; `ScopeFrame::bind` made idempotent so the later declaration re-uses the same short slot.
- **`.d.ts` quality improvements** (`dts_emit.mbt`):
  1. `Applied("__tsmbt_infer", [T])` → `infer T` (and `infer T extends Bound`).
  2. `Union([T, Undefined])` round-trips to `x?: T` everywhere (interface field, object type field, function / method / constructor parameter).
  3. Generic param bounds preserved (`<P extends Bound>` instead of `<P>`).
  4. Class constructor signature emitted from `constructor_params`.
  5. Class index signatures emitted.
  6. Empty inline object type as `{}` instead of `{ }`.
- **`--with-sourcemap` now works with `--mangle` / `--treeshake` / `--fold`.**  Combined-block path encodes each stmt's `(source-id, byte offset)` into the position int; transform passes propagate it verbatim; combined emit decodes and writes mappings against the right module's line index.  Encoding caps at 256 sources per bundle (plenty for the synthetic corpus and Hono).  `BundleOptions.mangle` comment updated from the stale "the rename pass doesn't carry positions yet".

## Test plan

- [x] `moon test --target native` — 1649 / 1649 pass
- [x] `moon check` — no errors
- [x] `bench/bundle_vs_rolldown.sh` — sizes / speed unchanged for the synthetic corpus (these are correctness / quality fixes, not perf)
- [x] Hono bundle no longer trips the four emit bugs above; remaining failure is a private-field lowering issue in the class desugar, scoped out of this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fr7HhoUVC4b72CQW7YYPJF)_