### PR TITLE
bundler/mangle/peephole: fix correctness bugs surfaced by real-world fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,17 @@
     "@types/react": "^19.2.14",
     "date-fns": "^4.1.0",
     "drizzle-orm": "^0.45.2",
+    "effect": "^3.21.2",
     "express": "^5.2.1",
     "glob": "^13.0.6",
     "hono": "^4.12.16",
     "preact": "^10.29.2",
+    "prettier": "^3.8.3",
     "react": "^19.2.5",
     "rolldown": "^1.0.2",
     "typescript": "^5.7.0",
     "vitest": "^4.1.5",
+    "yjs": "^13.6.31",
     "zod": "^4.4.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2
+      effect:
+        specifier: ^3.21.2
+        version: 3.21.2
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -35,6 +38,9 @@ importers:
       preact:
         specifier: ^10.29.2
         version: 10.29.2
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.3
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -47,6 +53,9 @@ importers:
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0))
+      yjs:
+        specifier: ^13.6.31
+        version: 13.6.31
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -533,6 +542,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  effect@3.21.2:
+    resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
+
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
@@ -569,6 +581,10 @@ packages:
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -644,6 +660,14 @@ packages:
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  isomorphic.js@0.2.5:
+    resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
+
+  lib0@0.2.117:
+    resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -808,9 +832,17 @@ packages:
   preact@10.29.2:
     resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
 
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
@@ -1022,6 +1054,10 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  yjs@13.6.31:
+    resolution: {integrity: sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -1338,6 +1374,11 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  effect@3.21.2:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
   encodeurl@2.0.0: {}
 
   es-define-property@1.0.1: {}
@@ -1392,6 +1433,10 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -1468,6 +1513,12 @@ snapshots:
   ipaddr.js@1.9.1: {}
 
   is-promise@4.0.0: {}
+
+  isomorphic.js@0.2.5: {}
+
+  lib0@0.2.117:
+    dependencies:
+      isomorphic.js: 0.2.5
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -1583,10 +1634,14 @@ snapshots:
 
   preact@10.29.2: {}
 
+  prettier@3.8.3: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  pure-rand@6.1.0: {}
 
   qs@6.15.1:
     dependencies:
@@ -1796,5 +1851,9 @@ snapshots:
       stackback: 0.0.2
 
   wrappy@1.0.2: {}
+
+  yjs@13.6.31:
+    dependencies:
+      lib0: 0.2.117
 
   zod@4.4.3: {}

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -1267,8 +1267,6 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
   }
   let key_temps : Array[String?] = [] // Temp var names for ALL elements' computed keys
   let key_init_stmts : Array[@ast.TsStmt] = [] // Initialization statements for computed keys
-  let mut key_index = 0
-
   // First pass: collect all computed keys and generate temp variables
   for element in elements {
     match element {
@@ -1276,8 +1274,8 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
         match key {
           Name(_) => key_temps.push(None)
           Computed(key_expr) => {
-            let temp_name = "__class_key_" + key_index.to_string()
-            key_index += 1
+            let temp_name = "__class_key_" + self.class_key_counter.to_string()
+            self.class_key_counter += 1
             key_temps.push(Some(temp_name))
             // Generate: let __class_key_N = key_expr;
             key_init_stmts.push(
@@ -1838,8 +1836,6 @@ fn Parser::parse_class_decl_with_abstract(
   }
   let key_temps : Array[String?] = [] // Temp var names for ALL elements' computed keys
   let key_init_stmts : Array[@ast.TsStmt] = [] // Initialization statements for computed keys
-  let mut key_index = 0
-
   // First pass: collect all computed keys and generate temp variables
   for element in elements {
     match element {
@@ -1847,8 +1843,8 @@ fn Parser::parse_class_decl_with_abstract(
         match key {
           Name(_) => key_temps.push(None)
           Computed(key_expr) => {
-            let temp_name = "__class_key_" + key_index.to_string()
-            key_index += 1
+            let temp_name = "__class_key_" + self.class_key_counter.to_string()
+            self.class_key_counter += 1
             key_temps.push(Some(temp_name))
             // Generate: let __class_key_N = key_expr;
             key_init_stmts.push(

--- a/src/parser/parser_core.mbt
+++ b/src/parser/parser_core.mbt
@@ -34,6 +34,11 @@ pub struct Parser {
   src : String
   allow_jsx : Bool
   mut class_id : Int // for private field brand generation
+  // File-level counter for computed-key temp variables (`__class_key_N`).
+  // A per-class local counter would reset to 0 for every class in the file,
+  // causing duplicate `let __class_key_0` declarations when multiple classes
+  // are bundled into a single scope.
+  mut class_key_counter : Int
   mut current_class_brand : String? // brand ID of current class being parsed
   mut last_runtime_class_decl : @ast.TsClassDecl?
   // The expression parsed by `parse_class_base_name` when the
@@ -120,6 +125,7 @@ pub fn Parser::new_with_strict_and_jsx(
     src: "",
     allow_jsx,
     class_id: 0,
+    class_key_counter: 0,
     current_class_brand: None,
     last_runtime_class_decl: None,
     pending_class_base_expr: None,
@@ -171,6 +177,7 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
     src,
     allow_jsx,
     class_id: 0,
+    class_key_counter: 0,
     current_class_brand: None,
     last_runtime_class_decl: None,
     pending_class_base_expr: None,

--- a/src/transform/bundle.mbt
+++ b/src/transform/bundle.mbt
@@ -323,6 +323,21 @@ pub fn bundle_modules(
     Err(e) => return Err(e)
   }
   let order = topological_order(modules, entry)
+  // Lift IIFE-lowered classes to native `class Name { … }` syntax on
+  // each module individually BEFORE the linker pass. The parser emits
+  // computed-key temp vars (`let __class_key_0 = expr`) inside the
+  // IIFE body; the lift hoists them to module-top-level. Running the
+  // lift here lets the linker see those names and rename duplicates
+  // (multiple modules each starting their counter at 0 would otherwise
+  // produce identical `let __class_key_0` at the bundle top-level).
+  for path in order {
+    let m = match modules.get(path) {
+      Some(node) => node
+      None => continue
+    }
+    let lifted = iife_class_lift_block(m.block)
+    modules[path] = { ..m, block: lifted }
+  }
   // Run the cross-module linker before any pass that operates on
   // the combined block. Phase 1 gives each module's top-level
   // bindings a globally-unique name when they collide; phase 2

--- a/src/transform/emit.mbt
+++ b/src/transform/emit.mbt
@@ -2145,8 +2145,16 @@ fn emit_expr_body(e : Emitter, expr : @ast.TsExpr) -> Unit {
           // returning an object literal. Wrap an ObjectLit-shaped
           // expression in parens to keep the JS parser on the
           // expression branch.
+          // An arrow expression body that starts with `{` is
+          // ambiguous: the JS parser reads it as a block statement.
+          // Any expression whose leftmost token is `{` needs wrapping.
           let needs_paren_for_obj = match inner {
             ObjectLit(_) => true
+            // `({...})[k]` / `({...}).prop` — the object literal is
+            // on the left of an index/member access.
+            IndexAccess(ObjectLit(_), _) => true
+            PropAccess(ObjectLit(_), _) => true
+            MethodCall(ObjectLit(_), _, _) => true
             _ => false
           }
           if needs_paren_for_obj {

--- a/src/transform/mangle.mbt
+++ b/src/transform/mangle.mbt
@@ -741,8 +741,14 @@ fn collect_var_refs_stmt(stmt : @ast.TsStmt, out : Map[String, Bool]) -> Unit {
   match stmt {
     Var(_, _, e) | Let(_, _, e) | Const(_, _, e) =>
       collect_var_refs_expr(e, out)
-    Assign(_, e) => collect_var_refs_expr(e, out)
-    CompoundAssign(_, _, e) => collect_var_refs_expr(e, out)
+    Assign(name, e) => {
+      out[name] = true
+      collect_var_refs_expr(e, out)
+    }
+    CompoundAssign(name, _, e) => {
+      out[name] = true
+      collect_var_refs_expr(e, out)
+    }
     IndexAssign(t, k, v) => {
       collect_var_refs_expr(t, out)
       collect_var_refs_expr(k, out)
@@ -828,10 +834,16 @@ fn collect_var_refs_expr(expr : @ast.TsExpr, out : Map[String, Bool]) -> Unit {
       collect_var_refs_expr(b, out)
     }
     UnaryOp(_, e) => collect_var_refs_expr(e, out)
-    Call(_, args) =>
+    Call(callee, args) => {
+      // `callee` is the bare identifier being called (`init(...)`).
+      // It is a free reference just like any other `Var`, so a nested
+      // function that calls an outer binding must mark its short name
+      // occupied or a local could shadow it.
+      out[callee] = true
       for a in args {
         collect_var_refs_expr(a, out)
       }
+    }
     CallExpr(f, args) => {
       collect_var_refs_expr(f, out)
       for a in args {
@@ -861,10 +873,12 @@ fn collect_var_refs_expr(expr : @ast.TsExpr, out : Map[String, Bool]) -> Unit {
       collect_var_refs_expr(k, out)
     }
     PropAccess(t, _) => collect_var_refs_expr(t, out)
-    New(_, args) =>
+    New(callee, args) => {
+      out[callee] = true
       for a in args {
         collect_var_refs_expr(a, out)
       }
+    }
     NewExpr(c, args) => {
       collect_var_refs_expr(c, out)
       for a in args {
@@ -877,7 +891,10 @@ fn collect_var_refs_expr(expr : @ast.TsExpr, out : Map[String, Bool]) -> Unit {
         collect_var_refs_expr(a, out)
       }
     }
-    AssignExpr(_, e) => collect_var_refs_expr(e, out)
+    AssignExpr(name, e) => {
+      out[name] = true
+      collect_var_refs_expr(e, out)
+    }
     AssignPattern(_, e) => collect_var_refs_expr(e, out)
     CompoundAssignExpr(t, _, v) => {
       collect_var_refs_expr(t, out)

--- a/src/transform/mangle_wbtest.mbt
+++ b/src/transform/mangle_wbtest.mbt
@@ -161,6 +161,36 @@ test "mangle: nested function bodies get their own scope" {
 }
 
 ///|
+test "mangle: nested call to outer binding is not shadowed by inner local" {
+  // Regression: a nested function that *calls* an outer binding
+  // (`init(...)`) must reserve that binding's short name so an
+  // inner local can't reuse it. The callee of `Call(name, args)`
+  // is stored as a bare string, so the free-variable collector
+  // used to miss it — letting `inst` and `init` collapse onto the
+  // same short name and turning `init(inst)` into `inst(inst)`.
+  let cfg = ManglerConfig::default()
+  let src =
+    #|function make() {
+    #|  function init(x) { return x; }
+    #|  function build(arg) {
+    #|    const inst = arg;
+    #|    return init(inst);
+    #|  }
+    #|  return build;
+    #|}
+  match mangle_to_js(src, cfg) {
+    Ok(js) => {
+      // `build`'s local `inst` is renamed to `c`; the call to the
+      // captured outer `init` (renamed `a`) must stay `a(c)`. The
+      // buggy collapse produced `c(c)` (calling the local instead).
+      assert_true(js.contains("a(c)"))
+      assert_false(js.contains("c(c)"))
+    }
+    Err(e) => fail("\{e}")
+  }
+}
+
+///|
 test "mangle: explicit reserved set overrides default" {
   // `keepMe` should NOT be mangled because the caller asked for it
   // to be reserved.

--- a/src/transform/peephole.mbt
+++ b/src/transform/peephole.mbt
@@ -512,8 +512,12 @@ fn peep_stmt(stmt : @ast.TsStmt, ctx : PeepCtx) -> @ast.TsStmt {
       // collapse further via the `if (c) return a; return b;` rule.
       match final_cases[:] {
         [{ test_expr: Some(case_e), body: case_body }] => {
+          // A `break` terminator is only valid inside a switch / loop, so
+          // don't lift a single-case switch to `if` when the body ends with
+          // `break` — the resulting `if(…){…;break}` would be a SyntaxError
+          // outside a switch or loop context.
           let is_non_fall_through = match case_body.stmts.last() {
-            Some(Return(_)) | Some(Throw(_)) | Some(Break(_)) => true
+            Some(Return(_)) | Some(Throw(_)) => true
             _ => false
           }
           if is_non_fall_through {
@@ -531,7 +535,7 @@ fn peep_stmt(stmt : @ast.TsStmt, ctx : PeepCtx) -> @ast.TsStmt {
           { test_expr: None, body: default_body },
         ] => {
           let is_non_fall_through = match case_body.stmts.last() {
-            Some(Return(_)) | Some(Throw(_)) | Some(Break(_)) => true
+            Some(Return(_)) | Some(Throw(_)) => true
             _ => false
           }
           if is_non_fall_through {
@@ -562,7 +566,9 @@ fn peep_stmt(stmt : @ast.TsStmt, ctx : PeepCtx) -> @ast.TsStmt {
               match c.test_expr {
                 Some(_) =>
                   match c.body.stmts.last() {
-                    Some(Return(_)) | Some(Throw(_)) | Some(Break(_)) => ()
+                    // Break is only valid inside switch/loop — don't
+                    // lift to if-else where it would be a SyntaxError.
+                    Some(Return(_)) | Some(Throw(_)) => ()
                     _ => {
                       ok = false
                       break


### PR DESCRIPTION
## Summary

Four correctness bugs fixed, all surfaced by running `pnpm install` and
executing `bench/realworld/check.sh` against the full package set.

### 1. mangle: captured call/assign targets missing from free-var collector (b9e11d6)

`collect_var_refs_expr` walked operands but dropped the identifier stored
as a bare string in `Call(name, args)`, `New(name, args)`, `Assign(name,…)`,
and `AssignExpr(name,…)`. A nested function that _called_ a captured outer
binding never reserved that binding's short name → inner local could collide,
turning `init(inst)` into `inst(inst)` and crashing at runtime.

Fixes: **zod** (`zod ok: ada 36 1` ✅), **datefns** ✅

### 2. bundle: duplicate `__class_key_N` from cross-module class lift (916dd8f)

Classes with computed static fields (`static [sym] = value`) are desugared via
the IIFE path, which stores `let __class_key_0 = sym` _inside_ the IIFE body.
`iife_class_lift_block` hoists that var to module-top-level, but it ran
_after_ the linker, so the linker never saw it and couldn't rename collisions
across modules (each file's parser counter resets to 0).

Fix: run `iife_class_lift_block` per-module _before_ `link_module_graph`.
Also switch the parser to use a file-level `class_key_counter` so within-file
multi-class names are unique too.

Fixes: **drizzle** past `PARSE FAIL` → runtime error (further progress),
       **effect** past `PARSE FAIL` → runtime error.

### 3. emit: arrow body `({…})[k]` missing parens (788941f)

`(r) => ({…})[r]` was emitted as `(r) => {...}[r]` — the `{` looked like
a block start, causing a syntax error. Extended the existing `ObjectLit` paren-
wrap check to also cover `IndexAccess(ObjectLit,_)`, `PropAccess(ObjectLit,_)`,
and `MethodCall(ObjectLit,_,_)`.

### 4. peephole: switch→if lift with `break` terminator (788941f)

The peephole converted single-case and multi-case switches to `if`/`if-else`
chains when every named case ended with a hard terminator, allowing `Break` as
a valid terminator. But `break` is only legal inside a switch/loop — lifting it
to an `if` body produces `SyntaxError: Illegal break statement`.

Restricted to `Return` and `Throw` only.

Fixes: **yjs** past `PARSE FAIL`.

### devDependencies

Added `yjs`, `effect`, `prettier` to `package.json` so the full
`bench/realworld/check.sh` suite can run in a fresh checkout.

---

## Results (`bench/realworld/check.sh`)

| fixture | before this PR | after |
|---------|---------------|-------|
| zod | WRONG OUTPUT | ✅ OK |
| datefns | WRONG OUTPUT | ✅ OK |
| drizzle | PARSE FAIL | WRONG OUTPUT (runtime, further) |
| effect | PARSE FAIL | WRONG OUTPUT (runtime, further) |
| yjs | PARSE FAIL | PARSE FAIL (different error: `super`) |
| hono | ✅ OK 18741 B | ✅ OK 18636 B |
| preact | ✅ OK | ✅ OK |

https://claude.ai/code/session_01NvF1NKtvy3nzahhrVLuhVV