### PR TITLE
checker/parser: typeof narrowing + symbol keyword + TS conformance baseline gate

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -3075,9 +3075,12 @@ fn infer_typeof_type(resolver : Resolver, ty : @ast.TsType) -> @ast.TsType {
     String_ | Literal(_) => lit("string")
     Number | Int | NumberLiteral(_) => lit("number")
     Boolean | BooleanLiteral(_) => lit("boolean")
+    BigInt | BigIntLiteral(_) => lit("bigint")
+    Symbol | UniqueSymbol(_) => lit("symbol")
     Null => lit("object")
-    Undefined => lit("undefined")
-    Func(_, _) => lit("function")
+    Array(_) | Tuple(_) | Object(_) | Struct(_, _) => lit("object")
+    Undefined | Void => lit("undefined")
+    Func(_, _) | Constructor(_, _, _) => lit("function")
     Union(parts) => {
       let seen : Map[String, Bool] = {}
       let tags : Array[@ast.TsType] = []

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -467,6 +467,57 @@ test "expr_check: typeof narrowing accepts compatible branch" {
 }
 
 ///|
+test "expr_check: typeof on array operand narrows to \"object\"" {
+  let src =
+    #|function f(xs: number[]): "object" {
+    #|  return typeof xs;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  @test.assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: typeof on bigint operand narrows to \"bigint\"" {
+  let src =
+    #|function f(x: bigint): "bigint" {
+    #|  return typeof x;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  @test.assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: typeof on function operand narrows to \"function\"" {
+  let src =
+    #|function f(fn: (x: number) => number): "function" {
+    #|  return typeof fn;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  @test.assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: typeof on string|number returns \"string\"|\"number\" union" {
+  let src =
+    #|function f(v: string | number): "boolean" {
+    #|  return typeof v;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  // typeof v: "string" | "number", not assignable to "boolean".
+  let mut found = false
+  for i in issues {
+    if i.message.contains("boolean") {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
 test "expr_check: new ClassName returns instance type and checks ctor args" {
   let src =
     #|class Point { constructor(x: number, y: number) {} }

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -500,6 +500,17 @@ test "expr_check: typeof on function operand narrows to \"function\"" {
 }
 
 ///|
+test "expr_check: typeof on symbol operand narrows to \"symbol\"" {
+  let src =
+    #|function f(s: symbol): "symbol" {
+    #|  return typeof s;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  @test.assert_eq(issues.length(), 0)
+}
+
+///|
 test "expr_check: typeof on string|number returns \"string\"|\"number\" union" {
   let src =
     #|function f(v: string | number): "boolean" {

--- a/src/parser/parser_type.mbt
+++ b/src/parser/parser_type.mbt
@@ -694,6 +694,8 @@ fn Parser::parse_primary_type(self : Parser) -> @ast.TsType raise ParseError {
         self.parse_named_type_tail(name)
       } else if name == "unknown" {
         Unknown
+      } else if name == "symbol" {
+        Symbol
       } else {
         Any
       }

--- a/src/parser/parser_typescript_wbtest.mbt
+++ b/src/parser/parser_typescript_wbtest.mbt
@@ -720,6 +720,140 @@ async test "checker: smoke-run against TypeScript conformance test corpus" {
 }
 
 ///|
+/// Strip the parent directory and the `.ts` / `.tsx` suffix off a path.
+/// `tests/cases/conformance/foo/bar/Baz.ts` -> `Baz`.
+fn ts_case_basename(path : String) -> String {
+  let parts = path.split("/")
+  let arr : Array[StringView] = []
+  for p in parts {
+    arr.push(p)
+  }
+  let mut name = if arr.length() == 0 {
+    path
+  } else {
+    arr[arr.length() - 1].to_owned()
+  }
+  if name.has_suffix(".tsx") {
+    name = name[:name.length() - 4].to_owned()
+  } else if name.has_suffix(".ts") {
+    name = name[:name.length() - 3].to_owned()
+  }
+  name
+}
+
+///|
+async fn baseline_errors_txt_exists(case_name : String) -> Bool {
+  let path = "typescript/tests/baselines/reference/" + case_name + ".errors.txt"
+  let kind = @fs.kind(path, follow_symlink=false) catch {
+    _ => @fs.FileKind::Unknown
+  }
+  kind is @fs.FileKind::Regular
+}
+
+///|
+/// Cross-check the checker's accuracy against the TypeScript test corpus.
+///
+/// The corpus convention is:
+///   - `tests/cases/conformance/.../<name>.ts` is the source.
+///   - `tests/baselines/reference/<name>.errors.txt` exists iff `tsc`
+///     reports at least one error on that source.
+///
+/// So for each parsed source we can sort the outcome into a 2x2 table:
+///   ┌────────────────┬──────────────┬──────────────┐
+///   │                │ baseline yes │ baseline no  │
+///   ├────────────────┼──────────────┼──────────────┤
+///   │ our issues > 0 │ recall hit   │ false pos.   │
+///   │ our issues = 0 │ recall miss  │ precision hit│
+///   └────────────────┴──────────────┴──────────────┘
+///
+/// The two "miss" columns are the failure side. The thresholds below are
+/// generous initial gates so the test starts useful without immediately
+/// failing on the (large) recall gap that exists today. Tighten them as
+/// the checker improves.
+async test "checker: accuracy against TypeScript conformance baselines" {
+  let dirs = [
+    "typescript/tests/cases/conformance/types/typeParameters", "typescript/tests/cases/conformance/controlFlow",
+    "typescript/tests/cases/conformance/expressions/typeGuards", "typescript/tests/cases/conformance/types/typeGuards",
+    "typescript/tests/cases/conformance/types/union", "typescript/tests/cases/conformance/types/intersection",
+    "typescript/tests/cases/conformance/types/tuple", "typescript/tests/cases/conformance/types/literal",
+    "typescript/tests/cases/conformance/types/conditional", "typescript/tests/cases/conformance/types/never",
+    "typescript/tests/cases/conformance/types/unknown", "typescript/tests/cases/conformance/types/any",
+    "typescript/tests/cases/conformance/types/keyof", "typescript/tests/cases/conformance/types/typeAliases",
+    "typescript/tests/cases/conformance/types/objectTypeLiteral", "typescript/tests/cases/conformance/types/primitives",
+    "typescript/tests/cases/conformance/types/stringLiteral", "typescript/tests/cases/conformance/types/uniqueSymbol",
+    "typescript/tests/cases/conformance/types/rest", "typescript/tests/cases/conformance/types/specifyingTypes",
+    "typescript/tests/cases/conformance/types/contextualTypes", "typescript/tests/cases/conformance/types/namedTypes",
+    "typescript/tests/cases/conformance/types/typeRelationships", "typescript/tests/cases/conformance/types/nonPrimitive",
+  ]
+  let mut total = 0
+  let mut parsed = 0
+  let mut recall_hit = 0
+  let mut recall_miss = 0
+  let mut precision_hit = 0
+  let mut precision_miss = 0
+  for dir in dirs {
+    let files = collect_ts_source_files_recursive(dir)
+    for path in files {
+      total += 1
+      let content = @fs.read_file(path).text() catch { _ => continue }
+      let allow_jsx = path.has_suffix(".tsx")
+      let module_ = try
+        Parser::from_source_with_jsx(content, allow_jsx).parse_module()
+      catch {
+        _ => continue
+      } noraise {
+        m => {
+          parsed += 1
+          m
+        }
+      }
+      let case_name = ts_case_basename(path)
+      let has_baseline = baseline_errors_txt_exists(case_name)
+      let issues = @checker.check_module_function_bodies(module_)
+      if issues.length() > 0 {
+        if has_baseline {
+          recall_hit += 1
+        } else {
+          precision_miss += 1
+        }
+      } else if has_baseline {
+        recall_miss += 1
+      } else {
+        precision_hit += 1
+      }
+    }
+  }
+  if total == 0 {
+    println("skip: no .ts sources found in pinned conformance corpus")
+    return
+  }
+  let with_baseline = recall_hit + recall_miss
+  let without_baseline = precision_hit + precision_miss
+  println(
+    "baseline accuracy: parsed=\{parsed}/\{total} | recall=\{recall_hit}/\{with_baseline} | precision=\{precision_hit}/\{without_baseline} (false-positives=\{precision_miss})",
+  )
+  // Regression gates calibrated against today's measurements. Tighten
+  // as accuracy improves; loosen only with justification.
+  //
+  // Recall floor: of the baseline-positive cases, we currently detect
+  // ~29 %. Set the floor at 25 % to flag a drop of >4 percentage
+  // points. A real recall regression should easily blow past that.
+  if with_baseline > 0 && recall_hit * 100 < with_baseline * 25 {
+    fail(
+      "recall floor breached: \{recall_hit}/\{with_baseline} baseline-positive cases caught (< 25 %)",
+    )
+  }
+  // Precision floor: we currently false-positive on ~24 % of clean
+  // cases. Set the cap at 28 % so a new false-positive class shows up
+  // as a test failure rather than silently widening the gap.
+  if without_baseline > 0 && precision_miss * 100 > without_baseline * 28 {
+    fail(
+      "precision floor breached: \{precision_miss}/\{without_baseline} clean cases reported as failing (> 28 %)",
+    )
+  }
+}
+
+///|
 async test "parser: smoke-run against the entire TypeScript repo source" {
   // Broader sweep than `typescript/src/compiler` — walks the full
   // `typescript/src` tree (compiler + services + server + harness +

--- a/src/parser/parser_wbtest.mbt
+++ b/src/parser/parser_wbtest.mbt
@@ -6728,6 +6728,16 @@ test "parser: parse bigint primitive type" {
 }
 
 ///|
+test "parser: parse symbol primitive type" {
+  let src = "export type S = symbol;"
+  let module_ = Parser::from_source(src).parse_module() catch {
+    e => fail("expected symbol primitive type to parse: \{e}")
+  }
+  assert_eq(module_.type_aliases.length(), 1)
+  assert_eq(module_.type_aliases[0].type_, @ast.TsType::Symbol)
+}
+
+///|
 test "parser: parse generic curried function return type" {
   let src =
     #|export declare function ap<F extends URIS2, G extends URIS>(


### PR DESCRIPTION
## Summary

- `infer_typeof_type` で BigInt / Symbol / Array / Tuple / Object / Struct / Constructor / Void を取りこぼしていたケースを narrow できるよう拡張 (closes #40)
- parser で `symbol` キーワードが `Any` に潰されていたのを `@ast.TsType::Symbol` に修正
- TS conformance corpus に対する `.errors.txt` baseline との照合テストを追加し、recall / precision 両方向の回帰を捕捉できるようにした

## Baseline accuracy (新テストの初期測定)

```
parsed=806/822 | recall=143/487 | precision=243/319 (false-positives=76)
```

- recall floor: 25 % (現状 29 %)
- precision floor: false-positive ≤ 28 % (現状 24 %)

## Test plan

- [x] `moon check --deny-warn` clean
- [x] `moon fmt --check` clean
- [x] `moon test --target native` — 2169 / 2169 passed
- [x] 新テスト `checker: accuracy against TypeScript conformance baselines` が通る
- [x] 既存 `parser: parse symbol primitive type` / `expr_check: typeof on {array,bigint,function,symbol,union} operand ...` 追加分も通る

https://claude.ai/code/session_01TSiyyQdph9otVVJNqTFgrv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSiyyQdph9otVVJNqTFgrv)_