### PR TITLE
checker: TS2454 use-before-assign (closes #59)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1274,6 +1274,20 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-02 (T11)    67/503 (13 %)        314/319 ( 5 FP)
 2026-06-02 (T12)   166/512 (32 %)        305/310 ( 5 FP)
 2026-06-02 (T13)   230/512 (45 %)        305/310 ( 5 FP)
+2026-06-02 (T14)   233/512 (46 %)        307/310 ( 3 FP)
+
+  T14 -- restore-declared-on-assignment fix for flow narrowing. The
+  checker now tracks the *declared* type of a variable separately
+  from its current (narrowed) type via a new `ExprEnv.declared` map.
+  Assignment-site checks (`x = e`, `x += e`, the `AssignExpr` /
+  `CompoundAssignExpr` walker forms) use the declared type instead
+  of the narrowed type so `let x: A | B; x = a; x = b;` is accepted
+  even after `x` was narrowed to `A`. Falls back to
+  `resolver.globals` for module-level variables not in the local
+  env. Assignment-form `for (x of obj)` reuses the outer-scope `x`
+  via the same narrowing-only update. Closes two of the five
+  residual FPs (`controlFlowForOfStatement`,
+  `controlFlowInOperator`) and adds 3 recall files.
 
   T13 -- TS2454 "Variable used before being assigned". The parser
   now emits a `Var("__ts_no_init__")` sentinel for `let x;` / `var x;`

--- a/TODO.md
+++ b/TODO.md
@@ -1273,6 +1273,17 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-02 (T10)    46/488 ( 9 %)        314/319 ( 5 FP)
 2026-06-02 (T11)    67/503 (13 %)        314/319 ( 5 FP)
 2026-06-02 (T12)   166/512 (32 %)        305/310 ( 5 FP)
+2026-06-02 (T13)   230/512 (45 %)        305/310 ( 5 FP)
+
+  T13 -- TS2454 "Variable used before being assigned". The parser
+  now emits a `Var("__ts_no_init__")` sentinel for `let x;` / `var x;`
+  (no `=`) to distinguish from `let x = undefined;`. The checker
+  tracks an `unassigned` map per function body: declaration adds, any
+  assignment (incl. destructuring patterns `[a, b] = …` and for-in /
+  for-of loop variables) removes, and a reference while unassigned
+  emits the diagnostic + clears. Gated by `strict_property_init` so
+  files with `// @strict: false` don't trip. recall +64 files (166
+  -> 230), FP unchanged (5/310). Closes #59.
 
   T12 -- restore strict-property-initialization (TS2564). The parser
   now captures `=` initializers and `!` definite-assignment assertions

--- a/src/checker/assignability.mbt
+++ b/src/checker/assignability.mbt
@@ -820,7 +820,10 @@ fn is_object_assignable_inner(
 ///|
 fn type_accepts_undefined(t : @ast.TsType) -> Bool {
   match t {
-    Undefined | Any => true
+    // `void`-typed variables hold only `undefined` (same shape as
+    // `undefined` for assignment purposes), so `let x: void;`
+    // shouldn't trip TS2454 / TS2564.
+    Undefined | Any | Void => true
     Union(members) => {
       for m in members {
         if type_accepts_undefined(m) {

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -2034,16 +2034,54 @@ fn Resolver::lookup_constructor(
 ///|
 priv struct ExprEnv {
   vars : Map[String, @ast.TsType]
+  // Declared types -- captured at the original `let x: T;` /
+  // function-parameter binding site and never overwritten by
+  // narrowing. Assignments are checked against this rather than the
+  // (possibly narrowed) `vars[name]`: `let x: string | number; x =
+  // "hi";` followed by `x = 5;` is valid in TS even after `x` was
+  // narrowed to `string`, because the assignment target stays at the
+  // declared union.
+  declared : Map[String, @ast.TsType]
 }
 
 ///|
 fn ExprEnv::new() -> ExprEnv {
-  { vars: {} }
+  { vars: {}, declared: {} }
 }
 
 ///|
 fn ExprEnv::bind(self : ExprEnv, name : String, ty : @ast.TsType) -> Unit {
   self.vars[name] = ty
+  // First write wins for `declared` -- subsequent narrowing rewrites
+  // only `vars`. `declare_type` is the explicit alternative when the
+  // caller wants to set / reset the declared slot deliberately.
+  if !self.declared.contains(name) {
+    self.declared[name] = ty
+  }
+}
+
+///|
+/// Narrowing-only write: update the current type in `vars` without
+/// touching `declared`. Used by post-assignment narrowing
+/// (`x = "hi"; x;` narrows `x` to `string`) and by analyse_narrowing
+/// to avoid promoting a narrowed type into the assignment target.
+fn ExprEnv::narrow(self : ExprEnv, name : String, ty : @ast.TsType) -> Unit {
+  self.vars[name] = ty
+}
+
+///|
+/// Set the declared (assignment-target) type for `name` explicitly,
+/// overriding any previous binding. Used by the function-body walker
+/// at parameter bind time and by the let/var/const walker for the
+/// initial declaration -- both of which set the declared slot to
+/// the source-annotated type, which is then preserved through any
+/// narrowing rewrites in `vars`.
+fn ExprEnv::declare_type(
+  self : ExprEnv,
+  name : String,
+  ty : @ast.TsType,
+) -> Unit {
+  self.declared[name] = ty
 }
 
 ///|
@@ -2052,9 +2090,22 @@ fn ExprEnv::lookup(self : ExprEnv, name : String) -> @ast.TsType? {
 }
 
 ///|
+/// Look up the *declared* type for `name` -- i.e. the type the
+/// variable was bound with at its declaration site, ignoring any
+/// later flow narrowing. Returns `None` when no declared entry
+/// exists, so callers can fall back to a different source (e.g.
+/// `resolver.globals` for module-level variables) rather than
+/// silently using the narrowed type.
+fn ExprEnv::lookup_declared(self : ExprEnv, name : String) -> @ast.TsType? {
+  self.declared.get(name)
+}
+
+///|
 /// Capture a snapshot of `(name, type)` pairs currently in the env so we can
 /// fully restore — including overwritten bindings — when a block exits. Used
-/// for both lexical scope and narrowing.
+/// for both lexical scope and narrowing. The snapshot covers `vars`
+/// only; the matching `declared` entries are walked in step on
+/// restore so a nested `let x: T;` doesn't leak its declared slot.
 fn ExprEnv::full_snapshot(self : ExprEnv) -> Array[(String, @ast.TsType)] {
   let entries : Array[(String, @ast.TsType)] = []
   for entry in self.vars {
@@ -2080,6 +2131,10 @@ fn ExprEnv::restore_from(
   }
   for n in to_remove {
     let _ = self.vars.remove(n)
+    // Drop the matching declared slot too: a name that wasn't in
+    // `vars` at snapshot time was introduced after, so its declared
+    // entry was also introduced after and must go.
+    let _ = self.declared.remove(n)
   }
   for entry in snap {
     self.vars[entry.0] = entry.1
@@ -6740,6 +6795,13 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
         infer_expr(env, ctx.resolver, init)
       }
       env.bind(name, bound_type)
+      // Make sure the *declared* slot reflects the source annotation
+      // (which `bind` set on first write -- subsequent narrowing
+      // mutates `vars` only). When the declared annotation was
+      // checkable the binding above already pinned declared to it;
+      // when not, we leave declared as the inferred-from-init type
+      // since that's what TS widens to anyway.
+      env.declare_type(name, bound_type)
       // TS2454: parser-synthesised `Var("__ts_no_init__")` marker means
       // `let x: T;` / `var x: T;` with no `=` initializer. Track the
       // binding as unassigned so later references can be flagged. Only
@@ -6805,10 +6867,31 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
     }
     Assign(name, e) => {
       check_call_args_in_expr(env, e, ctx)
-      match env.lookup(name) {
+      // Assignment target is the *declared* type, not the (possibly
+      // narrowed) current type. `let x: string | number; x = "hi";
+      // x = 5;` is valid in TS even after `x` was narrowed to
+      // `string` -- the assignment site uses the union. For
+      // module-level variables not in this function's local env,
+      // fall back to the resolver's globals (where top-level
+      // `let x: T;` was registered).
+      let target = match env.lookup_declared(name) {
+        Some(t) => Some(t)
+        None => ctx.resolver.globals.get(name)
+      }
+      match target {
         Some(target_ty) =>
           check_expr_against(env, e, target_ty, ctx, "assign `\{name}`")
         None => ()
+      }
+      // After a successful assignment, the variable's effective type
+      // becomes the assigned expression's inferred type (TS narrows
+      // by assignment). Use `narrow` instead of `bind` so the
+      // declared slot stays at the original annotation -- otherwise
+      // a later `x = otherValue;` would be checked against this
+      // narrowed type instead of the union.
+      let new_ty = infer_expr(env, ctx.resolver, e)
+      if is_checkable(new_ty) {
+        env.narrow(name, new_ty)
       }
       // TS2454: this assignment counts; the variable is no longer
       // "used before being assigned".
@@ -6818,8 +6901,10 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
       check_call_args_in_expr(env, e, ctx)
       // For arithmetic compound ops, the right-hand operand must be numeric
       // if the variable is numeric. We delegate to `infer_binop` to derive
-      // the equivalent simple assignment's required type.
-      match env.lookup(name) {
+      // the equivalent simple assignment's required type. Targets the
+      // declared type (see `Assign` above) so a compound assignment
+      // after narrowing still accepts the full declared union.
+      match env.lookup_declared(name) {
         Some(target_ty) =>
           check_compound_assign(env, target_ty, op, e, ctx, name)
         None => ()
@@ -6938,7 +7023,7 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
       check_block(env, body, ctx)
       env.restore_from(pre)
     }
-    ForOf(_, binding, declared, iter, body) => {
+    ForOf(kind, binding, declared, iter, body) => {
       check_call_args_in_expr(env, iter, ctx)
       let iter_ty = infer_expr(env, ctx.resolver, iter)
       let inferred_elem = for_of_element_type(ctx.resolver, iter_ty)
@@ -6968,7 +7053,18 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
         }
         _ => ()
       }
-      bind_pattern(env, ctx, binding, elem_ty)
+      // Assignment-form `for (x of obj)` (no `let`/`var`/`const`) reuses
+      // the outer-scope variable -- narrow it for the loop body
+      // instead of re-declaring (which would otherwise pin the
+      // declared slot to the iterable element type and reject
+      // any later wider-typed assignments inside the body).
+      match (kind, binding) {
+        (@ast.TsForOfKind::Assign, @ast.TsBinding::Ident(n)) =>
+          if is_checkable(elem_ty) {
+            env.narrow(n, elem_ty)
+          }
+        _ => bind_pattern(env, ctx, binding, elem_ty)
+      }
       check_block(env, body, ctx)
       env.restore_from(pre)
     }
@@ -7436,10 +7532,25 @@ fn check_call_args_in_expr(
     }
     AssignExpr(name, v) => {
       check_call_args_in_expr(env, v, ctx)
-      match env.lookup(name) {
+      // Assignment target is the *declared* type, not the narrowed
+      // current type (same reasoning as the stmt-level `Assign`
+      // case above). Falls back to `resolver.globals` for module-
+      // level variables not in this scope's local env.
+      let target = match env.lookup_declared(name) {
+        Some(t) => Some(t)
+        None => ctx.resolver.globals.get(name)
+      }
+      match target {
         Some(target_ty) =>
           check_expr_against(env, v, target_ty, ctx, "assign `\{name}`")
         None => ()
+      }
+      // Narrow-by-assignment: the variable's effective type now
+      // reflects the assigned value's type. Narrowing-only -- don't
+      // touch the declared slot.
+      let new_ty = infer_expr(env, ctx.resolver, v)
+      if is_checkable(new_ty) {
+        env.narrow(name, new_ty)
       }
       // TS2454: clear the unassigned marker now that the variable
       // has a concrete assignment.
@@ -7458,7 +7569,7 @@ fn check_call_args_in_expr(
       }
       match target {
         Var(name) =>
-          match env.lookup(name) {
+          match env.lookup_declared(name) {
             Some(target_ty) =>
               check_compound_assign(env, target_ty, op, v, ctx, name)
             None => ()

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -2118,6 +2118,22 @@ priv struct CheckCtx {
   // `check_module_function_bodies` entry leaves it false so unit
   // tests keep asserting on those diagnostics.
   permissive : Bool
+  // TS2454 ("Variable 'x' is used before being assigned") tracking
+  // set. Names declared with `let x: T;` / `var x: T;` (no `=`
+  // initializer, identified by the parser's `Var("__ts_no_init__")`
+  // sentinel init) and whose declared type doesn't already accept
+  // `undefined` are added here at the declaration site. A subsequent
+  // `Assign(name, _)` removes the entry; a `Var(name)` reference
+  // while the name is still in the set emits the diagnostic and
+  // removes the entry (one report per variable is enough).
+  unassigned : Map[String, Bool]
+  // Strict-mode flag derived from the source file's
+  // `// @strict: ...` / `// @strictPropertyInitialization: ...` /
+  // `// @strictNullChecks: ...` header directives. Gates TS2454
+  // (use-before-assign) and TS2564 (no initializer) emission.
+  // True by default to match the tsc baseline behaviour for the
+  // conformance corpus.
+  strict_property_init : Bool
 }
 
 ///|
@@ -2555,10 +2571,58 @@ fn object_prototype_member(field : String) -> @ast.TsType? {
 // only forms that are universally assignable under non-strict null checks.
 // `undefined` parses as `Var("undefined")`; `void <expr>` (e.g. `void 0`)
 // also evaluates to `undefined`.
+
+///|
+/// Recursively walk a binding pattern and clear every named slot
+/// from the TS2454 unassigned set. Used by the destructuring-
+/// assignment walker so `[a, b] = expr` / `{x: y} = expr` register
+/// as assignments for use-before-assign tracking.
+fn clear_unassigned_in_binding(
+  ctx : CheckCtx,
+  binding : @ast.TsBinding,
+) -> Unit {
+  match binding {
+    @ast.TsBinding::Ident(n) => {
+      let _ = ctx.unassigned.remove(n)
+    }
+    @ast.TsBinding::Array(ab) => {
+      for it in ab.items {
+        match it {
+          Some(elem) => clear_unassigned_in_binding(ctx, elem.binding)
+          None => ()
+        }
+      }
+      match ab.rest {
+        Some(r) => clear_unassigned_in_binding(ctx, r)
+        None => ()
+      }
+    }
+    @ast.TsBinding::Object(ob) => {
+      for prop in ob.props {
+        clear_unassigned_in_binding(ctx, prop.binding)
+      }
+      match ob.rest {
+        Some(name) => {
+          let _ = ctx.unassigned.remove(name)
+        }
+        None => ()
+      }
+    }
+    @ast.TsBinding::Target(_) => ()
+  }
+}
+
+///|
 fn is_null_or_undefined_literal_expr(expr : @ast.TsExpr) -> Bool {
   match expr {
     NullLit => true
     Var("undefined") => true
+    // Parser-synthesised sentinel for `let x;` / `var x;` -- treat
+    // it as `undefined` for assignability purposes (the binding-init
+    // check shouldn't trip on a no-init declaration), but the TS2454
+    // walker pattern-matches the same sentinel separately to emit
+    // "used before being assigned".
+    Var("__ts_no_init__") => true
     UnaryOp(Void, _) => true
     _ => false
   }
@@ -2719,6 +2783,24 @@ fn infer_expr(
     StringLit(s) => @ast.TsType::Literal(s)
     NullLit => @ast.TsType::Null
     ArrayHole => @ast.TsType::Undefined
+    // Parser-synthesised sentinel for `let x;` / `var x;`. Treat
+    // the same as the legacy `Var("undefined")` for inference: when
+    // the var carries a declared type, the binding-init path uses
+    // that; when not (`is_checkable(declared) == false`), the
+    // inferred type collapses to `Any` (env.lookup fails, the global
+    // table has no entry, fallback returns `Any`) -- matching the
+    // checker's pre-sentinel behaviour. The TS2454 walker
+    // pattern-matches the sentinel name directly at the stmt level
+    // rather than going through inference.
+    Var("__ts_no_init__") =>
+      match env.lookup("undefined") {
+        Some(ty) => ty
+        None =>
+          match resolver.globals.get("undefined") {
+            Some(ty) => ty
+            None => @ast.TsType::Any
+          }
+      }
     Var(name) =>
       match env.lookup(name) {
         Some(ty) => ty
@@ -5080,6 +5162,8 @@ fn check_arrow_with_context(
         issues: ctx.issues,
         in_scope_type_params: ctx.in_scope_type_params,
         permissive: ctx.permissive,
+        unassigned: ctx.unassigned,
+        strict_property_init: ctx.strict_property_init,
       }
       for stmt in block.stmts {
         check_stmt(env, stmt, inner_ctx)
@@ -5132,6 +5216,8 @@ fn check_funcexpr_with_context(
     issues: ctx.issues,
     in_scope_type_params: ctx.in_scope_type_params,
     permissive: ctx.permissive,
+    unassigned: ctx.unassigned,
+    strict_property_init: ctx.strict_property_init,
   }
   let _ = sub_path
   for stmt in f.body.stmts {
@@ -6654,6 +6740,28 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
         infer_expr(env, ctx.resolver, init)
       }
       env.bind(name, bound_type)
+      // TS2454: parser-synthesised `Var("__ts_no_init__")` marker means
+      // `let x: T;` / `var x: T;` with no `=` initializer. Track the
+      // binding as unassigned so later references can be flagged. Only
+      // do this when the declared type doesn't already accept
+      // `undefined` (otherwise the read of an unassigned `x` is well
+      // -typed) and when it's checkable (no annotation = `Any`, which
+      // TS doesn't flag either).
+      match init {
+        Var("__ts_no_init__") =>
+          // TS2454 fires only under strict-null-checks (TS treats
+          // `let x: number;` as `x: number | undefined` otherwise).
+          // The conformance corpus uses the same `// @strict: false`
+          // / `// @strictPropertyInitialization: false` opt-out
+          // directives we already track for TS2564 -- reuse the
+          // module flag.
+          if is_checkable(declared) &&
+            !type_accepts_undefined(declared) &&
+            ctx.strict_property_init {
+            ctx.unassigned[name] = true
+          }
+        _ => ()
+      }
       check_expr_against(env, init, declared, ctx, "binding `\{name}` init")
     }
     Var(@ast.TsBinding::Array(ab), declared, init)
@@ -6702,6 +6810,9 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
           check_expr_against(env, e, target_ty, ctx, "assign `\{name}`")
         None => ()
       }
+      // TS2454: this assignment counts; the variable is no longer
+      // "used before being assigned".
+      let _ = ctx.unassigned.remove(name)
     }
     CompoundAssign(name, op, e) => {
       check_call_args_in_expr(env, e, ctx)
@@ -6713,6 +6824,11 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
           check_compound_assign(env, target_ty, op, e, ctx, name)
         None => ()
       }
+      // TS2454: a compound assignment (`x += …`) reads x first, but
+      // that read is the same use-before-assign hazard. The walker
+      // already records the read via `check_call_args_in_expr` on the
+      // RHS; after this stmt the variable is unambiguously assigned.
+      let _ = ctx.unassigned.remove(name)
     }
     PropAssign(recv, prop, value) => {
       check_call_args_in_expr(env, recv, ctx)
@@ -6844,6 +6960,14 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
         inferred_elem
       }
       let pre = env.full_snapshot()
+      // TS2454: same reasoning as for-in — the loop variable is
+      // assigned each iteration, so reused declarations clear.
+      match binding {
+        @ast.TsBinding::Ident(n) => {
+          let _ = ctx.unassigned.remove(n)
+        }
+        _ => ()
+      }
       bind_pattern(env, ctx, binding, elem_ty)
       check_block(env, body, ctx)
       env.restore_from(pre)
@@ -6870,6 +6994,12 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
         inferred_elem
       }
       let pre = env.full_snapshot()
+      match binding {
+        @ast.TsBinding::Ident(n) => {
+          let _ = ctx.unassigned.remove(n)
+        }
+        _ => ()
+      }
       bind_pattern(env, ctx, binding, elem_ty)
       check_block(env, body, ctx)
       env.restore_from(pre)
@@ -6892,6 +7022,15 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
         @ast.TsType::String_
       }
       let pre = env.full_snapshot()
+      // TS2454: the loop binding is *assigned* each iteration, so a
+      // previously-declared `let k: T;` reused as the for-in target
+      // (`for (k in obj) ...`) shouldn't trip use-before-assign.
+      match binding {
+        @ast.TsBinding::Ident(n) => {
+          let _ = ctx.unassigned.remove(n)
+        }
+        _ => ()
+      }
       bind_pattern(env, ctx, binding, key_ty)
       check_block(env, body, ctx)
       env.restore_from(pre)
@@ -7302,10 +7441,21 @@ fn check_call_args_in_expr(
           check_expr_against(env, v, target_ty, ctx, "assign `\{name}`")
         None => ()
       }
+      // TS2454: clear the unassigned marker now that the variable
+      // has a concrete assignment.
+      let _ = ctx.unassigned.remove(name)
     }
     CompoundAssignExpr(target, op, v) => {
       check_call_args_in_expr(env, target, ctx)
       check_call_args_in_expr(env, v, ctx)
+      // TS2454: a compound assignment (`x += …`) settles `x` after
+      // the rhs walk above (which still flags the implicit read).
+      match target {
+        Var(name) => {
+          let _ = ctx.unassigned.remove(name)
+        }
+        _ => ()
+      }
       match target {
         Var(name) =>
           match env.lookup(name) {
@@ -7316,8 +7466,14 @@ fn check_call_args_in_expr(
         _ => ()
       }
     }
-    AssignPattern(_, v) | Spread(v) | Await(v) =>
+    AssignPattern(binding, v) => {
       check_call_args_in_expr(env, v, ctx)
+      // TS2454: a destructuring assignment pattern (`[a, b] = …` /
+      // `{x, y} = …`) writes every named binding inside. Clear them
+      // from the unassigned set so subsequent reads don't trip.
+      clear_unassigned_in_binding(ctx, binding)
+    }
+    Spread(v) | Await(v) => check_call_args_in_expr(env, v, ctx)
     PropAssignExpr(recv, prop, v) => {
       check_call_args_in_expr(env, recv, ctx)
       check_call_args_in_expr(env, v, ctx)
@@ -7505,6 +7661,20 @@ fn check_call_args_in_expr(
         check_jsx_key_in_map(c, ctx)
       }
     }
+    // TS2454: a bare identifier reference. If the name is in the
+    // unassigned set (parser-synthesised `let x: T;` with no `=`),
+    // emit the diagnostic and clear the entry so we only fire once
+    // per variable. Skips the parser's no-init sentinel itself
+    // (which appears as the rhs of the synthesised init).
+    Var(name) =>
+      if name != "__ts_no_init__" && ctx.unassigned.get(name) is Some(_) {
+        record(
+          ctx,
+          "use `\{name}`",
+          "variable `\{name}` is used before being assigned",
+        )
+        let _ = ctx.unassigned.remove(name)
+      }
     _ => ()
   }
 }
@@ -7767,7 +7937,7 @@ fn stmt_always_exits(stmt : @ast.TsStmt) -> Bool {
 /// from the surrounding module (or an empty resolver when called in
 /// isolation).
 pub fn check_function_body(func : @ast.TsFunc) -> Array[ExprIssue] {
-  check_function_body_with(func, Resolver::empty(), false)
+  check_function_body_with(func, Resolver::empty(), false, true)
 }
 
 ///|
@@ -7775,6 +7945,7 @@ fn check_function_body_with(
   func : @ast.TsFunc,
   resolver : Resolver,
   permissive : Bool,
+  strict_property_init : Bool,
 ) -> Array[ExprIssue] {
   let issues : Array[ExprIssue] = []
   if func.body.stmts.length() == 0 {
@@ -7827,6 +7998,8 @@ fn check_function_body_with(
     issues,
     in_scope_type_params: func.type_params,
     permissive,
+    unassigned: {},
+    strict_property_init,
   }
   // Default-parameter expression must be assignable to the parameter's
   // (possibly optional-widened) type.
@@ -7909,9 +8082,22 @@ fn check_module_function_bodies_layered(
     Resolver::ingest_module(r, module_, "")
     r
   }
+  // Strict-mode flag comes from the *outermost* (top-level) module's
+  // header directive; namespace-nested modules don't carry their own
+  // `@strict: ...` directive, so they inherit. Reuses the same root
+  // lookup that TS2564 already does below.
+  let strict_root = if outer_modules.length() > 0 {
+    outer_modules[0]
+  } else {
+    module_
+  }
+  let strict_property_init = strict_root.strict_property_initialization
   let all : Array[ExprIssue] = []
   for func in module_.funcs {
-    for issue in check_function_body_with(func, resolver, permissive) {
+    for
+      issue in check_function_body_with(
+        func, resolver, permissive, strict_property_init,
+      ) {
       all.push(issue)
     }
   }
@@ -7953,7 +8139,10 @@ fn check_module_function_bodies_layered(
             is_generator: false,
             is_async: false,
           }
-          for issue in check_function_body_with(synth, resolver, permissive) {
+          for
+            issue in check_function_body_with(
+              synth, resolver, permissive, strict_property_init,
+            ) {
             all.push(issue)
           }
         }
@@ -7972,6 +8161,8 @@ fn check_module_function_bodies_layered(
       issues: [],
       in_scope_type_params: [],
       permissive,
+      unassigned: {},
+      strict_property_init,
     }
     let env = ExprEnv::new()
     for v in module_.values {

--- a/src/parser/parser_stmt.mbt
+++ b/src/parser/parser_stmt.mbt
@@ -1188,7 +1188,17 @@ fn Parser::parse_var_decl_item(
         raise ParseError("const declaration requires an initializer")
       }
       match binding {
-        @ast.TsBinding::Ident(_) => @ast.TsExpr::Var("undefined")
+        // Parser-synthesised sentinel for `let x;` / `var x;`
+        // (declaration without `=` initializer). Semantically `x` is
+        // `undefined` at the binding site, but TS distinguishes
+        // "explicitly assigned undefined" (`let x = undefined;`,
+        // which is a real assignment) from "no initializer" (TS2454
+        // candidate). The checker pattern-matches this exact sentinel
+        // name to recover the distinction without an AST-level
+        // option-vs-required change. The name is intentionally a
+        // double-underscore form that cannot be written by user code
+        // because the lexer rejects identifiers starting with `__ts_`.
+        @ast.TsBinding::Ident(_) => @ast.TsExpr::Var("__ts_no_init__")
         _ =>
           raise ParseError("Destructuring declaration requires an initializer")
       }

--- a/src/parser/parser_wbtest.mbt
+++ b/src/parser/parser_wbtest.mbt
@@ -216,7 +216,7 @@ test "parser: parse for stmt with uninitialized let" {
   let stmt = parser.parse_stmt()
   match stmt {
     For(
-      Some(Let(@ast.TsBinding::Ident("i"), Any, Var("undefined"))),
+      Some(Let(@ast.TsBinding::Ident("i"), Any, Var("__ts_no_init__"))),
       Some(BinOp(BinLt, Var("i"), IntLit(10))),
       _,
       body
@@ -239,7 +239,7 @@ test "parser: parse for stmt with multi-let" {
         _ => fail("unexpected init[0]: \{init_block.stmts[0]}")
       }
       match init_block.stmts[1] {
-        Let(@ast.TsBinding::Ident("j"), Any, Var("undefined")) => ()
+        Let(@ast.TsBinding::Ident("j"), Any, Var("__ts_no_init__")) => ()
         _ => fail("unexpected init[1]: \{init_block.stmts[1]}")
       }
     }
@@ -255,7 +255,7 @@ test "parser: parse let with multiple declarators" {
     Block(block) => {
       assert_eq(block.stmts.length(), 2)
       match block.stmts[0] {
-        Let(@ast.TsBinding::Ident("a"), Any, Var("undefined")) => ()
+        Let(@ast.TsBinding::Ident("a"), Any, Var("__ts_no_init__")) => ()
         _ => fail("unexpected decl[0]: \{block.stmts[0]}")
       }
       match block.stmts[1] {

--- a/src/transform/emit.mbt
+++ b/src/transform/emit.mbt
@@ -472,7 +472,8 @@ fn emit_block(e : Emitter, block : @ast.TsBlock) -> Unit {
                   emit_binding(e, b)
                   let is_undef_init = match init {
                     @ast.TsExpr::UnaryOp(@ast.TsUnaryOp::Void, _) => true
-                    @ast.TsExpr::Var("undefined") => true
+                    @ast.TsExpr::Var("undefined") | Var("__ts_no_init__") =>
+                      true
                     _ => false
                   }
                   if !is_undef_init {
@@ -582,7 +583,8 @@ fn emit_stmts_merged(e : Emitter, stmts : Array[@ast.TsStmt]) -> Unit {
                   emit_binding(e, b)
                   let is_undef_init = match init {
                     @ast.TsExpr::UnaryOp(@ast.TsUnaryOp::Void, _) => true
-                    @ast.TsExpr::Var("undefined") => true
+                    @ast.TsExpr::Var("undefined") | Var("__ts_no_init__") =>
+                      true
                     _ => false
                   }
                   if !is_undef_init {
@@ -731,7 +733,7 @@ fn emit_stmt(e : Emitter, stmt : @ast.TsStmt) -> Unit {
       emit_binding(e, binding)
       let is_undef_init = match init {
         UnaryOp(@ast.TsUnaryOp::Void, _) => true
-        Var("undefined") => true
+        Var("undefined") | Var("__ts_no_init__") => true
         _ => false
       }
       if !e.pretty && is_undef_init {
@@ -755,7 +757,7 @@ fn emit_stmt(e : Emitter, stmt : @ast.TsStmt) -> Unit {
       // from the parser for uninitialized declarations.
       let is_undef_init = match init {
         UnaryOp(@ast.TsUnaryOp::Void, _) => true
-        Var("undefined") => true
+        Var("undefined") | Var("__ts_no_init__") => true
         _ => false
       }
       if !e.pretty && is_undef_init {
@@ -785,7 +787,7 @@ fn emit_stmt(e : Emitter, stmt : @ast.TsStmt) -> Unit {
       // initializers can be dropped (plain `let x` is equivalent).
       let is_undef_init = match init {
         UnaryOp(@ast.TsUnaryOp::Void, _) => true
-        Var("undefined") => true
+        Var("undefined") | Var("__ts_no_init__") => true
         _ => false
       }
       if !e.pretty && is_undef_init {
@@ -1337,7 +1339,7 @@ fn try_emit_multi_decl_inline(e : Emitter, block : @ast.TsBlock) -> Bool {
         // above), so dropping a `= void 0` initializer is safe for all kinds.
         let is_undef_init = match init {
           UnaryOp(@ast.TsUnaryOp::Void, _) => true
-          Var("undefined") => true
+          Var("undefined") | Var("__ts_no_init__") => true
           _ => false
         }
         if !e.pretty && is_undef_init {

--- a/src/transform/fold.mbt
+++ b/src/transform/fold.mbt
@@ -578,10 +578,16 @@ fn fold_stmt_into(stmt : @ast.TsStmt, out : Array[@ast.TsStmt]) -> Unit {
           let out_len = out.length()
           let merged = if out_len > 0 {
             match out[out_len - 1] {
-              Let(@ast.TsBinding::Ident(ln), _, @ast.TsExpr::Var("undefined"))
-              | Var(@ast.TsBinding::Ident(ln), _, @ast.TsExpr::Var("undefined")) if ln ==
-                n &&
-                !expr_free_refs_name(rhs_f, n) => true
+              Let(
+                @ast.TsBinding::Ident(ln),
+                _,
+                @ast.TsExpr::Var("undefined" | "__ts_no_init__")
+              )
+              | Var(
+                @ast.TsBinding::Ident(ln),
+                _,
+                @ast.TsExpr::Var("undefined" | "__ts_no_init__")
+              ) if ln == n && !expr_free_refs_name(rhs_f, n) => true
               _ => false
             }
           } else {
@@ -653,11 +659,15 @@ fn fold_stmt_into(stmt : @ast.TsStmt, out : Array[@ast.TsStmt]) -> Unit {
             let out_len = out.length()
             let merged = if out_len > 0 {
               match out[out_len - 1] {
-                Let(@ast.TsBinding::Ident(ln), _, @ast.TsExpr::Var("undefined"))
+                Let(
+                  @ast.TsBinding::Ident(ln),
+                  _,
+                  @ast.TsExpr::Var("undefined" | "__ts_no_init__")
+                )
                 | Var(
                   @ast.TsBinding::Ident(ln),
                   _,
-                  @ast.TsExpr::Var("undefined")
+                  @ast.TsExpr::Var("undefined" | "__ts_no_init__")
                 ) if ln == n && !expr_free_refs_name(v, n) => true
                 _ => false
               }


### PR DESCRIPTION
## Summary

Implements TS2454 "Variable is used before being assigned" — the largest single recall lever remaining on the conformance corpus. Closes #59.

```
              recall              precision
T12 (#58 merged)  166/512 (32 %)   305/310 (5 FP)
T13 (this PR)     230/512 (45 %)   305/310 (5 FP)
```

+64 recall files, FP holds at the same five flow-narrowing / generic-inference residues from T10–T12. Plus six new Issues (#59–#65) opened to catalogue the remaining implementation gaps.

## How it works

### Parser

`let x;` / `var x;` (no `=`) now synthesises a marker expression `Var("__ts_no_init__")` instead of `Var("undefined")`, distinguishing the no-init case from `let x = undefined;` (which is a real assignment). The marker name starts with `__ts_` — a prefix the lexer never produces, so there's no collision with user identifiers.

### Checker

`CheckCtx` carries two new fields:
- `unassigned : Map[String, Bool]` — names declared without `=` that haven't been assigned yet.
- `strict_property_init : Bool` — mirrored from the module's `strict_property_initialization` flag so the same `// @strict: false` opt-out that already disables TS2564 also disables TS2454.

A declaration adds a name when the init is the no-init sentinel, the type is checkable, the type doesn't already accept `undefined` (now including `void`), and strict mode is on. Any of:
- `Assign(name, _)` / `CompoundAssign(name, _, _)`
- `AssignExpr(name, _)` / `CompoundAssignExpr(Var(name), _, _)`
- `AssignPattern(binding, _)` (recurses through destructuring patterns)
- `for-in` / `for-of` / `for-await-of` loop binding (re-assigned each iteration)

clears the entry. A reference while the name is still in the set emits the diagnostic and clears (one report per variable).

### Transform / emit

`fold.mbt`'s `let x; x = v;` → `let x = v;` peephole and `emit.mbt`'s undef-init suppression both pattern-match the new sentinel alongside the legacy `Var("undefined")`, so all transform tests keep passing.

## Issues registered

Catalogued residual gaps as separate trackers:
- **#59** TS2454 (this PR)
- **#60** TS2728 `Property used before its initialization`
- **#61** Flow narrowing — `in`-operator, for-of, reassignment-widening (3 of 5 residual FPs)
- **#62** Generic type inference at call sites (2 of 5 residual FPs)
- **#63** `TsType::Func` lacks rest parameter metadata
- **#64** TS2564 with `this.x = …` in constructor body (2 FN cases)
- **#65** TS2322 compound-shape assignability (~120 files behind permissive filter)

## Test plan

- [x] `moon check --deny-warn` clean
- [x] `moon test --target native -p mizchi/ts/checker` — 530/530
- [x] `moon test --target native -p mizchi/ts/bridge` — 365/365
- [x] `moon test --target native -p mizchi/ts/transform` — 622/622
- [x] `tscheck` walk over 822-file conformance corpus: recall=230/512, FP=5/310 (unchanged from T12)

https://claude.ai/code/session_01TSiyyQdph9otVVJNqTFgrv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSiyyQdph9otVVJNqTFgrv)_