### PR TITLE
checker: T15 — recall 233 → 247, FP 3 → 2

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1275,6 +1275,44 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-02 (T12)   166/512 (32 %)        305/310 ( 5 FP)
 2026-06-02 (T13)   230/512 (45 %)        305/310 ( 5 FP)
 2026-06-02 (T14)   233/512 (46 %)        307/310 ( 3 FP)
+2026-06-02 (T15)   247/512 (48 %)        308/310 ( 2 FP)
+
+  T15 -- three small composable wins.
+
+    1. Param destructure: `check_function_body_with` walked
+       `func.params` and bound `p.name -> p.type_`, treating
+       `function f({ a, b }: T)` as binding the synthesized first
+       name of the pattern to the full `T`. Inside the body `a`, `b`
+       then looked up as `Any`. Now: when `p.binding` is a
+       `TsBinding::Object` / `TsBinding::Array`, walk via
+       `bind_pattern` so inner names point at per-field /
+       per-element types.
+
+    2. `||` narrowing: `Or => narrow_union(l, r)` ignored short-
+       circuit semantics, so `(T | undefined) || T` typed as
+       `T | undefined`. Switched to
+       `narrow_union(non_nullable(l), r)`.
+
+    3. Type-guard intersection: `apply_type_predicate_narrowing`
+       fell back to `target` when `narrow_keep` reduced to `Never`,
+       which happens when `cur` is a single Named that isn't
+       structurally assignable to `target` (e.g.
+       `function hasLegs(x: Beast): x is Legged` where Legged is a
+       narrower shape than Beast). TS narrows to `cur & target`,
+       not just `target` — preserving the source-type association.
+
+    4. Bare-Named admission in the permissive filter, with a 3-char
+       + lowercase guard to exclude conventional type-parameter
+       names (`T`, `S2`).
+
+    5. Property / method missing on a bare-primitive receiver
+       (`number` / `string` / `boolean` / `bigint`) is admitted —
+       prototype dispatch covers the genuine uses, so a remaining
+       miss is real.
+
+    Together: +14 recall, -1 FP (controlFlowElementAccessNoCrash1
+    cleared; intersection narrowing prevented a new typeGuards FP).
+    Both remaining FPs are Issue #62 territory.
 
   T14 -- restore-declared-on-assignment fix for flow narrowing. The
   checker now tracks the *declared* type of a variable separately

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -2244,9 +2244,29 @@ fn is_permissively_suppressed(sub_path : String, message : String) -> Bool {
       message.contains("does not exist on target type") ||
       message.contains("is required by")
     ) {
+    // Carve out a narrow exception: when the receiver renders as a
+    // bare primitive type (`number`, `string`, `boolean`, `bigint`),
+    // missing-property is a reliable signal — prototype dispatch
+    // covers the legitimate uses (`(1).toString()`, `"x".charAt(0)`)
+    // via `prim["method"]` lookup, so a remaining miss is a real bug.
+    if message.contains("does not exist on `number`") ||
+      message.contains("does not exist on `string`") ||
+      message.contains("does not exist on `boolean`") ||
+      message.contains("does not exist on `bigint`") {
+      return false
+    }
     return true
   }
   if message.has_prefix("method `") && message.contains("does not exist on") {
+    // Same carve-out as the property branch: bare-primitive receiver
+    // produces a reliable missing-method signal because prototype
+    // dispatch covers the genuine uses already.
+    if message.contains("does not exist on `number`") ||
+      message.contains("does not exist on `string`") ||
+      message.contains("does not exist on `boolean`") ||
+      message.contains("does not exist on `bigint`") {
+      return false
+    }
     return true
   }
   if message.contains("argument(s), got ") {

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -3701,8 +3701,13 @@ fn infer_binop(
     // `a && b` — when `a` is truthy the result is `b`; otherwise the falsy
     // `a`. Conservative: union both sides.
     And => narrow_union(l, r)
-    // `a || b` — when `a` is truthy the result is `a`; otherwise `b`.
-    Or => narrow_union(l, r)
+    // `a || b` — when `a` is truthy the result is `a`; otherwise `b`. TS
+    // narrows the truthy branch by stripping always-falsy variants from
+    // `l` (null / undefined are the practically-relevant ones here, since
+    // we don't model literal-value falsiness for primitives like
+    // `0` / `""` / `false`). Matches the common `x || default` pattern
+    // where `x: T | undefined` and `default: T` produce `T`.
+    Or => narrow_union(non_nullable(l), r)
     // `a ?? b` — `b` is only evaluated when `a` is null/undefined, so the
     // result strips nullish from `a` and unions with `b`'s type.
     Coalesce => narrow_union(non_nullable(l), r)
@@ -8063,9 +8068,6 @@ fn check_function_body_with(
     return issues
   }
   let env = ExprEnv::new()
-  for p in func.params {
-    env.bind(p.name, p.type_)
-  }
   // Inside an async function body, `return x` returns the inner type — the
   // wrapping `Promise<T>` is what the *caller* sees. So we unwrap once for
   // the body-level return check.
@@ -8111,6 +8113,21 @@ fn check_function_body_with(
     permissive,
     unassigned: {},
     strict_property_init,
+  }
+  // Bind parameter names into the environment. Destructured params
+  // (`function f({ a, b }: T)` / `function f([a, b]: T[])`) carry a
+  // `TsBinding::Object` / `TsBinding::Array` and need pattern walking
+  // so the inner names point at the field/element types — not the
+  // whole parameter type.
+  for p in func.params {
+    match p.binding {
+      Some(@ast.TsBinding::Object(_)) | Some(@ast.TsBinding::Array(_)) =>
+        match p.binding {
+          Some(b) => bind_pattern(env, ctx, b, p.type_)
+          None => env.bind(p.name, p.type_)
+        }
+      _ => env.bind(p.name, p.type_)
+    }
   }
   // Default-parameter expression must be assignable to the parameter's
   // (possibly optional-widened) type.

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -2452,7 +2452,21 @@ fn is_reliable_mismatch_type(s : String) -> Bool {
     | "true"
     | "false"
     | "object" => return true
+    // `type` is the fallback string from `type_display` for Object /
+    // Struct / Null / NumberLiteral / BooleanLiteral etc. — opaque
+    // shapes where we can't be confident about reliability.
+    "type" | "function" => return false
     _ => ()
+  }
+  // Bare identifier: a single Named type (e.g. `C`, `I`, `Point`).
+  // These come from interface / class / type-alias references. When
+  // both sides of a mismatch render as a bare identifier, it's a
+  // clean Named-vs-Named comparison that strict assignability gets
+  // right (no flow narrowing, no generic inference, no anonymous
+  // shapes to flatten). Conservative shape check: first char is a
+  // letter or `_`, rest are alphanumeric or `_`.
+  if s.length() > 0 && is_bare_identifier(s) {
+    return true
   }
   // String literal types: `"foo" (string)` exactly (no embedded
   // newlines, no compound suffix). The strict `"X" (string)` match
@@ -2474,6 +2488,49 @@ fn is_reliable_mismatch_type(s : String) -> Bool {
     }
   }
   false
+}
+
+///|
+/// True when `s` is a bare identifier that is *unlikely* to be a type
+/// parameter name. Conventional type parameters in TS test fixtures are
+/// short uppercase forms (`T`, `U`, `K`, `V`, `S2`, `T2`); concrete
+/// class/interface/alias names almost always contain a lowercase letter
+/// (`Beast`, `Point`, `Promise`) or are at least 3+ chars. Used by
+/// `is_reliable_mismatch_type` to admit Named-vs-Named mismatches
+/// (e.g. `expected `Beast` but got `Legged``) through the permissive
+/// filter without unleashing Type-parameter-vs-Type-parameter false
+/// positives from generic call sites.
+fn is_bare_identifier(s : String) -> Bool {
+  if s.length() < 3 {
+    return false
+  }
+  let bytes = s.to_array()
+  let head = bytes[0]
+  let head_ok = (head >= 'a' && head <= 'z') ||
+    (head >= 'A' && head <= 'Z') ||
+    head == '_' ||
+    head == '$'
+  if !head_ok {
+    return false
+  }
+  let mut i = 1
+  let mut has_lower = head >= 'a' && head <= 'z'
+  while i < bytes.length() {
+    let c = bytes[i]
+    let ok = (c >= 'a' && c <= 'z') ||
+      (c >= 'A' && c <= 'Z') ||
+      (c >= '0' && c <= '9') ||
+      c == '_' ||
+      c == '$'
+    if !ok {
+      return false
+    }
+    if c >= 'a' && c <= 'z' {
+      has_lower = true
+    }
+    i = i + 1
+  }
+  has_lower
 }
 
 ///|
@@ -6230,11 +6287,20 @@ fn apply_type_predicate_narrowing(
   match args[idx] {
     Var(arg_name) => {
       let cur = env_lookup_full(env, resolver, arg_name)
-      // Positive: narrow to T. If `keep` produces Never (e.g. cur is Any),
-      // fall back to target.
+      // Positive: narrow to T. If `keep` produces Never (e.g. cur is a
+      // single Named that isn't assignable to `target` but the source
+      // type genuinely supports the predicate, like
+      // `function hasLegs(x: Beast): x is Legged`), fall back to the
+      // intersection `cur & target` — TS narrows to that intersection,
+      // not just to `target`, so subsequent calls expecting `cur` still
+      // accept the narrowed value.
       let then_ty = narrow_keep(cur, fn(v) { is_assignable_to(v, target) })
       let then_resolved = match then_ty {
-        Never => target
+        Never =>
+          match cur {
+            Any => target
+            _ => @ast.TsType::Intersection([cur, target])
+          }
         _ => then_ty
       }
       pair_pos.push((arg_name, then_resolved))

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -6073,3 +6073,131 @@ test "expr_check: valid TS patterns are not false-positives" {
   }
   @test.assert_eq(fps, 0)
 }
+
+///|
+/// Minimal: destructuring param's array field, then index it.
+test "expr_check: minimal — destructure array field, index it" {
+  let src =
+    #|interface Edit { caption: string; }
+    #|interface Input { edits: Edit[]; index: number; }
+    #|function f({ edits, index }: Input): string {
+    #|  return edits[index].caption;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  if issues.length() != 0 {
+    println("MINIMAL A UNEXPECTED:")
+    for i in issues {
+      println("  \{i.path} -> \{i.message}")
+    }
+  }
+  @test.assert_eq(issues.length(), 0)
+}
+
+///|
+/// Add nested destructuring on result of index.
+test "expr_check: nested destructure on index result" {
+  let src =
+    #|interface Edit { caption: string; }
+    #|interface Input { edits: Edit[]; index: number; }
+    #|function f({ edits, index }: Input): string {
+    #|  const { caption } = edits[index];
+    #|  return caption;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  if issues.length() != 0 {
+    println("MINIMAL B UNEXPECTED:")
+    for i in issues {
+      println("  \{i.path} -> \{i.message}")
+    }
+  }
+  @test.assert_eq(issues.length(), 0)
+}
+
+///|
+/// Test with explicit parameter type (no destructuring at param) — does it still fail?
+test "expr_check: nested destructure on index result (no param destructure)" {
+  let src =
+    #|interface Edit { caption: string; }
+    #|interface Input { edits: Edit[]; index: number; }
+    #|function f(input: Input): string {
+    #|  const { caption } = input.edits[input.index];
+    #|  return caption;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  if issues.length() != 0 {
+    println("MINIMAL B2 UNEXPECTED:")
+    for i in issues {
+      println("  \{i.path} -> \{i.message}")
+    }
+  }
+  @test.assert_eq(issues.length(), 0)
+}
+
+///|
+/// Test with intermediate let binding.
+test "expr_check: nested destructure with let intermediate" {
+  let src =
+    #|interface Edit { caption: string; }
+    #|interface Input { edits: Edit[]; index: number; }
+    #|function f({ edits, index }: Input): string {
+    #|  const e = edits[index];
+    #|  const { caption } = e;
+    #|  return caption;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  if issues.length() != 0 {
+    println("MINIMAL B3 UNEXPECTED:")
+    for i in issues {
+      println("  \{i.path} -> \{i.message}")
+    }
+  }
+  @test.assert_eq(issues.length(), 0)
+}
+
+///|
+/// Regression: controlFlowElementAccessNoCrash1.ts. `edits` is bound via
+/// destructuring of an interface field typed `readonly TestTscEdit[]`.
+/// Indexing it should yield `TestTscEdit`, and a nested destructuring
+/// `{ caption }` from that should yield `caption: string` rather than
+/// `undefined`.
+test "expr_check: nested destructuring through array index from interface field" {
+  let src =
+    #|interface TestTscEdit {
+    #|  caption: string;
+    #|  commandLineArgs?: readonly string[];
+    #|}
+    #|interface TestTscCompile {
+    #|  subScenario: string;
+    #|  commandLineArgs: readonly string[];
+    #|}
+    #|interface VerifyTscEditDiscrepanciesInput {
+    #|  index: number;
+    #|  edits: readonly TestTscEdit[];
+    #|  commandLineArgs: TestTscCompile["commandLineArgs"];
+    #|}
+    #|function testTscCompile(input: TestTscCompile) {}
+    #|function verifyTscEditDiscrepancies({
+    #|  index,
+    #|  edits,
+    #|  commandLineArgs,
+    #|}: VerifyTscEditDiscrepanciesInput) {
+    #|  const { caption } = edits[index];
+    #|  testTscCompile({
+    #|    subScenario: caption,
+    #|    commandLineArgs: edits[index].commandLineArgs || commandLineArgs,
+    #|  });
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  if issues.length() != 0 {
+    println("UNEXPECTED ISSUES:")
+    for i in issues {
+      println("  \{i.path} -> \{i.message}")
+    }
+  }
+  @test.assert_eq(issues.length(), 0)
+}


### PR DESCRIPTION
## Summary

Five composable wins on the conformance corpus. Net: **+14 recall**
(233 → 247, 45 % → 48 %) and **−1 FP** (3 → 2).

```
                   recall              precision
T14 (merged)       233/512 (46 %)      307/310 ( 3 FP)
T15 (this PR)      247/512 (48 %)      308/310 ( 2 FP)
```

The two remaining FPs are both Issue #62 (generic call type inference).

## Changes

1. **Param destructure** (`bind_pattern` in `check_function_body_with`).
   `function f({ edits }: T)` previously bound the synthesised first
   name of the pattern to the whole `T`, so `edits` was `Any` inside
   the body. Now walks the pattern via `bind_pattern` so inner names
   point at per-field / per-element types. Closes the
   `controlFlowElementAccessNoCrash1` FP at the root.

2. **`||` short-circuit narrowing**. `Or => narrow_union(l, r)` ignored
   the falsy branch, so `(T | undefined) || T` typed as
   `T | undefined`. Now `narrow_union(non_nullable(l), r)`, matching
   the `Coalesce` shape. Doesn't strip literal-value falsiness
   (`0`/`""`/`false`) — only nullish.

3. **Type-guard intersection narrowing**. `apply_type_predicate_narrowing`
   fell back to bare `target` when `narrow_keep` reduced to `Never` —
   so `function hasLegs(x: Beast): x is Legged` narrowed `beast` to
   plain `Legged`, breaking the next `hasWings(beast)` call. TS narrows
   to `cur & target`; we now do the same.

4. **Bare-Named admission in the permissive filter**.
   `is_reliable_mismatch_pair` admits single bare identifiers
   (`expected `Beast` but got `Legged``). To avoid type-parameter
   FPs from generic call sites (`expected `T` but got `S2``), the
   admission requires at least 3 characters AND at least one
   lowercase letter — heuristic but matches conventional TS naming.

5. **Primitive-receiver missing-prop / missing-method admission**.
   Previously the filter suppressed all `property X does not exist
   on Y` and `method X does not exist on Y` diagnostics. Carved out
   `number` / `string` / `boolean` / `bigint` receivers — prototype
   dispatch covers the legitimate uses, so a remaining miss is real.

## Per-directory delta (from T14)

```
typescript/tests/cases/conformance/controlFlow:                15 / 10 (was 14 / 11)
typescript/tests/cases/conformance/expressions/typeGuards:     38 / 10 (was 37 / 11)
typescript/tests/cases/conformance/types/typeRelationships:    93 / 76 (was 82 / 87)
```

(other dirs roughly unchanged)

## Test plan

- [x] `moon check --deny-warn` clean
- [x] `moon test --target native` — 2188 / 2188
- [x] tscheck walk over 822-file conformance corpus:
      recall=247/512 (48 %), FP=2/310 (0.6 %)

## Related Issues

- Both remaining FPs: Issue #62 (generic call type inference)
- Recall residual still dominated by Issue #65 (TS2322 compound shape)
  and Issue #60 (TS2728 property used before init)

https://claude.ai/code/session_01TSiyyQdph9otVVJNqTFgrv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSiyyQdph9otVVJNqTFgrv)_