### PR TITLE
checker: generic method-level type-parameter shadowing (Issue #62)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1282,6 +1282,36 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-02 (T19)   278/572 (49 %)        332/334 ( 2 FP)
 2026-06-02 (T20)   345/815 (42 %)        412/414 ( 2 FP)
 2026-06-02 (T21)   351/815 (43 %)        412/414 ( 2 FP)
+2026-06-02 (T22)   350/815 (43 %)        413/414 ( 1 FP)
+
+  T22 -- generic method-level type-parameter shadowing (Issue #62).
+
+    Root cause: `interface I<T> { m<T>(x: T): T }` and `class C<T> {
+    m<T>(x: T) {} }` redeclare `T` at the method boundary — a fresh
+    type variable unrelated to the enclosing `I`/`C`'s instantiated
+    `T`. When resolving `i.m(...)` / `c.m(...)`, the resolver was
+    substituting the receiver's type argument into the method's
+    parameters, so `i.m3(true, 1)` on `I<string, number>` checked
+    `boolean` against the instantiated `string` and false-flagged.
+
+    Fix:
+      - AST: `TsInterface` gains `method_type_params : Array[(String,
+        Array[String])]` (per-method generic names, keyed by field).
+      - Parser: capture the method's `<...>` names instead of skipping
+        them when building interface members.
+      - Checker (`lookup_field_core`): both the class-method arm and the
+        interface `Applied(n, args)` arm now drop a method's own type
+        parameters from the substitution map before substituting, so the
+        method's shadowing generics stay as bare `Named(...)` (which the
+        assignability check then leaves unconstrained).
+
+    Clears the `genericCallTypeArgumentInference.ts` FP (FP 2 → 1).
+    The remaining typeInference FP
+    (`genericCallWithGenericSignatureArguments.ts`) needs best-common-
+    type inference across multiple callback arguments — deferred. The
+    -1 recall is a coincidental class-generic-method detection in a
+    baseline-positive file that the (correct) shadowing fix now
+    suppresses.
 
   T21 -- `type_display` improvements + permissive filter extensions.
 

--- a/src/ast/pkg.generated.mbti
+++ b/src/ast/pkg.generated.mbti
@@ -67,6 +67,7 @@ pub impl Show for TsBindingElem
 
 pub(all) struct TsBlock {
   stmts : Array[TsStmt]
+  stmt_positions : Array[Int]
 } derive(@debug.Debug)
 pub impl Show for TsBlock
 
@@ -74,6 +75,9 @@ pub(all) struct TsClassDecl {
   name : String
   type_params : Array[String]
   base_names : Array[String]
+  base_expr : TsExpr?
+  static_field_inits : Array[(String, TsExpr)]
+  instance_field_inits : Array[(String, TsExpr)]
   constructor_params : Array[(String, TsType)]?
   properties : Array[TsClassPropertyDecl]
   methods : Array[TsClassMethodDecl]
@@ -90,9 +94,15 @@ pub(all) struct TsClassMethodDecl {
   type_params : Array[String]
   type_param_bounds : Array[(String, TsType)]
   params : Array[(String, TsType)]
+  param_defaults : Array[TsExpr?]
+  param_is_rest : Array[Bool]
   return_type : TsType
   is_static : Bool
   body : TsBlock?
+  accessor : String
+  key_expr : TsExpr?
+  is_async : Bool
+  is_generator : Bool
 } derive(@debug.Debug)
 pub impl Show for TsClassMethodDecl
 
@@ -186,6 +196,8 @@ pub(all) enum TsExpr {
   Seq(TsExpr, TsExpr)
   ArrowFunc(Array[TsParam], TsType, TsArrowBody, Bool)
   FuncExpr(TsFunc)
+  PureCall(TsExpr)
+  NativeClassExpr(TsClassDecl, TsFunc?)
   Yield(TsExpr?)
   YieldStar(TsExpr)
   Await(TsExpr)
@@ -250,6 +262,7 @@ pub(all) struct TsInterface {
   fields : Array[(String, TsType)]
   readonly_fields : Array[String]
   index_signatures : Array[(TsType, TsType)]
+  method_type_params : Array[(String, Array[String])]
 } derive(@debug.Debug)
 pub impl Show for TsInterface
 
@@ -263,7 +276,9 @@ pub(all) struct TsModule {
   namespaces : Array[TsNamespaceDecl]
   enums : Array[TsEnumDecl]
   module_augmentations : Array[(String, TsModule)]
+  top_level_stmts : Array[TsStmt]
   strict_property_initialization : Bool
+  use_define_for_class_fields : Bool
 } derive(@debug.Debug)
 pub impl Show for TsModule
 
@@ -273,6 +288,10 @@ pub(all) struct TsModuleBlock {
   exports : Array[TsExportSpec]
   reexports : Array[TsReExportSpec]
   enums : Array[TsEnumDecl]
+  internal_names : Map[String, Bool]
+  deprecations : Map[String, String]
+  pure_declarations : Map[String, Bool]
+  type_aliases : Array[TsTypeAlias]
 } derive(@debug.Debug)
 pub impl Show for TsModuleBlock
 
@@ -343,6 +362,7 @@ pub(all) enum TsStmt {
   Debugger
   Label(String, TsStmt)
   Block(TsBlock)
+  NativeClassStmt(TsClassDecl, TsFunc?)
   Break(String?)
   Continue(String?)
 } derive(@debug.Debug)
@@ -364,6 +384,7 @@ pub(all) enum TsType {
   Symbol
   UniqueSymbol(String)
   Any
+  Unknown
   Never
   Null
   Undefined

--- a/src/ast/types.mbt
+++ b/src/ast/types.mbt
@@ -511,6 +511,13 @@ pub(all) struct TsInterface {
   // `op_get` / `op_set` accessors without conflating them with regular
   // named fields. Empty for interfaces with no index signature.
   index_signatures : Array[(TsType, TsType)]
+  // Method-level generic type parameters keyed by field name: a generic
+  // method `foo<T>(...)` records `("foo", ["T"])`. The checker consults
+  // this so the interface's own type-argument substitution does not
+  // capture a method's *shadowing* type parameter (`interface I<T> { m<T>
+  // (x: T): T }` — the `m`-level `T` is fresh, unrelated to `I`'s `T`).
+  // Empty for interfaces with no generic methods.
+  method_type_params : Array[(String, Array[String])]
 } derive(Debug)
 
 ///|

--- a/src/bridge/moonbit_decl.mbt
+++ b/src/bridge/moonbit_decl.mbt
@@ -2700,6 +2700,7 @@ fn props_with_children_named_interface_spec(
           fields,
         ),
         index_signatures: origin.iface.index_signatures,
+        method_type_params: [],
       })
     }
     None => None
@@ -2749,6 +2750,7 @@ fn props_with_children_interface_spec(
         fields,
         readonly_fields: [],
         index_signatures: [],
+        method_type_params: [],
       })
     }
     _ =>
@@ -2863,6 +2865,7 @@ fn component_props_with_ref_interface_spec(
               fields,
             ),
             index_signatures: origin.iface.index_signatures,
+            method_type_params: [],
           })
         }
         None => None
@@ -3027,6 +3030,7 @@ fn utility_mapped_interface_spec(
           readonly_fields_for_fields(origin.iface.readonly_fields, fields)
         },
         index_signatures: origin.iface.index_signatures,
+        method_type_params: [],
       })
     }
     None => None
@@ -3089,6 +3093,7 @@ fn utility_projection_interface_spec(
           fields,
         ),
         index_signatures: [],
+        method_type_params: [],
       })
     }
     None => None
@@ -3891,6 +3896,7 @@ fn type_alias_record_to_interface_fields(
     fields,
     readonly_fields: [],
     index_signatures: [],
+    method_type_params: [],
   })
 }
 
@@ -3980,6 +3986,7 @@ fn project_interface_fields(
     fields,
     readonly_fields: readonly_fields_for_fields(iface.readonly_fields, fields),
     index_signatures: [],
+    method_type_params: [],
   })
 }
 
@@ -4009,6 +4016,7 @@ fn map_interface_fields(
       readonly_fields_for_fields(iface.readonly_fields, fields)
     },
     index_signatures: iface.index_signatures,
+    method_type_params: [],
   })
 }
 
@@ -4072,6 +4080,7 @@ fn type_alias_object_to_interface(
         fields: iface_fields,
         readonly_fields: [],
         index_signatures: [],
+        method_type_params: [],
       })
     }
     _ => None
@@ -5393,6 +5402,7 @@ fn tuple_result_interface_spec(
           fields,
           readonly_fields: [],
           index_signatures: [],
+          method_type_params: [],
         },
       })
     }
@@ -5439,6 +5449,7 @@ fn inline_object_result_interface_spec(
           fields: iface_fields,
           readonly_fields: [],
           index_signatures: [],
+          method_type_params: [],
         },
       })
     None => None
@@ -5794,6 +5805,7 @@ fn normalize_specialized_node_interfaces(
       ],
       readonly_fields: [],
       index_signatures: [],
+      method_type_params: [],
     })
   }
   if needs_crypto_helpers {
@@ -5806,6 +5818,7 @@ fn normalize_specialized_node_interfaces(
         fields: [("plaintextLength", @ast.TsType::Number)],
         readonly_fields: [],
         index_signatures: [],
+        method_type_params: [],
       })
     }
     if !exported_names.contains("GenerateKeyOptions") {
@@ -5817,6 +5830,7 @@ fn normalize_specialized_node_interfaces(
         fields: [("length", @ast.TsType::Number)],
         readonly_fields: [],
         index_signatures: [],
+        method_type_params: [],
       })
     }
     if !exported_names.contains("DiffieHellmanOptions") {
@@ -5831,6 +5845,7 @@ fn normalize_specialized_node_interfaces(
         ],
         readonly_fields: [],
         index_signatures: [],
+        method_type_params: [],
       })
     }
   }
@@ -5847,6 +5862,7 @@ fn normalize_specialized_node_interfaces(
       ],
       readonly_fields: [],
       index_signatures: [],
+      method_type_params: [],
     })
   }
   interfaces
@@ -5966,6 +5982,7 @@ fn clone_resolved_interface_origin(
     fields,
     readonly_fields: readonly_fields_for_fields(readonly_fields, fields),
     index_signatures: origin.iface.index_signatures,
+    method_type_params: [],
   }
 }
 
@@ -6310,6 +6327,7 @@ fn clone_exported_interface(
     fields,
     readonly_fields: readonly_fields_for_fields(readonly_fields, fields),
     index_signatures: exported.iface.index_signatures,
+    method_type_params: [],
   }
 }
 

--- a/src/bridge/moonbit_js_ffi_wbtest.mbt
+++ b/src/bridge/moonbit_js_ffi_wbtest.mbt
@@ -4787,6 +4787,7 @@ test "bridge: FFI struct generation deduplicates sanitized field names" {
     ],
     readonly_fields: [],
     index_signatures: [],
+    method_type_params: [],
   }
   let actual = ffi_struct_decl_to_moonbit(state, iface)
   assert_eq(count_occurrences_in_ffi_output(actual, "  _new_ : DateType"), 1)
@@ -4857,6 +4858,7 @@ test "bridge: FFI struct generation sanitizes keyword and discard fields" {
     ],
     readonly_fields: [],
     index_signatures: [],
+    method_type_params: [],
   }
   let actual = ffi_struct_decl_to_moonbit(state, iface)
   assert_true(actual.contains("  declare_ : DeclarationParser"))
@@ -4903,6 +4905,7 @@ test "bridge: FFI struct generation adds method wrappers for function fields" {
     ],
     readonly_fields: [],
     index_signatures: [],
+    method_type_params: [],
   }
   let actual = ffi_struct_decl_to_moonbit(state, iface)
   assert_true(actual.contains("  createIdentifier : (String) -> Identifier"))
@@ -4944,6 +4947,7 @@ test "bridge: FFI struct method wrappers unwrap optional arguments" {
     ],
     readonly_fields: [],
     index_signatures: [],
+    method_type_params: [],
   }
   let actual = ffi_struct_decl_to_moonbit(state, iface)
   assert_true(
@@ -5042,6 +5046,7 @@ test "bridge: FFI struct generation keeps generic method wrappers non-extern" {
     ],
     readonly_fields: [],
     index_signatures: [],
+    method_type_params: [],
   }
   let actual = ffi_struct_decl_to_moonbit(state, iface)
   assert_true(
@@ -5079,6 +5084,7 @@ test "bridge: FFI struct generation caps method wrappers but keeps function fiel
     ],
     readonly_fields: [],
     index_signatures: [],
+    method_type_params: [],
   }
   let actual = ffi_struct_decl_to_moonbit(state, iface)
   assert_true(actual.contains("  call2 : () -> Unit"))
@@ -5122,6 +5128,7 @@ test "bridge: FFI struct generation keeps callable wrapper beyond cap" {
     ],
     readonly_fields: [],
     index_signatures: [],
+    method_type_params: [],
   }
   let actual = ffi_struct_decl_to_moonbit(state, iface)
   assert_true(actual.contains("  _call_ : (String) -> Assertion"))
@@ -5197,6 +5204,7 @@ test "bridge: FFI struct preserves selected interface type parameters locally" {
     ],
     readonly_fields: [],
     index_signatures: [],
+    method_type_params: [],
   }
   let actual = ffi_struct_decl_to_moonbit(state, iface)
   assert_true(actual.contains("pub(all) struct StatsBase[T]"))

--- a/src/checker/check_module_wbtest.mbt
+++ b/src/checker/check_module_wbtest.mbt
@@ -29,6 +29,7 @@ fn iface_for_check(
     fields,
     readonly_fields: [],
     index_signatures: [],
+    method_type_params: [],
   }
 }
 
@@ -244,6 +245,7 @@ test "check_module: detects interface extends cycle" {
     fields: [],
     readonly_fields: [],
     index_signatures: [],
+    method_type_params: [],
   })
   m.interfaces.push({
     name: "B",
@@ -253,6 +255,7 @@ test "check_module: detects interface extends cycle" {
     fields: [],
     readonly_fields: [],
     index_signatures: [],
+    method_type_params: [],
   })
   let report = check_module(m)
   let cycles = report.issues.filter(fn(i) { i.kind == InterfaceExtendsCycle })
@@ -270,6 +273,7 @@ test "check_module: terminating extends chain is fine" {
     fields: [],
     readonly_fields: [],
     index_signatures: [],
+    method_type_params: [],
   })
   m.interfaces.push({
     name: "Dog",
@@ -279,6 +283,7 @@ test "check_module: terminating extends chain is fine" {
     fields: [],
     readonly_fields: [],
     index_signatures: [],
+    method_type_params: [],
   })
   let report = check_module(m)
   let cycles = report.issues.filter(fn(i) { i.kind == InterfaceExtendsCycle })
@@ -361,6 +366,7 @@ test "check_module: arity check ignores generic params in scope" {
     fields: [("value", Applied("Wrap", [Named("U")]))],
     readonly_fields: [],
     index_signatures: [],
+    method_type_params: [],
   })
   let report = check_module(m)
   let arity_issues = report.issues.filter(fn(i) {

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -118,6 +118,13 @@ fn merge_interfaces(
   for sig in b.index_signatures {
     index_signatures.push(sig)
   }
+  let method_type_params : Array[(String, Array[String])] = []
+  for mtp in a.method_type_params {
+    method_type_params.push(mtp)
+  }
+  for mtp in b.method_type_params {
+    method_type_params.push(mtp)
+  }
   // Type parameters: use `a`'s. TS requires them to match across
   // declarations, so it shouldn't matter which we pick.
   {
@@ -128,6 +135,7 @@ fn merge_interfaces(
     fields,
     readonly_fields,
     index_signatures,
+    method_type_params,
   }
 }
 
@@ -683,6 +691,41 @@ fn array_prototype_member(elem : @ast.TsType, field : String) -> @ast.TsType? {
 }
 
 ///|
+/// Return a copy of `bindings` with the named field's method-level type
+/// parameters removed, so a generic method's shadowing type variable
+/// (`interface I<T> { m<T>(x: T): T }`) is left unsubstituted instead of
+/// being captured by the interface's instantiated `T`. When the field has
+/// no recorded method generics the original map is returned unchanged.
+fn scoped_bindings_for_method(
+  bindings : Map[String, @ast.TsType],
+  method_type_params : Array[(String, Array[String])],
+  field : String,
+) -> Map[String, @ast.TsType] {
+  let mut shadowed : Array[String]? = None
+  for mtp in method_type_params {
+    if mtp.0 == field {
+      shadowed = Some(mtp.1)
+      break
+    }
+  }
+  match shadowed {
+    None => bindings
+    Some(names) => {
+      if names.length() == 0 {
+        return bindings
+      }
+      let scoped : Map[String, @ast.TsType] = {}
+      for kv in bindings {
+        if !names.contains(kv.0) {
+          scoped[kv.0] = kv.1
+        }
+      }
+      scoped
+    }
+  }
+}
+
+///|
 fn Resolver::lookup_field(
   self : Resolver,
   recv : @ast.TsType,
@@ -942,7 +985,16 @@ fn Resolver::lookup_field_core(
           }
           for f in iface.fields {
             if f.0 == field {
-              return Some(substitute_params(f.1, bindings))
+              // Method-level generics shadow the interface's type params:
+              // drop any shadowed names so a generic method keeps its own
+              // fresh type variable rather than resolving it to the
+              // interface's instantiated argument.
+              let scoped = scoped_bindings_for_method(
+                bindings,
+                iface.method_type_params,
+                field,
+              )
+              return Some(substitute_params(f.1, scoped))
             }
           }
           let mut j = 0
@@ -1002,14 +1054,32 @@ fn Resolver::lookup_field_core(
               }
               for m in cls.methods {
                 if m.name == field && !m.is_static {
+                  // Method-level type parameters shadow the class's: a
+                  // `foo3<T>(t: T, u: U)` declares a fresh `T` that is
+                  // unrelated to the class's instantiated `T`. Drop any
+                  // shadowed names from the substitution map so the method's
+                  // own generics stay as bare `Named(...)` references (which
+                  // the assignability check then leaves unconstrained)
+                  // instead of being resolved to the class's type argument.
+                  let method_bindings = if m.type_params.length() > 0 {
+                    let scoped : Map[String, @ast.TsType] = {}
+                    for kv in bindings {
+                      if !m.type_params.contains(kv.0) {
+                        scoped[kv.0] = kv.1
+                      }
+                    }
+                    scoped
+                  } else {
+                    bindings
+                  }
                   let param_types : Array[@ast.TsType] = []
                   for mp in m.params {
-                    param_types.push(substitute_params(mp.1, bindings))
+                    param_types.push(substitute_params(mp.1, method_bindings))
                   }
                   return Some(
                     @ast.TsType::Func(
                       param_types,
-                      substitute_params(m.return_type, bindings),
+                      substitute_params(m.return_type, method_bindings),
                     ),
                   )
                 }

--- a/src/checker/pkg.generated.mbti
+++ b/src/checker/pkg.generated.mbti
@@ -21,6 +21,8 @@ pub fn check_module(@ast.TsModule) -> TypeCheckReport
 
 pub fn check_module_function_bodies(@ast.TsModule) -> Array[ExprIssue]
 
+pub fn check_module_function_bodies_permissive(@ast.TsModule) -> Array[ExprIssue]
+
 pub fn classify_optional_like_union(@ast.TsType) -> (@ast.TsType, Bool)?
 
 pub fn classify_transparent_intersection(@ast.TsType) -> @ast.TsType?

--- a/src/checker/validate_wbtest.mbt
+++ b/src/checker/validate_wbtest.mbt
@@ -29,6 +29,7 @@ fn iface(
     fields,
     readonly_fields: [],
     index_signatures: [],
+    method_type_params: [],
   }
 }
 
@@ -103,6 +104,7 @@ test "validate_module: ignores generic parameters in scope" {
     fields: [("value", Named("T"))],
     readonly_fields: [],
     index_signatures: [],
+    method_type_params: [],
   })
   let unresolved = unresolved_type_references(mod)
   assert_eq(unresolved.length(), 0)

--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -1078,6 +1078,7 @@ pub fn Parser::parse_interface(
   let fields : Array[(String, @ast.TsType)] = []
   let readonly_fields : Array[String] = []
   let index_signatures : Array[(@ast.TsType, @ast.TsType)] = []
+  let method_type_params : Array[(String, Array[String])] = []
   while !self.check(RBrace) && !self.check(Eof) {
     // Skip readonly modifier
     let mut is_readonly_field = false
@@ -1353,8 +1354,11 @@ pub fn Parser::parse_interface(
       k =>
         raise ParseError("Expected field name at \{self.peek().pos}, got \{k}")
     }
-    // Skip method type parameters <T>
-    self.skip_type_params()
+    // Capture method-level type parameters `<T>` so the checker can keep
+    // a generic method's shadowing type parameter distinct from the
+    // interface's own. (Only meaningful for method signatures; harmless
+    // on properties, which never carry `<...>`.)
+    let (m_type_params, _) = self.parse_type_param_names_and_bounds()
     // Check for optional marker ?
     let is_optional = self.match_(Question)
     // Method signature: name(...): T or name<T>(...): U
@@ -1385,6 +1389,9 @@ pub fn Parser::parse_interface(
             },
           ),
         )
+        if m_type_params.length() > 0 {
+          method_type_params.push((field_name, m_type_params))
+        }
       }
     } else if self.check(Colon) {
       // Property: name: T
@@ -1436,6 +1443,7 @@ pub fn Parser::parse_interface(
     fields,
     readonly_fields,
     index_signatures,
+    method_type_params,
   }
 }
 
@@ -1510,6 +1518,7 @@ fn type_alias_object_fields_to_interface(
         fields: iface_fields,
         readonly_fields: [],
         index_signatures: [],
+        method_type_params: [],
       })
     }
     _ => None

--- a/src/parser/pkg.generated.mbti
+++ b/src/parser/pkg.generated.mbti
@@ -19,19 +19,27 @@ pub fn emit_moonbit_decl_with_sections_and_types(@ast.TsModule, Array[String], A
 
 pub fn emit_moonbit_decl_with_sections_types_and_arities(@ast.TsModule, Array[String], Array[String], Map[String, Int], Bool) -> String
 
+pub fn lower_enum_decl_to_runtime_stmts(@ast.TsEnumDecl) -> Array[@ast.TsStmt]
+
 pub fn moonbit_sanitize_type_param_name(String) -> String
 
 pub fn parse_block_from_source(String) -> @ast.TsBlock raise ParseError
 
 pub fn parse_block_from_source_strict(String, Bool) -> @ast.TsBlock raise ParseError
 
+pub fn parse_block_from_source_with_positions(String) -> (@ast.TsBlock, Array[Int]) raise ParseError
+
 pub fn parse_expr_from_source(String) -> @ast.TsExpr? raise ParseError
 
 pub fn parse_expr_from_source_strict(String, Bool) -> @ast.TsExpr? raise ParseError
 
+pub fn parse_jsdoc_block(String) -> JsdocBlock?
+
 pub fn parse_module_block_from_source(String) -> @ast.TsModuleBlock raise ParseError
 
 pub fn parse_module_from_source_with_const_values(String, Map[String, @ast.TsExpr]) -> @ast.TsModule raise ParseError
+
+pub fn parse_type_from_source(String) -> @ast.TsType raise ParseError
 
 pub async fn resolve_runtime_module_specifier(String, String) -> String?
 
@@ -44,6 +52,31 @@ pub(all) suberror ParseError {
 pub impl Show for ParseError
 
 // Types and methods
+pub(all) struct JsdocBlock {
+  description : String
+  tags : Array[JsdocTag]
+} derive(@debug.Debug)
+pub fn JsdocBlock::is_empty(Self) -> Bool
+
+pub(all) enum JsdocTag {
+  Param(String, String?, String)
+  Returns(String?, String)
+  Throws(String?, String)
+  Deprecated(String)
+  Internal
+  Public
+  Private
+  Protected
+  Readonly
+  Pure
+  NoSideEffects
+  See(String)
+  Example(String)
+  Template(String, String)
+  Typedef(String?, String)
+  Other(String, String)
+} derive(Eq, @debug.Debug)
+
 pub struct Lexer {
   src : String
   mut pos : Int
@@ -51,6 +84,12 @@ pub struct Lexer {
   mut pending : Array[Token]
   mut pending_index : Int
   mut newline_before_next : Bool
+  mut pending_pure_marker : Bool
+  mut pending_internal_marker : Bool
+  mut pending_jsdoc : JsdocBlock?
+  pure_marker_positions : Map[Int, Bool]
+  internal_marker_positions : Map[Int, Bool]
+  jsdoc_at_pos : Map[Int, JsdocBlock]
 } derive(@debug.Debug)
 pub fn Lexer::new(String) -> Self
 pub fn Lexer::next_token(Self) -> Token
@@ -70,14 +109,25 @@ pub struct Parser {
   mut in_function : Bool
   mut in_iteration : Bool
   mut in_switch : Bool
+  mut in_ambient_module : Bool
   labels : Array[String]
   src : String
   allow_jsx : Bool
   mut class_id : Int
+  mut class_key_counter : Int
   mut current_class_brand : String?
   mut last_runtime_class_decl : @ast.TsClassDecl?
+  mut pending_class_base_expr : @ast.TsExpr?
   local_type_param_bounds : Array[(String, @ast.TsType)]
   pending_decorators : Array[@ast.TsExpr]
+  param_property_scopes : Array[Array[String]]
+  pure_marker_positions : Map[Int, Bool]
+  internal_marker_positions : Map[Int, Bool]
+  collected_internal_names : Map[String, Bool]
+  jsdoc_at_pos : Map[Int, JsdocBlock]
+  collected_deprecations : Map[String, String]
+  collected_pure_declarations : Map[String, Bool]
+  collected_type_aliases : Array[@ast.TsTypeAlias]
 } derive(@debug.Debug)
 pub fn Parser::from_source(String) -> Self
 pub fn Parser::from_source_with_jsx(String, Bool) -> Self


### PR DESCRIPTION
## Summary

Implements generic method-level type-parameter shadowing (Issue #62, path A).

A generic method redeclares the enclosing interface/class type parameter at its own boundary — `interface I<T> { m<T>(x: T): T }` / `class C<T> { m<T>(x: T) {} }` — so the method-level `T` is a fresh variable, unrelated to the instantiated `I`/`C`. The resolver was substituting the receiver's type argument into the method's parameters, making `i.m(true, 1)` on `I<string, number>` check `boolean` against the instantiated `string` and false-flag.

## Changes

- **AST**: `TsInterface` gains `method_type_params : Array[(String, Array[String])]` — per-method generic names, keyed by field.
- **Parser** (`parser_function.mbt`): capture a method signature's `<...>` names instead of skipping them when building interface members.
- **Checker** (`expr_check.mbt`, `lookup_field_core`): the class-method arm and the interface `Applied(n, args)` arm now drop a method's own type parameters from the substitution map before substituting, leaving the shadowing generics as bare `Named(...)` (which assignability leaves unconstrained via the existing unresolvable-Named carve-out).

## Results

- Clears `genericCallTypeArgumentInference.ts` false positive.
- Conformance: **recall 350/815, FP 1/414** (was 2).
- All **2188** unit tests pass; `moon check --deny-warn` clean.

The remaining typeInference FP (`genericCallWithGenericSignatureArguments.ts`) needs best-common-type inference across multiple callback arguments and is deferred.

## Test plan

- [x] `moon check --deny-warn --target native` clean
- [x] `moon test --target native` — 2188/2188 pass
- [x] `tscheck --verbose` on `genericCallTypeArgumentInference.ts` reports 0 issues
- [x] Accuracy harness: recall 350/815, FP 1/414

https://claude.ai/code/session_01TSiyyQdph9otVVJNqTFgrv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSiyyQdph9otVVJNqTFgrv)_