### PR TITLE
checker: soft / hard generic inference candidates (Issue #62 path B, FP 1 → 0)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1283,6 +1283,39 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-02 (T20)   345/815 (42 %)        412/414 ( 2 FP)
 2026-06-02 (T21)   351/815 (43 %)        412/414 ( 2 FP)
 2026-06-02 (T22)   350/815 (43 %)        413/414 ( 1 FP)
+2026-06-02 (T23)   348/815 (43 %)        414/414 ( 0 FP)
+
+  T23 -- soft / hard generic inference candidates (Issue #62 path B).
+
+    Closes the second typeInference FP
+    (`genericCallWithGenericSignatureArguments.ts`). The case
+    `foo<T>(a: (x: T) => T, b: (x: T) => T)` called with
+    `foo((x) => 1, (x) => '')` is `{} => {}` in TS — the conflicting
+    candidates from the two arrow body returns produce a no-information
+    fallback, not a type error. Our solver previously locked `T` to the
+    first inference (`number`), then contextual-typed the second arrow
+    body `''` against `T = number` and false-flagged.
+
+    Fix: thread a `soft` flag through `infer_param_bindings`. The flag is
+    `true` only when the recursion is inside the return position of a
+    `Func` formal (a covariant slot fed by an arrow body), and `false`
+    otherwise. On a direct `Named(T)` hit:
+      - existing binding is `Any`: take the actual.
+      - actual is `Any`: keep existing (no information).
+      - soft conflict (both sides non-Any): union via `narrow_union`.
+      - hard conflict: first-wins (preserve strict detection on
+        `indexOf<T>(xs: T[], item: T)` style calls).
+
+    This widens `T = number | string` for the FP case, so each arrow
+    body's return is assignable to the substituted formal. Real
+    inconsistencies like `indexOf(arr: number[], "abc")` still flag
+    because the second candidate is a *hard* inference (formal `T`
+    appears at top level, not nested under a `Func`-typed formal).
+
+    Conformance: recall 350 → 348 (−2 baseline-positive cases that
+    relied on the prior over-strict behavior; arguably real-bug
+    detections we lost, worth revisiting if a follow-up tightens the
+    soft-conflict rule). FP 1 → 0.
 
   T22 -- generic method-level type-parameter shadowing (Issue #62).
 

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -3688,13 +3688,19 @@ fn infer_expr(
 /// from `type_params`, bind it to `actual`. Compound shapes (Array,
 /// Tuple, Func, Applied, Union…) are walked structurally so type
 /// parameters embedded inside them get bound from the matching position
-/// in `actual`. First binding wins; later occurrences are only honored
-/// if the existing binding was `Any`.
+/// in `actual`. The `soft` flag is `true` when the recursion is currently
+/// inside the return position of a `Func` formal — that is, a covariant
+/// inference candidate coming from an arrow's body type. Multiple
+/// soft candidates for the same parameter are unioned (best-common-type
+/// approximation), but a hard inference (top-level `T`, `T[]`, etc.)
+/// retains the first-wins semantics so real argument-type mismatches
+/// still surface as diagnostics.
 fn infer_param_bindings(
   type_params : Array[String],
   formal : @ast.TsType,
   actual : @ast.TsType,
   bindings : Map[String, @ast.TsType],
+  soft : Bool,
 ) -> Unit {
   // Direct hit: formal is exactly a type parameter we're solving for.
   match formal {
@@ -3702,7 +3708,15 @@ fn infer_param_bindings(
       if type_params.contains(name) {
         match bindings.get(name) {
           Some(Any) | None => bindings[name] = actual
-          Some(_) => () // first concrete binding wins
+          Some(existing) =>
+            // `soft` widens; hard inferences keep the first concrete
+            // binding so the per-arg assignability check catches a real
+            // mismatch (e.g. `indexOf(arr: number[], "abc")`). Any-actual
+            // contributes no information.
+            match actual {
+              Any => ()
+              _ => if soft { bindings[name] = narrow_union(existing, actual) }
+            }
         }
         return
       }
@@ -3711,16 +3725,22 @@ fn infer_param_bindings(
   // Structural matching — peel matching outer shapes.
   match (formal, actual) {
     (Array(f_elem), Array(a_elem)) =>
-      infer_param_bindings(type_params, f_elem, a_elem, bindings)
+      infer_param_bindings(type_params, f_elem, a_elem, bindings, soft)
     (Array(f_elem), Applied("Array", a_args)) if a_args.length() == 1 =>
-      infer_param_bindings(type_params, f_elem, a_args[0], bindings)
+      infer_param_bindings(type_params, f_elem, a_args[0], bindings, soft)
     (Applied("Array", f_args), Array(a_elem)) if f_args.length() == 1 =>
-      infer_param_bindings(type_params, f_args[0], a_elem, bindings)
+      infer_param_bindings(type_params, f_args[0], a_elem, bindings, soft)
     (Applied(f_name, f_args), Applied(a_name, a_args)) =>
       if f_name == a_name && f_args.length() == a_args.length() {
         let mut i = 0
         while i < f_args.length() {
-          infer_param_bindings(type_params, f_args[i], a_args[i], bindings)
+          infer_param_bindings(
+            type_params,
+            f_args[i],
+            a_args[i],
+            bindings,
+            soft,
+          )
           i = i + 1
         }
       }
@@ -3732,11 +3752,22 @@ fn infer_param_bindings(
       }
       let mut i = 0
       while i < n {
-        infer_param_bindings(type_params, f_items[i], a_items[i], bindings)
+        infer_param_bindings(
+          type_params,
+          f_items[i],
+          a_items[i],
+          bindings,
+          soft,
+        )
         i = i + 1
       }
     }
     (Func(f_params, f_ret), Func(a_params, a_ret)) => {
+      // Param positions: keep the surrounding softness (a contravariant
+      // slot under an arrow doesn't get a covariance bonus). Return
+      // position: mark `soft = true` so multiple unannotated arrows
+      // contributing different body return types union instead of
+      // first-wins.
       let n = if f_params.length() < a_params.length() {
         f_params.length()
       } else {
@@ -3744,10 +3775,16 @@ fn infer_param_bindings(
       }
       let mut i = 0
       while i < n {
-        infer_param_bindings(type_params, f_params[i], a_params[i], bindings)
+        infer_param_bindings(
+          type_params,
+          f_params[i],
+          a_params[i],
+          bindings,
+          soft,
+        )
         i = i + 1
       }
-      infer_param_bindings(type_params, f_ret, a_ret, bindings)
+      infer_param_bindings(type_params, f_ret, a_ret, bindings, true)
     }
     (Union(f_parts), _) =>
       // Best-effort: try the first part that isn't a bare type parameter
@@ -3757,7 +3794,7 @@ fn infer_param_bindings(
         match part {
           Named(n) if type_params.contains(n) => continue
           _ => {
-            infer_param_bindings(type_params, part, actual, bindings)
+            infer_param_bindings(type_params, part, actual, bindings, soft)
             return
           }
         }
@@ -3789,7 +3826,7 @@ fn solve_generic_bindings(
   let mut i = 0
   while i < n {
     let actual = infer_expr(env, resolver, args[i])
-    infer_param_bindings(type_params, params[i], actual, bindings)
+    infer_param_bindings(type_params, params[i], actual, bindings, false)
     i = i + 1
   }
   bindings
@@ -4927,6 +4964,7 @@ fn check_jsx_attrs(
                     formal,
                     maybe_widen(sf.1),
                     bindings,
+                    false,
                   )
                 None => ()
               }
@@ -4946,6 +4984,7 @@ fn check_jsx_attrs(
                   formal,
                   maybe_widen(actual),
                   bindings,
+                  false,
                 )
               }
               None => ()


### PR DESCRIPTION
## Summary

Closes the second and final FP in Issue #62 — generic inference soft / hard candidate split.

The case `foo<T>(a: (x: T) => T, b: (x: T) => T)` called with `foo((x) => 1, (x) => '')` infers `T = {}` in TS (BCT fallback for conflicting candidates from arrow body returns). Our solver was locking `T` to the first inference (`number`), then contextual-typed the second arrow body `''` against `T = number` and false-flagged.

## Change

Thread a `soft : Bool` flag through `infer_param_bindings`, `true` only inside the return position of a `Func` formal — a covariant slot fed by an arrow body. On a direct `Named(T)` hit with both sides already concrete:
- **soft** conflict (e.g. two arrow body returns differ): `narrow_union` — widen `T = number | string`.
- **hard** conflict (e.g. `indexOf<T>(xs: T[], item: T)` with `arr: number[]` and `"abc"`): first-wins — preserve strict detection so real argument-type mismatches still surface.
- existing `Any` or `actual = Any`: unchanged (no information case).

## Results

- **FP 1 → 0** (precision now 414/414 clean).
- recall 350 → 348 (two baseline-positive cases relied on the prior over-strict behavior).
- All **2188** unit tests pass; `moon check --deny-warn` clean.

Closes Issue #62.

## Test plan

- [x] `moon check --deny-warn --target native` clean
- [x] `moon test --target native` — 2188/2188 pass
- [x] `tscheck --verbose` on both `genericCallWithGenericSignatureArguments.ts` and `genericCallTypeArgumentInference.ts` report 0 issues
- [x] Accuracy harness: recall 348/815, **FP 0/414**

https://claude.ai/code/session_01TSiyyQdph9otVVJNqTFgrv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSiyyQdph9otVVJNqTFgrv)_