### PR TITLE
checker: TS2454 on unassigned call targets (recall 376→379, FP 0)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -7781,6 +7781,16 @@ fn check_call_args_in_expr(
 ) -> Unit {
   match expr {
     Call(name, args) => {
+      // TS2454: invoking an as-yet-unassigned variable (`var f: T; f()`)
+      // reads it before assignment, same as a bare reference.
+      if name != "__ts_no_init__" && ctx.unassigned.get(name) is Some(_) {
+        record(
+          ctx,
+          "use `\{name}`",
+          "variable `\{name}` is used before being assigned",
+        )
+        let _ = ctx.unassigned.remove(name)
+      }
       let callee_ty = match env.lookup(name) {
         Some(t) => t
         None =>


### PR DESCRIPTION
## Summary

Follow-up to #71/#72. Extends the used-before-assigned check; **precision held at 414/414 (0 false-positives)**, all 2188 tests pass.

`baseline accuracy: recall 376/815 → 379/815, precision 414/414 (FP 0)`

## Change (`src/checker/expr_check.mbt`)

### TS2454 — invoking an unassigned variable
The used-before-assigned check previously fired only on a *bare* reference to a tracked `var x: T;` (no initializer). A function **call** reads its callee too, so `var f: T; f()` is equally a use-before-assignment. The `Call` branch of the expression walker now checks the callee name against the unassigned set, matching tsc on the union/overload call-signature fixtures (`unionTypeCallSignatures2/3`, `intersectionTypeOverloading`, …).

## Notes for follow-up

The remaining TS2454 misses all declare the variable with an **object-type-literal annotation** (`var b: { m(): T }`), which the parser currently lowers to `Any` — so the binding is never tracked. Relaxing the gate to fire on `Any` would false-positive on genuinely-untyped `var b;`, so the real fix is parser-side (preserve object-type annotations on `var` declarations) and is left out of this PR.

I also prototyped a duplicate-class/type-alias detector (TS2300, +6 recall) but reverted it: it false-positives on multi-`@filename` conformance fixtures, which our harness parses as a single module (so two `class C3` in separate virtual files look like a duplicate). Preserving the precision-100% invariant won out; a proper fix needs per-`@filename` scoping in the parser or test harness.

https://claude.ai/code/session_01S5m8xKHBeZVYKrScqb9btt

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5m8xKHBeZVYKrScqb9btt)_