### PR TITLE
bridge: fix false unresolved-ref notes on generics & expose index-signature accessors in .mbti

### DIFF
--- a/src/bridge/moonbit_bridge.mbt
+++ b/src/bridge/moonbit_bridge.mbt
@@ -638,6 +638,47 @@ fn collect_bridge_struct_decls(bridge_mbt : String) -> Array[BridgeStructDecl] {
 }
 
 ///|
+/// Collect the public-interface form of each index-signature accessor
+/// (`op_get` / `op_set`) emitted into `bridge.mbt`, keyed by the struct's
+/// type name. The FFI side renders these as
+/// `pub extern "js" fn Foo::op_get(...) -> V? = #| <js body>`; the `.mbti`
+/// form drops the `extern "js"` keyword and the trailing JS body so the
+/// generated contract advertises that `Foo` supports `foo[key]` indexing
+/// instead of presenting a bare, seemingly field-less struct.
+fn collect_bridge_index_accessor_mbti(
+  bridge_mbt : String,
+) -> Map[String, Array[String]] {
+  let marker = "pub extern \"js\" fn "
+  let result : Map[String, Array[String]] = {}
+  for line_view in bridge_mbt.split("\n") {
+    let trimmed = line_view.to_owned().trim().to_owned()
+    if !trimmed.has_prefix(marker) {
+      continue
+    }
+    if !(trimmed.contains("::op_get(") || trimmed.contains("::op_set(")) {
+      continue
+    }
+    let rest = trimmed[marker.length():].to_owned()
+    let name = match rest.find("::") {
+      Some(idx) => rest[:idx].to_owned()
+      None => continue
+    }
+    // Drop the trailing ` =` that precedes the multi-line `#|` JS body.
+    let mut sig = rest.trim().to_owned()
+    if sig.has_suffix("=") {
+      sig = sig[:sig.length() - 1].to_owned().trim().to_owned()
+    }
+    let mbti_line = "pub fn \{sig}"
+    let entry = result.get(name).unwrap_or([])
+    if !entry.contains(mbti_line) {
+      entry.push(mbti_line)
+    }
+    result[name] = entry
+  }
+  result
+}
+
+///|
 fn find_bridge_struct_decl(
   decls : Array[BridgeStructDecl],
   name : String,
@@ -671,6 +712,7 @@ fn expose_bridge_struct_decls_in_mbti(
   if struct_decls.is_empty() {
     return bridge_mbti
   }
+  let accessors = collect_bridge_index_accessor_mbti(bridge_mbt)
   let lines : Array[String] = []
   for line_view in bridge_mbti.split("\n") {
     let line = line_view.to_owned()
@@ -678,7 +720,17 @@ fn expose_bridge_struct_decls_in_mbti(
     match parse_bridge_public_type_name_line(trimmed) {
       Some(name) =>
         match find_bridge_struct_decl(struct_decls, name) {
-          Some(decl) => lines.push(render_bridge_struct_mbti_decl(decl))
+          Some(decl) => {
+            let mut rendered = render_bridge_struct_mbti_decl(decl)
+            match accessors.get(name) {
+              Some(accessor_lines) =>
+                for accessor in accessor_lines {
+                  rendered = rendered + "\n\n///|\n" + accessor
+                }
+              None => ()
+            }
+            lines.push(rendered)
+          }
           None => lines.push(line)
         }
       None => lines.push(line)

--- a/src/bridge/moonbit_bridge_wbtest.mbt
+++ b/src/bridge/moonbit_bridge_wbtest.mbt
@@ -1059,3 +1059,41 @@ test "bridge: bridge top-level fn parser keeps function-typed parameters intact"
     None => fail("expected function declaration to parse")
   }
 }
+
+///|
+test "bridge mbti: index-signature accessors are exposed in the interface" {
+  // `.mbt` carries the struct plus its `op_get` / `op_set` externs; the
+  // `.mbti` only had a `declare pub type` placeholder. The exposer must
+  // surface the public accessor signatures so the generated contract shows
+  // that the record supports `dict[key]` indexing.
+  let bridge_mbt =
+    #|#warnings("-9")
+    #|pub(all) struct Dict {
+    #|}
+    #|
+    #|pub extern "js" fn Dict::op_get(self : Dict, key : String) -> Double? =
+    #|  #| (self, key) => { const v = self[key]; return v === undefined ? null : v; }
+    #|
+    #|pub extern "js" fn Dict::op_set(self : Dict, key : String, value : Double) -> Unit =
+    #|  #| (self, key, value) => { self[key] = value; }
+  let bridge_mbti =
+    #|///|
+    #|/// TS interface Dict
+    #|declare pub type Dict
+  let exposed = expose_bridge_struct_decls_in_mbti(bridge_mbti, bridge_mbt)
+  assert_true(exposed.contains("pub(all) struct Dict {"))
+  assert_true(
+    exposed.contains(
+      "pub fn Dict::op_get(self : Dict, key : String) -> Double?",
+    ),
+  )
+  assert_true(
+    exposed.contains(
+      "pub fn Dict::op_set(self : Dict, key : String, value : Double) -> Unit",
+    ),
+  )
+  // The JS body and the `extern "js"` keyword must not leak into the
+  // interface form.
+  assert_false(exposed.contains("extern"))
+  assert_false(exposed.contains("self[key]"))
+}

--- a/src/checker/validate.mbt
+++ b/src/checker/validate.mbt
@@ -26,17 +26,18 @@ pub fn unresolved_type_references(module_ : @ast.TsModule) -> Array[String] {
     check_type(ta.type_, scope, acc)
   }
   for f in module_.funcs {
-    let scope = declared
+    let scope = scope_with(declared, f.type_params)
     for param in f.params {
       check_type(param.type_, scope, acc)
     }
     check_type(f.return_type, scope, acc)
   }
   for i in module_.imports {
+    let scope = scope_with(declared, i.type_params)
     for param in i.params {
-      check_type(param.1, declared, acc)
+      check_type(param.1, scope, acc)
     }
-    check_type(i.return_type, declared, acc)
+    check_type(i.return_type, scope, acc)
   }
   for v in module_.values {
     check_type(v.type_, declared, acc)

--- a/src/checker/validate_wbtest.mbt
+++ b/src/checker/validate_wbtest.mbt
@@ -109,3 +109,34 @@ test "validate_module: ignores generic parameters in scope" {
   let unresolved = unresolved_type_references(mod)
   assert_eq(unresolved.length(), 0)
 }
+
+///|
+test "validate_module: ignores generic parameters of declared functions" {
+  let mod = empty_module()
+  // declare function identity<T>(x: T): T -- `T` is in scope, not unresolved.
+  mod.imports.push({
+    name: "identity",
+    module_: "m",
+    type_params: ["T"],
+    params: [("x", Named("T"))],
+    return_type: Named("T"),
+  })
+  let unresolved = unresolved_type_references(mod)
+  assert_eq(unresolved.length(), 0)
+}
+
+///|
+test "validate_module: still surfaces genuinely undeclared function refs" {
+  let mod = empty_module()
+  // declare function f<T>(x: T): Missing -- `T` resolves, `Missing` does not.
+  mod.imports.push({
+    name: "f",
+    module_: "m",
+    type_params: ["T"],
+    params: [("x", Named("T"))],
+    return_type: Named("Missing"),
+  })
+  let unresolved = unresolved_type_references(mod)
+  assert_eq(unresolved.length(), 1)
+  assert_eq(unresolved[0], "Missing")
+}


### PR DESCRIPTION
## Summary

Two bridge-output quality fixes found while auditing generated `.d.ts` → MoonBit bridges. Both are scoped, covered by new unit tests, and leave the full suite green (`moon test --target native`: all pass, `moon check --deny-warn` clean).

### 1. Generic type parameters falsely reported as "unresolved type reference"

`unresolved_type_references` put interface and type-alias type parameters in scope (via `scope_with`) but the function and import loops used the bare `declared` set. A generic `declare function identity<T>(x: T): T` therefore reported `T` as unresolved, surfacing a misleading `// Unresolved type reference T` comment in **every generated bridge for a generic export**.

Fix: thread each declaration's own `type_params` through both loops. Genuinely undeclared references (e.g. a missing return type) are still surfaced.

- `src/checker/validate.mbt`
- `src/checker/validate_wbtest.mbt` (+2 tests: generic param resolves; genuinely-missing ref still flagged)

### 2. Index-signature `op_get` / `op_set` accessors missing from `bridge.mbti`

An interface that is only an index signature (`interface Dict { [k: string]: number }`) lowers to an empty `pub(all) struct Dict {}` plus `op_get` / `op_set` externs in `bridge.mbt`. Those accessors are `pub`, so consumers can already index a `Dict` — but the generated `bridge.mbti` contract showed only the bare, field-less struct, hiding that the record is indexable from anyone (or any tooling) reading the interface.

Fix: collect the accessor signatures emitted into `bridge.mbt` and surface their public-interface form (`pub fn Dict::op_get(self, key) -> V?`) alongside the exposed struct, dropping the `extern "js"` keyword and JS body. The `.mbti` contract now matches the public surface.

- `src/bridge/moonbit_bridge.mbt`
- `src/bridge/moonbit_bridge_wbtest.mbt` (+1 test)

## Validation

- `moon check --deny-warn` — clean
- `moon test --target native` — all pass (incl. 3 new tests)
- `verify-scaffolds` / `verify-generated-fixtures` fail identically on `main` (pre-existing TS5101 `baseUrl` deprecation) — not introduced here.

## Note for reviewers

The `.mbti` change in (2) adds `pub fn X::op_get` / `op_set` method lines (containing `::`) to the generated contract. If the companion **vite-plugin-moonbit** binding/tree-shake parser reads `bridge.mbti`, please confirm it ignores `::` method lines rather than treating them as top-level export bindings. I could not verify against the plugin repo from this environment.

https://claude.ai/code/session_01S5m8xKHBeZVYKrScqb9btt

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5m8xKHBeZVYKrScqb9btt)_