### PR TITLE
checker: improve TypeScript compatibility, gated by a conformance oracle

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,3 +69,30 @@ jobs:
 
       - name: Verify examples
         run: just verify-examples
+
+  # Soundness gate against the TypeScript conformance corpus. Kept in a
+  # separate job because it needs the (large) `typescript` submodule, which
+  # the main `test` job deliberately skips to stay fast.
+  checker-soundness:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - name: Install MoonBit CLI
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+
+      - name: Install just
+        uses: extractions/setup-just@v4
+
+      - name: Moon update
+        run: moon update || true
+
+      # Builds the `tscheck` binary and fails if the checker reports more
+      # conformance false positives than the documented budget.
+      - name: Verify checker soundness
+        run: just verify-checker-soundness

--- a/justfile
+++ b/justfile
@@ -111,8 +111,17 @@ bridge-quality:
 checker-conformance-oracle *ARGS:
     bash scripts/checker_conformance_oracle.sh {{ARGS}}
 
+# Soundness gate: build the native binary and fail if the checker reports
+# more conformance false positives than the current budget. The oracle
+# script skips cleanly when the `typescript` submodule isn't populated, so
+# this is safe to run anywhere. Keep the budget in lockstep with the
+# documented standing FP count.
+verify-checker-soundness:
+    moon build --target native
+    bash scripts/checker_conformance_oracle.sh --max-fp 13
+
 # Full CI check
-ci: fmt check test verify-mbti-dts verify-scaffolds verify-generated-fixtures verify-examples
+ci: fmt check test verify-mbti-dts verify-scaffolds verify-generated-fixtures verify-examples verify-checker-soundness
 
 # Update dependencies
 update:

--- a/justfile
+++ b/justfile
@@ -103,6 +103,14 @@ verify-realworld-typescript:
 bridge-quality:
     bash scripts/bridge_quality_report.sh
 
+# Correlate the checker against the TypeScript conformance error baselines.
+# Reports agreement (TP), expected misses (subset checker), and — the
+# signal that matters — false positives where TS accepts but we flag.
+# Requires `moon build --target native` and the populated `typescript`
+# submodule. Opt-in (not part of `ci`).
+checker-conformance-oracle *ARGS:
+    bash scripts/checker_conformance_oracle.sh {{ARGS}}
+
 # Full CI check
 ci: fmt check test verify-mbti-dts verify-scaffolds verify-generated-fixtures verify-examples
 

--- a/scripts/checker_conformance_oracle.sh
+++ b/scripts/checker_conformance_oracle.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Correlate the checker against the TypeScript conformance baselines.
+#
+# Each conformance case `foo.ts` is shipped alongside a baseline directory.
+# When the official compiler reports an error, a `foo.errors.txt` baseline
+# exists; when the program is accepted, it does not. That gives a free
+# oracle for the checker's *soundness*: we don't model every TS type rule,
+# so missing some flagged cases is expected — but flagging a case the
+# compiler accepts is a compatibility bug.
+#
+# For every single-file conformance `.ts` (multi-file `// @filename` cases
+# are skipped — the single-file parser can't model them) this classifies:
+#
+#   TP   has .errors.txt  &&  we flag    (agreement — TS errors, we agree)
+#   MISS has .errors.txt  &&  we silent  (expected: we are a subset of TS)
+#   FP   no  .errors.txt  &&  we flag    (***soundness bug — TS accepts***)
+#   TN   no  .errors.txt  &&  we silent  (agreement — both accept)
+#
+# Usage:
+#   scripts/checker_conformance_oracle.sh                 # print summary + FP list
+#   scripts/checker_conformance_oracle.sh --max-fp 7      # gate: exit 1 if FP > 7
+#   scripts/checker_conformance_oracle.sh --dir types     # restrict to a subtree
+#
+# Exit codes:
+#   0  ran (or FP within --max-fp budget)
+#   1  FP count exceeded --max-fp, or no corpus / binary found
+
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+TSCHECK="_build/native/release/build/cmd/tscheck/tscheck.exe"
+if [ ! -x "$TSCHECK" ]; then
+  TSCHECK="_build/native/debug/build/cmd/tscheck/tscheck.exe"
+fi
+if [ ! -x "$TSCHECK" ]; then
+  echo "tscheck binary not found — run \`moon build --target native\`" >&2
+  exit 1
+fi
+
+BASELINES="typescript/tests/baselines/reference"
+CONFORMANCE="typescript/tests/cases/conformance"
+SUBDIR=""
+MAX_FP=-1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --max-fp) MAX_FP="$2"; shift 2 ;;
+    --dir)    SUBDIR="$2"; shift 2 ;;
+    *)        echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+ROOT="$CONFORMANCE"
+[ -n "$SUBDIR" ] && ROOT="$CONFORMANCE/$SUBDIR"
+
+if [ ! -d "$ROOT" ] || [ ! -d "$BASELINES" ]; then
+  echo "conformance corpus not populated ($ROOT / $BASELINES missing) — skipping." >&2
+  exit 0
+fi
+
+declare -i tp=0 miss=0 fp=0 tn=0 parsefail=0
+fp_files=()
+
+while IFS= read -r f; do
+  # Multi-file cases need a project graph the single-file CLI lacks.
+  grep -q "@filename" "$f" 2>/dev/null && continue
+  base=$(basename "$f" .ts)
+  # A case run under multiple settings emits suffixed baselines such as
+  # `foo(target=es5).errors.txt`, so match the bare name and any
+  # parenthesised variant.
+  if [ -f "$BASELINES/${base}.errors.txt" ] || \
+     compgen -G "$BASELINES/${base}(*).errors.txt" >/dev/null 2>&1; then
+    has=1
+  else
+    has=0
+  fi
+  out=$("$TSCHECK" "$f" 2>&1 | tail -1)
+  if echo "$out" | grep -q "error:"; then
+    parsefail+=1
+    continue
+  fi
+  iss=$(echo "$out" | grep -oP '\d+ issues' | grep -oP '\d+' || echo 0)
+  if [ "${iss:-0}" -gt 0 ]; then flag=1; else flag=0; fi
+  if   [ "$has" = 1 ] && [ "$flag" = 1 ]; then tp+=1
+  elif [ "$has" = 1 ];                    then miss+=1
+  elif [ "$flag" = 1 ];                   then fp+=1; fp_files+=("$f")
+  else                                         tn+=1
+  fi
+done < <(find "$ROOT" -name "*.ts")
+
+total=$((tp + miss + fp + tn))
+echo "=== Checker vs TypeScript conformance baselines ==="
+echo "Corpus root   : $ROOT"
+echo "Classified    : $total  (parse failures skipped: $parsefail)"
+echo "TP  err+flag  : $tp"
+echo "MISS err+quiet: $miss   (expected — checker models a subset of TS)"
+echo "FP  ok +flag  : $fp     (soundness bugs — TS accepts these)"
+echo "TN  ok +quiet : $tn"
+if [ "$fp" -gt 0 ]; then
+  echo "--- false positives (TS accepts, we flag) ---"
+  for f in "${fp_files[@]}"; do echo "  $f"; done
+fi
+
+if [ "$MAX_FP" -ge 0 ] && [ "$fp" -gt "$MAX_FP" ]; then
+  echo "FAIL: false-positive count $fp exceeds budget $MAX_FP" >&2
+  exit 1
+fi

--- a/src/ast/types.mbt
+++ b/src/ast/types.mbt
@@ -543,6 +543,10 @@ pub(all) struct TsImport {
   // generic ambient declarations.
   type_params : Array[String]
   params : Array[(String, TsType)] // parameter (name, type)
+  // Positionally aligned with `params`: true when the parameter is a rest
+  // parameter (`...name: T[]`). An empty array means "no rest params", so
+  // older producers that don't populate it stay correct by default.
+  param_is_rest : Array[Bool]
   return_type : TsType // return valuetype
 } derive(Debug)
 

--- a/src/ast/types.mbt
+++ b/src/ast/types.mbt
@@ -659,6 +659,10 @@ pub(all) struct TsClassDecl {
   // separately, but keep an empty array to satisfy literal construction.
   instance_field_inits : Array[(String, TsExpr)]
   constructor_params : Array[(String, TsType)]?
+  // Positionally aligned with `constructor_params`: true when the parameter
+  // is a rest parameter (`constructor(...args: T[])`). Empty array means
+  // "no rest params", so producers that don't populate it stay correct.
+  constructor_param_is_rest : Array[Bool]
   properties : Array[TsClassPropertyDecl]
   methods : Array[TsClassMethodDecl]
   is_abstract : Bool

--- a/src/bridge/moonbit_decl.mbt
+++ b/src/bridge/moonbit_decl.mbt
@@ -2225,6 +2225,7 @@ fn collect_exported_decls(
             class_: {
               ..exported.class_,
               constructor_params: None,
+              constructor_param_is_rest: [],
               properties,
               methods,
               is_constructible: false,
@@ -8967,6 +8968,7 @@ fn clone_exported_class(
     static_field_inits: [],
     instance_field_inits: [],
     constructor_params,
+    constructor_param_is_rest: exported.class_.constructor_param_is_rest,
     properties,
     methods,
     is_abstract: exported.class_.is_abstract,

--- a/src/bridge/moonbit_decl.mbt
+++ b/src/bridge/moonbit_decl.mbt
@@ -6427,6 +6427,9 @@ fn clone_exported_import(
     module_: exported.import_.module_,
     type_params: exported.import_.type_params,
     params,
+    // `params` is rebuilt positionally from the source import, so the
+    // original rest-parameter flags stay aligned.
+    param_is_rest: exported.import_.param_is_rest,
     return_type: rewrite_inline_result_return_type(
       exported.export_name,
       return_type,

--- a/src/bridge/moonbit_decl.mbt
+++ b/src/bridge/moonbit_decl.mbt
@@ -9202,6 +9202,7 @@ pub async fn emit_moonbit_decl_from_entry_path(
       DuplicateDeclaration => "Duplicate top-level name"
       CircularTypeAlias => "Circular type alias"
       TypeAliasArityMismatch => "Type alias arity mismatch"
+      TypeParameterConstraintViolation => "Type parameter constraint violation"
       InterfaceFieldDuplicate => "Duplicate interface field"
       EnumMemberDuplicate => "Duplicate enum member"
       InterfaceExtendsCycle => "Interface extends cycle"

--- a/src/bridge/moonbit_js_ffi_wbtest.mbt
+++ b/src/bridge/moonbit_js_ffi_wbtest.mbt
@@ -4982,6 +4982,7 @@ test "bridge: FFI class methods unwrap optional arguments" {
     static_field_inits: [],
     instance_field_inits: [],
     constructor_params: None,
+    constructor_param_is_rest: [],
     properties: [],
     methods: [],
     is_abstract: false,

--- a/src/checker/assignability.mbt
+++ b/src/checker/assignability.mbt
@@ -533,9 +533,22 @@ fn is_assignable_to_inner(
     }
     _ => ()
   }
-  // Source intersection: at least one component must satisfy the target.
+  // Source intersection. When every component is an object-like type we
+  // merge their properties into one shape first — TS treats `{a} & {b}` as
+  // the combined `{a, b}`, which is assignable to a merged target the
+  // per-component fallback below cannot express. Both checks only ever
+  // return `true`; a definite `false` is deferred to the end, so neither
+  // rule can introduce a false positive.
   match source {
     Intersection(members) => {
+      match merge_object_intersection(members) {
+        Some(merged) =>
+          if is_assignable_to_inner(merged, target, bivariant_params) {
+            return true
+          }
+        None => ()
+      }
+      // Fallback: at least one component on its own satisfies the target.
       for m in members {
         if is_assignable_to_inner(m, target, bivariant_params) {
           return true
@@ -690,6 +703,48 @@ fn is_assignable_to_inner(
     }
     _ => false
   }
+}
+
+///|
+// Object-like field list for an `Object`/`Struct`, or `None` for anything
+// that is not a property bag (so an intersection containing a primitive or
+// named reference declines the merge and uses the per-component rule).
+fn object_like_fields(t : @ast.TsType) -> Array[(@ast.TsType, @ast.TsType)]? {
+  match t {
+    Object(fields) => Some(fields)
+    Struct(_, fields) => Some(struct_fields_to_object(fields))
+    _ => None
+  }
+}
+
+///|
+// Merge an intersection of object-like members into a single object shape.
+// Returns `None` unless every member is object-like. Overlapping keys take
+// the intersection of their value types, matching how TS combines
+// properties shared across an `&`.
+fn merge_object_intersection(members : Array[@ast.TsType]) -> @ast.TsType? {
+  let merged : Array[(@ast.TsType, @ast.TsType)] = []
+  for m in members {
+    match object_like_fields(m) {
+      Some(fields) =>
+        for f in fields {
+          let (key, value) = f
+          let mut found = false
+          for i in 0..<merged.length() {
+            if merged[i].0 == key {
+              merged[i] = (key, Intersection([merged[i].1, value]))
+              found = true
+              break
+            }
+          }
+          if !found {
+            merged.push((key, value))
+          }
+        }
+      None => return None
+    }
+  }
+  Some(Object(merged))
 }
 
 ///|

--- a/src/checker/assignability.mbt
+++ b/src/checker/assignability.mbt
@@ -580,6 +580,15 @@ fn is_assignable_to_inner(
     (NumberLiteral(_), Number) => true
     (BigIntLiteral(_), BigInt) => true
     (BooleanLiteral(_), Boolean) => true
+    // A primitive is assignable to its boxed wrapper interface (`number`
+    // flows into `Number`, `string` into `String`, etc.). The reverse does
+    // not hold and is intentionally omitted. Literals reach the wrappers
+    // transitively via their primitive companion above.
+    (Number | NumberLiteral(_), Named("Number")) => true
+    (String_ | Literal(_), Named("String")) => true
+    (Boolean | BooleanLiteral(_), Named("Boolean")) => true
+    (BigInt | BigIntLiteral(_), Named("BigInt")) => true
+    (Symbol, Named("Symbol")) => true
     // Arrays / typed arrays are iterable: `T[]` is assignable to
     // `Iterable<T>` / `IterableIterator<T>` / `ArrayLike<T>` and the
     // `ReadonlyArray<T>` form. Element type is covariant.

--- a/src/checker/assignability_wbtest.mbt
+++ b/src/checker/assignability_wbtest.mbt
@@ -505,3 +505,15 @@ test "is_assignable_to: intersection with a non-object member declines the merge
     is_assignable_to(s, Struct("AB", [("a", String_), ("b", Number)])),
   )
 }
+
+///|
+test "is_assignable_to: symbol index signature accepts a symbol-keyed source" {
+  // `{ [k: symbol]: number }` is satisfied by a source whose symbol
+  // index signature carries a compatible value type.
+  let target : @ast.TsType = Object([(Symbol, Number)])
+  let ok : @ast.TsType = Object([(Symbol, NumberLiteral("1"))])
+  assert_true(is_assignable_to(ok, target))
+  // A symbol index signature whose value type does not fit is rejected.
+  let bad : @ast.TsType = Object([(Symbol, String_)])
+  assert_false(is_assignable_to(bad, target))
+}

--- a/src/checker/assignability_wbtest.mbt
+++ b/src/checker/assignability_wbtest.mbt
@@ -517,3 +517,12 @@ test "is_assignable_to: symbol index signature accepts a symbol-keyed source" {
   let bad : @ast.TsType = Object([(Symbol, String_)])
   assert_false(is_assignable_to(bad, target))
 }
+
+///|
+test "is_assignable_to: a primitive flows into its boxed wrapper" {
+  // `number` is assignable to `Number`, but not the reverse.
+  assert_true(is_assignable_to(Number, Named("Number")))
+  assert_true(is_assignable_to(String_, Named("String")))
+  assert_true(is_assignable_to(Boolean, Named("Boolean")))
+  assert_false(is_assignable_to(Named("Number"), Number))
+}

--- a/src/checker/assignability_wbtest.mbt
+++ b/src/checker/assignability_wbtest.mbt
@@ -468,3 +468,40 @@ test "is_assignable_to: applied generics match by name and argument assignabilit
   // Box<string> is not assignable to Box<number>.
   assert_false(is_assignable_to(s, Applied("Box", [Number])))
 }
+
+///|
+test "is_assignable_to: source object intersection merges into a combined shape" {
+  // `{a: string} & {b: number}` is assignable to `{a: string, b: number}` —
+  // TS merges the members, which the old per-component rule could not.
+  let s : @ast.TsType = Intersection([
+    Struct("A", [("a", String_)]),
+    Struct("B", [("b", Number)]),
+  ])
+  let t : @ast.TsType = Struct("AB", [("a", String_), ("b", Number)])
+  assert_true(is_assignable_to(s, t))
+  // The merged shape also still satisfies either single member.
+  assert_true(is_assignable_to(s, Struct("A", [("a", String_)])))
+  // A field the merge does not provide is still rejected.
+  assert_false(is_assignable_to(s, Struct("C", [("c", Boolean)])))
+}
+
+///|
+test "is_assignable_to: object-literal intersection merges too" {
+  let s : @ast.TsType = Intersection([
+    Object([(Literal("x"), Number)]),
+    Object([(Literal("y"), String_)]),
+  ])
+  let t : @ast.TsType = Object([(Literal("x"), Number), (Literal("y"), String_)])
+  assert_true(is_assignable_to(s, t))
+}
+
+///|
+test "is_assignable_to: intersection with a non-object member declines the merge" {
+  // `{a: string} & number` is not an object bag; the per-component fallback
+  // applies, so it flows into `number` but not into `{a: string, b: number}`.
+  let s : @ast.TsType = Intersection([Struct("A", [("a", String_)]), Number])
+  assert_true(is_assignable_to(s, Number))
+  assert_false(
+    is_assignable_to(s, Struct("AB", [("a", String_), ("b", Number)])),
+  )
+}

--- a/src/checker/check_module.mbt
+++ b/src/checker/check_module.mbt
@@ -10,6 +10,7 @@ pub(all) enum TypeIssueKind {
   DuplicateDeclaration
   CircularTypeAlias
   TypeAliasArityMismatch
+  TypeParameterConstraintViolation
   InterfaceFieldDuplicate
   EnumMemberDuplicate
   InterfaceExtendsCycle
@@ -245,7 +246,229 @@ pub fn check_module(module_ : @ast.TsModule) -> TypeCheckReport {
     let scope : Array[String] = []
     check_arity(v.type_, scope, arities, issues)
   }
+
+  // 6. Generic type-parameter constraint violations: every
+  //    `Applied(Name, args)` that resolves to a top-level type alias
+  //    declared with `<P extends Bound>` must supply an argument that
+  //    satisfies `Bound`. We use the three-valued `extends_decision`
+  //    relation (TS's own constraint check) and only flag a *definite*
+  //    `Some(false)` — opaque / nominal / unresolved shapes report
+  //    `None` and stay silent, so external references and type-parameter
+  //    forwarding never produce a false positive.
+  let alias_params : Map[String, Array[String]] = {}
+  let alias_bounds : Map[String, Array[(String, @ast.TsType)]] = {}
+  let non_generic_alias_bodies : Map[String, @ast.TsType] = {}
+  for ta in module_.type_aliases {
+    if ta.type_param_bounds.length() > 0 {
+      alias_params[ta.name] = ta.type_params
+      alias_bounds[ta.name] = ta.type_param_bounds
+    }
+    // A non-generic alias can stand in for its body when deciding the
+    // constraint relation (`type MyStr = string` lets `Foo<MyStr>`
+    // satisfy `P extends string`). Generic aliases are left opaque.
+    if ta.type_params.length() == 0 {
+      non_generic_alias_bodies[ta.name] = ta.type_
+    }
+  }
+  let resolve = fn(name : String) -> @ast.TsType? {
+    non_generic_alias_bodies.get(name)
+  }
+  if alias_bounds.length() > 0 {
+    for iface in module_.interfaces {
+      let scope = scope_with_iface_params(iface)
+      for field in iface.fields {
+        check_constraints(
+          field.1,
+          scope,
+          alias_params,
+          alias_bounds,
+          resolve,
+          issues,
+        )
+      }
+    }
+    for ta in module_.type_aliases {
+      check_constraints(
+        ta.type_,
+        ta.type_params,
+        alias_params,
+        alias_bounds,
+        resolve,
+        issues,
+      )
+    }
+    for f in module_.funcs {
+      for p in f.params {
+        check_constraints(
+          p.type_,
+          [],
+          alias_params,
+          alias_bounds,
+          resolve,
+          issues,
+        )
+      }
+      check_constraints(
+        f.return_type,
+        [],
+        alias_params,
+        alias_bounds,
+        resolve,
+        issues,
+      )
+    }
+    for v in module_.values {
+      check_constraints(
+        v.type_,
+        [],
+        alias_params,
+        alias_bounds,
+        resolve,
+        issues,
+      )
+    }
+  }
   { issues, }
+}
+
+///|
+// Walk a type looking for `Applied(name, args)` references to a generic
+// type alias declared with `extends` bounds, and flag arguments that
+// definitely violate their parameter's constraint. Mirrors
+// `check_arity`'s traversal so every nested type position is covered.
+fn check_constraints(
+  type_ : @ast.TsType,
+  scope : Array[String],
+  alias_params : Map[String, Array[String]],
+  alias_bounds : Map[String, Array[(String, @ast.TsType)]],
+  resolve : (String) -> @ast.TsType?,
+  issues : Array[TypeIssue],
+) -> Unit {
+  match type_ {
+    Applied(name, args) => {
+      if !scope.contains(name) {
+        match (alias_params.get(name), alias_bounds.get(name)) {
+          (Some(params), Some(bounds)) =>
+            // Only check when the supplied arity matches the declared
+            // parameters; arity mismatches are reported separately and
+            // would make the positional substitution below meaningless.
+            if params.length() == args.length() {
+              for pair in bounds {
+                let (pname, bound) = pair
+                // Locate the constrained parameter's position so we can
+                // pull the matching argument.
+                let mut idx = -1
+                for i in 0..<params.length() {
+                  if params[i] == pname {
+                    idx = i
+                    break
+                  }
+                }
+                if idx >= 0 {
+                  // Substitute every parameter with its argument inside the
+                  // bound so dependent constraints like `K extends keyof T`
+                  // are evaluated against the concrete `T`.
+                  let mut substituted = bound
+                  for i in 0..<params.length() {
+                    substituted = substitute_named(
+                      substituted,
+                      params[i],
+                      args[i],
+                    )
+                  }
+                  let target = simplify_type(substituted)
+                  let arg = simplify_type(args[idx])
+                  match extends_decision_with(arg, target, resolve) {
+                    Some(false) => {
+                      let issue_name = "\{name}<\{pname}>"
+                      let already = issues
+                        .iter()
+                        .any(fn(i) {
+                          i.kind == TypeParameterConstraintViolation &&
+                          i.name == issue_name
+                        })
+                      if !already {
+                        issues.push({
+                          kind: TypeParameterConstraintViolation,
+                          name: issue_name,
+                          detail: "type argument does not satisfy the `\{pname}` constraint",
+                        })
+                      }
+                    }
+                    _ => ()
+                  }
+                }
+              }
+            }
+          _ => ()
+        }
+      }
+      for a in args {
+        check_constraints(a, scope, alias_params, alias_bounds, resolve, issues)
+      }
+    }
+    Array(inner) =>
+      check_constraints(
+        inner, scope, alias_params, alias_bounds, resolve, issues,
+      )
+    Tuple(items) =>
+      for it in items {
+        check_constraints(
+          it, scope, alias_params, alias_bounds, resolve, issues,
+        )
+      }
+    Object(fields) =>
+      for f in fields {
+        check_constraints(
+          f.0,
+          scope,
+          alias_params,
+          alias_bounds,
+          resolve,
+          issues,
+        )
+        check_constraints(
+          f.1,
+          scope,
+          alias_params,
+          alias_bounds,
+          resolve,
+          issues,
+        )
+      }
+    Struct(_, fields) =>
+      for f in fields {
+        check_constraints(
+          f.1,
+          scope,
+          alias_params,
+          alias_bounds,
+          resolve,
+          issues,
+        )
+      }
+    Func(params, ret) => {
+      for p in params {
+        check_constraints(p, scope, alias_params, alias_bounds, resolve, issues)
+      }
+      check_constraints(ret, scope, alias_params, alias_bounds, resolve, issues)
+    }
+    Union(items) | Intersection(items) =>
+      for m in items {
+        check_constraints(m, scope, alias_params, alias_bounds, resolve, issues)
+      }
+    Conditional(c, e, t, f) => {
+      check_constraints(c, scope, alias_params, alias_bounds, resolve, issues)
+      check_constraints(e, scope, alias_params, alias_bounds, resolve, issues)
+      check_constraints(t, scope, alias_params, alias_bounds, resolve, issues)
+      check_constraints(f, scope, alias_params, alias_bounds, resolve, issues)
+    }
+    IndexedAccess(b, k) => {
+      check_constraints(b, scope, alias_params, alias_bounds, resolve, issues)
+      check_constraints(k, scope, alias_params, alias_bounds, resolve, issues)
+    }
+    _ => ()
+  }
 }
 
 ///|

--- a/src/checker/check_module_wbtest.mbt
+++ b/src/checker/check_module_wbtest.mbt
@@ -139,6 +139,7 @@ test "check_module: detects duplicate class instance properties" {
     static_field_inits: [],
     instance_field_inits: [],
     constructor_params: None,
+    constructor_param_is_rest: [],
     properties: [
       {
         name: "value",
@@ -185,6 +186,7 @@ test "check_module: instance and static with same name is OK" {
     static_field_inits: [],
     instance_field_inits: [],
     constructor_params: None,
+    constructor_param_is_rest: [],
     properties: [
       {
         name: "value",

--- a/src/checker/check_module_wbtest.mbt
+++ b/src/checker/check_module_wbtest.mbt
@@ -389,3 +389,132 @@ test "check_module: alias body containing union of named is not a cycle if all t
   let report = check_module(m)
   assert_eq(report.issues.length(), 0)
 }
+
+///|
+fn alias_with_bounds_for_check(
+  name : String,
+  type_params : Array[String],
+  bounds : Array[(String, @ast.TsType)],
+  body : @ast.TsType,
+) -> @ast.TsTypeAlias {
+  { name, type_params, type_param_bounds: bounds, type_: body }
+}
+
+///|
+test "check_module: flags a type argument that violates an extends bound" {
+  let m = empty_module_for_check()
+  // type Box<T extends string> = { v: T }
+  m.type_aliases.push(
+    alias_with_bounds_for_check(
+      "Box",
+      ["T"],
+      [("T", String_)],
+      Struct("Box", [("v", Named("T"))]),
+    ),
+  )
+  // type Use = Box<number>  — number does not extend string
+  m.type_aliases.push(alias_for_check("Use", [], Applied("Box", [Number])))
+  let report = check_module(m)
+  let violations = report.of_kind(TypeParameterConstraintViolation)
+  assert_eq(violations.length(), 1)
+  assert_eq(violations[0].name, "Box<T>")
+}
+
+///|
+test "check_module: a satisfied extends bound produces no violation" {
+  let m = empty_module_for_check()
+  m.type_aliases.push(
+    alias_with_bounds_for_check(
+      "Box",
+      ["T"],
+      [("T", String_)],
+      Struct("Box", [("v", Named("T"))]),
+    ),
+  )
+  // type Use = Box<"hi">  — string literal extends string
+  m.type_aliases.push(
+    alias_for_check("Use", [], Applied("Box", [Literal("hi")])),
+  )
+  let report = check_module(m)
+  assert_eq(report.count_of_kind(TypeParameterConstraintViolation), 0)
+}
+
+///|
+test "check_module: opaque type argument never trips the constraint check" {
+  let m = empty_module_for_check()
+  m.type_aliases.push(
+    alias_with_bounds_for_check(
+      "Box",
+      ["T"],
+      [("T", String_)],
+      Struct("Box", [("v", Named("T"))]),
+    ),
+  )
+  // type Use = Box<External>  — unresolved nominal arg ⇒ undecidable ⇒ silent
+  m.type_aliases.push(
+    alias_for_check("Use", [], Applied("Box", [Named("External")])),
+  )
+  let report = check_module(m)
+  assert_eq(report.count_of_kind(TypeParameterConstraintViolation), 0)
+}
+
+///|
+test "check_module: a non-generic alias resolves through to satisfy a bound" {
+  let m = empty_module_for_check()
+  m.type_aliases.push(
+    alias_with_bounds_for_check(
+      "Box",
+      ["T"],
+      [("T", String_)],
+      Struct("Box", [("v", Named("T"))]),
+    ),
+  )
+  // type MyStr = string;  type Use = Box<MyStr>
+  m.type_aliases.push(alias_for_check("MyStr", [], String_))
+  m.type_aliases.push(
+    alias_for_check("Use", [], Applied("Box", [Named("MyStr")])),
+  )
+  let report = check_module(m)
+  assert_eq(report.count_of_kind(TypeParameterConstraintViolation), 0)
+}
+
+///|
+test "check_module: a parameter forwarded within scope is not flagged" {
+  let m = empty_module_for_check()
+  m.type_aliases.push(
+    alias_with_bounds_for_check(
+      "Box",
+      ["T"],
+      [("T", String_)],
+      Struct("Box", [("v", Named("T"))]),
+    ),
+  )
+  // type Wrap<U> = Box<U>  — U is in scope, so the constraint is deferred
+  // to Wrap's own use sites rather than flagged here.
+  m.type_aliases.push(
+    alias_with_bounds_for_check("Wrap", ["U"], [], Applied("Box", [Named("U")])),
+  )
+  let report = check_module(m)
+  assert_eq(report.count_of_kind(TypeParameterConstraintViolation), 0)
+}
+
+///|
+test "check_module: dependent bound is evaluated against the concrete argument" {
+  let m = empty_module_for_check()
+  // type Rel<T, K extends T> = ...  used as Rel<string, number>
+  m.type_aliases.push(
+    alias_with_bounds_for_check(
+      "Rel",
+      ["T", "K"],
+      [("K", Named("T"))],
+      Struct("Rel", [("k", Named("K"))]),
+    ),
+  )
+  m.type_aliases.push(
+    alias_for_check("Use", [], Applied("Rel", [String_, Number])),
+  )
+  let report = check_module(m)
+  let violations = report.of_kind(TypeParameterConstraintViolation)
+  assert_eq(violations.length(), 1)
+  assert_eq(violations[0].name, "Rel<K>")
+}

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -6230,8 +6230,31 @@ fn check_arguments_with_sig(
   } else {
     @ast.TsType::Any
   }
+  // A spread argument (`foo(...arr)`) distributes an unknown number of
+  // values across the remaining parameters, so positional matching is
+  // unreliable from the first spread onward — checking the array against a
+  // scalar parameter would wrongly report `expected string but got
+  // string[]`. Type-check the positions *before* the first spread; the
+  // spread operand itself (and everything after) is still validated for
+  // internal errors by the `check_call_args_in_expr` recursion at the call
+  // site.
+  let first_spread : Int = {
+    let mut idx = -1
+    let mut j = 0
+    while j < args.length() {
+      if args[j] is Spread(_) {
+        idx = j
+        break
+      }
+      j = j + 1
+    }
+    idx
+  }
   let mut i = 0
   while i < args.length() {
+    if first_spread >= 0 && i >= first_spread {
+      break
+    }
     let sub_path = "\{call_path} arg[\{i}]"
     if rest_index >= 0 && i >= rest_index {
       check_expr_against(env, args[i], rest_elem_type, ctx, sub_path)
@@ -8295,11 +8318,33 @@ fn check_call_args_in_expr(
     UnaryOp(op, inner) => {
       check_call_args_in_expr(env, inner, ctx)
       match op {
-        Neg | Plus | BitwiseNot => {
+        Neg | BitwiseNot => {
           let inner_ty = ctx.resolver.unwrap(
             infer_expr(env, ctx.resolver, inner),
           )
           if is_checkable(inner_ty) && is_definitely_not_arithmetic(inner_ty) {
+            record(
+              ctx,
+              "unary op",
+              "operand `\{type_display(inner_ty)}` is not a valid number type",
+            )
+          }
+        }
+        // Unary `+` is the explicit numeric-coercion operator, so TypeScript
+        // accepts string operands (`+"5"`, `+templateString`, `+forInKey`)
+        // as well as number / bigint / any. Only operands that cannot
+        // coerce at all (objects, arrays, …) are flagged.
+        Plus => {
+          let inner_ty = ctx.resolver.unwrap(
+            infer_expr(env, ctx.resolver, inner),
+          )
+          let is_stringish = match inner_ty {
+            String_ | Literal(_) => true
+            _ => false
+          }
+          if is_checkable(inner_ty) &&
+            is_definitely_not_arithmetic(inner_ty) &&
+            !is_stringish {
             record(
               ctx,
               "unary op",

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -4653,42 +4653,18 @@ fn check_expr_against(
       return
     }
     (ArrayLit(items), Array(elem)) => {
-      for i, item in items {
-        check_expr_against(
-          env,
-          item,
-          elem,
-          ctx,
-          sub_path + "[" + i.to_string() + "]",
-        )
-      }
+      check_array_lit_elements_against(env, items, elem, ctx, sub_path)
       return
     }
     (ArrayLit(items), Applied("Array", [elem]))
     | (ArrayLit(items), Applied("ReadonlyArray", [elem])) => {
-      for i, item in items {
-        check_expr_against(
-          env,
-          item,
-          elem,
-          ctx,
-          sub_path + "[" + i.to_string() + "]",
-        )
-      }
+      check_array_lit_elements_against(env, items, elem, ctx, sub_path)
       return
     }
     // `Readonly<T[]>` contextual typing — delegate to element checking on
     // the inner array type so `['a', 'b'] as Readonly<string[]>` works.
     (ArrayLit(items), Applied("Readonly", [Array(elem)])) => {
-      for i, item in items {
-        check_expr_against(
-          env,
-          item,
-          elem,
-          ctx,
-          sub_path + "[" + i.to_string() + "]",
-        )
-      }
+      check_array_lit_elements_against(env, items, elem, ctx, sub_path)
       return
     }
     _ => ()
@@ -5159,6 +5135,29 @@ fn is_named_decl(ty : @ast.TsType, resolver : Resolver) -> Bool {
 /// (more literal entries than tuple slots, or vice versa) emit an arity
 /// issue; trailing `Spread(...)` entries waive the arity check the same way
 /// they do for call-site arguments.
+/// Check each element of an array literal against the array's element type
+/// `elem`. A `Spread(e)` element contributes `e`'s *elements*, not `e`
+/// itself, so it is checked against `elem[]` (e.g. `[...nums]` where `nums:
+/// number[]` is valid for `number[]`) rather than against the scalar `elem`,
+/// which would wrongly report `expected number but got number[]`.
+fn check_array_lit_elements_against(
+  env : ExprEnv,
+  items : Array[@ast.TsExpr],
+  elem : @ast.TsType,
+  ctx : CheckCtx,
+  sub_path : String,
+) -> Unit {
+  for i, item in items {
+    let item_path = sub_path + "[" + i.to_string() + "]"
+    match item {
+      Spread(inner) =>
+        check_expr_against(env, inner, Array(elem), ctx, item_path)
+      _ => check_expr_against(env, item, elem, ctx, item_path)
+    }
+  }
+}
+
+///|
 fn check_array_lit_against_tuple(
   env : ExprEnv,
   items : Array[@ast.TsExpr],

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -4165,8 +4165,12 @@ fn infer_expr(
       // is the return type of `tag` when it's a known function — this
       // is what library helpers like `gql\`...\`` / `css\`...\`` /
       // `sql\`...\`` rely on for end-to-end typing.
-      match infer_expr(env, resolver, tag) {
+      match resolver.unwrap(infer_expr(env, resolver, tag)) {
         Func(_, ret) => ret
+        // A tag typed `any` produces `any` (calling `any` yields `any`), so
+        // member access on the result must not be flagged. Anything else
+        // falls back to the cooked-string type.
+        Any => @ast.TsType::Any
         _ => @ast.TsType::String_
       }
     TemplateLiteral(_, _) => @ast.TsType::String_
@@ -8018,14 +8022,10 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
         inferred_elem
       }
       let pre = env.full_snapshot()
-      // TS2454: same reasoning as for-in — the loop variable is
-      // assigned each iteration, so reused declarations clear.
-      match binding {
-        @ast.TsBinding::Ident(n) => {
-          let _ = ctx.unassigned.remove(n)
-        }
-        _ => ()
-      }
+      // TS2454: same reasoning as for-in — the loop variable is assigned
+      // each iteration, so reused declarations clear. A destructuring
+      // pattern (`for ([k, v] of …)`) assigns every name it binds.
+      clear_unassigned_in_binding(ctx, binding)
       // Assignment-form `for (x of obj)` (no `let`/`var`/`const`) reuses
       // the outer-scope variable -- narrow it for the loop body
       // instead of re-declaring (which would otherwise pin the
@@ -8063,12 +8063,7 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
         inferred_elem
       }
       let pre = env.full_snapshot()
-      match binding {
-        @ast.TsBinding::Ident(n) => {
-          let _ = ctx.unassigned.remove(n)
-        }
-        _ => ()
-      }
+      clear_unassigned_in_binding(ctx, binding)
       bind_pattern(env, ctx, binding, elem_ty)
       check_block(env, body, ctx)
       env.restore_from(pre)
@@ -8094,12 +8089,7 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
       // TS2454: the loop binding is *assigned* each iteration, so a
       // previously-declared `let k: T;` reused as the for-in target
       // (`for (k in obj) ...`) shouldn't trip use-before-assign.
-      match binding {
-        @ast.TsBinding::Ident(n) => {
-          let _ = ctx.unassigned.remove(n)
-        }
-        _ => ()
-      }
+      clear_unassigned_in_binding(ctx, binding)
       bind_pattern(env, ctx, binding, key_ty)
       check_block(env, body, ctx)
       env.restore_from(pre)

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -225,11 +225,16 @@ fn Resolver::ingest_module(
     // signature path used by `apply_type_predicate_narrowing` can map
     // the predicate's parameter name to an argument index.
     let synth_params : Array[@ast.TsParam] = []
-    for p in imp.params {
+    for idx, p in imp.params {
+      // Preserve the rest-parameter flag (`...args: T[]`) so the call
+      // checker compares each variadic argument against the element type
+      // rather than the whole array. `param_is_rest` is positionally
+      // aligned with `params`; an empty array means "no rest params".
+      let is_rest = idx < imp.param_is_rest.length() && imp.param_is_rest[idx]
       synth_params.push({
         name: p.0,
         binding: None,
-        is_rest: false,
+        is_rest,
         type_: p.1,
         default: None,
       })
@@ -6197,8 +6202,18 @@ fn check_arguments_with_sig(
   }
   let rest_elem_type : @ast.TsType = if rest_index >= 0 &&
     rest_index < params.length() {
-    match params[rest_index] {
+    // The rest slot may arrive as a bare array, an `Applied("Array", …)` /
+    // iterable, a tuple, or any of those wrapped in the `Rest(...)` variadic
+    // marker (the `module_.funcs` builder wraps rest params that way).
+    // Unwrap one `Rest` layer first, then read the element type.
+    let slot = match params[rest_index] {
+      Rest(inner) => inner
+      other => other
+    }
+    match slot {
       Array(elem) => elem
+      Applied("Array", [elem]) => elem
+      Applied(n, [elem]) if is_array_like_iterable_name(n) => elem
       // `...args: [string, number]` — rest is typed as a tuple; each
       // individual rest argument is the union of all tuple element types.
       Tuple(parts) if parts.length() > 0 => {

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -8553,7 +8553,14 @@ fn check_call_args_in_expr(
       check_call_args_in_expr(env, idx, ctx)
       check_call_args_in_expr(env, v, ctx)
       let recv_ty = infer_expr(env, ctx.resolver, recv)
-      match recv_ty {
+      match ctx.resolver.unwrap(recv_ty) {
+        // `ReadonlyArray<T>` (and the `readonly [...]` tuple form, when it
+        // survives as such) permits reads only — element assignment is a
+        // type error in TypeScript (TS2542).
+        Applied("ReadonlyArray", _) =>
+          record(
+            ctx, "assign element", "index signature in a `ReadonlyArray` only permits reading",
+          )
         Array(elem) =>
           check_expr_against(env, v, elem, ctx, "assign array element")
         Tuple(items) =>

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -467,7 +467,18 @@ fn Resolver::unwrap(self : Resolver, ty : @ast.TsType) -> @ast.TsType {
               seen[n] = true
               cur = aliased.type_
             }
-            None => keep_going = false
+            None =>
+              // A pure array-alias interface (`interface I extends Array<T>
+              // {}` / `ReadonlyArray<T>`, no own members) is structurally an
+              // array — resolve it so array-literal contextual typing and
+              // assignability see the element type.
+              match interface_pure_array_element(self, n) {
+                Some(elem) => {
+                  seen[n] = true
+                  cur = Array(elem)
+                }
+                None => keep_going = false
+              }
           }
         }
       Applied(n, args) =>
@@ -2064,6 +2075,34 @@ fn Resolver::lookup_class_field(
 }
 
 ///|
+/// Element type of a "pure array-alias" interface: one whose only content is
+/// `extends Array<T>` (or `ReadonlyArray<T>`) with no own fields or index
+/// signatures. Returns `None` for interfaces that add members (those are not
+/// interchangeable with a plain array) or that extend anything else.
+fn interface_pure_array_element(
+  resolver : Resolver,
+  name : String,
+) -> @ast.TsType? {
+  match resolver.interfaces.get(name) {
+    Some(iface) =>
+      if iface.fields.length() == 0 &&
+        iface.index_signatures.length() == 0 &&
+        iface.extends_names.length() == 1 &&
+        iface.extends_args.length() == 1 &&
+        (
+          iface.extends_names[0] == "Array" ||
+          iface.extends_names[0] == "ReadonlyArray"
+        ) &&
+        iface.extends_args[0].length() == 1 {
+        Some(iface.extends_args[0][0])
+      } else {
+        None
+      }
+    None => None
+  }
+}
+
+///|
 /// Look up a method's `(params, return)` signature. Returns `None` when the
 /// receiver shape is opaque.
 fn Resolver::lookup_method_sig(
@@ -2096,6 +2135,41 @@ fn Resolver::lookup_constructor(
           Some(types)
         }
         None => Some([])
+      }
+    None => None
+  }
+}
+
+///|
+/// Rich constructor signature (`TsParam` list carrying the rest-parameter
+/// flag) for `class_name`, so a `new` call validates each variadic argument
+/// against the element type instead of the whole array. Returns `None` for
+/// an unknown class; `Some([])` for a class with no declared constructor.
+fn Resolver::lookup_constructor_sig(
+  self : Resolver,
+  class_name : String,
+) -> (Array[@ast.TsType], Array[@ast.TsParam])? {
+  match self.classes.get(class_name) {
+    Some(cls) =>
+      match cls.constructor_params {
+        Some(params) => {
+          let types : Array[@ast.TsType] = []
+          let sig : Array[@ast.TsParam] = []
+          for idx, p in params {
+            types.push(p.1)
+            let is_rest = idx < cls.constructor_param_is_rest.length() &&
+              cls.constructor_param_is_rest[idx]
+            sig.push({
+              name: p.0,
+              binding: None,
+              is_rest,
+              type_: p.1,
+              default: None,
+            })
+          }
+          Some((types, sig))
+        }
+        None => Some(([], []))
       }
     None => None
   }
@@ -8286,9 +8360,16 @@ fn check_call_args_in_expr(
     }
     New(class_name, args) => {
       check_abstract_instantiation(ctx, class_name)
-      match ctx.resolver.lookup_constructor(class_name) {
-        Some(params) => {
-          check_arguments(env, params, args, ctx, "new `\{class_name}`")
+      match ctx.resolver.lookup_constructor_sig(class_name) {
+        Some((params, sig)) => {
+          check_arguments_with_sig(
+            env,
+            params,
+            Some(sig),
+            args,
+            ctx,
+            "new `\{class_name}`",
+          )
           for a in args {
             check_call_args_in_expr(env, a, ctx)
           }

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -6301,3 +6301,19 @@ test "expr_check: unary minus still rejects a string operand" {
   let unary = issues.filter(fn(i) { i.message.contains("valid number type") })
   @test.assert_eq(unary.length(), 1)
 }
+
+///|
+test "expr_check: a spread element in an array literal is not a scalar item" {
+  // `[...nums]` where `nums: number[]` is a valid `number[]`; the spread
+  // contributes elements, so it must not be compared to the scalar `number`.
+  let src =
+    #|function f(nums: number[]): number[] {
+    #|  return [0, ...nums, 9];
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let elem_issues = issues.filter(fn(i) {
+    i.path.contains("init") || i.path.contains("[")
+  })
+  @test.assert_eq(elem_issues.length(), 0)
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -6317,3 +6317,47 @@ test "expr_check: a spread element in an array literal is not a scalar item" {
   })
   @test.assert_eq(elem_issues.length(), 0)
 }
+
+///|
+test "expr_check: an interface extending Array is a valid array target" {
+  // `interface NumList extends Array<number> {}` is structurally an array,
+  // so an array literal of numbers assigns without complaint.
+  let src =
+    #|interface NumList extends Array<number> {}
+    #|function f(): NumList {
+    #|  return [1, 2, 3];
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  @test.assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: a constructor rest parameter checks against the element type" {
+  // `constructor(label: string, ...nums: number[])` — extra args are
+  // numbers; a valid `new` must not be flagged, a wrong-typed one must.
+  let ok =
+    #|class B {
+    #|  constructor(label: string, ...nums: number[]) {}
+    #|}
+    #|function f(): void {
+    #|  let b = new B("x", 1, 2, 3);
+    #|}
+  let issues_ok = check_module_function_bodies(parse_module_or_empty(ok))
+  @test.assert_eq(
+    issues_ok.filter(fn(i) { i.path.contains("arg[") }).length(),
+    0,
+  )
+  let bad =
+    #|class B {
+    #|  constructor(label: string, ...nums: number[]) {}
+    #|}
+    #|function f(): void {
+    #|  let b = new B("x", 1, "bad");
+    #|}
+  let issues_bad = check_module_function_bodies(parse_module_or_empty(bad))
+  @test.assert_eq(
+    issues_bad.filter(fn(i) { i.path.contains("arg[") }).length(),
+    1,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -6361,3 +6361,36 @@ test "expr_check: a constructor rest parameter checks against the element type" 
     1,
   )
 }
+
+///|
+test "expr_check: for-of destructuring pattern assigns its bound names" {
+  // `for ([k, v] of entries)` assigns k and v each iteration — using them
+  // in the body must not trip use-before-assignment.
+  let src =
+    #|function f(entries: [string, number][]): void {
+    #|  let k: string, v: number;
+    #|  for ([k, v] of entries) {
+    #|    k;
+    #|    v;
+    #|  }
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let uba = issues.filter(fn(i) {
+    i.message.contains("used before being assigned")
+  })
+  @test.assert_eq(uba.length(), 0)
+}
+
+///|
+test "expr_check: a tag typed any yields any from a tagged template" {
+  // `f` `...` ` where `f: any` produces `any`, so member access is fine.
+  let src =
+    #|function f(tag: any): void {
+    #|  tag`abc`.member;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let prop = issues.filter(fn(i) { i.message.contains("does not exist") })
+  @test.assert_eq(prop.length(), 0)
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -6259,3 +6259,45 @@ test "expr_check: a wrong-typed rest argument is still flagged" {
   let arg_issues = issues.filter(fn(i) { i.path.contains("arg[") })
   @test.assert_eq(arg_issues.length(), 1)
 }
+
+///|
+test "expr_check: a spread argument is not matched positionally" {
+  // `foo(...arr)` distributes; the array must not be compared to a scalar
+  // parameter (which would wrongly report `expected string but got
+  // string[]`).
+  let src =
+    #|declare function foo(a: string, b: string, c: string): void;
+    #|function f(arr: string[]): void {
+    #|  foo(...arr);
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let arg_issues = issues.filter(fn(i) { i.path.contains("arg[") })
+  @test.assert_eq(arg_issues.length(), 0)
+}
+
+///|
+test "expr_check: unary plus accepts a string operand" {
+  // `+s` is the explicit numeric coercion — valid on a string in TS.
+  let src =
+    #|function f(s: string): number {
+    #|  return +s;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let unary = issues.filter(fn(i) { i.message.contains("valid number type") })
+  @test.assert_eq(unary.length(), 0)
+}
+
+///|
+test "expr_check: unary minus still rejects a string operand" {
+  // Unlike `+`, unary `-` requires a numeric operand.
+  let src =
+    #|function f(s: string): number {
+    #|  return -s;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let unary = issues.filter(fn(i) { i.message.contains("valid number type") })
+  @test.assert_eq(unary.length(), 1)
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -6230,3 +6230,32 @@ test "expr_check: assigning to a mutable array element is fine" {
   })
   @test.assert_eq(readonly_issues.length(), 0)
 }
+
+///|
+test "expr_check: rest-parameter args are checked against the element type" {
+  // `...keys: number[]` — each individual argument is a `number`, not the
+  // whole array. A valid call must not be flagged.
+  let src =
+    #|declare function collect(label: string, ...nums: number[]): void;
+    #|function f(): void {
+    #|  collect("x", 1, 2, 3);
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let arg_issues = issues.filter(fn(i) { i.path.contains("arg[") })
+  @test.assert_eq(arg_issues.length(), 0)
+}
+
+///|
+test "expr_check: a wrong-typed rest argument is still flagged" {
+  // The element type is `number`, so a string vararg is a genuine error.
+  let src =
+    #|declare function collect(label: string, ...nums: number[]): void;
+    #|function f(): void {
+    #|  collect("x", 1, "bad", 3);
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let arg_issues = issues.filter(fn(i) { i.path.contains("arg[") })
+  @test.assert_eq(arg_issues.length(), 1)
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -6202,3 +6202,31 @@ test "expr_check: nested destructuring through array index from interface field"
   }
   @test.assert_eq(issues.length(), 0)
 }
+
+///|
+test "expr_check: assigning to a ReadonlyArray element is a read-only error" {
+  let src =
+    #|function f(a: ReadonlyArray<number>): void {
+    #|  a[0] = 5;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let readonly_issues = issues.filter(fn(i) {
+    i.message.contains("only permits reading")
+  })
+  @test.assert_eq(readonly_issues.length(), 1)
+}
+
+///|
+test "expr_check: assigning to a mutable array element is fine" {
+  let src =
+    #|function f(a: number[]): void {
+    #|  a[0] = 5;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let readonly_issues = issues.filter(fn(i) {
+    i.message.contains("only permits reading")
+  })
+  @test.assert_eq(readonly_issues.length(), 0)
+}

--- a/src/checker/simplify.mbt
+++ b/src/checker/simplify.mbt
@@ -168,6 +168,11 @@ pub fn simplify_type(type_ : @ast.TsType) -> @ast.TsType {
     MappedType(_, _, _, _) => simplify_mapped_type(recursed)
     MappedTypeRemap(_, _, _, _, _) => simplify_mapped_type_remap(recursed)
     TemplateLiteralType(_, _) => simplify_template_literal(recursed)
+    Applied(name, args) =>
+      match simplify_string_intrinsic(name, args) {
+        Some(t) => t
+        None => recursed
+      }
     _ => recursed
   }
 }
@@ -519,6 +524,55 @@ fn apply_string_intrinsic(intrinsic : String, value : String) -> String? {
       }
     "Uppercase" => Some(value.to_upper())
     "Lowercase" => Some(value.to_lower())
+    _ => None
+  }
+}
+
+///|
+/// Recognize the four TypeScript intrinsic string-mapping type names.
+fn is_string_intrinsic_name(name : String) -> Bool {
+  name == "Uppercase" ||
+  name == "Lowercase" ||
+  name == "Capitalize" ||
+  name == "Uncapitalize"
+}
+
+///|
+/// Simplify a standalone intrinsic string-mapping application such as
+/// `Uppercase<"foo">` -> `"FOO"` or `Capitalize<"a" | "b">` -> `"A" | "B"`.
+/// Distributes over a finite union of literals exactly like TypeScript.
+/// Returns `None` when the argument is not a finite literal set so the
+/// caller keeps the original `Applied(...)` for a later retry. Outside of
+/// template-literal interpolation this is the only place a bare
+/// `Uppercase<...>` etc. gets folded.
+fn simplify_string_intrinsic(
+  name : String,
+  args : Array[@ast.TsType],
+) -> @ast.TsType? {
+  if !is_string_intrinsic_name(name) {
+    return None
+  }
+  match args {
+    [arg] =>
+      match resolve_literal_value_set(arg) {
+        Some(values) => {
+          let mapped : Array[@ast.TsType] = []
+          for v in values {
+            match apply_string_intrinsic(name, v) {
+              Some(new_v) => mapped.push(Literal(new_v))
+              None => return None
+            }
+          }
+          if mapped.length() == 0 {
+            Some(Never)
+          } else if mapped.length() == 1 {
+            Some(mapped[0])
+          } else {
+            Some(Union(mapped))
+          }
+        }
+        None => None
+      }
     _ => None
   }
 }

--- a/src/checker/simplify_wbtest.mbt
+++ b/src/checker/simplify_wbtest.mbt
@@ -385,3 +385,41 @@ test "simplify_type: template literal preserved when arg is opaque" {
   let t : @ast.TsType = TemplateLiteralType(["prefix-", ""], [Named("T")])
   assert_eq(simplify_type(t), t)
 }
+
+///|
+test "simplify_type: folds standalone Uppercase over a literal" {
+  // `Uppercase<'foo'>` ⇒ `'FOO'`
+  let t : @ast.TsType = Applied("Uppercase", [Literal("foo")])
+  assert_eq(simplify_type(t), Literal("FOO"))
+}
+
+///|
+test "simplify_type: folds standalone Capitalize over a literal" {
+  let t : @ast.TsType = Applied("Capitalize", [Literal("red")])
+  assert_eq(simplify_type(t), Literal("Red"))
+}
+
+///|
+test "simplify_type: distributes a string intrinsic over a literal union" {
+  // `Uppercase<'a' | 'b'>` ⇒ `'A' | 'B'`
+  let t : @ast.TsType = Applied("Uppercase", [
+    Union([Literal("a"), Literal("b")]),
+  ])
+  assert_eq(simplify_type(t), Union([Literal("A"), Literal("B")]))
+}
+
+///|
+test "simplify_type: nests string intrinsics" {
+  // `Uppercase<Lowercase<'FoO'>>` ⇒ `'FOO'`
+  let t : @ast.TsType = Applied("Uppercase", [
+    Applied("Lowercase", [Literal("FoO")]),
+  ])
+  assert_eq(simplify_type(t), Literal("FOO"))
+}
+
+///|
+test "simplify_type: keeps string intrinsic opaque when arg is not a literal" {
+  // `Uppercase<T>` for opaque `T` stays put for a later retry.
+  let t : @ast.TsType = Applied("Uppercase", [Named("T")])
+  assert_eq(simplify_type(t), t)
+}

--- a/src/checker/validate_wbtest.mbt
+++ b/src/checker/validate_wbtest.mbt
@@ -119,6 +119,7 @@ test "validate_module: ignores generic parameters of declared functions" {
     module_: "m",
     type_params: ["T"],
     params: [("x", Named("T"))],
+    param_is_rest: [],
     return_type: Named("T"),
   })
   let unresolved = unresolved_type_references(mod)
@@ -134,6 +135,7 @@ test "validate_module: still surfaces genuinely undeclared function refs" {
     module_: "m",
     type_params: ["T"],
     params: [("x", Named("T"))],
+    param_is_rest: [],
     return_type: Named("Missing"),
   })
   let unresolved = unresolved_type_references(mod)

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -59,11 +59,13 @@ fn build_runtime_class_decl(
   let properties : Array[@ast.TsClassPropertyDecl] = []
   let methods : Array[@ast.TsClassMethodDecl] = []
   let instance_field_inits : Array[(String, @ast.TsExpr)] = []
+  let constructor_param_is_rest : Array[Bool] = []
   let constructor_params = match ctor_opt {
     Some(ctor) => {
       let params : Array[(String, @ast.TsType)] = []
       for index, param in ctor.params {
         params.push((runtime_class_param_name(param, index), param.type_))
+        constructor_param_is_rest.push(param.is_rest)
       }
       Some(params)
     }
@@ -227,6 +229,7 @@ fn build_runtime_class_decl(
     static_field_inits: [],
     instance_field_inits,
     constructor_params,
+    constructor_param_is_rest,
     properties,
     methods,
     index_signatures,
@@ -1362,6 +1365,7 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
     static_field_inits: runtime_decl.static_field_inits,
     instance_field_inits: runtime_decl.instance_field_inits,
     constructor_params: runtime_decl.constructor_params,
+    constructor_param_is_rest: runtime_decl.constructor_param_is_rest,
     properties: runtime_decl.properties,
     methods: runtime_decl.methods,
     index_signatures: runtime_decl.index_signatures,

--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -1715,9 +1715,10 @@ pub fn Parser::parse_declare_function(
   // parameter
   let _ = self.expect(LParen)
   let params : Array[(String, @ast.TsType)] = []
+  let param_is_rest : Array[Bool] = []
   while !self.check(RParen) && !self.check(Eof) {
     // Handle rest parameter: ...name
-    let _ = self.match_ellipsis()
+    let is_rest = self.match_ellipsis()
     let param_name = self.parse_declare_param_name()
     // Handle optional parameter: name?
     let is_optional = self.match_(Question)
@@ -1741,6 +1742,7 @@ pub fn Parser::parse_declare_function(
     // `function f(this, ...)`, which Node rejects as a syntax error.
     if !(param_name == "this" && params.length() == 0) {
       params.push((param_name, computed_param_type))
+      param_is_rest.push(is_rest)
     }
     if self.check(Comma) {
       let _ = self.advance()
@@ -1759,7 +1761,7 @@ pub fn Parser::parse_declare_function(
   }
   self.restore_local_type_param_bounds(local_type_param_bound_len)
   self.consume_semicolon()
-  { name, module_: "env", type_params, params, return_type }
+  { name, module_: "env", type_params, params, param_is_rest, return_type }
 }
 
 ///|

--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -2421,6 +2421,9 @@ fn Parser::parse_declare_class(
     static_field_inits: [],
     instance_field_inits: [],
     constructor_params,
+    // The ambient `declare class` param parser does not surface rest flags;
+    // leave empty (rest detection just no-ops for these).
+    constructor_param_is_rest: [],
     properties,
     methods,
     index_signatures,

--- a/src/transform/iife_class_lift.mbt
+++ b/src/transform/iife_class_lift.mbt
@@ -228,6 +228,7 @@ fn try_lift_iife_value(
     static_field_inits,
     instance_field_inits: [],
     constructor_params: None,
+    constructor_param_is_rest: [],
     properties: [],
     methods: all_methods,
     is_abstract: false,


### PR DESCRIPTION
## Summary

Improves the `src/checker` type-system layer's fidelity to TypeScript, then introduces a measurement tool and CI gate that uses the official TypeScript conformance corpus as an oracle. False positives on the conformance corpus (programs TS accepts but we flagged) dropped from **28 → 13**, with the full test suite green throughout (2191 → 2225).

## The oracle

A conformance case `foo.ts` ships an `foo.errors.txt` baseline iff the official compiler rejects it; its absence means TS accepts the program. That gives a free soundness oracle. `scripts/checker_conformance_oracle.sh` (`just checker-conformance-oracle`) runs `tscheck` over the single-file conformance cases and classifies each against its baseline:

| | meaning |
|---|---|
| **TP** | TS errors & we flag (agreement) |
| **MISS** | TS errors & we're silent (expected — we model a subset of TS) |
| **FP** | TS accepts & we flag (**soundness bug**) |
| **TN** | TS accepts & we're silent (agreement) |

The checker is a deliberate subset of TS's type system, so MISS is expected and not a goal to drive to zero — the enforceable invariant is the soundness direction (don't flag valid programs). Current standing: TP=686, MISS=2226, **FP=13**, TN=1577.

## Checker fidelity improvements

- **Generic type-parameter constraints** — `check_module` now validates `Applied(Name, args)` against an alias's `<P extends Bound>` using the three-valued `extends_decision` (only definite `Some(false)` is reported, so opaque/nominal/unresolved args never false-positive). Dependent bounds (`K extends keyof T`) are evaluated against the concrete arguments.
- **String-intrinsic folding** — `Uppercase<"foo">` → `"FOO"` (and union distribution) at the top level, not only inside template literals.
- **Object-intersection merge** — `{a} & {b}` is assignable to `{a, b}`.
- **Read-only array writes** — assigning to a `ReadonlyArray<T>` element is reported (TS2542).

## False-positive fixes (each verified against the oracle)

- Rest-parameter arguments checked against the element type, not the array (`...keys: K[]`, `...values: T`), incl. preserving rest info on `TsImport` / constructors.
- Spread call arguments (`foo(...arr)`) no longer matched positionally against scalar params.
- Unary `+` accepts string operands (`+"5"`, `+key`) while `-` / `~` stay strict.
- Spread elements in array literals (`[0, ...nums, 9]`) contribute their elements.
- `interface I extends Array<T> {}` (pure array alias) resolves to `Array<T>`.
- Primitives are assignable to their boxed wrappers (`number` → `Number`, …).
- Constructor rest parameters check per-element (new `constructor_param_is_rest` on `TsClassDecl`).
- for-of / for-in / for-await-of destructuring patterns clear every bound name (definite-assignment).
- Tagged templates with an `any` tag yield `any`.

## CI gate

`just verify-checker-soundness` builds the native `tscheck` binary and runs the oracle with `--max-fp 13` (the current budget); it's added to the `ci` aggregate. Because it needs the large `typescript` submodule, it runs as a separate `checker-soundness` GitHub Actions job. The oracle skips cleanly when the corpus is absent, so the gate is safe to invoke anywhere and only bites once the submodule is populated.

## Remaining 13 false positives

Distinct one-off cases (class-method overload sets, generic-inference-through-rest, and ~11 singletons across parser/jsdoc/generators/salsa/decorators/etc.). They're now fenced by the gate so the count can't grow silently.

## Testing

- `moon test --target native` — 2225 tests, all passing (+34 new regression tests).
- `moon check --deny-warn` clean; `moon fmt` applied.
- Conformance smoke corpus: 1840 checked, no crashes.

https://claude.ai/code/session_01S5m8xKHBeZVYKrScqb9btt

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5m8xKHBeZVYKrScqb9btt)_