### PR TITLE
checker: flag duplicate enum members and interface fields (TS2300)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -10087,6 +10087,103 @@ pub fn check_module_function_bodies_permissive(
 /// are ingested first at bare names so inner code can reference
 /// outer-scope types unqualified (the way TypeScript scoping works),
 /// then this module is ingested to shadow on top.
+
+///|
+/// True for the interface-member sentinel keys the parser uses for call /
+/// construct / computed / index signatures, which are not real named members
+/// and may legitimately repeat.
+fn is_signature_sentinel(name : String) -> Bool {
+  name == "<call>" ||
+  name == "<new>" ||
+  name == "<computed>" ||
+  name == "<index_signature>"
+}
+
+///|
+/// TS2300 ("Duplicate identifier") for the structurally-unambiguous cases:
+/// an enum that lists the same member name twice, and an interface that
+/// declares the same field name twice. Same-name *method* signatures are
+/// legal overloads, so an interface name is only flagged when at least one
+/// occurrence is a non-method (property) field; signature sentinels are
+/// skipped. Both are decided from declaration shape alone — no type
+/// resolution — so they carry no false-positive risk on resolvable input.
+fn check_structural_duplicates(module_ : @ast.TsModule) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  for e in module_.enums {
+    let seen : Map[String, Bool] = {}
+    let reported : Map[String, Bool] = {}
+    for em in e.members {
+      if seen.get(em.name) is Some(_) {
+        if !(reported.get(em.name) is Some(_)) {
+          reported[em.name] = true
+          issues.push({
+            path: "enum \{e.name}",
+            message: "duplicate identifier `\{em.name}`",
+          })
+        }
+      } else {
+        seen[em.name] = true
+      }
+    }
+  }
+  // An object type-literal alias body (`type T = { a: X; a: Y }`) is
+  // synthesized into an interface by the parser, so the interface loop
+  // below already covers it -- no separate type-alias pass is needed.
+  for iface in module_.interfaces {
+    for name in member_name_duplicates(iface.fields) {
+      issues.push({
+        path: "interface \{iface.name}",
+        message: "duplicate identifier `\{name}`",
+      })
+    }
+  }
+  issues
+}
+
+///|
+/// Names that appear more than once in a member list where at least one
+/// occurrence is a non-method (property) field. All-method repeats are legal
+/// overloads, and signature sentinels (`<call>` / `<new>` / …) are skipped.
+fn member_name_duplicates(
+  fields : Array[(String, @ast.TsType)],
+) -> Array[String] {
+  let count : Map[String, Int] = {}
+  let has_property : Map[String, Bool] = {}
+  let order : Array[String] = []
+  for f in fields {
+    let name = f.0
+    if is_signature_sentinel(name) {
+      continue
+    }
+    match count.get(name) {
+      Some(n) => count[name] = n + 1
+      None => {
+        count[name] = 1
+        order.push(name)
+      }
+    }
+    let is_method = match f.1 {
+      Func(_, _) => true
+      _ => false
+    }
+    if !is_method {
+      has_property[name] = true
+    }
+  }
+  let dups : Array[String] = []
+  for name in order {
+    let n = match count.get(name) {
+      Some(v) => v
+      None => 0
+    }
+    if n >= 2 && has_property.get(name) is Some(_) {
+      dups.push(name)
+    }
+  }
+  dups
+}
+
+///|
 fn check_module_function_bodies_layered(
   module_ : @ast.TsModule,
   outer_modules : Array[@ast.TsModule],
@@ -10237,6 +10334,9 @@ fn check_module_function_bodies_layered(
     }
   }
   for issue in check_module_decl_signatures(module_) {
+    all.push(issue)
+  }
+  for issue in check_structural_duplicates(module_) {
     all.push(issue)
   }
   // Walk class field initialisation. Namespaced classes need to

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -325,6 +325,39 @@ fn parse_module_or_empty(src : String) -> @ast.TsModule {
 }
 
 ///|
+test "expr_check: flags duplicate enum member and interface field (TS2300)" {
+  let src =
+    #|enum E { A, B, A }
+    #|interface I { a: number; a: string }
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let mut saw_enum = false
+  let mut saw_iface = false
+  for i in issues {
+    if i.message.contains("duplicate identifier `A`") {
+      saw_enum = true
+    }
+    if i.message.contains("duplicate identifier `a`") {
+      saw_iface = true
+    }
+  }
+  assert_true(saw_enum)
+  assert_true(saw_iface)
+}
+
+///|
+test "expr_check: same-name interface method overloads are not duplicates" {
+  // `foo(): void; foo(x): void` are legal overloads, not TS2300.
+  let src =
+    #|interface I { foo(): void; foo(x: number): void; bar: number }
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  for i in issues {
+    assert_true(!i.message.contains("duplicate identifier"))
+  }
+}
+
+///|
 test "expr_check: argument count mismatch on top-level function call" {
   let src =
     #|function add(a: number, b: number): number { return a + b; }


### PR DESCRIPTION
A safe, structural recall win: duplicate-identifier (TS2300) detection in the function-bodies checker (the path the conformance oracle runs). **TP 787 → 792**, with **no new false positives** and no gate change.

## What it flags
- An **enum** that lists the same member name twice (`enum E { A, B, A }`).
- An **interface** that declares the same field name twice (`interface I { a: number; a: string }`). Same-name **method** signatures are legal overloads, so a name is flagged only when at least one occurrence is a non-method (property) field; `<call>`/`<new>`/`<computed>`/`<index_signature>` sentinels are skipped. Object type-literal alias bodies (`type T = { a; a }`) are covered via the interface the parser synthesizes for them.

Both decisions are made from declaration shape alone — **no type resolution** — so they carry no false-positive risk on resolvable input.

## Verification
```
TP   : 792  (was 787)
MISS : 1893
FP   : 3    (unchanged — standing parser-limitation residuals)
TN   : 1402
```
Full suite green (2227 tests, +2 new); `moon check --deny-warn` clean. Soundness gate unchanged at `--max-fp 3`.

https://claude.ai/code/session_01S5m8xKHBeZVYKrScqb9btt

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5m8xKHBeZVYKrScqb9btt)_