### PR TITLE
parser: close three gaps, restoring conformance FP=0

### DIFF
--- a/justfile
+++ b/justfile
@@ -114,19 +114,11 @@ checker-conformance-oracle *ARGS:
 # Soundness gate: build the native binary and fail if the checker reports
 # more conformance false positives than the current budget. The oracle
 # script skips cleanly when the `typescript` submodule isn't populated, so
-# this is safe to run anywhere. Keep the budget in lockstep with the
-# documented standing FP count.
-#
-# The standing budget is 3. All three are pre-existing *parser* limitations
-# surfaced by the TS2304 ("cannot find name") check, not checker-logic
-# bugs: an `import x = Y` alias the parser discards
-# (internalModules/.../importStatements), an ASI-split `let\nx`
-# (VariableDeclaration12_es6), and a unicode identifier the lexer fragments
-# (parserUnicode2). Each is a tracked parser gap to close separately; the
-# gate fences the count so it can't grow.
+# this is safe to run anywhere. The budget is 0: the checker reports no
+# false positives on the conformance corpus.
 verify-checker-soundness:
     moon build --target native
-    bash scripts/checker_conformance_oracle.sh --max-fp 3
+    bash scripts/checker_conformance_oracle.sh --max-fp 0
 
 # Full CI check
 ci: fmt check test verify-mbti-dts verify-scaffolds verify-generated-fixtures verify-examples verify-checker-soundness

--- a/src/parser/lexer.mbt
+++ b/src/parser/lexer.mbt
@@ -727,7 +727,12 @@ fn Lexer::scan_ident(self : Lexer) -> TokenKind {
       (b >= 'A'.to_int() && b <= 'Z'.to_int()) ||
       (b >= '0'.to_int() && b <= '9'.to_int()) ||
       b == '_'.to_int() ||
-      b == '$'.to_int() {
+      b == '$'.to_int() ||
+      // Non-ASCII identifier characters (CJK, accented letters, …). TS uses
+      // the Unicode ID_Continue set; we over-approximate with "any code unit
+      // >= 0x80" so a unicode-named identifier scans as a single token
+      // instead of fragmenting into per-character tokens.
+      b >= 0x80 {
       self.pos += 1
     } else {
       break
@@ -2450,7 +2455,18 @@ pub fn Lexer::next_token(self : Lexer) -> Token {
           self.enqueue_template_tokens(pos)
           return self.next_token()
         }
-        _ => Ident(c.to_string())
+        _ =>
+          // A non-ASCII character starts a unicode identifier (CJK, accented
+          // letters, …): back up and scan the whole run as one identifier
+          // token rather than emitting a single-character `Ident`, which
+          // would fragment `var café = 1` into pieces. ASCII characters that
+          // reach here are genuinely unknown and keep the legacy fallback.
+          if c.to_int() >= 0x80 {
+            self.pos -= 1
+            self.scan_ident()
+          } else {
+            Ident(c.to_string())
+          }
       }
       self.allow_regex = next_allow_regex(self.allow_regex, kind)
       { kind, pos, has_newline_before: has_newline }

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -3127,7 +3127,20 @@ fn Parser::parse_module_with_seeded_const_values_internal(
     } else if self.check(Import) &&
       self.peek_at(1).kind != LParen &&
       self.peek_at(1).kind != Dot {
+      // `import a = Ns;` (import-equals alias) declares a value-level binding
+      // `a`. `parse_import_stmt` consumes but discards it, so capture the
+      // alias name first and record it as a value so references resolve
+      // (otherwise it reads as an undefined identifier).
+      let import_equals_alias = match
+        (self.peek_at(1).kind, self.peek_at(2).kind) {
+        (Ident(n), Eq) => Some(n)
+        _ => None
+      }
       self.parse_import_stmt()
+      match import_equals_alias {
+        Some(n) => values.push({ name: n, type_: @ast.TsType::Any })
+        None => ()
+      }
     } else if self.check(Import) {
       // `import(...)` (dynamic import) / `import.meta` in statement position —
       // parse as an expression statement rather than an import declaration.

--- a/src/parser/parser_stmt.mbt
+++ b/src/parser/parser_stmt.mbt
@@ -1026,6 +1026,14 @@ fn Parser::is_let_identifier_expr_start(self : Parser) -> Bool {
       if next == LBracket {
         return false
       }
+      // `let <identifier>` / `let {` is always a lexical declaration — two
+      // identifiers can't form an expression, so a line terminator between
+      // `let` and the binding name does NOT trigger ASI (`let\nx` declares
+      // `x`). Only treat `let` as a free identifier reference when what
+      // follows cannot begin a binding.
+      if next is Ident(_) || next == LBrace {
+        return false
+      }
       if next == Semicolon || next == RBrace || next == Eof {
         return true
       }

--- a/src/parser/parser_wbtest.mbt
+++ b/src/parser/parser_wbtest.mbt
@@ -312,11 +312,14 @@ test "parser: let destructuring requires initializer" {
 }
 
 ///|
-test "parser: parse let expr statement with newline" {
+test "parser: let followed by identifier across a newline is a declaration" {
+  // `let <identifier>` is a lexical declaration even with an intervening
+  // line terminator -- two identifiers can't form an expression, so ASI
+  // does not split `let` off as a standalone reference.
   let parser = Parser::from_source("let\nx = 1;")
   let stmt = parser.parse_stmt()
   match stmt {
-    Expr(Var("let")) => ()
+    Let(@ast.TsBinding::Ident("x"), _, IntLit(1)) => ()
     _ => fail("unexpected result: \{stmt}")
   }
 }


### PR DESCRIPTION
Closes the three parser limitations the TS2304 check surfaced, so the checker reports **zero** false positives on the conformance corpus again. The soundness gate is tightened back to `--max-fp 0`.

## Fixes
1. **Unicode identifiers** — the lexer now scans non-ASCII identifier characters (code unit ≥ `0x80`) as part of an identifier instead of emitting a single-character token per code unit. `var café = 1` and CJK-named bindings tokenise as one identifier. *(Also rescues one previously-unparseable conformance case: classified 4090 → 4091, parse failures 408 → 407.)*
2. **`let` ASI** — `let <identifier>` (and `let {`) is a lexical declaration even with an intervening line terminator; two identifiers can't form an expression, so ASI must not split `let` off as a standalone reference. `let\nx` now declares `x`.
3. **import-equals aliases** — `import a = Ns;` declares a value-level binding `a`; the module parser now records it as a value so references resolve instead of reading as an undefined identifier.

## Verification
```
TP   : 792
FP   : 0    (was 3 — all three were these parser gaps)
MISS : 1893
TN   : 1406
```
Full suite green (2228 tests); `moon check --deny-warn` clean. Gate restored to `--max-fp 0`.

https://claude.ai/code/session_01S5m8xKHBeZVYKrScqb9btt

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5m8xKHBeZVYKrScqb9btt)_