### PR TITLE
checker: surface constructor-call arity in permissive mode (TS2554)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -2640,7 +2640,14 @@ fn Resolver::lookup_constructor_sig(
           }
           Some((types, sig))
         }
-        None => Some(([], []))
+        // No explicit constructor. With no base class the constructor is the
+        // implicit zero-arg one, so its arity is known exactly. With a base
+        // (named or expression heritage) the constructor is *inherited*, and
+        // we don't resolve the base's parameter list here -- return `None` so
+        // the call site skips arity / argument checks rather than assuming
+        // zero parameters (which would be a false positive on `new Derived(x)`
+        // when the base takes `x`).
+        None => if cls.base_names.length() == 0 { Some(([], [])) } else { None }
       }
     None => None
   }
@@ -3084,6 +3091,16 @@ fn is_permissively_suppressed(sub_path : String, message : String) -> Bool {
     return true
   }
   if message.contains("argument(s), got ") {
+    // Constructor-call arity (`new C(...)`) is reliable in permissive mode:
+    // `lookup_constructor_sig` only yields a signature for a user class whose
+    // parameter list is known exactly (an explicit constructor, or the
+    // implicit zero-arg constructor of a base-less class -- inherited and
+    // unknown constructors return `None` and never reach here). Function-call
+    // arity stays suppressed (overloads / optional / builtin signatures we
+    // don't fully model make it false-positive-prone).
+    if sub_path.contains("new `") {
+      return false
+    }
     return true
   }
   if message.contains("is not callable") {

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -325,6 +325,32 @@ fn parse_module_or_empty(src : String) -> @ast.TsModule {
 }
 
 ///|
+test "expr_check: permissive flags constructor arity for a base-less class" {
+  // `new C(arg)` where C has no base and no (or a known) constructor is a
+  // reliable arity error even in permissive mode. A derived class whose
+  // constructor is inherited must NOT be flagged (the base may take args).
+  let src =
+    #|class C { x = 1 }
+    #|class B { constructor(a: number) {} }
+    #|class D extends B {}
+    #|function f(): void {
+    #|  let c = new C(null)
+    #|  let d = new D(5)
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies_permissive(module_)
+  let mut saw_c = false
+  for i in issues {
+    if i.path.contains("new `C`") && i.message.contains("argument(s), got 1") {
+      saw_c = true
+    }
+    // The inherited-constructor call must never be flagged.
+    assert_true(!i.path.contains("new `D`"))
+  }
+  assert_true(saw_c)
+}
+
+///|
 test "expr_check: flags duplicate enum member and interface field (TS2300)" {
   let src =
     #|enum E { A, B, A }


### PR DESCRIPTION
Lifts conformance recall by surfacing **constructor-call arity (TS2554)** in permissive mode — the reliable subset of argument-count checking.

## Context
The conformance oracle (and tscheck's default) run the **permissive** checker, which suppresses every `"expected N argument(s), got M"` diagnostic because function / builtin / overload signatures we don't fully model make general arity FP-prone. Constructor calls are different: we only have a constructor signature when the class's arity is known exactly.

## Changes
- `lookup_constructor_sig` now returns `None` for a class with **no explicit constructor *and* a base** (named or expression heritage): the constructor is inherited and we don't resolve the base's parameter list, so assuming zero parameters would false-positive on `new Derived(x)`. A base-less class keeps its known implicit zero-arg signature, and a class with its own constructor keeps that.
- Permissive suppression keeps **function**-call arity dropped but lets **`new`-path** arity through.

Net: `new C(null)` (base-less) is flagged; `new D(5)` (D extends B, inherited ctor) is not.

## Verification
```
TP   : 792 → 800   (+8 constructor-arity cases)
FP   : 0           (unchanged)
MISS : 1885
TN   : 1406
```
Full suite green (2229 tests, +1 new); `moon check --deny-warn` clean. Gate stays `--max-fp 0`.

https://claude.ai/code/session_01S5m8xKHBeZVYKrScqb9btt

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5m8xKHBeZVYKrScqb9btt)_