### PR TITLE
checker: raise conformance recall 433→476 (TS2411 + TS5107 + cycle/arity)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1286,10 +1286,24 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-02 (T23)   348/815 (43 %)        414/414 ( 0 FP)
 2026-06-05 (T24)   435/815 (53 %)        414/414 ( 0 FP)
 2026-06-05 (T25)   473/815 (58 %)        414/414 ( 0 FP)
+2026-06-05 (T26)   476/815 (58 %)        414/414 ( 0 FP)
 
   Note: the T24 starting point (433/815) is higher than the T23 row
   because the TS2554 constructor/function-arity commits (PRs #84-#86)
   landed after the T23 measurement without refreshing this table.
+
+  T26 -- surface module-level cycle / arity validation in the body pass.
+
+    The accuracy walk only runs `check_module_function_bodies`, so the
+    `check_module` structural validation never counted toward recall. A
+    strict FP-safe whitelist (`CircularTypeAlias`, `InterfaceExtendsCycle`,
+    `TypeAliasArityMismatch`) is now wired into the top-level body pass.
+    The remaining kinds were measured and rejected: admitting
+    `InterfaceFieldDuplicate` / `TypeParameterConstraintViolation` etc.
+    cost 12 precision FPs for +7 recall (the structural duplicate pass
+    mis-reads call / construct / method overloads as duplicate fields, and
+    the constraint check false-flags `infer` / forwarded bounds). +3
+    recall (473 -> 476), 0 FP.
 
   T25 -- deprecated `@target` directives (TS5107).
 

--- a/TODO.md
+++ b/TODO.md
@@ -1284,6 +1284,42 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-02 (T21)   351/815 (43 %)        412/414 ( 2 FP)
 2026-06-02 (T22)   350/815 (43 %)        413/414 ( 1 FP)
 2026-06-02 (T23)   348/815 (43 %)        414/414 ( 0 FP)
+2026-06-05 (T24)   435/815 (53 %)        414/414 ( 0 FP)
+2026-06-05 (T25)   473/815 (58 %)        414/414 ( 0 FP)
+
+  Note: the T24 starting point (433/815) is higher than the T23 row
+  because the TS2554 constructor/function-arity commits (PRs #84-#86)
+  landed after the T23 measurement without refreshing this table.
+
+  T25 -- deprecated `@target` directives (TS5107).
+
+    TypeScript 6.0+ reports `target=ES3` / `target=ES5` as deprecated.
+    The conformance corpus exercises this through multi-target directive
+    lists like `// @target: esnext, es2015, es5`. The parser scans the
+    leading `// @target:` header, tokenizes the comma list, and records
+    canonical `target=ES5` / `target=ES3` entries on a new
+    `TsModule.deprecated_compiler_options` field; the checker surfaces one
+    diagnostic per entry from its top-level pass. Empirically verified
+    against the walked corpus: every file carrying an es3/es5 target has a
+    baseline, so the detection is false-positive-free. The directive
+    comments only appear in test corpora, so real `.d.ts` / `.ts` bridge
+    inputs never trigger it. +38 recall (435 -> 473), 0 FP.
+
+  T24 -- extend the TS2411 index-signature constraint check.
+
+    The runtime class parser stored an `Any`/`Any` placeholder for class
+    index signatures, leaving the class branch of the TS2411 check dead;
+    it now captures the real key/value types via
+    `try_parse_class_index_signature`. The constraint check widened beyond
+    scalar-vs-object to the structurally-certain cases: two concrete
+    scalars where the property is not assignable to the index scalar
+    (`number` vs `string` index); a scalar index value with an
+    object/function/array/tuple property; and the existing object-shaped
+    index value with a scalar property. Numeric index signatures constrain
+    only numeric-named properties (a conservative canonical-integer name
+    subset), string index signatures constrain every named property.
+    Accessor-named members are excluded (imprecise parser-stored type).
+    +2 recall (433 -> 435), 0 FP.
 
   T23 -- soft / hard generic inference candidates (Issue #62 path B).
 

--- a/src/ast/pkg.generated.mbti
+++ b/src/ast/pkg.generated.mbti
@@ -279,6 +279,7 @@ pub(all) struct TsModule {
   top_level_stmts : Array[TsStmt]
   strict_property_initialization : Bool
   use_define_for_class_fields : Bool
+  deprecated_compiler_options : Array[String]
 } derive(@debug.Debug)
 pub impl Show for TsModule
 

--- a/src/ast/types.mbt
+++ b/src/ast/types.mbt
@@ -767,6 +767,13 @@ pub(all) struct TsModule {
   // Detected from `// @useDefineForClassFields: true` directives or
   // an `@target: es2022`/`esnext` directive (the TS default).
   use_define_for_class_fields : Bool
+  // Deprecated compiler options detected in the conformance test header
+  // directives (`// @target: es5`, etc.). Each entry is a human-readable
+  // option string such as `"target=ES5"`; the checker surfaces one
+  // diagnostic per entry (TS5107). Only populated from the `// @<option>`
+  // directive comments that the test corpus uses — real `.d.ts` / `.ts`
+  // bridge inputs never carry these, so the field stays empty for them.
+  deprecated_compiler_options : Array[String]
 } derive(Debug)
 
 ///|

--- a/src/bridge/moonbit_decl.mbt
+++ b/src/bridge/moonbit_decl.mbt
@@ -416,6 +416,7 @@ async fn load_decl_module_info(
           top_level_stmts: [],
           strict_property_initialization: true,
           use_define_for_class_fields: false,
+          deprecated_compiler_options: [],
         }
       }
   }
@@ -9183,6 +9184,7 @@ pub async fn emit_moonbit_decl_from_entry_path(
     top_level_stmts: [],
     strict_property_initialization: true,
     use_define_for_class_fields: false,
+    deprecated_compiler_options: [],
   }
   // Run the checker over the final module shape and surface anything it
   // catches as a generator-level note. The emit pipeline is internally

--- a/src/checker/check_module_wbtest.mbt
+++ b/src/checker/check_module_wbtest.mbt
@@ -12,6 +12,7 @@ fn empty_module_for_check() -> @ast.TsModule {
     module_augmentations: [],
     strict_property_initialization: true,
     use_define_for_class_fields: false,
+    deprecated_compiler_options: [],
     top_level_stmts: [],
   }
 }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -10559,6 +10559,16 @@ fn check_module_function_bodies_layered(
     ) {
     all.push(issue)
   }
+  // TS5107: deprecated compiler-option directives (`// @target: es5`, …).
+  // These live only in the top-level module header, so emit once per file.
+  if outer_modules.length() == 0 {
+    for opt in module_.deprecated_compiler_options {
+      all.push({
+        path: "compiler options",
+        message: "option `\{opt}` is deprecated",
+      })
+    }
+  }
   // Recurse into namespace bodies. Each level threads its own ancestor
   // chain so a nested namespace can reference parent-scope types by their
   // bare name (TypeScript scoping). Synthetic `<global>` blocks

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -10568,6 +10568,32 @@ fn check_module_function_bodies_layered(
         message: "option `\{opt}` is deprecated",
       })
     }
+    // Module-level structural validation that doesn't depend on function
+    // bodies. Only the kinds that are sound *and* not already covered by
+    // the body pass *and* false-positive-free are admitted:
+    //   - `CircularTypeAlias` / `InterfaceExtendsCycle`: self-referential
+    //     declarations TS always rejects.
+    //   - `TypeAliasArityMismatch`: wrong type-argument count against a
+    //     locally-declared alias.
+    // Excluded: `UnresolvedReference` (lib / cross-file refs we don't
+    // resolve), `DuplicateDeclaration` (legal declaration merging),
+    // `InterfaceFieldDuplicate` / `EnumMemberDuplicate` (the body pass
+    // already flags real dups while tolerating call / construct / method
+    // overloads, which the structural pass mis-reads as duplicate
+    // `<call>` / `<new>` / method fields), `ClassPropertyDuplicate` (the
+    // parser merges duplicate fields, so it never fires), and
+    // `TypeParameterConstraintViolation` (false-flags `infer` / forwarded
+    // type-parameter bounds).
+    for issue in check_module(module_).issues {
+      let keep = match issue.kind {
+        CircularTypeAlias | InterfaceExtendsCycle | TypeAliasArityMismatch =>
+          true
+        _ => false
+      }
+      if keep {
+        all.push({ path: issue.name, message: issue.detail })
+      }
+    }
   }
   // Recurse into namespace bodies. Each level threads its own ancestor
   // chain so a nested namespace can reference parent-scope types by their

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -10990,22 +10990,86 @@ fn check_interface_extends_compat(
       }
     }
   }
-  // TS2411 ("Property 'X' of type 'T' is not assignable to 'string' index
-  // type 'V'"): when a declaration carries an object-typed index
-  // signature, a scalar-typed named property can never satisfy it. Same
-  // reliable scalar-vs-object shape as the extends check above -- we stay
-  // silent on Named-vs-Named (subtype-dependent) to avoid false positives.
+  // TS2411 ("Property 'X' of type 'T' is not assignable to '<key>' index
+  // type 'V'"): an index signature `[k: K]: V` constrains the named
+  // members of its containing type -- every constrained property's type
+  // must be assignable to the index value type `V`. A numeric index
+  // signature (`[k: number]: V`) only constrains numeric-named properties;
+  // a string index signature (`[k: string]: V`) constrains every named
+  // property (a numeric name is also a string name).
+  //
+  // We only emit when the violation is structurally certain so the
+  // declaration-level check never false-flags subtype-dependent pairs:
+  //   - both sides are concrete scalars and the property scalar is not
+  //     assignable to the index scalar (`number` vs `string` index, etc.);
+  //   - the index value is a scalar but the property is object-shaped /
+  //     function / array / tuple (never assignable to a primitive);
+  //   - the index value is object-shaped but the property is a scalar
+  //     (a primitive can never satisfy an object index type).
+  // `any` / `unknown` / unresolved `Named` / generic-dependent property
+  // types fall through to "no diagnostic".
+  //
+  // A property name is treated as numeric only when it is a canonical
+  // non-negative integer literal (`"0"`, `"42"`); this is a deliberate
+  // subset of TS's numeric-literal-name rule, chosen so every name we
+  // count as numeric really is one (no false positives), accepting a
+  // conservative miss on fractional numeric names.
+  fn is_numeric_name(name : String) -> Bool {
+    let chars = name.to_array()
+    if chars.length() == 0 {
+      return false
+    }
+    if chars.length() > 1 && chars[0] == '0' {
+      return false
+    }
+    for c in chars {
+      if c < '0' || c > '9' {
+        return false
+      }
+    }
+    true
+  }
+  fn violates_index_value(prop : @ast.TsType, value : @ast.TsType) -> Bool {
+    let t = strip_optional(prop)
+    // Index value is object-shaped: a scalar property can never satisfy it.
+    if is_object_shaped(value) {
+      return is_scalar(t)
+    }
+    // Index value is a primitive scalar: the property must be assignable
+    // to it. Only decide for concrete property shapes.
+    if is_scalar(value) {
+      if is_scalar(t) {
+        return !is_assignable_to(t, value)
+      }
+      if is_object_shaped(t) {
+        return true
+      }
+      return match t {
+        Func(_, _) | Constructor(_, _, _) | Array(_) | Tuple(_) => true
+        _ => false
+      }
+    }
+    false
+  }
   fn check_index_props(
     index_sigs : Array[(@ast.TsType, @ast.TsType)],
     fields : Array[(String, @ast.TsType)],
     owner : String,
   ) -> Unit {
     for sig in index_sigs {
-      if !is_object_shaped(sig.1) {
-        continue
+      let numeric_only = match sig.0 {
+        Number | Int => true
+        String_ => false
+        // Symbol / template-literal / other index keys aren't constrained
+        // here (and the `Any` placeholder from an unparsed signature must
+        // never constrain anything).
+        _ => continue
       }
       for f in fields {
-        if is_scalar(f.1) {
+        if numeric_only && !is_numeric_name(f.0) {
+          continue
+        }
+        if violates_index_value(f.1, sig.1) {
           issues.push({
             path: owner,
             message: "property `\{f.0}` of type `\{type_display(f.1)}` is not assignable to index type `\{type_display(sig.1)}`",
@@ -11026,9 +11090,13 @@ fn check_interface_extends_compat(
   }
   for c in module_.classes {
     if c.type_params.length() == 0 {
+      // Getters / setters are upserted into `properties` by the parser
+      // with an imprecise (often `Any`) type, so exclude accessor-named
+      // members to keep the constraint check on real data fields.
+      let accessors = class_instance_accessor_names(c)
       let fields : Array[(String, @ast.TsType)] = []
       for p in c.properties {
-        if !p.is_static {
+        if !p.is_static && !accessors.contains(p.name) {
           fields.push((p.name, p.type_))
         }
       }

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -6542,3 +6542,89 @@ test "expr_check: a tag typed any yields any from a tagged template" {
   let prop = issues.filter(fn(i) { i.message.contains("does not exist") })
   @test.assert_eq(prop.length(), 0)
 }
+
+///|
+test "expr_check: string index signature constrains class properties (TS2411)" {
+  // `[x: string]: number` requires every named property to be assignable
+  // to `number`. The parser must capture the class index value type (it
+  // historically stored an `Any`/`Any` placeholder, which silenced this).
+  let src =
+    #|class C {
+    #|  [s: string]: number;
+    #|  x: number; // ok
+    #|  y: string; // error
+    #|  z: boolean; // error
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let idx = issues.filter(fn(i) {
+    i.message.contains("is not assignable to index type")
+  })
+  let names = idx.map(fn(i) { i.message })
+  assert_true(names.iter().any(fn(m) { m.contains("property `y`") }))
+  assert_true(names.iter().any(fn(m) { m.contains("property `z`") }))
+  // The matching `number` property must never be flagged.
+  assert_true(!names.iter().any(fn(m) { m.contains("property `x`") }))
+}
+
+///|
+test "expr_check: numeric index signature only constrains numeric-named properties (TS2411)" {
+  // `[x: number]: string` constrains numeric-named properties only. A
+  // string-named `number` property (`b`) is unconstrained; a numeric-named
+  // `number` property (`2`) violates the `string` index value type.
+  let src =
+    #|class C {
+    #|  [s: number]: string;
+    #|  a: string; // ok (string name, string value)
+    #|  b: number; // ok (string name, not numeric-constrained)
+    #|  0: string; // ok (numeric name, string value)
+    #|  2: number; // error (numeric name, number value)
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let idx = issues.filter(fn(i) {
+    i.message.contains("is not assignable to index type")
+  })
+  let names = idx.map(fn(i) { i.message })
+  assert_true(names.iter().any(fn(m) { m.contains("property `2`") }))
+  assert_true(!names.iter().any(fn(m) { m.contains("property `b`") }))
+  assert_true(!names.iter().any(fn(m) { m.contains("property `a`") }))
+  assert_true(!names.iter().any(fn(m) { m.contains("property `0`") }))
+}
+
+///|
+test "expr_check: index constraint stays silent on any / matching types (TS2411)" {
+  // `any` and assignable scalar properties must not be flagged, and a
+  // matching string index over string properties is clean.
+  let src =
+    #|class C {
+    #|  [s: string]: string;
+    #|  a: string; // ok
+    #|  b: any; // ok (any is assignable to anything)
+    #|  c: "literal"; // ok (string literal is a string)
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let idx = issues.filter(fn(i) {
+    i.message.contains("is not assignable to index type")
+  })
+  @test.assert_eq(idx.length(), 0)
+}
+
+///|
+test "expr_check: interface string index constrains fields (TS2411)" {
+  let src =
+    #|interface I {
+    #|  [x: string]: number;
+    #|  a: number; // ok
+    #|  b: string; // error
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let idx = issues.filter(fn(i) {
+    i.message.contains("is not assignable to index type")
+  })
+  let names = idx.map(fn(i) { i.message })
+  assert_true(names.iter().any(fn(m) { m.contains("property `b`") }))
+  assert_true(!names.iter().any(fn(m) { m.contains("property `a`") }))
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -6666,3 +6666,42 @@ test "expr_check: deprecated @target es3 directive is flagged (TS5107)" {
   })
   assert_true(dep.length() >= 1)
 }
+
+///|
+test "expr_check: surfaces circular type alias and arity mismatch via body pass" {
+  // The module-level structural validation (circular aliases, extends
+  // cycles, type-alias arity) is wired into the function-body check entry
+  // so the accuracy walk counts these declaration errors.
+  let src =
+    #|type Loop = Loop;
+    #|type Pair<A, B> = [A, B];
+    #|type Bad = Pair<number>;
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let circular = issues.filter(fn(i) {
+    i.message.contains("resolves to itself")
+  })
+  let arity = issues.filter(fn(i) { i.message.contains("used with") })
+  assert_true(circular.length() >= 1)
+  assert_true(arity.length() >= 1)
+}
+
+///|
+test "expr_check: interface method overloads are not flagged as duplicates" {
+  // Multiple call signatures / method overloads share a field name in the
+  // parser representation; the structural pass must NOT be admitted for
+  // `InterfaceFieldDuplicate` or these would false-positive.
+  let src =
+    #|interface I {
+    #|  foo(x: string): string;
+    #|  foo(x: number): number;
+    #|  (x: string): string;
+    #|  (x: number): number;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let dup = issues.filter(fn(i) {
+    i.message.contains("same field name more than once")
+  })
+  @test.assert_eq(dup.length(), 0)
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -317,6 +317,7 @@ fn parse_module_or_empty(src : String) -> @ast.TsModule {
         module_augmentations: [],
         strict_property_initialization: true,
         use_define_for_class_fields: false,
+        deprecated_compiler_options: [],
         top_level_stmts: [],
       }
   } noraise {
@@ -6627,4 +6628,41 @@ test "expr_check: interface string index constrains fields (TS2411)" {
   let names = idx.map(fn(i) { i.message })
   assert_true(names.iter().any(fn(m) { m.contains("property `b`") }))
   assert_true(!names.iter().any(fn(m) { m.contains("property `a`") }))
+}
+
+///|
+test "expr_check: deprecated @target es5 directive is flagged (TS5107)" {
+  let src =
+    #|// @target: esnext, es2015, es5
+    #|class C { x: number = 1 }
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let dep = issues.filter(fn(i) {
+    i.message.contains("deprecated") && i.message.contains("target=ES5")
+  })
+  assert_true(dep.length() >= 1)
+}
+
+///|
+test "expr_check: non-deprecated @target es2015 is not flagged (TS5107)" {
+  let src =
+    #|// @target: es2015
+    #|class C { x: number = 1 }
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let dep = issues.filter(fn(i) { i.message.contains("deprecated") })
+  @test.assert_eq(dep.length(), 0)
+}
+
+///|
+test "expr_check: deprecated @target es3 directive is flagged (TS5107)" {
+  let src =
+    #|// @target: es3
+    #|var x: number = 1;
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let dep = issues.filter(fn(i) {
+    i.message.contains("deprecated") && i.message.contains("target=ES3")
+  })
+  assert_true(dep.length() >= 1)
 }

--- a/src/checker/generics_wbtest.mbt
+++ b/src/checker/generics_wbtest.mbt
@@ -100,6 +100,7 @@ test "module_alias_resolver: combines parsed aliases with stdlib utilities" {
     module_augmentations: [],
     strict_property_initialization: true,
     use_define_for_class_fields: false,
+    deprecated_compiler_options: [],
     top_level_stmts: [],
   }
   let resolve = module_alias_resolver(m)
@@ -135,6 +136,7 @@ test "module_alias_resolver: include_standard=false omits stdlib" {
     module_augmentations: [],
     strict_property_initialization: true,
     use_define_for_class_fields: false,
+    deprecated_compiler_options: [],
     top_level_stmts: [],
   }
   let resolve = module_alias_resolver(m, include_standard=false)
@@ -172,6 +174,7 @@ test "module_alias_resolver: module aliases shadow stdlib on name clash" {
     module_augmentations: [],
     strict_property_initialization: true,
     use_define_for_class_fields: false,
+    deprecated_compiler_options: [],
     top_level_stmts: [],
   }
   let resolve = module_alias_resolver(m)

--- a/src/checker/validate_wbtest.mbt
+++ b/src/checker/validate_wbtest.mbt
@@ -12,6 +12,7 @@ fn empty_module() -> @ast.TsModule {
     module_augmentations: [],
     strict_property_initialization: true,
     use_define_for_class_fields: false,
+    deprecated_compiler_options: [],
     top_level_stmts: [],
   }
 }

--- a/src/cmd/mtsc/main.mbt
+++ b/src/cmd/mtsc/main.mbt
@@ -420,6 +420,7 @@ async fn mtsc_load_bundle_files(
           module_augmentations: [],
           strict_property_initialization: true,
           use_define_for_class_fields: false,
+          deprecated_compiler_options: [],
           top_level_stmts: [],
         }
     }
@@ -618,6 +619,7 @@ async fn main {
           module_augmentations: [],
           strict_property_initialization: true,
           use_define_for_class_fields: false,
+          deprecated_compiler_options: [],
           top_level_stmts: [],
         })
         let local_names : Array[String] = []
@@ -720,6 +722,7 @@ async fn main {
             module_augmentations: [],
             strict_property_initialization: true,
             use_define_for_class_fields: false,
+            deprecated_compiler_options: [],
             top_level_stmts: [],
           })
           // Filter exports through the entry's `@internal` set so

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -14,12 +14,14 @@ priv enum ClassElement {
   // strict-property-initialization check (TS2564) in the checker.
   Field(Bool, ClassKey, @ast.TsType, @ast.TsExpr?, Bool, Bool)
   StaticBlock(@ast.TsBlock)
-  // Marker for `[k: KeyType]: ValueType` index signatures. The body is
-  // skipped (we don't model index access through the class type), but
-  // the presence of any index signature opts the class out of strict-
-  // property-initialization (TS2564) because every concrete field is
-  // implicitly covered by the indexer.
-  IndexSig
+  // Marker for `[k: KeyType]: ValueType` index signatures, carrying the
+  // captured key / value types. The presence of any index signature opts
+  // the class out of strict-property-initialization (TS2564) because every
+  // concrete field is implicitly covered by the indexer; the captured value
+  // type also feeds the TS2411 index-constraint check (named properties must
+  // be assignable to the index value type). When the signature shape can't be
+  // parsed precisely the key/value default to `Any` (no constraint).
+  IndexSig(@ast.TsType, @ast.TsType)
 }
 
 ///|
@@ -211,17 +213,14 @@ fn build_runtime_class_decl(
     }
   }
   // Track index-signature presence so the TS2564 check can opt-out
-  // (an indexer implicitly types every concrete field). We don't
-  // model index lookups against class instances, so the value is an
-  // `Any` -> `Any` placeholder -- only the length matters for the
-  // skip predicate.
+  // (an indexer implicitly types every concrete field), and carry the
+  // captured key/value types so the TS2411 index-constraint check can
+  // verify named properties are assignable to the index value type.
   let index_signatures : Array[(@ast.TsType, @ast.TsType)] = []
   let static_blocks : Array[@ast.TsBlock] = []
   for element in elements {
-    if element is IndexSig {
-      index_signatures.push((@ast.TsType::Any, @ast.TsType::Any))
-    }
     match element {
+      IndexSig(key, value) => index_signatures.push((key, value))
       StaticBlock(block) => static_blocks.push(block)
       _ => ()
     }
@@ -952,8 +951,21 @@ fn Parser::parse_class_body(
     if parsed_static_block {
       continue // Continue to next class element
     }
+    // Prefer the type-capturing index-signature parser so the value type
+    // is available for the TS2411 index-constraint check. Fall back to the
+    // permissive skip path (recording an `Any`/`Any` placeholder) for
+    // shapes the precise parser declines, e.g. computed key expressions.
+    if self.check(LBracket) && self.is_index_signature_shape_after_lbracket() {
+      match self.try_parse_class_index_signature() {
+        Some((key, value)) => {
+          elements.push(IndexSig(key, value))
+          continue
+        }
+        None => ()
+      }
+    }
     if self.try_skip_class_index_signature() {
-      elements.push(IndexSig)
+      elements.push(IndexSig(@ast.TsType::Any, @ast.TsType::Any))
       continue
     }
     let mut accessor_kind : String? = None
@@ -1426,7 +1438,7 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
           }
         }
       StaticBlock(_) => key_temps.push(None) // Placeholder to keep indices aligned
-      IndexSig => key_temps.push(None)
+      IndexSig(_, _) => key_temps.push(None)
     }
   }
 
@@ -1782,7 +1794,7 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
         ])
         stmts.push(Expr(call_expr))
       }
-      IndexSig => ()
+      IndexSig(_, _) => ()
     }
   }
   stmts.push(Return(Some(@ast.TsExpr::Var(tmp_name))))
@@ -2009,7 +2021,7 @@ fn Parser::parse_class_decl_with_abstract(
           }
         }
       StaticBlock(_) => key_temps.push(None) // Placeholder to keep indices aligned
-      IndexSig => key_temps.push(None)
+      IndexSig(_, _) => key_temps.push(None)
     }
   }
 
@@ -2363,7 +2375,7 @@ fn Parser::parse_class_decl_with_abstract(
         ])
         stmts.push(Expr(call_expr))
       }
-      IndexSig => ()
+      IndexSig(_, _) => ()
     }
   }
   if stmts.length() == 1 {

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -132,6 +132,7 @@ fn empty_ts_module() -> @ast.TsModule {
     strict_property_initialization: true,
     use_define_for_class_fields: false,
     top_level_stmts: [],
+    deprecated_compiler_options: [],
   }
 }
 
@@ -3247,7 +3248,55 @@ fn Parser::parse_module_with_seeded_const_values_internal(
       self.src,
     ),
     use_define_for_class_fields: detect_use_define_for_class_fields(self.src),
+    deprecated_compiler_options: detect_deprecated_compiler_options(self.src),
   }
+}
+
+///|
+/// Scan the leading `// @target: ...` test-header directive for deprecated
+/// compiler-option values. TypeScript 6.0+ reports `target=ES3` / `target=ES5`
+/// as deprecated (TS5107); the conformance corpus exercises these through
+/// multi-target directive lists like `// @target: esnext, es2015, es5`. We
+/// only surface the unambiguous `ES3` / `ES5` targets so the check stays
+/// false-positive-free, and we return canonical `target=ES5` / `target=ES3`
+/// strings for the diagnostic. Returns at most one entry per deprecated
+/// target value, in declaration order.
+fn detect_deprecated_compiler_options(src : String) -> Array[String] {
+  let out : Array[String] = []
+  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
+  let head = src[:head_len].to_owned()
+  // Find the `@target:` directive line and tokenize its comma list.
+  let needle = "@target:"
+  match head.find(needle) {
+    Some(idx) => {
+      // Take the rest of that directive line.
+      let after = head[idx + needle.length():].to_owned()
+      let line = match after.find("\n") {
+        Some(nl) => after[:nl].to_owned()
+        None => after
+      }
+      let mut saw_es3 = false
+      let mut saw_es5 = false
+      for raw in line.split(",") {
+        let tok = raw.trim().to_owned().to_lower()
+        if tok == "es3" {
+          saw_es3 = true
+        } else if tok == "es5" {
+          saw_es5 = true
+        }
+      }
+      // Match TS's report order (lowest deprecated target first as it
+      // appears); emit one diagnostic per distinct deprecated value.
+      if saw_es5 {
+        out.push("target=ES5")
+      }
+      if saw_es3 {
+        out.push("target=ES3")
+      }
+    }
+    None => ()
+  }
+  out
 }
 
 ///|


### PR DESCRIPTION
## Summary

Three safe, data-driven recall improvements measured against the TypeScript conformance baselines (`.errors.txt` = ground truth), each verified false-positive-free.

| step | recall | precision | FP |
|---|---|---|---|
| baseline (post #84-#86) | 433/815 | 414/414 | 0 |
| **T24** TS2411 extension | 435/815 | 414/414 | **0** |
| **T25** TS5107 deprecated `@target` | 473/815 | 414/414 | **0** |
| **T26** cycle/arity validation wiring | **476/815 (58%)** | 414/414 | **0** |

**Net: +43 recall (53%→58%), precision held at 414/414 (0 false positives) throughout. All 2240 tests pass.**

## Changes

**T24 — extend the TS2411 index-signature constraint check**
The runtime class parser stored an `Any`/`Any` placeholder for class index signatures, leaving the class branch of TS2411 dead. It now captures the real key/value types via `try_parse_class_index_signature`. The constraint check widened beyond scalar-vs-object to the structurally-certain cases: two concrete scalars where the property isn't assignable to the index scalar (`number` vs `string` index); a scalar index value with an object/function/array/tuple property; and the existing object-shaped index value with a scalar property. Numeric index signatures constrain only numeric-named properties (conservative canonical-integer subset); string index signatures constrain every named property. Accessor-named members excluded.

**T25 — detect deprecated `@target` es3/es5 directives (TS5107)**
TypeScript 6.0+ reports `target=ES3`/`target=ES5` as deprecated. The parser scans the leading `// @target:` header, tokenizes the comma list, and records canonical entries on a new `TsModule.deprecated_compiler_options` field; the checker surfaces one diagnostic per entry. Empirically verified FP-free (every walked-corpus file carrying an es3/es5 target has a baseline). Only fires on conformance-style directive comments, never on real `.d.ts` / `.ts` bridge inputs.

**T26 — surface module-level cycle/arity validation in the body pass**
The accuracy walk only runs `check_module_function_bodies`, so `check_module`'s structural validation never counted toward recall. A strict FP-safe whitelist (`CircularTypeAlias`, `InterfaceExtendsCycle`, `TypeAliasArityMismatch`) is now wired into the top-level body pass. The other kinds were measured and rejected — admitting `InterfaceFieldDuplicate` / `TypeParameterConstraintViolation` etc. cost 12 precision FPs for +7 recall (the structural duplicate pass mis-reads call/construct/method overloads; the constraint check false-flags `infer` / forwarded bounds).

## Testing
- `moon check --deny-warn`, `moon fmt --check`, `moon test --target native` (2240 tests) all green.
- Added focused unit tests for each behavior (TS2411 string/numeric index constraints, TS5107 positive/negative, cycle+arity wiring, overload non-duplication).
- Recall log updated in `TODO.md` (T24/T25/T26).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6VaaouEL5wQAR71SLieRV)_