### PR TITLE
checker: raise conformance recall 476→483 (TS2506 + deprecated options + TS2367 loose equality)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1288,10 +1288,24 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-05 (T25)   473/815 (58 %)        414/414 ( 0 FP)
 2026-06-05 (T26)   476/815 (58 %)        414/414 ( 0 FP)
 2026-06-05 (T27)   480/815 (59 %)        414/414 ( 0 FP)
+2026-06-05 (T28)   483/815 (59 %)        414/414 ( 0 FP)
 
   Note: the T24 starting point (433/815) is higher than the T23 row
   because the TS2554 constructor/function-arity commits (PRs #84-#86)
   landed after the T23 measurement without refreshing this table.
+
+  T28 -- distinct-literal loose equality + `<T>` cast type preservation.
+
+    The loose-equality (`==` / `!=`) TS2367 branch skipped bare
+    literal-vs-literal pairs to dodge a false positive on dropped type
+    assertions (`"foo" == (<any>"bar")`). Root cause: the angle-bracket
+    cast parser discarded its asserted type and returned the bare inner
+    expression, so `<any>"bar"` inferred as the literal `"bar"` rather than
+    `any`. Fixed at the source -- `parse_angle_bracket_type_assertion`
+    now wraps the operand in an `As(expr, ty)` node (same shape as
+    `expr as T`), so the cast widens through inference and the literal-const
+    skip is no longer needed. Genuine `"foo" == "bar"` now flags like the
+    strict `===` branch. +3 recall (480 -> 483), 0 FP.
 
   T27 -- class self-extension (TS2506) + presence-based deprecated options.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1287,10 +1287,22 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-05 (T24)   435/815 (53 %)        414/414 ( 0 FP)
 2026-06-05 (T25)   473/815 (58 %)        414/414 ( 0 FP)
 2026-06-05 (T26)   476/815 (58 %)        414/414 ( 0 FP)
+2026-06-05 (T27)   480/815 (59 %)        414/414 ( 0 FP)
 
   Note: the T24 starting point (433/815) is higher than the T23 row
   because the TS2554 constructor/function-arity commits (PRs #84-#86)
   landed after the T23 measurement without refreshing this table.
+
+  T27 -- class self-extension (TS2506) + presence-based deprecated options.
+
+    TS2506: a class that directly references itself in its own base
+    expression (`class C extends C {}`, `class D<T> extends D<T> {}`) is
+    flagged from the body pass -- `base_names` carrying the class's own
+    name is always an error and never a legal shape. Also extends the
+    deprecated compiler-option directive scan to the presence-based
+    options `outFile` / `out` / `baseUrl` / `downlevelIteration` (TS5101 /
+    TS5107), which TypeScript reports whenever specified regardless of
+    value. +4 recall (476 -> 480), 0 FP.
 
   T26 -- surface module-level cycle / arity validation in the body pass.
 

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -10761,6 +10761,20 @@ fn check_class_member_structure(
 ) -> Array[ExprIssue] {
   let issues : Array[ExprIssue] = []
   for decl in module_.classes {
+    // --- TS2506: a class directly references itself in its own base
+    // expression (`class C extends C {}`, `class D<T> extends D<T> {}`).
+    // `base_names` carries the bare extended name, so a self-reference is
+    // exactly an entry equal to the class's own name. This is always an
+    // error and never a legal shape, so it is false-positive-free.
+    for base in decl.base_names {
+      if base == decl.name {
+        issues.push({
+          path: "class \{decl.name}",
+          message: "`\{decl.name}` is referenced directly in its own base expression",
+        })
+        break
+      }
+    }
     // --- Duplicate get / set accessors within the same class body. ---
     // Key by "name|static" so an instance and a static accessor of the
     // same name don't collide. A computed key (`name == "<computed>"`)

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -4131,24 +4131,19 @@ fn check_binop_operands(
           _ => false
         }
       }
-      // Both operands written as bare literal constants is exactly where
-      // a dropped type assertion (`"x" == (<any>"y")`, `... == ("y" as
-      // string)`) leaves behind a spurious literal-vs-literal shape, so
-      // skip that pair. Real always-false comparisons in the corpus pair
-      // a literal-typed *variable* with a literal, which is still flagged.
-      let is_literal_const = fn(e : @ast.TsExpr) -> Bool {
-        match e {
-          StringLit(_) | NumberLit(_) | IntLit(_) | BoolLit(_) | BigIntLit(_) =>
-            true
-          _ => false
-        }
-      }
+      // A dropped type assertion (`"x" == (<any>"y")`, `... == ("y" as
+      // string)`) used to leave behind a spurious literal-vs-literal shape
+      // here, but the parser now binds `as` / cast tighter than equality
+      // (T19), so those RHS operands are `As` / cast nodes whose inferred
+      // type is `string` / `any` and already overlaps. A genuine bare
+      // `"foo" == "bar"` therefore stays the only literal-vs-literal pair
+      // reaching this point, and TS reports it as TS2367 -- matching the
+      // strict-equality branch above.
       let lt = ctx.resolver.unwrap(infer_expr(env, ctx.resolver, l))
       let rt = ctx.resolver.unwrap(infer_expr(env, ctx.resolver, r))
       match (equality_primitive_family(lt), equality_primitive_family(rt)) {
         (Some(fa), Some(fb)) =>
           if fa == fb &&
-            !(is_literal_const(l) && is_literal_const(r)) &&
             !is_typeof(l) &&
             !is_typeof(r) &&
             !types_can_overlap(lt, rt) {

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -6705,3 +6705,34 @@ test "expr_check: interface method overloads are not flagged as duplicates" {
   })
   @test.assert_eq(dup.length(), 0)
 }
+
+///|
+test "expr_check: class that extends itself is flagged (TS2506)" {
+  let src =
+    #|class C extends C {}
+    #|class D<T> extends D<T> {}
+    #|class Ok extends Object {}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let self_ext = issues.filter(fn(i) {
+    i.message.contains("its own base expression")
+  })
+  let names = self_ext.map(fn(i) { i.path })
+  assert_true(names.iter().any(fn(p) { p.contains("class C") }))
+  assert_true(names.iter().any(fn(p) { p.contains("class D") }))
+  // A class extending a different base must never be flagged.
+  assert_true(!names.iter().any(fn(p) { p.contains("class Ok") }))
+}
+
+///|
+test "expr_check: deprecated @outFile directive is flagged (TS5101)" {
+  let src =
+    #|// @outFile: out.js
+    #|var x: number = 1;
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let dep = issues.filter(fn(i) {
+    i.message.contains("deprecated") && i.message.contains("outFile")
+  })
+  assert_true(dep.length() >= 1)
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -6736,3 +6736,37 @@ test "expr_check: deprecated @outFile directive is flagged (TS5101)" {
   })
   assert_true(dep.length() >= 1)
 }
+
+///|
+test "expr_check: distinct string-literal loose equality is flagged (TS2367)" {
+  // `"foo" == "bar"` has no overlap -> always false. The loose-equality
+  // branch now flags bare literal-vs-literal pairs (matching strict ===),
+  // because the `<any>` / `as` widening that used to require a blanket
+  // skip is now preserved through inference.
+  let src =
+    #|function f(): void {
+    #|  let b = "foo" == "bar";
+    #|  b;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let af = issues.filter(fn(i) { i.message.contains("always be false") })
+  assert_true(af.length() >= 1)
+}
+
+///|
+test "expr_check: angle-bracket cast widens operand type, no false TS2367" {
+  // `<any>"bar"` must infer as `any` (not the literal `"bar"`), so the
+  // comparison overlaps and is not flagged. Guards the parser fix that
+  // wraps `<T>expr` in an `As` node.
+  let src =
+    #|function f(): void {
+    #|  let b = "foo" == (<any>"bar");
+    #|  let c = "foo" == ("bar" as string);
+    #|  b; c;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let af = issues.filter(fn(i) { i.message.contains("always be false") })
+  @test.assert_eq(af.length(), 0)
+}

--- a/src/parser/parser_expr.mbt
+++ b/src/parser/parser_expr.mbt
@@ -2489,9 +2489,12 @@ fn Parser::parse_angle_bracket_type_assertion_from_source(
   }
   let type_src = self.src[type_start:type_end].to_owned()
   let type_parser = Parser::from_source_with_jsx(type_src, false)
-  let _ = type_parser.parse_type()
+  let ty = type_parser.parse_type()
   self.advance_to_source_pos(end_pos)
-  self.parse_unary()
+  // Preserve the asserted type as an `As` node (same shape as `expr as T`)
+  // so downstream inference widens to the asserted type rather than the
+  // inner expression's narrower type (e.g. `<any>"x"` is `any`, not `"x"`).
+  @ast.TsExpr::As(self.parse_unary(), ty)
 }
 
 ///|
@@ -2499,7 +2502,7 @@ fn Parser::parse_angle_bracket_type_assertion_with_tokens(
   self : Parser,
 ) -> @ast.TsExpr raise ParseError {
   let _ = self.expect(Lt)
-  let _ = self.parse_type()
+  let ty = self.parse_type()
   if !self.match_(Gt) {
     let prev_kind = if self.pos > 0 {
       self.tokens[self.pos - 1].kind
@@ -2511,7 +2514,10 @@ fn Parser::parse_angle_bracket_type_assertion_with_tokens(
       _ => raise ParseError("Expected Gt, got \{self.peek().kind}")
     }
   }
-  self.parse_unary()
+  // Preserve the asserted type as an `As` node (same shape as `expr as T`)
+  // so downstream inference widens to the asserted type rather than the
+  // inner expression's narrower type (e.g. `<any>"x"` is `any`, not `"x"`).
+  @ast.TsExpr::As(self.parse_unary(), ty)
 }
 
 ///|

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -3253,24 +3253,29 @@ fn Parser::parse_module_with_seeded_const_values_internal(
 }
 
 ///|
-/// Scan the leading `// @target: ...` test-header directive for deprecated
-/// compiler-option values. TypeScript 6.0+ reports `target=ES3` / `target=ES5`
-/// as deprecated (TS5107); the conformance corpus exercises these through
-/// multi-target directive lists like `// @target: esnext, es2015, es5`. We
-/// only surface the unambiguous `ES3` / `ES5` targets so the check stays
-/// false-positive-free, and we return canonical `target=ES5` / `target=ES3`
-/// strings for the diagnostic. Returns at most one entry per deprecated
-/// target value, in declaration order.
+/// Scan the leading test-header directives for deprecated compiler options
+/// that TypeScript 6.0+ reports (TS5107 / TS5101). Two shapes are handled:
+///
+///   - value-specific: `target=ES3` / `target=ES5`, exercised through
+///     multi-target directive lists like `// @target: esnext, es2015, es5`.
+///     Only the unambiguous `ES3` / `ES5` targets are surfaced.
+///   - presence-based: `outFile` / `out` / `baseUrl` / `downlevelIteration`
+///     are deprecated whenever specified, regardless of value, so the bare
+///     presence of the `// @<option>:` directive is enough.
+///
+/// The directive comments only appear in the conformance corpus; real
+/// `.d.ts` / `.ts` bridge inputs never carry them, so this stays empty for
+/// them. Returns one canonical option string per detected deprecation, in a
+/// stable order.
 fn detect_deprecated_compiler_options(src : String) -> Array[String] {
   let out : Array[String] = []
   let head_len = if src.length() < 1024 { src.length() } else { 1024 }
   let head = src[:head_len].to_owned()
-  // Find the `@target:` directive line and tokenize its comma list.
-  let needle = "@target:"
-  match head.find(needle) {
+  let head_lower = head.to_lower()
+  // Value-specific: the `@target:` directive's comma list.
+  match head.find("@target:") {
     Some(idx) => {
-      // Take the rest of that directive line.
-      let after = head[idx + needle.length():].to_owned()
+      let after = head[idx + "@target:".length():].to_owned()
       let line = match after.find("\n") {
         Some(nl) => after[:nl].to_owned()
         None => after
@@ -3285,8 +3290,7 @@ fn detect_deprecated_compiler_options(src : String) -> Array[String] {
           saw_es5 = true
         }
       }
-      // Match TS's report order (lowest deprecated target first as it
-      // appears); emit one diagnostic per distinct deprecated value.
+      // One diagnostic per distinct deprecated value.
       if saw_es5 {
         out.push("target=ES5")
       }
@@ -3295,6 +3299,14 @@ fn detect_deprecated_compiler_options(src : String) -> Array[String] {
       }
     }
     None => ()
+  }
+  // Presence-based options. `@out:` and `@outFile:` are distinct directives;
+  // the trailing colon keeps `@out:` from matching inside `@outFile:` /
+  // `@outDir:`.
+  for opt in ["outFile", "out", "baseUrl", "downlevelIteration"] {
+    if head_lower.find("@" + opt.to_lower() + ":") is Some(_) {
+      out.push(opt)
+    }
   }
   out
 }


### PR DESCRIPTION
## Summary

Two more data-driven, false-positive-free recall steps on top of the merged T24–T26 work. Recall/FP tracked as KPIs against the TypeScript conformance baselines.

| step | recall | precision | FP |
|---|---|---|---|
| main (T26) | 476/815 | 414/414 | 0 |
| **T27** TS2506 + presence-based deprecated options | 480/815 | 414/414 | **0** |
| **T28** loose-equality TS2367 + `<T>` cast fix | **483/815 (59%)** | 414/414 | **0** |

**+7 recall, precision held at 414/414 (0 false positives). All 2242 tests pass.**

## Changes

**T27 — class self-extension (TS2506) + presence-based deprecated options**
- TS2506: a class that directly references itself in its own base expression (`class C extends C {}`, `class D<T> extends D<T> {}`). `base_names` carrying the class's own name is always an error, never a legal shape.
- Extend the deprecated compiler-option directive scan (TS5101/TS5107) to the presence-based options `outFile` / `out` / `baseUrl` / `downlevelIteration`, which TypeScript reports as deprecated whenever specified regardless of value. The trailing colon keeps `@out:` from matching inside `@outFile:` / `@outDir:`.

**T28 — distinct-literal loose equality + `<T>` cast type preservation**
The loose-equality (`==`/`!=`) TS2367 branch skipped bare literal-vs-literal pairs to dodge a false positive on dropped type assertions (`"foo" == (<any>"bar")`). The **root cause** was a parser bug: the angle-bracket cast parser discarded its asserted type and returned the bare inner expression, so `<any>"bar"` inferred as the literal `"bar"` instead of `any`. Fixed at the source — `parse_angle_bracket_type_assertion` (both token and from-source variants) now wraps the operand in an `As(expr, ty)` node, the same shape `expr as T` already produces. With the cast widened through inference, the literal-const skip is no longer needed, and genuine `"foo" == "bar"` comparisons flag like the strict `===` branch already does.

## Testing
- `moon check --deny-warn`, `moon fmt --check`, `moon test --target native` (2242 tests) all green.
- Added unit tests: TS2506 self-extension (positive + negative base), `@outFile` directive, distinct-literal loose equality, and `<any>` / `as` cast widening (guards the parser fix).
- Recall log updated in `TODO.md` (T27/T28).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6VaaouEL5wQAR71SLieRV)_