### PR TITLE
checker: shift toward TS compatibility — emit TS2339, fix discriminated-union `type` discriminant + void rule

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1290,10 +1290,37 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-05 (T27)   480/815 (59 %)        414/414 ( 0 FP)
 2026-06-05 (T28)   483/815 (59 %)        414/414 ( 0 FP)
 2026-06-05 (T29)   484/815 (59 %)        414/414 ( 0 FP)
+2026-06-05 (T30)   500/815 (61 %)        406/414 ( 8 FP)
+
+  Policy shift (T30 onward): the goal is TypeScript compatibility, not a
+  zero-false-positive score. Recall AND false positives are both tracked as
+  KPIs; a small, bounded FP rate (cap 5 %) is accepted when emitting a core
+  TS diagnostic family moves us closer to tsc. The strict-mode view (emit
+  everything the checker detects) is the fidelity yardstick: as of T30 it is
+  recall 563/815, precision 350/414 (64 FP). The remaining gap to tsc is
+  flow-narrowing depth, generic inference, union/overload signature
+  resolution, and contextual typing -- the hard machinery to build next.
 
   Note: the T24 starting point (433/815) is higher than the T23 row
   because the TS2554 constructor/function-arity commits (PRs #84-#86)
   landed after the T23 measurement without refreshing this table.
+
+  T30 -- compatibility shift: emit TS2339 + discriminated-union / void fixes.
+
+    Reframed the goal from zero-FP to tsc compatibility. Two correctness
+    fixes plus a policy change:
+      - Parser: object-type-literal property names now accept keyword
+        tokens via `parse_property_name_token`. A property named `type`
+        (the canonical discriminated-union discriminant) previously dropped
+        the whole object type, producing spurious "property does not exist"
+        diagnostics on every field.
+      - Checker: the void-returning-function rule (`() => number` assignable
+        to `() => void`, and callback bodies against a contextual `void`
+        return) now matches tsc.
+      - Policy: the property / method `does not exist` family (TS2339) is
+        emitted in the permissive conformance walk instead of being
+        suppressed. +16 recall for 8 residual flow-narrowing-gap FPs.
+    recall 484 -> 500, precision 414 -> 406 (8 FP).
 
   T29 -- validate parameter default initializers everywhere (TS2322).
 

--- a/src/checker/assignability.mbt
+++ b/src/checker/assignability.mbt
@@ -690,6 +690,14 @@ fn is_assignable_to_inner(
       if !func_params_assignable(s_params, t_params, bivariant_params) {
         return false
       }
+      // TS's "void-returning function" rule: a function returning any type
+      // is assignable to one whose return type is `void`, because a caller
+      // that expects a void callback ignores the returned value. So
+      // `() => number` is assignable to `() => void` (e.g. an arrow body
+      // passed to `Array.forEach`).
+      if t_ret is Void {
+        return true
+      }
       // Covariant return.
       is_assignable_to_inner(s_ret, t_ret, bivariant_params)
     }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -3115,7 +3115,7 @@ fn is_permissively_suppressed(sub_path : String, message : String) -> Bool {
     if message.has_suffix("| undefined`") || message.has_suffix("| null`") {
       return false
     }
-    return true
+    return false
   }
   if message.has_prefix("method `") && message.contains("does not exist on") {
     // Same carve-out as the property branch: bare-primitive receiver
@@ -3130,7 +3130,7 @@ fn is_permissively_suppressed(sub_path : String, message : String) -> Bool {
     if message.has_suffix("| undefined`") || message.has_suffix("| null`") {
       return false
     }
-    return true
+    return false
   }
   if message.contains("argument(s), got ") {
     // Arity diagnostics are suppressed by default in permissive mode

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -6811,7 +6811,15 @@ fn check_arrow_with_context(
   match body {
     ArrowExpr(e) => {
       let want = unwrap_async_return(is_async, formal_ret)
-      check_expr_against(env, e, want, inner_ctx, "\{sub_path} arrow body")
+      // Void-returning callback rule (matches tsc): when the contextual
+      // return type is `void`, the callback's body value is ignored, so any
+      // expression is allowed -- `run(() => 42)` for `run(cb: () => void)`
+      // is not an error. Still walk the body for nested call-argument checks.
+      if want is Void {
+        check_call_args_in_expr(env, e, inner_ctx)
+      } else {
+        check_expr_against(env, e, want, inner_ctx, "\{sub_path} arrow body")
+      }
     }
     ArrowBlock(block) =>
       // Recheck the block with the new env and the formal_ret as the

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -6793,3 +6793,36 @@ test "expr_check: parameter default must match annotation (TS2322)" {
   // The valid default `a: string = "yes"` must not be flagged.
   assert_true(!names.iter().any(fn(p) { p.contains("`a`") }))
 }
+
+///|
+test "expr_check: keyword property name `type` in object type is resolved" {
+  // `{ type: ... }` is the canonical discriminated-union discriminant. The
+  // object-type-literal parser previously rejected the `type` keyword as a
+  // property name, dropping the whole shape and producing spurious
+  // "property does not exist" diagnostics. All accesses below are valid.
+  let src =
+    #|type A = { type: "a"; value: number } | { type: "b"; label: string };
+    #|function f(x: A): void {
+    #|  x.type;
+    #|  if (x.type === "a") { x.value; } else { x.label; }
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let missing = issues.filter(fn(i) { i.message.contains("does not exist") })
+  @test.assert_eq(missing.length(), 0)
+}
+
+///|
+test "expr_check: void-returning function assignable to void callback" {
+  // A function returning a value is assignable to one expecting `void`
+  // return (TS's void-returning-function rule).
+  let src =
+    #|function run(cb: () => void): void {}
+    #|function f(): void { run(() => 42); }
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let mism = issues.filter(fn(i) {
+    i.message.contains("not assignable") || i.message.contains("but got")
+  })
+  @test.assert_eq(mism.length(), 0)
+}

--- a/src/parser/parser_type.mbt
+++ b/src/parser/parser_type.mbt
@@ -386,12 +386,21 @@ fn Parser::try_parse_simple_object_type(self : Parser) -> @ast.TsType? {
       None => ()
     }
     while !self.check(Eof) && !self.check(RBrace) {
-      let field_name = match self.advance().kind {
-        Ident(name) => name
-        _ => {
+      // Accept identifiers *and* keyword tokens as property names
+      // (`{ type: T }`, `{ default: U }`, …). `type` is the canonical
+      // discriminated-union discriminant, so rejecting it here dropped the
+      // whole object type and produced spurious "property does not exist"
+      // diagnostics. `parse_property_name_token` handles every keyword the
+      // interface parser does and raises on a genuine non-name token (call
+      // / construct / index signatures, string/number literal names), which
+      // the enclosing `try` turns into a clean fall-through to the fuller
+      // member parser.
+      let field_name = match self.peek().kind {
+        LParen | Lt | New | LBracket | Str(_) | Number(_) | Int(_) => {
           self.pos = saved_pos
           return None
         }
+        _ => self.parse_property_name_token()
       }
       let _ = self.match_(Question)
       let _ = self.expect(Colon)

--- a/src/parser/parser_typescript_wbtest.mbt
+++ b/src/parser/parser_typescript_wbtest.mbt
@@ -1225,10 +1225,13 @@ async test "checker: accuracy against TypeScript conformance baselines" {
       "recall floor breached: \{recall_hit}/\{with_baseline} baseline-positive cases caught (< 20 %)",
     )
   }
-  // Precision floor: residual 5 / 310 FPs (1.6 %). All five are flow-
-  // narrowing / generic-inference gaps -- multi-day features. Cap at
-  // 5 % so a single new pattern re-introducing several FPs trips
-  // immediately.
+  // Precision floor. The goal is TypeScript compatibility, not zero false
+  // positives: the property / method `does not exist` family is now emitted
+  // in permissive mode (it is a core TS diagnostic), trading a small number
+  // of residual flow-narrowing-gap FPs (this-guards, optional-chain unions,
+  // intersection members) for ~16 recall. Current residual is ~8 / 414
+  // (1.9 %); the cap stays at 5 % so a regression that re-introduces a
+  // whole family of FPs still trips immediately.
   if without_baseline > 0 && precision_miss * 100 > without_baseline * 5 {
     fail(
       "precision floor breached: \{precision_miss}/\{without_baseline} clean cases reported as failing (> 5 %)",


### PR DESCRIPTION
## Summary

Reframes the conformance goal from **zero false positives** to **TypeScript compatibility** (matching tsc), tracking recall *and* FP as KPIs. A small, bounded FP rate is now accepted when emitting a core TS diagnostic moves us closer to tsc.

| step | recall | precision | FP |
|---|---|---|---|
| main (T29) | 484/815 | 414/414 | 0 |
| **T30** | **500/815 (61%)** | 406/414 | 8 (1.9%) |

Strict-mode fidelity view (emit everything detected): recall 563/815, precision 350/414 (was 348). All 2247 tests pass.

## Changes

**1. Parser — discriminated-union `type` discriminant (correctness)**
Object-type-literal property names only accepted `Ident` tokens, so a property named with a keyword — most importantly `type`, the canonical discriminated-union discriminant (`{ type: "a"; … } | { type: "b"; … }`) — caused the *whole object type* to be dropped, producing spurious "property does not exist" diagnostics on every field. Both object-type parsers now use the comprehensive `parse_property_name_token` helper (the keyword set the interface parser already accepts).

**2. Checker — void-returning-function rule (correctness)**
A function returning any type is assignable to one whose return type is `void` (`() => number` → `() => void`), both for function-value assignability and for a callback body checked against a contextual `void` return (`run(() => 42)`). tsc does not flag these.

**3. Policy — emit TS2339 in permissive mode**
The property/method `does not exist` family (TS2339) is now emitted in the conformance walk instead of being suppressed wholesale. Viable now that fix #1 removed the dominant FP source. The narrowing engine (typeof/instanceof/in/truthiness/type-guards) handles common cases; the 8 residual FPs are deeper narrowing gaps (this-type guards, optional-chain unions, intersection members) — the next hard targets.

## Testing
- `moon check --deny-warn`, `moon fmt --check`, `moon test --target native` (2247 tests) all green.
- Accuracy test passes within the 5% precision floor (8/414 = 1.9%).
- Added unit tests for the `type`-discriminant union and the void rule.
- Recall log + policy note updated in `TODO.md` (T30).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6VaaouEL5wQAR71SLieRV)_