### PR TITLE
checker: narrow receiver on `this is T` type guards

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1291,6 +1291,7 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-05 (T28)   483/815 (59 %)        414/414 ( 0 FP)
 2026-06-05 (T29)   484/815 (59 %)        414/414 ( 0 FP)
 2026-06-05 (T30)   500/815 (61 %)        406/414 ( 8 FP)
+2026-06-05 (T31)   500/815 (61 %)        407/414 ( 7 FP)
 
   Policy shift (T30 onward): the goal is TypeScript compatibility, not a
   zero-false-positive score. Recall AND false positives are both tracked as
@@ -1304,6 +1305,25 @@ conformance sources (`.errors.txt` baseline = ground truth):
   Note: the T24 starting point (433/815) is higher than the T23 row
   because the TS2554 constructor/function-arity commits (PRs #84-#86)
   landed after the T23 measurement without refreshing this table.
+
+  T31 -- `this is T` type-guard receiver narrowing.
+
+    `this is T` predicate methods / arrow-field guards narrow the *receiver*,
+    not a positional argument (`if (a.isLead()) { a.lead(); }`). The
+    method-predicate narrowing only handled argument predicates, so the
+    receiver stayed unnarrowed and `lead` was falsely reported missing.
+    Now: when the predicate parameter name is `this`, narrow the receiver's
+    binding; resolve arrow-function class field guards via `lookup_field`
+    (the parser synthesizes their `Func` type from a type-predicate arrow
+    return). Clears typeGuardFunctionOfFormThis. precision 406 -> 407 (FP
+    8 -> 7), recall steady at 500.
+
+    Investigated but reverted: blanket-skipping mangled `__private_brand__`
+    private-access diagnostics cleared 2 FP files but suppressed 8
+    baseline-positive private-access errors (wrong-class / typo private
+    accesses tsc flags), a net -8 recall. Distinguishing a legal in-class
+    brand access from an erroneous one needs real private-member
+    resolution -- deferred.
 
   T30 -- compatibility shift: emit TS2339 + discriminated-union / void fixes.
 

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -8084,11 +8084,38 @@ fn apply_method_type_predicate_narrowing(
   let recv_ty = infer_expr(env, resolver, receiver)
   let ret = match resolver.lookup_method_sig(recv_ty, method_name) {
     Some((_, ret)) => ret
-    None => return
+    None =>
+      // Arrow-function class field predicate: `isElite = (): this is T =>
+      // {...}` is stored as a `Func`-typed property, not a method, so
+      // `lookup_method_sig` misses it. Fall back to the field's return type.
+      match resolver.lookup_field(recv_ty, method_name) {
+        Some(Func(_, r)) => r
+        _ => return
+      }
   }
   let (param_name, target) = match ret {
     TypePredicate(p, t) => (p, t)
     _ => return
+  }
+  // `this is T` predicate (`isLeader(): this is LeadGuard`): the guard
+  // narrows the *receiver* itself, not a positional argument. Narrow the
+  // receiver's binding (`if (a.isLeader()) { a.lead() }`).
+  if param_name == "this" {
+    match narrowing_key_for_expr(receiver) {
+      Some(key) => {
+        let cur = narrowing_current_type(env, resolver, key)
+        let then_ty = narrow_keep(cur, fn(v) { is_assignable_to(v, target) })
+        let then_resolved = match then_ty {
+          Never => target
+          _ => then_ty
+        }
+        pair_pos.push((key, then_resolved))
+        let else_ty = narrow_remove(cur, fn(v) { is_assignable_to(v, target) })
+        pair_neg.push((key, else_ty))
+      }
+      None => ()
+    }
+    return
   }
   // Without per-method TsParam metadata, fall back to first positional arg.
   let _ = param_name

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -6826,3 +6826,25 @@ test "expr_check: void-returning function assignable to void callback" {
   })
   @test.assert_eq(mism.length(), 0)
 }
+
+///|
+test "expr_check: this-type-guard narrows the receiver (method and arrow field)" {
+  // `m(): this is T` narrows the *receiver* (not an argument) in the
+  // then-branch. Covers both method-form guards and arrow-function class
+  // field guards (`g = (): this is T => ...`).
+  let src =
+    #|class Base {
+    #|  isLead(): this is Lead { return this instanceof Lead; }
+    #|  isArrow = (): this is Arrow => { return this instanceof Arrow; }
+    #|}
+    #|class Lead extends Base { lead(): void {} }
+    #|class Arrow extends Base { shoot(): void {} }
+    #|function use(b: Base): void {
+    #|  if (b.isLead()) { b.lead(); }
+    #|  if (b.isArrow()) { b.shoot(); }
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let missing = issues.filter(fn(i) { i.message.contains("does not exist") })
+  @test.assert_eq(missing.length(), 0)
+}

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -86,9 +86,29 @@ fn build_runtime_class_decl(
         has_definite_assertion
       ) =>
         if is_public_runtime_class_member_name(field_name) {
+          // An unannotated field initialized by an arrow whose return type
+          // is a type predicate (`isElite = (): this is T => {...}`) is a
+          // callable guard. Synthesize its `Func` type so method-predicate
+          // narrowing can see the `this is T` return (arrow-field guards
+          // narrow the receiver the same way method guards do).
+          let effective_type = match (field_type, init) {
+            (@ast.TsType::Any, Some(@ast.TsExpr::ArrowFunc(aparams, aret, _, _))
+            ) =>
+              match aret {
+                @ast.TsType::TypePredicate(_, _) => {
+                  let pts : Array[@ast.TsType] = []
+                  for p in aparams {
+                    pts.push(p.type_)
+                  }
+                  @ast.TsType::Func(pts, aret)
+                }
+                _ => field_type
+              }
+            _ => field_type
+          }
           upsert_class_property(properties, {
             name: field_name,
-            type_: field_type,
+            type_: effective_type,
             is_static,
             is_readonly,
             is_accessor: false,


### PR DESCRIPTION
## Summary

Continues the TypeScript-compatibility push (recall + FP as KPIs) by implementing `this is T` type-guard receiver narrowing — a real TS narrowing feature the checker lacked.

| step | recall | precision | FP |
|---|---|---|---|
| main (T30) | 500/815 | 406/414 | 8 |
| **T31** | 500/815 (61%) | **407/414** | **7** |

All 2248 tests pass.

## Change

`this is T` predicate methods and arrow-function field guards narrow the **receiver**, not a positional argument:

```ts
class Base { isLead(): this is Lead { return this instanceof Lead; } }
if (a.isLead()) { a.lead(); }   // a narrows to Lead here
```

The existing method-predicate narrowing only handled *argument* predicates (`isFoo(x): x is T`), so `if (a.isLead())` left `a` unnarrowed and `a.lead()` was falsely reported missing. Now:
- When the predicate parameter name is `this`, narrow the receiver expression's binding to the predicate target.
- Resolve arrow-function class field guards too (`isArrow = (): this is T => …`): they're stored as `Func`-typed properties, so fall back to `lookup_field` when `lookup_method_sig` misses, and the parser synthesizes the field's `Func` type from a type-predicate arrow return.

Clears `typeGuardFunctionOfFormThis` (FP 8 → 7).

## Investigated and reverted (logged in TODO)
Blanket-skipping mangled `__private_brand__` private-access diagnostics cleared 2 FP files but suppressed **8** baseline-positive private-access errors (wrong-class / typo private accesses tsc flags) — a net −8 recall. Distinguishing a legal in-class brand access from an erroneous one needs real private-member resolution; deferred.

## Testing
- `moon check --deny-warn`, `moon fmt --check`, `moon test --target native` (2248 tests) all green.
- Added a unit test covering method-form and arrow-field `this is T` narrowing.
- Recall log updated in `TODO.md` (T31).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6VaaouEL5wQAR71SLieRV)_