### PR TITLE
checker: emit all renderable type mismatches + fix keyof any (compatibility over zero-FP)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1292,6 +1292,7 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-05 (T29)   484/815 (59 %)        414/414 ( 0 FP)
 2026-06-05 (T30)   500/815 (61 %)        406/414 ( 8 FP)
 2026-06-05 (T31)   500/815 (61 %)        407/414 ( 7 FP)
+2026-06-05 (T32)   532/815 (65 %)        386/414 (28 FP)
 
   Policy shift (T30 onward): the goal is TypeScript compatibility, not a
   zero-false-positive score. Recall AND false positives are both tracked as
@@ -1305,6 +1306,23 @@ conformance sources (`.errors.txt` baseline = ground truth):
   Note: the T24 starting point (433/815) is higher than the T23 row
   because the TS2554 constructor/function-arity commits (PRs #84-#86)
   landed after the T23 measurement without refreshing this table.
+
+  T32 -- emit all renderable type mismatches + `keyof any` fix.
+
+    Policy escalation (owner directive: "FP may exceed the gate; we must
+    recognize wrong things as wrong"). Two parts:
+      - `keyof any` is `string | number | symbol`; normalize `Keyof(Any)`
+        in `simplify_keyof` and `is_assignable_to_inner` so primitives flow
+        into a `keyof any` position. A genuine checker bug (we were wrong).
+      - `is_reliable_mismatch_pair` now admits *any renderable* mismatch
+        (unions / generics included), suppressing only `type`-residue pairs
+        (where `type_display` failed, so the checker -- not tsc -- is likely
+        wrong) plus the widening / rest residue carve-outs.
+    Regression gates reframed as catastrophe nets: recall floor 20 % ->
+    45 %, precision cap 5 % -> 20 % (FP tracked, not minimized). The
+    residual ~28 FPs are generic-inference / flow-narrowing / contextual-
+    typing gaps -- the next hard machinery to build.
+    recall 500 -> 532 (65 %), FP 7 -> 28.
 
   T31 -- `this is T` type-guard receiver narrowing.
 

--- a/src/checker/assignability.mbt
+++ b/src/checker/assignability.mbt
@@ -454,6 +454,17 @@ fn is_assignable_to_inner(
   // Conditional types pick a branch when `extends` is decidable.
   let source = reduce_conditional(source)
   let target = reduce_conditional(target)
+  // `keyof any` is the union of all property-key types
+  // (`string | number | symbol`); normalize both sides so primitives flow
+  // into a `keyof any` position.
+  let normalize_keyof_any = fn(t : @ast.TsType) -> @ast.TsType {
+    match t {
+      Keyof(Any) => Union([String_, Number, Symbol])
+      _ => t
+    }
+  }
+  let source = normalize_keyof_any(source)
+  let target = normalize_keyof_any(target)
   if source == target {
     return true
   }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -3074,10 +3074,13 @@ fn check_abstract_instantiation(ctx : CheckCtx, class_name : String) -> Unit {
 /// strict mode anyway and contribute recall without inflating FP.
 fn is_permissively_suppressed(sub_path : String, message : String) -> Bool {
   if message.has_prefix("expected `") && message.contains("but got `") {
-    // Restore primitive-vs-primitive (and a few other reliable
-    // shapes) so the strict diagnostic isn't fully lost in
-    // permissive mode -- the common `var x: number = "hello"` style
-    // mistake is a clean signal we can keep.
+    // Compatibility goal: a type mismatch is a real TS error, so emit it
+    // even when the shapes involve unions / generics rather than only the
+    // narrow "reliable" primitive subset (see `is_reliable_mismatch_pair`,
+    // which now admits any renderable pair). We still suppress where *we*
+    // are likely to be wrong, never tsc: a `type` residue token (our
+    // `type_display` couldn't render the shape), widening-direction
+    // residue, and rest-parameter residue.
     match extract_mismatch_types(message) {
       Some((exp, got)) =>
         if is_reliable_mismatch_pair(exp, got) &&
@@ -3246,35 +3249,20 @@ fn is_reliable_mismatch_pair(exp : String, got : String) -> Bool {
     (is_bare_primitive(exp) && is_short_named_identifier(got)) {
     return true
   }
-  // Primitive-vs-shape and shape-vs-primitive: an obvious category
-  // mismatch (`number = [1, "a"]`, `string[] = 5`). TS flags these
-  // and our assignability gets them right. We still suppress when
-  // either side contains `|` (union -> flow narrowing residue) or
-  // `<` (generic application -> inference residue).
-  if exp.contains("|") || got.contains("|") {
-    return false
-  }
-  if exp.contains("<") || got.contains("<") {
-    return false
-  }
   if is_reliable_mismatch_type(exp) && is_simple_shape_type(got) {
     return true
   }
   if is_simple_shape_type(exp) && is_reliable_mismatch_type(got) {
     return true
   }
-  // Simple-shape vs simple-shape: both render as `T[]`, `{...}`, or
-  // `(...) => T`. When neither carries `|`/`<` (filtered above), the
-  // structural mismatch is concrete enough to keep. Excludes cases
-  // where either side carries the bare-`type` token (substitution
-  // residue) since that's our checker's "I don't know" rendering.
-  if is_simple_shape_type(exp) &&
-    is_simple_shape_type(got) &&
-    !has_type_residue_token(exp) &&
-    !has_type_residue_token(got) {
-    return true
-  }
-  false
+  // Compatibility goal: admit every *renderable* mismatch -- a type
+  // mismatch is a real TS error even when the shapes are unions or generic
+  // applications. The only pairs we still treat as unreliable are those
+  // carrying the `type` residue token, which means our `type_display`
+  // couldn't render the shape (mapped type / unresolved generic): we can't
+  // claim a mismatch on a type we can't even print, and that is the family
+  // where the checker is the one likely to be wrong rather than tsc.
+  !has_type_residue_token(exp) && !has_type_residue_token(got)
 }
 
 ///|

--- a/src/checker/simplify.mbt
+++ b/src/checker/simplify.mbt
@@ -222,6 +222,10 @@ fn simplify_keyof(t : @ast.TsType) -> @ast.TsType {
             Union(keys)
           }
         }
+        // `keyof any` is `string | number | symbol` (every possible
+        // property key). Resolving it lets primitives flow into a
+        // `keyof any` position without a spurious mismatch.
+        Any => Union([String_, Number, Symbol])
         _ => t
       }
     _ => t

--- a/src/parser/parser_typescript_wbtest.mbt
+++ b/src/parser/parser_typescript_wbtest.mbt
@@ -1210,31 +1210,31 @@ async test "checker: accuracy against TypeScript conformance baselines" {
   println(
     "baseline accuracy: parsed=\{parsed}/\{total} | recall=\{recall_hit}/\{with_baseline} | precision=\{precision_hit}/\{without_baseline} (false-positives=\{precision_miss})",
   )
-  // Regression gates calibrated against today's measurements. Tighten
-  // as accuracy improves; loosen only with justification.
+  // Regression gates. The goal is TypeScript compatibility -- recall is the
+  // primary KPI; false positives are tracked but deliberately NOT minimized
+  // to zero (a real type error must be reported even when our incomplete
+  // modelling also misfires on some valid code). Both gates are catastrophe
+  // nets, not tight bounds: they trip only on a wholesale pipeline
+  // regression, leaving room to keep emitting more diagnostics.
   //
-  // Recall floor: T11 adds TS2564 (class-field definite-assignment) +
-  // counts parse-fail-with-baseline as a detection + admits primitive
-  // -vs- shape mismatches through the permissive filter. Measured
-  // 2026-06-02 via `tscheck` (with target-suffix baseline detection):
-  // recall is 166 / 512 ≈ 32 %. Floor at 20 % so a genuine pipeline
-  // regression (parser stops producing modules, parse-fail counting
-  // turns off, TS2564 emission disappears) trips immediately.
-  if with_baseline > 0 && recall_hit * 100 < with_baseline * 20 {
+  // Recall floor: measured ~532 / 815 (65 %) as of the mismatch-family
+  // un-suppression. Floor at 45 % so a genuine regression (parser stops
+  // producing modules, parse-fail counting turns off, a whole diagnostic
+  // family disappears) trips immediately.
+  if with_baseline > 0 && recall_hit * 100 < with_baseline * 45 {
     fail(
-      "recall floor breached: \{recall_hit}/\{with_baseline} baseline-positive cases caught (< 20 %)",
+      "recall floor breached: \{recall_hit}/\{with_baseline} baseline-positive cases caught (< 45 %)",
     )
   }
-  // Precision floor. The goal is TypeScript compatibility, not zero false
-  // positives: the property / method `does not exist` family is now emitted
-  // in permissive mode (it is a core TS diagnostic), trading a small number
-  // of residual flow-narrowing-gap FPs (this-guards, optional-chain unions,
-  // intersection members) for ~16 recall. Current residual is ~8 / 414
-  // (1.9 %); the cap stays at 5 % so a regression that re-introduces a
-  // whole family of FPs still trips immediately.
-  if without_baseline > 0 && precision_miss * 100 > without_baseline * 5 {
+  // Precision floor: the checker now emits the mismatch / property / method
+  // families in full, so the residual FP rate (~28 / 414 ≈ 7 %) reflects
+  // genuine modelling gaps (generic inference, flow narrowing, contextual
+  // typing) that mis-flag some valid code -- the cost of recognizing real
+  // errors. Cap at 20 % purely as a catastrophe net (a new pattern that
+  // floods clean files with FPs), not as a zero-FP target.
+  if without_baseline > 0 && precision_miss * 100 > without_baseline * 20 {
     fail(
-      "precision floor breached: \{precision_miss}/\{without_baseline} clean cases reported as failing (> 5 %)",
+      "precision floor breached: \{precision_miss}/\{without_baseline} clean cases reported as failing (> 20 %)",
     )
   }
 }


### PR DESCRIPTION
## Summary

Acts on the owner directive: **false positives may exceed the old gate — the checker must recognize genuinely-wrong code as wrong.** Recall is the primary KPI; FP is tracked, not minimized to zero.

| step | recall | precision | FP |
|---|---|---|---|
| main (T31) | 500/815 | 407/414 | 7 |
| **T32** | **532/815 (65%)** | 386/414 | 28 |

All 2248 tests pass.

## Changes

**1. `keyof any` = `string | number | symbol` (genuine checker bug)**
The checker preserved `Keyof(Any)` unreduced, so a `string`/`number`/`symbol` argument flowing into a `keyof any` parameter was falsely flagged. Normalized in both `simplify_keyof` and `is_assignable_to_inner`. This is a case where *we* were wrong — fixed, not suppressed.

**2. Emit all renderable type mismatches (TS2322/TS2345)**
A type mismatch is a real TS error, so it's now emitted even when the shapes are unions or generic applications — not only the narrow primitive subset. `is_reliable_mismatch_pair` admits any *renderable* pair; the only suppressed mismatches are:
- `type`-residue pairs (where `type_display` couldn't render the shape, so the checker — not tsc — is the one likely wrong);
- the existing widening-direction and rest-parameter residue carve-outs.

**3. Regression gates reframed as catastrophe nets**
- Recall floor 20% → 45% (now ~65%).
- Precision cap 5% → 20% (FP tracked, not minimized; trips only on a wholesale FP flood).

The residual ~28/414 FPs are genuine modelling gaps — generic inference, flow narrowing, contextual typing — the next hard machinery to build.

## Testing
- `moon check --deny-warn`, `moon fmt --check`, `moon test --target native` (2248 tests) all green.
- Recall log updated in `TODO.md` (T32).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6VaaouEL5wQAR71SLieRV)_