### PR TITLE
checker: co-inductive structural assignability for recursive named types (+ hang fix)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1293,6 +1293,7 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-05 (T30)   500/815 (61 %)        406/414 ( 8 FP)
 2026-06-05 (T31)   500/815 (61 %)        407/414 ( 7 FP)
 2026-06-05 (T32)   532/815 (65 %)        386/414 (28 FP)
+2026-06-05 (T33)   532/815 (65 %)        387/414 (27 FP)
 
   Policy shift (T30 onward): the goal is TypeScript compatibility, not a
   zero-false-positive score. Recall AND false positives are both tracked as
@@ -1306,6 +1307,21 @@ conformance sources (`.errors.txt` baseline = ground truth):
   Note: the T24 starting point (433/815) is higher than the T23 row
   because the TS2554 constructor/function-arity commits (PRs #84-#86)
   landed after the T23 measurement without refreshing this table.
+
+  T33 -- co-inductive structural assignability for recursive named types.
+
+    First piece of real machinery after the policy shift (chosen over
+    further filter tweaks, which were measured net-negative). Structural
+    class/interface assignability compared field types nominally, so
+    distinct-but-shape-identical recursive types (`class S { foo: S }` vs
+    `class T { foo: T }`) were falsely flagged. `is_structurally_assignable_named`
+    now recurses through itself with a `visited` (source, target) name-pair
+    set -- re-encountering a pair returns true (co-induction, how tsc
+    relates recursive types). A depth cap (48) is a required safety net for
+    generic recursive shapes (`Wrapped<Wrapped<T>>`) whose substituted field
+    type deepens each level; without it the recursion hung the checker.
+    recall steady 532, FP 28 -> 27. Net-positive, no recall loss, and fixes
+    a hang.
 
   T32 -- emit all renderable type mismatches + `keyof any` fix.
 

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -5614,28 +5614,80 @@ fn is_structurally_assignable_named(
   target : @ast.TsType,
   resolver : Resolver,
 ) -> Bool {
-  // Only engage when both sides resolve as class / interface shapes.
-  // `lookup_field` returns `None` for opaque receivers, so this filter
-  // also weeds out unresolvable references (generic type parameters,
-  // qualified names) without false promotion.
-  if !is_named_decl(source, resolver) || !is_named_decl(target, resolver) {
+  struct_assignable_named_rec(source, target, resolver, [])
+}
+
+///|
+/// Co-inductive structural assignability for class / interface references.
+/// Field types are compared *recursively* through this same relation (not
+/// the nominal `is_assignable_to`) so two distinct-but-shape-identical
+/// recursive types assign -- e.g. `class S { foo: S }` and
+/// `class T { foo: T }`, where `S.foo` (`S`) must be checked against `T.foo`
+/// (`T`). `visited` records the (source, target) name pairs currently being
+/// proven; re-encountering a pair returns `true` (co-induction), which is
+/// how TypeScript itself relates recursive types and breaks the cycle.
+fn struct_assignable_named_rec(
+  source : @ast.TsType,
+  target : @ast.TsType,
+  resolver : Resolver,
+  visited : Array[(String, String)],
+) -> Bool {
+  // Depth cap: generic recursive shapes (`Wrapped<Wrapped<T>>`) deepen the
+  // substituted field type at every level, so the `visited` co-induction key
+  // never repeats and the recursion would not terminate. Bail conservatively
+  // (can't *prove* assignability) once the chain is implausibly deep -- the
+  // caller falls through to its other relations / the diagnostic.
+  if visited.length() >= 48 {
     return false
   }
-  let target_fields = collect_declared_fields(target, resolver)
+  let s = resolver.unwrap(source)
+  let t = resolver.unwrap(target)
+  if s == t {
+    return true
+  }
+  // Only engage when both sides resolve as class / interface (or object)
+  // shapes. `lookup_field` returns `None` for opaque receivers, so this
+  // also weeds out unresolvable references (generic type parameters,
+  // qualified names) without false promotion.
+  if !is_named_decl(s, resolver) || !is_named_decl(t, resolver) {
+    return false
+  }
+  let key = (type_display(s), type_display(t))
+  if visited.contains(key) {
+    return true
+  }
+  visited.push(key)
+  let target_fields = collect_declared_fields(t, resolver)
   if target_fields.length() == 0 {
+    let _ = visited.pop()
     return false
   }
   for f in target_fields {
-    let key = f.0
-    let want = f.1
-    match resolver.lookup_field(source, key) {
-      Some(have) =>
-        if !is_assignable_to(resolver.unwrap(have), resolver.unwrap(want)) {
+    let want = resolver.unwrap(f.1)
+    match resolver.lookup_field(s, f.0) {
+      Some(have) => {
+        let have_u = resolver.unwrap(have)
+        // Recurse structurally when both field types are themselves
+        // class / interface references (covers the recursive case); fall
+        // back to the well-tested nominal / builtin relation otherwise.
+        let ok = if is_named_decl(have_u, resolver) &&
+          is_named_decl(want, resolver) {
+          struct_assignable_named_rec(have_u, want, resolver, visited)
+        } else {
+          is_assignable_to(have_u, want)
+        }
+        if !ok {
+          let _ = visited.pop()
           return false
         }
-      None => return false
+      }
+      None => {
+        let _ = visited.pop()
+        return false
+      }
     }
   }
+  let _ = visited.pop()
   true
 }
 


### PR DESCRIPTION
## Summary

First piece of real type-inference machinery after the compatibility policy shift (chosen over further filter tweaks, which measured net-negative on recall).

| step | recall | precision | FP |
|---|---|---|---|
| main (T32) | 532/815 | 386/414 | 28 |
| **T33** | 532/815 | 387/414 | **27** |

Net-positive: −1 FP, **no recall loss**, and it fixes a checker **hang**.

## Change

Structural class/interface assignability (`is_structurally_assignable_named`) compared field types with the *nominal* `is_assignable_to`, so two distinct-but-shape-identical **recursive** types were falsely flagged — e.g. `class S { foo: S }` assigned to `class T { foo: T }` failed because `S.foo` (`S`) was compared nominally against `T.foo` (`T`).

It now recurses through itself for class/interface field types, with a `visited` set of `(source, target)` name pairs: re-encountering a pair returns `true` (**co-induction** — exactly how tsc relates recursive types and breaks the cycle).

**Depth cap (48) — a required safety net:** generic recursive shapes like `Wrapped<Wrapped<T>>` deepen the substituted field type at every level, so the co-induction key never repeats and the recursion would not terminate. Without the cap the checker **hung** on `objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts` (caught during measurement). The cap bails conservatively (can't *prove* assignability) past an implausible depth.

## Testing
- `moon check --deny-warn`, `moon fmt --check`, `moon test --target native` (2248 tests) all green.
- Verified the previously-hanging recursive file now terminates.
- `assignmentCompatWithObjectMembers`' recursive `S`/`T`/`S2`/`T2` assignments now resolve.
- Recall log updated in `TODO.md` (T33).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6VaaouEL5wQAR71SLieRV)_