### PR TITLE
checker: union flow narrowing — ||-else branch + && falsy subset

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1294,6 +1294,7 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-05 (T31)   500/815 (61 %)        407/414 ( 7 FP)
 2026-06-05 (T32)   532/815 (65 %)        386/414 (28 FP)
 2026-06-05 (T33)   532/815 (65 %)        387/414 (27 FP)
+2026-06-05 (T34)   532/815 (65 %)        389/414 (25 FP)
 
   Policy shift (T30 onward): the goal is TypeScript compatibility, not a
   zero-false-positive score. Recall AND false positives are both tracked as
@@ -1307,6 +1308,21 @@ conformance sources (`.errors.txt` baseline = ground truth):
   Note: the T24 starting point (433/815) is higher than the T23 row
   because the TS2554 constructor/function-arity commits (PRs #84-#86)
   landed after the T23 measurement without refreshing this table.
+
+  T34 -- union/destructuring flow narrowing (two real-machinery fixes).
+
+    - `||` typeguard else-branch: `collect_narrowing` only handled `||`
+      under a negation, so `if (typeof x === "a" || typeof x === "b") {}
+      else { ... }` left `x` unnarrowed in the else. The else holds when
+      both disjuncts are false; narrow by the first's false-side then the
+      second's (composed via a scratch env), yielding the discriminant
+      residue removal. Clears typeGuardOfFormExpr1OrExpr2.
+    - `a && b` result type: was `typeof a | typeof b`; now
+      `(falsy subset of a) | typeof b`. Always-truthy operands (object /
+      class / array / function) have an empty falsy subset, so
+      `(x: Beast) && cond` is `boolean`. Clears typeGuardIntersectionTypes
+      predicate bodies.
+    recall steady 532, FP 27 -> 25. Both net-positive, no recall loss.
 
   T33 -- co-inductive structural assignability for recursive named types.
 

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -7792,9 +7792,30 @@ fn collect_narrowing(
       }
     BinOp(Or, l, r) =>
       if !then_sense {
-        // Both must be false in the else-branch.
+        // Under a negation: `!(l || r)` is `!l && !r`, so both hold.
         collect_narrowing(env, resolver, l, then_binds, else_binds, true)
         collect_narrowing(env, resolver, r, then_binds, else_binds, true)
+      } else {
+        // `if (l || r) { } else { /* l false AND r false */ }`. The
+        // else-branch narrows by l-false *then* r-false (composed), which
+        // is the common `typeof x === "a" || typeof x === "b"` discriminant
+        // residue: in the else, x has both "a" and "b" types removed.
+        // Apply l's false narrowing to a scratch env so r's narrowing sees
+        // the already-reduced type, then collect both into else_binds
+        // (later push wins per key, which yields the composed result).
+        let lo = analyze_narrowing(env, resolver, l)
+        for b in lo.else_binds {
+          else_binds.push(b)
+        }
+        let snap = env.full_snapshot()
+        for b in lo.else_binds {
+          env.bind(b.0, b.1)
+        }
+        let ro = analyze_narrowing(env, resolver, r)
+        env.restore_from(snap)
+        for b in ro.else_binds {
+          else_binds.push(b)
+        }
       }
     BinOp(Coalesce, l, r) =>
       // `x ?? y`: when truthy, x is non-nullish; when falsy, narrowing from r.

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -4236,7 +4236,7 @@ fn infer_expr(
     BinOp(op, l, r) => {
       let lt = resolver.unwrap(infer_expr(env, resolver, l))
       let rt = resolver.unwrap(infer_expr(env, resolver, r))
-      infer_binop(op, lt, rt)
+      infer_binop(op, lt, rt, resolver)
     }
     UnaryOp(op, inner) => {
       let inner_ty = infer_expr(env, resolver, inner)
@@ -5153,10 +5153,47 @@ fn infer_index(
 }
 
 ///|
+/// The subset of `t`'s values that are falsy -- what the left operand of
+/// `a && b` contributes to the result type. Always-truthy shapes (object /
+/// class / interface / array / tuple / function references) contribute
+/// nothing (`never`), so `(x: Beast) && cond` is `boolean`, not
+/// `Beast | boolean`. Primitives are kept conservatively (we don't model
+/// `0` / `""` / `false` literal falsiness).
+fn falsy_subset(resolver : Resolver, t : @ast.TsType) -> @ast.TsType {
+  let u = resolver.unwrap(t)
+  match u {
+    Object(_)
+    | Struct(_, _)
+    | Array(_)
+    | Tuple(_)
+    | Func(_, _)
+    | Constructor(_, _, _) => @ast.TsType::Never
+    Named(_) | Applied(_, _) =>
+      if is_named_decl(u, resolver) {
+        @ast.TsType::Never
+      } else {
+        u
+      }
+    Union(ms) => {
+      let kept : Array[@ast.TsType] = []
+      for m in ms {
+        let f = falsy_subset(resolver, m)
+        if !(f is Never) {
+          kept.push(f)
+        }
+      }
+      union_of(kept)
+    }
+    _ => u
+  }
+}
+
+///|
 fn infer_binop(
   op : @ast.TsBinOp,
   l : @ast.TsType,
   r : @ast.TsType,
+  resolver : Resolver,
 ) -> @ast.TsType {
   match op {
     Add =>
@@ -5196,8 +5233,9 @@ fn infer_binop(
     | In
     | Instanceof => @ast.TsType::Boolean
     // `a && b` — when `a` is truthy the result is `b`; otherwise the falsy
-    // `a`. Conservative: union both sides.
-    And => narrow_union(l, r)
+    // subset of `a`. An always-truthy object/class operand contributes
+    // nothing, so `(x: Beast) && cond` is `boolean`, not `Beast | boolean`.
+    And => narrow_union(falsy_subset(resolver, l), r)
     // `a || b` — when `a` is truthy the result is `a`; otherwise `b`. TS
     // narrows the truthy branch by stripping always-falsy variants from
     // `l` (null / undefined are the practically-relevant ones here, since


### PR DESCRIPTION
## Summary

Two real flow-narrowing machinery fixes for the union FPs (continuing the "build machinery, don't suppress" approach).

| step | recall | precision | FP |
|---|---|---|---|
| main (T33) | 532/815 | 387/414 | 27 |
| **T34** | 532/815 | 389/414 | **25** |

Both net-positive: **no recall loss**, FP 27→25, all 2248 tests pass.

## Changes

**1. `||` typeguard else-branch narrowing**
`collect_narrowing` only handled an `||` condition under a negation, so a plain `if (typeof x === "a" || typeof x === "b") {} else { ... }` left `x` unnarrowed in the **else-branch** — producing false `expected boolean but got string | number | boolean` mismatches when the narrowed value is assigned/returned there. The else-branch holds when *both* disjuncts are false, so narrow by the first's false-side **then** the second's (composed via a scratch env so the second sees the already-reduced type). Symmetric to the existing `&&`/negation handling. Clears `typeGuardOfFormExpr1OrExpr2`.

**2. `a && b` result type uses the falsy subset of `a`**
`infer_binop` typed `a && b` as `typeof a | typeof b`, but TS uses `(falsy subset of a) | typeof b`. An always-truthy operand (object / class / interface / array / tuple / function reference) has an empty falsy subset (`never`), so `(x: Beast) && cond` is `boolean`, not `Beast | boolean` — the latter produced false mismatches in predicate bodies like `function hasLegs(x: Beast): x is Legged { return x && typeof x.legs === 'number'; }`. Primitives are kept conservatively (we don't model `0`/`""`/`false` literal falsiness), so only always-truthy operands change. Clears `typeGuardIntersectionTypes`.

## Testing
- `moon check --deny-warn`, `moon fmt --check`, `moon test --target native` (2248 tests) all green.
- Recall log updated in `TODO.md` (T34).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6VaaouEL5wQAR71SLieRV)_