### PR TITLE
checker: structural optional fields + && then-branch narrowing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1295,6 +1295,7 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-05 (T32)   532/815 (65 %)        386/414 (28 FP)
 2026-06-05 (T33)   532/815 (65 %)        387/414 (27 FP)
 2026-06-05 (T34)   532/815 (65 %)        389/414 (25 FP)
+2026-06-05 (T35)   532/815 (65 %)        393/414 (21 FP)
 
   Policy shift (T30 onward): the goal is TypeScript compatibility, not a
   zero-false-positive score. Recall AND false positives are both tracked as
@@ -1308,6 +1309,19 @@ conformance sources (`.errors.txt` baseline = ground truth):
   Note: the T24 starting point (433/815) is higher than the T23 row
   because the TS2554 constructor/function-arity commits (PRs #84-#86)
   landed after the T23 measurement without refreshing this table.
+
+  T35 -- structural optional fields + `&&` then-branch narrowing.
+
+    - Optional target fields no longer block structural assignability:
+      `struct_assignable_named_rec` required every declared target field on
+      the source, but an optional `bar?: T` may be absent (TS allows
+      `s2 = t2` when `t2` omits `s2`'s optional members). Skip the missing-
+      on-source failure when the field type accepts `undefined`. Clears
+      assignmentCompatWithObjectMembers 2 / 3 / NumericNames.
+    - `&&` then-branch narrowing composes (mirror of T34's `||` else fix):
+      `typeof x !== "a" && typeof x !== "b"` now removes both types from
+      `x` in the then-branch. Clears typeGuardOfFormExpr1AndExpr2.
+    recall steady 532, FP 25 -> 21. Both net-positive, no recall loss.
 
   T34 -- union/destructuring flow narrowing (two real-machinery fixes).
 

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -7829,9 +7829,26 @@ fn collect_narrowing(
   match cond {
     BinOp(And, l, r) =>
       if then_sense {
-        // Both sub-conditions must hold in the then-branch.
-        collect_narrowing(env, resolver, l, then_binds, else_binds, true)
-        collect_narrowing(env, resolver, r, then_binds, else_binds, true)
+        // `if (l && r) { /* l true AND r true */ }`. Both hold in the
+        // then-branch, composed: narrow by l-true *then* r-true so the
+        // second condition sees the first's narrowing (mirrors the `||`
+        // else-branch). This is the `typeof x !== "a" && typeof x !== "b"`
+        // residue -- the then-branch removes both "a" and "b" from x. The
+        // else-branch of `&&` is a union (`!l | (l & !r)`) we can't narrow
+        // cleanly, so leave else_binds untouched.
+        let lo = analyze_narrowing(env, resolver, l)
+        for b in lo.then_binds {
+          then_binds.push(b)
+        }
+        let snap = env.full_snapshot()
+        for b in lo.then_binds {
+          env.bind(b.0, b.1)
+        }
+        let ro = analyze_narrowing(env, resolver, r)
+        env.restore_from(snap)
+        for b in ro.then_binds {
+          then_binds.push(b)
+        }
       }
     BinOp(Or, l, r) =>
       if !then_sense {

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -5719,10 +5719,15 @@ fn struct_assignable_named_rec(
           return false
         }
       }
-      None => {
-        let _ = visited.pop()
-        return false
-      }
+      None =>
+        // A field missing on the source is only a failure when the target
+        // field is *required*. An optional target field (`bar?: T`, encoded
+        // as a `| undefined` type) may be absent on the source -- TS allows
+        // `s2 = t2` when `t2` simply omits `s2`'s optional members.
+        if !type_accepts_undefined(want) {
+          let _ = visited.pop()
+          return false
+        }
     }
   }
   let _ = visited.pop()


### PR DESCRIPTION
## Summary

Two more real flow-narrowing / structural-typing fixes (continuing T33–T34).

| step | recall | precision | FP |
|---|---|---|---|
| main (T34) | 532/815 | 389/414 | 25 |
| **T35** | 532/815 | 393/414 | **21** |

Both net-positive: **no recall loss**, FP 25→21, all 2248 tests pass.

## Changes

**1. Optional target fields don't block structural assignability**
`struct_assignable_named_rec` required *every* declared target field on the source, but an optional `bar?: T` may be absent — TS allows `s2 = t2` when `t2` omits `s2`'s optional members. Skip the missing-on-source failure when the target field type accepts `undefined` (the encoding of `?`). Clears `assignmentCompatWithObjectMembers` 2 / 3 / NumericNames.

**2. `&&` then-branch narrowing composes (mirror of T34's `||` else fix)**
The `&&` then-branch holds when both conjuncts are true, but `collect_narrowing` collected each conjunct's then-narrowing as parallel binds (last wins per key), so `typeof x !== "a" && typeof x !== "b"` only removed one type from `x`. Compose instead — apply `l`-true to a scratch env so `r`-true sees the reduced type, then collect both. The `&&` else-branch is a union we can't narrow cleanly, so it's left untouched (the previous else collection was unsound anyway). Clears `typeGuardOfFormExpr1AndExpr2`.

## Testing
- `moon check --deny-warn`, `moon fmt --check`, `moon test --target native` (2248 tests) all green.
- Recall log updated in `TODO.md` (T35).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6VaaouEL5wQAR71SLieRV)_