### PR TITLE
checker: join variable types at if/else merge points (flow narrowing)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1296,6 +1296,7 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-05 (T33)   532/815 (65 %)        387/414 (27 FP)
 2026-06-05 (T34)   532/815 (65 %)        389/414 (25 FP)
 2026-06-05 (T35)   532/815 (65 %)        393/414 (21 FP)
+2026-06-05 (T36)   532/815 (65 %)        394/414 (20 FP)
 
   Policy shift (T30 onward): the goal is TypeScript compatibility, not a
   zero-false-positive score. Recall AND false positives are both tracked as
@@ -1309,6 +1310,18 @@ conformance sources (`.errors.txt` baseline = ground truth):
   Note: the T24 starting point (433/815) is higher than the T23 row
   because the TS2554 constructor/function-arity commits (PRs #84-#86)
   landed after the T23 measurement without refreshing this table.
+
+  T36 -- join variable types at if/else merge points.
+
+    Control-flow branch join: after an `if` where neither branch exits, a
+    variable's type becomes the union of its type at the end of each branch
+    (covering the condition's narrowing *and* in-branch reassignment). So
+    `if (id === undefined) { id = "1"; }` leaves `id` as `string` -- the
+    then-branch reassigns it, the else path narrows out `undefined`. Union-
+    join only widens back toward the pre-`if` type, so it never over-
+    narrows (verified: no regressions across 2248 tests + the conformance
+    walk). `check_block_narrowing_exit` captures each branch's exit env.
+    recall steady 532, FP 21 -> 20 (clears controlFlowInOperator).
 
   T35 -- structural optional fields + `&&` then-branch narrowing.
 

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -8659,12 +8659,16 @@ fn check_block(env : ExprEnv, block : @ast.TsBlock, ctx : CheckCtx) -> Unit {
 }
 
 ///|
-fn check_block_with_narrowing(
+/// Checks `block` with the given narrowing `binds` applied, then returns
+/// the variable types in effect at the *end* of the block (after the binds
+/// plus any in-block assignment narrowing) before restoring the outer env.
+/// The `if` handler uses this to join branch exits at the merge point.
+fn check_block_narrowing_exit(
   env : ExprEnv,
   block : @ast.TsBlock,
   ctx : CheckCtx,
   binds : Array[(String, @ast.TsType)],
-) -> Unit {
+) -> Map[String, @ast.TsType] {
   let pre = env.full_snapshot()
   for b in binds {
     env.bind(b.0, b.1)
@@ -8672,7 +8676,12 @@ fn check_block_with_narrowing(
   for stmt in block.stmts {
     check_stmt(env, stmt, ctx)
   }
+  let exit : Map[String, @ast.TsType] = {}
+  for e in env.full_snapshot() {
+    exit[e.0] = e.1
+  }
   env.restore_from(pre)
+  exit
 }
 
 ///|
@@ -8871,15 +8880,36 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
     Throw(e) => check_call_args_in_expr(env, e, ctx)
     If(cond, then_block, else_block) => {
       check_call_args_in_expr(env, cond, ctx)
+      let pre_map : Map[String, @ast.TsType] = {}
+      for e in env.full_snapshot() {
+        pre_map[e.0] = e.1
+      }
       let effect = analyze_narrowing(env, ctx.resolver, cond)
-      check_block_with_narrowing(env, then_block, ctx, effect.then_binds)
+      let then_exit = check_block_narrowing_exit(
+        env,
+        then_block,
+        ctx,
+        effect.then_binds,
+      )
       let then_exits = block_always_exits(then_block)
-      let else_exits = match else_block {
-        Some(b) => {
-          check_block_with_narrowing(env, b, ctx, effect.else_binds)
-          block_always_exits(b)
+      let (else_exit, else_exits) = match else_block {
+        Some(b) =>
+          (
+            check_block_narrowing_exit(env, b, ctx, effect.else_binds),
+            block_always_exits(b),
+          )
+        // No `else`: the else path is the fall-through with the condition's
+        // else-narrowing applied and no statements.
+        None => {
+          let m : Map[String, @ast.TsType] = {}
+          for k, v in pre_map {
+            m[k] = v
+          }
+          for bnd in effect.else_binds {
+            m[bnd.0] = bnd.1
+          }
+          (m, false)
         }
-        None => false
       }
       // Narrowing after early return: when one branch unconditionally exits,
       // the surrounding scope continues with the opposite branch's effect
@@ -8892,6 +8922,39 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
       } else if else_exits && !then_exits {
         for b in effect.then_binds {
           env.bind(b.0, b.1)
+        }
+      } else if !then_exits && !else_exits {
+        // Merge-point join: a variable's type after the `if` is the union of
+        // its type at the end of each branch (covering both the condition's
+        // narrowing and in-branch reassignment). This makes
+        // `if (id === undefined) { id = "1"; }` leave `id` as `string`.
+        // Union can only widen back toward the pre-`if` type, so the join
+        // never over-narrows. Only touch variables that actually changed in
+        // a branch.
+        let cands : Map[String, Unit] = {}
+        for k, v in then_exit {
+          if pre_map.get(k) != Some(v) {
+            cands[k] = ()
+          }
+        }
+        for k, v in else_exit {
+          if pre_map.get(k) != Some(v) {
+            cands[k] = ()
+          }
+        }
+        for k, _ in cands {
+          let tt = match then_exit.get(k) {
+            Some(t) => Some(t)
+            None => pre_map.get(k)
+          }
+          let et = match else_exit.get(k) {
+            Some(t) => Some(t)
+            None => pre_map.get(k)
+          }
+          match (tt, et) {
+            (Some(a), Some(b)) => env.narrow(k, narrow_union(a, b))
+            _ => ()
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Adds **control-flow branch join** at `if`/`else` merge points — a fundamental flow-analysis capability the checker lacked.

| step | recall | precision | FP |
|---|---|---|---|
| main (T35) | 532/815 | 393/414 | 21 |
| **T36** | 532/815 | 394/414 | **20** |

Net-positive: no recall loss, FP 21→20, all 2248 tests pass.

## Change

After an `if` where neither branch exits, a variable's type becomes the **union of its type at the end of each branch** — covering both the condition's narrowing *and* in-branch reassignment. This makes:

```ts
function uniqueID(id: string | undefined, ...): string {
  if (id === undefined) { id = "1"; }   // then: reassigned to string; else: undefined narrowed out
  if (!(id in seenIDs)) { return id; }  // id is now string, not string | undefined
  ...
}
```

`check_block_narrowing_exit` captures each branch's exit env (subsuming the old `check_block_with_narrowing`); the join unions then-exit and else-exit per variable that changed (no-`else` uses the fall-through with the condition's else-narrowing).

**Soundness:** union-join can only widen back toward the pre-`if` type, so it never over-narrows. Verified across the full 2248-test suite and the conformance walk — no regressions.

## Testing
- `moon check --deny-warn`, `moon fmt --check`, `moon test --target native` (2248 tests) all green.
- Clears `controlFlowInOperator`; recall log updated in `TODO.md` (T36).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6VaaouEL5wQAR71SLieRV)_