### PR TITLE
checker: structural detection of incompatible interface-extends (TS2430, +recall)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1297,6 +1297,18 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-05 (T34)   532/815 (65 %)        389/414 (25 FP)
 2026-06-05 (T35)   532/815 (65 %)        393/414 (21 FP)
 2026-06-05 (T36)   532/815 (65 %)        394/414 (20 FP)
+2026-06-05 (T37)   533/815 (65 %)        394/414 (20 FP)
+
+  T37 -- structural detection of incompatible interface-extends (TS2430).
+
+    First recall-raising *detection* after a run of precision fixes (recall
+    had been flat at 532). `check_interface_extends_compat` now decides a
+    redeclared member structurally via `struct_assignable_named_rec` when
+    both member types are plain (non-generic) class / interface refs -- so
+    `interface B extends A { bar: Base }` over `interface A { bar: Derived }`
+    is flagged (Base lacks Derived's members). The full field sets make
+    `false` a reliable "not assignable", and generic `Applied` shapes are
+    excluded to stay FP-free. recall 532 -> 533, FP steady 20.
 
   Policy shift (T30 onward): the goal is TypeScript compatibility, not a
   zero-false-positive score. Recall AND false positives are both tracked as

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -11170,7 +11170,10 @@ fn check_class_member_structure(
       }
     }
   }
-  for issue in check_interface_extends_compat(module_, outer_object_names) {
+  for
+    issue in check_interface_extends_compat(
+      module_, outer_object_names, resolver,
+    ) {
     issues.push(issue)
   }
   issues
@@ -11196,6 +11199,7 @@ fn check_class_member_structure(
 fn check_interface_extends_compat(
   module_ : @ast.TsModule,
   outer_object_names : Map[String, Unit],
+  resolver : Resolver,
 ) -> Array[ExprIssue] {
   let issues : Array[ExprIssue] = []
   // Index declared interfaces by name (non-generic only).
@@ -11292,7 +11296,27 @@ fn check_interface_extends_compat(
             // Optionality weakening: derived optional over required base.
             let d_payload = strip_optional(df.1)
             let b_payload = strip_optional(btype)
+            // Both members are plain (non-generic) class / interface
+            // references: decide structurally. `struct_assignable_named_rec`
+            // has the full field sets, so a `false` here is a reliable
+            // "not assignable" (e.g. derived `bar: Base` over base
+            // `bar: Derived`, where `Base` lacks `Derived`'s members), not a
+            // "couldn't determine". Generic `Applied` shapes are excluded
+            // (no type-arg substitution) to stay false-positive-free.
+            let both_plain_named = match
+              (resolver.unwrap(d_payload), resolver.unwrap(b_payload)) {
+              (Named(_), Named(_)) =>
+                is_named_decl(d_payload, resolver) &&
+                is_named_decl(b_payload, resolver)
+              _ => false
+            }
             if is_scalar(d_payload) && is_object_shaped(b_payload) {
+              issues.push({
+                path: "interface \{iface.name}",
+                message: "interface incorrectly extends `\{base_name}`: property `\{df.0}` of type `\{type_display(df.1)}` is not assignable to the base type `\{type_display(btype)}`",
+              })
+            } else if both_plain_named &&
+              !struct_assignable_named_rec(d_payload, b_payload, resolver, []) {
               issues.push({
                 path: "interface \{iface.name}",
                 message: "interface incorrectly extends `\{base_name}`: property `\{df.0}` of type `\{type_display(df.1)}` is not assignable to the base type `\{type_display(btype)}`",


### PR DESCRIPTION
## Summary

First **recall-raising** change after a run of precision fixes (recall had been flat at 532). Uses the structural-assignability machinery from T33 to soundly *detect* incompatible interface-extends, rather than suppress FPs.

| step | recall | precision | FP |
|---|---|---|---|
| main (T36) | 532/815 | 394/414 | 20 |
| **T37** | **533/815** | 394/414 | 20 |

Net-positive on recall, no new FPs, all 2248 tests pass.

## Change

`check_interface_extends_compat` previously only flagged scalar-vs-object and optionality-weakening mismatches. It now decides a redeclared member **structurally** via `struct_assignable_named_rec` when both the derived and base member types are plain (non-generic) class / interface references:

```ts
interface A { foo: Base; bar: Derived; }
interface B extends A { foo: Derived; /* ok */ bar: Base; /* TS2430: Base not assignable to Derived */ }
```

The recursive structural relation has the full field sets, so a `false` result is a reliable "not assignable" (not a "couldn't determine"). Generic `Applied` shapes are excluded (no type-arg substitution) to stay false-positive-free.

This is a **detection** (the file was a detection gap — strict emitted nothing), so it raises recall directly. Clears `subtypingWithObjectMembers3` (and the same machinery covers sibling `subtypingWithObjectMembers`/2/Optionality cases).

## Testing
- `moon check --deny-warn`, `moon fmt --check`, `moon test --target native` (2248 tests) all green.
- Recall log updated in `TODO.md` (T37).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6VaaouEL5wQAR71SLieRV)_