### PR TITLE
checker: detect incompatible index signatures in interface-extends (+recall)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1298,6 +1298,16 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-05 (T35)   532/815 (65 %)        393/414 (21 FP)
 2026-06-05 (T36)   532/815 (65 %)        394/414 (20 FP)
 2026-06-05 (T37)   533/815 (65 %)        394/414 (20 FP)
+2026-06-05 (T38)   535/815 (66 %)        394/414 (20 FP)
+
+  T38 -- incompatible index signatures in interface-extends (TS2430).
+
+    A derived index signature's value must be assignable to the base's
+    same-keyed index value: `interface B extends A { [x: string]: Base }`
+    over `interface A { [x: string]: Derived }` is incompatible (Base lacks
+    Derived's members). Decided structurally, gated to plain named-decl
+    values (generic `A<T>` index cases stay unflagged). recall 533 -> 535,
+    FP steady 20 (clears subtypingWith{String,Numeric}Indexer2).
 
   T37 -- structural detection of incompatible interface-extends (TS2430).
 

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -11331,6 +11331,34 @@ fn check_interface_extends_compat(
           None => ()
         }
       }
+      // Index-signature compatibility: a derived index signature's value
+      // type must be assignable to the base's same-keyed index signature
+      // value. `interface B extends A { [x: string]: Base }` over
+      // `interface A { [x: string]: Derived }` is incompatible because
+      // `Base` lacks `Derived`'s members. Decide structurally and only when
+      // both values are plain (non-generic) named decls, so it's a reliable
+      // "not assignable" with no FP from unresolved generics.
+      for d_sig in iface.index_signatures {
+        for b_sig in base.index_signatures {
+          if d_sig.0 == b_sig.0 {
+            let dv = strip_optional(d_sig.1)
+            let bv = strip_optional(b_sig.1)
+            let both_plain_named = match
+              (resolver.unwrap(dv), resolver.unwrap(bv)) {
+              (Named(_), Named(_)) =>
+                is_named_decl(dv, resolver) && is_named_decl(bv, resolver)
+              _ => false
+            }
+            if both_plain_named &&
+              !struct_assignable_named_rec(dv, bv, resolver, []) {
+              issues.push({
+                path: "interface \{iface.name}",
+                message: "interface incorrectly extends `\{base_name}`: index signatures are incompatible",
+              })
+            }
+          }
+        }
+      }
     }
   }
   // TS2411 ("Property 'X' of type 'T' is not assignable to '<key>' index


### PR DESCRIPTION
## Summary

Second recall-raising detection using the structural machinery — incompatible **index signatures** in interface-extends.

| step | recall | precision | FP |
|---|---|---|---|
| main (T37) | 533/815 | 394/414 | 20 |
| **T38** | **535/815** | 394/414 | 20 |

Net-positive on recall, no new FPs, all 2248 tests pass.

## Change

A derived index signature's value type must be assignable to the base's same-keyed index value:

```ts
interface A { [x: string]: Derived; }
interface B extends A { [x: string]: Base; }  // TS2430: Base not assignable to Derived
```

Decided structurally via `struct_assignable_named_rec`, gated to plain (non-generic) named-decl values — so a `false` is a reliable "not assignable" with no FP from unresolved generics (the generic `A<T>` index cases stay unflagged). Both files were detection gaps (strict emitted nothing), so this raises recall. Clears `subtypingWithStringIndexer2` and `subtypingWithNumericIndexer2`.

## Testing
- `moon check --deny-warn`, `moon fmt --check`, `moon test --target native` (2248 tests) all green.
- Recall log updated in `TODO.md` (T38).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6VaaouEL5wQAR71SLieRV)_