### PR TITLE
checker/parser: close TS2728/TS2564/mapped-type/enum issues (#60, #43, #49, #64)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -12005,16 +12005,325 @@ fn is_in_scope_type_param(ctx : CheckCtx, ty : @ast.TsType) -> Bool {
 }
 
 ///|
+/// True when `expr` refers to the constructor receiver, looking through
+/// casts / assertions that don't change the value (`this as T`, `this!`,
+/// `this satisfies T`, an optional-chain wrapper, a `@__PURE__` marker).
+/// Used so `(this as Foo).x = …` / `this!.x = …` are recognised as
+/// assigning `this.x` and don't trigger a false TS2564.
+fn expr_is_this(expr : @ast.TsExpr) -> Bool {
+  match expr {
+    Var("this") => true
+    As(inner, _)
+    | Satisfies(inner, _)
+    | NonNull(inner)
+    | OptionalChain(inner)
+    | PureCall(inner) => expr_is_this(inner)
+    _ => false
+  }
+}
+
+///|
+/// Collect, into `members`, every field name referenced as `this.<name>`
+/// (property access or string-literal index) anywhere in a constructor
+/// body — reads included. This over-approximates "assigned in the
+/// constructor" by mere presence: a field that never appears cannot have
+/// been assigned, so it is a sound TS2564 candidate; a field that appears
+/// (even only read) is left alone to stay false-positive-free without
+/// modelling control flow.
+///
+/// `opaque[0]` is set when the body uses a form we don't model precisely
+/// enough to be sure which member it touches — a dynamic `this[expr]`, a
+/// destructuring assignment, or a nested class. The caller then skips the
+/// whole class rather than risk a false positive. Every `TsExpr` / `TsStmt`
+/// variant is matched explicitly so a future AST addition fails to compile
+/// here instead of silently going untraversed (which could cause an FP).
+fn collect_ctor_this_members_block(
+  block : @ast.TsBlock,
+  members : Map[String, Unit],
+  opaque : Array[Bool],
+) -> Unit {
+  for stmt in block.stmts {
+    collect_ctor_this_members_stmt(stmt, members, opaque)
+  }
+}
+
+///|
+fn collect_ctor_this_members_stmt(
+  stmt : @ast.TsStmt,
+  members : Map[String, Unit],
+  opaque : Array[Bool],
+) -> Unit {
+  match stmt {
+    Var(_, _, e) | Let(_, _, e) | Const(_, _, e) | Assign(_, e) =>
+      collect_ctor_this_members_expr(e, members, opaque)
+    CompoundAssign(_, _, e) =>
+      collect_ctor_this_members_expr(e, members, opaque)
+    IndexAssign(recv, idx, val) => {
+      if expr_is_this(recv) {
+        match idx {
+          StringLit(name) => members[name] = ()
+          _ => {
+            opaque[0] = true
+            collect_ctor_this_members_expr(idx, members, opaque)
+          }
+        }
+      } else {
+        collect_ctor_this_members_expr(recv, members, opaque)
+        collect_ctor_this_members_expr(idx, members, opaque)
+      }
+      collect_ctor_this_members_expr(val, members, opaque)
+    }
+    PropAssign(recv, name, val) => {
+      if expr_is_this(recv) {
+        members[name] = ()
+      } else {
+        collect_ctor_this_members_expr(recv, members, opaque)
+      }
+      collect_ctor_this_members_expr(val, members, opaque)
+    }
+    Expr(e) | Throw(e) => collect_ctor_this_members_expr(e, members, opaque)
+    Return(opt) =>
+      match opt {
+        Some(e) => collect_ctor_this_members_expr(e, members, opaque)
+        None => ()
+      }
+    Try(b, _, c, f) => {
+      collect_ctor_this_members_block(b, members, opaque)
+      match c {
+        Some(cb) => collect_ctor_this_members_block(cb, members, opaque)
+        None => ()
+      }
+      match f {
+        Some(fb) => collect_ctor_this_members_block(fb, members, opaque)
+        None => ()
+      }
+    }
+    If(c, t, e) => {
+      collect_ctor_this_members_expr(c, members, opaque)
+      collect_ctor_this_members_block(t, members, opaque)
+      match e {
+        Some(eb) => collect_ctor_this_members_block(eb, members, opaque)
+        None => ()
+      }
+    }
+    While(c, b) | DoWhile(c, b) => {
+      collect_ctor_this_members_expr(c, members, opaque)
+      collect_ctor_this_members_block(b, members, opaque)
+    }
+    For(init, cond, update, body) => {
+      match init {
+        Some(s) => collect_ctor_this_members_stmt(s, members, opaque)
+        None => ()
+      }
+      match cond {
+        Some(e) => collect_ctor_this_members_expr(e, members, opaque)
+        None => ()
+      }
+      match update {
+        Some(s) => collect_ctor_this_members_stmt(s, members, opaque)
+        None => ()
+      }
+      collect_ctor_this_members_block(body, members, opaque)
+    }
+    ForOf(_, _, _, it, body)
+    | ForAwaitOf(_, _, _, it, body)
+    | ForIn(_, _, _, it, body) => {
+      collect_ctor_this_members_expr(it, members, opaque)
+      collect_ctor_this_members_block(body, members, opaque)
+    }
+    Switch(e, cases) => {
+      collect_ctor_this_members_expr(e, members, opaque)
+      for cse in cases {
+        match cse.test_expr {
+          Some(te) => collect_ctor_this_members_expr(te, members, opaque)
+          None => ()
+        }
+        collect_ctor_this_members_block(cse.body, members, opaque)
+      }
+    }
+    With(e, b) => {
+      collect_ctor_this_members_expr(e, members, opaque)
+      collect_ctor_this_members_block(b, members, opaque)
+    }
+    Label(_, s) => collect_ctor_this_members_stmt(s, members, opaque)
+    Block(b) => collect_ctor_this_members_block(b, members, opaque)
+    NativeClassStmt(_, _) => opaque[0] = true
+    Debugger | Break(_) | Continue(_) | Empty => ()
+  }
+}
+
+///|
+fn collect_ctor_this_members_expr(
+  expr : @ast.TsExpr,
+  members : Map[String, Unit],
+  opaque : Array[Bool],
+) -> Unit {
+  match expr {
+    NumberLit(_)
+    | IntLit(_)
+    | BigIntLit(_)
+    | BoolLit(_)
+    | StringLit(_)
+    | NullLit
+    | ArrayHole
+    | Var(_)
+    | ImportMeta => ()
+    PropAccess(recv, name) =>
+      if expr_is_this(recv) {
+        members[name] = ()
+      } else {
+        collect_ctor_this_members_expr(recv, members, opaque)
+      }
+    IndexAccess(recv, idx) =>
+      if expr_is_this(recv) {
+        match idx {
+          StringLit(name) => members[name] = ()
+          _ => {
+            opaque[0] = true
+            collect_ctor_this_members_expr(idx, members, opaque)
+          }
+        }
+      } else {
+        collect_ctor_this_members_expr(recv, members, opaque)
+        collect_ctor_this_members_expr(idx, members, opaque)
+      }
+    BinOp(_, a, b) | Seq(a, b) => {
+      collect_ctor_this_members_expr(a, members, opaque)
+      collect_ctor_this_members_expr(b, members, opaque)
+    }
+    UnaryOp(_, a)
+    | Spread(a)
+    | PureCall(a)
+    | Await(a)
+    | NonNull(a)
+    | OptionalChain(a)
+    | YieldStar(a)
+    | As(a, _)
+    | Satisfies(a, _) => collect_ctor_this_members_expr(a, members, opaque)
+    Call(_, args) | New(_, args) =>
+      for a in args {
+        collect_ctor_this_members_expr(a, members, opaque)
+      }
+    CallExpr(callee, args) | NewExpr(callee, args) => {
+      collect_ctor_this_members_expr(callee, members, opaque)
+      for a in args {
+        collect_ctor_this_members_expr(a, members, opaque)
+      }
+    }
+    MethodCall(recv, _, args) => {
+      collect_ctor_this_members_expr(recv, members, opaque)
+      for a in args {
+        collect_ctor_this_members_expr(a, members, opaque)
+      }
+    }
+    Cond(a, b, c) => {
+      collect_ctor_this_members_expr(a, members, opaque)
+      collect_ctor_this_members_expr(b, members, opaque)
+      collect_ctor_this_members_expr(c, members, opaque)
+    }
+    ArrayLit(items) =>
+      for it in items {
+        collect_ctor_this_members_expr(it, members, opaque)
+      }
+    ObjectLit(entries) =>
+      for e in entries {
+        collect_ctor_this_members_expr(e.1, members, opaque)
+      }
+    ComputedProp(k, v) => {
+      collect_ctor_this_members_expr(k, members, opaque)
+      collect_ctor_this_members_expr(v, members, opaque)
+    }
+    AssignExpr(_, val) => collect_ctor_this_members_expr(val, members, opaque)
+    PropAssignExpr(recv, name, val) => {
+      if expr_is_this(recv) {
+        members[name] = ()
+      } else {
+        collect_ctor_this_members_expr(recv, members, opaque)
+      }
+      collect_ctor_this_members_expr(val, members, opaque)
+    }
+    CompoundAssignExpr(target, _, val) => {
+      collect_ctor_this_members_expr(target, members, opaque)
+      collect_ctor_this_members_expr(val, members, opaque)
+    }
+    IndexAssignExpr(recv, idx, val) => {
+      if expr_is_this(recv) {
+        match idx {
+          StringLit(name) => members[name] = ()
+          _ => {
+            opaque[0] = true
+            collect_ctor_this_members_expr(idx, members, opaque)
+          }
+        }
+      } else {
+        collect_ctor_this_members_expr(recv, members, opaque)
+        collect_ctor_this_members_expr(idx, members, opaque)
+      }
+      collect_ctor_this_members_expr(val, members, opaque)
+    }
+    ArrowFunc(_, _, body, _) =>
+      match body {
+        ArrowExpr(e) => collect_ctor_this_members_expr(e, members, opaque)
+        ArrowBlock(b) => collect_ctor_this_members_block(b, members, opaque)
+      }
+    FuncExpr(f) => collect_ctor_this_members_block(f.body, members, opaque)
+    TemplateLiteral(_, exprs) =>
+      for e in exprs {
+        collect_ctor_this_members_expr(e, members, opaque)
+      }
+    TaggedTemplate(tag, _, _, exprs) => {
+      collect_ctor_this_members_expr(tag, members, opaque)
+      for e in exprs {
+        collect_ctor_this_members_expr(e, members, opaque)
+      }
+    }
+    Yield(opt) =>
+      match opt {
+        Some(e) => collect_ctor_this_members_expr(e, members, opaque)
+        None => ()
+      }
+    DynamicImport(a, b) => {
+      collect_ctor_this_members_expr(a, members, opaque)
+      match b {
+        Some(e) => collect_ctor_this_members_expr(e, members, opaque)
+        None => ()
+      }
+    }
+    JsxElement(_, attrs, children) => {
+      for at in attrs {
+        match at.1 {
+          Some(e) => collect_ctor_this_members_expr(e, members, opaque)
+          None => ()
+        }
+      }
+      for ch in children {
+        collect_ctor_this_members_expr(ch, members, opaque)
+      }
+    }
+    // Forms that may bind a `this`-member in a way we don't model, or a
+    // nested class shape — be conservative so the caller skips the class.
+    AssignPattern(_, val) => {
+      opaque[0] = true
+      collect_ctor_this_members_expr(val, members, opaque)
+    }
+    NativeClassExpr(_, _) => opaque[0] = true
+  }
+}
+
+///|
 /// TS2564 ("Property 'X' has no initializer and is not definitely
 /// assigned in the constructor") for native (runtime) class
-/// declarations. We catch the common shape where the class has no
-/// constructor at all and the field has neither an `=` initializer
-/// nor a `!` definite-assignment assertion, and the declared type
-/// doesn't already accept `undefined`. The constructor-body-walk
-/// variant (which would also catch `class C { x: T; constructor() {
-/// this.x = ...; } }`) requires CFA over constructor bodies and is
-/// deferred -- 91 of 93 TS2564 cases in the conformance corpus have
-/// no constructor at all.
+/// declarations. Catches both the no-constructor shape and the
+/// constructor-bearing shape: when a constructor is present we walk its
+/// body (via `collect_ctor_this_members_block`) and skip any field whose
+/// name it touches through `this.<name>`. A field that the constructor
+/// never references — and that has neither an `=` initializer nor a `!`
+/// definite-assignment assertion, with a declared type that doesn't
+/// already accept `undefined` — is reported. The constructor walk
+/// over-approximates assignment by presence, so it never produces a
+/// false positive; classes using forms we can't model precisely
+/// (dynamic `this[expr]`, destructuring assignment, nested classes) are
+/// skipped entirely.
 fn check_native_class_property_initializers(
   module_ : @ast.TsModule,
   resolver : Resolver,
@@ -12051,14 +12360,40 @@ fn check_native_class_property_initializers(
     if decl.index_signatures.length() > 0 {
       continue
     }
-    // Skip when the class declares a constructor: its body might
-    // assign `this.x` and we don't model the constructor body in the
-    // TsClassDecl form (only the parameter list survives). A false
-    // negative here is much better than the false positive of
-    // claiming an initialised field is uninitialised.
+    // Collect the field names the constructor touches via `this.<name>`
+    // (reads included — `collect_ctor_this_members_block` over-approximates
+    // assignment by presence to stay false-positive-free). Parameter
+    // properties (`constructor(public x: T)`) auto-assign, so their names
+    // are seeded in too. A field that never appears is a sound TS2564
+    // candidate even when a constructor is present.
+    let ctor_members : Map[String, Unit] = {}
+    let ctor_opaque : Array[Bool] = [false]
     match decl.constructor_params {
-      Some(_) => continue
-      None => ()
+      Some(params) => {
+        for entry in params {
+          ctor_members[entry.0] = ()
+        }
+        // A constructor with parameters but no retained body is one we
+        // can't inspect (overload signature / parser gap) — skip the
+        // class to avoid a false positive.
+        match decl.constructor_body {
+          Some(body) =>
+            collect_ctor_this_members_block(body, ctor_members, ctor_opaque)
+          None => ctor_opaque[0] = true
+        }
+      }
+      None =>
+        // No declared constructor: nothing assigns `this.x`, so every
+        // uninitialized field is reported below (unchanged behaviour).
+        // A body may still be present via a desugared path; walk it when so.
+        match decl.constructor_body {
+          Some(body) =>
+            collect_ctor_this_members_block(body, ctor_members, ctor_opaque)
+          None => ()
+        }
+    }
+    if ctor_opaque[0] {
+      continue
     }
     // Build a set of names backed by a getter/setter method so we can
     // skip them below. `class C { get x() {…} }` upserts `x` into
@@ -12083,6 +12418,11 @@ fn check_native_class_property_initializers(
         continue
       }
       if prop.has_initializer || prop.has_definite_assertion {
+        continue
+      }
+      // The constructor references `this.<name>` (assignment, or a read we
+      // treat as a possible assignment) — assume definitely assigned.
+      if ctor_members.contains(prop.name) {
         continue
       }
       // Skip when the declared type already accepts `undefined`

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -7472,3 +7472,59 @@ test "expr_check: TS2728 silent for method references from a field init" {
   let issues = check_class_property_init_order(module_)
   @test.assert_eq(issues.length(), 0)
 }
+
+///|
+// Issue #64: TS2564 now walks the constructor body. A field the constructor
+// never assigns via `this.<name>` is reported even when a constructor is
+// present; fields the constructor touches (directly, conditionally, through
+// an arrow, a parameter property, or behind a cast / `!`) stay silent. The
+// constructor body walk over-approximates assignment by presence, so it
+// never produces a false positive.
+fn ts2564_flagged(src : String) -> Array[String] {
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let names : Array[String] = []
+  for i in issues {
+    if i.message.contains("no initializer and is not definitely assigned") {
+      names.push(i.message)
+    }
+  }
+  names
+}
+
+///|
+test "expr_check: TS2564 flags fields not assigned in the constructor body" {
+  // Empty constructor leaves `x` uninitialized.
+  @test.assert_eq(
+    ts2564_flagged("class C { x: number; constructor() {} }").length(),
+    1,
+  )
+  // Only the field the constructor never touches (`y`) is flagged.
+  @test.assert_eq(
+    ts2564_flagged(
+      "class C { x: number; y: number; constructor() { this.x = 1; } }",
+    ).length(),
+    1,
+  )
+}
+
+///|
+test "expr_check: TS2564 silent when the constructor assigns the field" {
+  let srcs = [
+    // Direct assignment.
+    "class C { x: number; constructor() { this.x = 5; } }",
+    // Conditional assignment (presence is enough — false-positive-free).
+     "class C { x: number; constructor(b: boolean) { if (b) { this.x = 1; } } }",
+    // Parameter property auto-assigns.
+     "class C { constructor(public y: number) {} }",
+    // Assignment inside an arrow callback (lexical `this`).
+     "class C { x: number; constructor() { [1].forEach(() => { this.x = 1; }); } }",
+    // Assignment through a cast / non-null receiver.
+     "class C { x: number; constructor() { (this as C).x = 1; } }", "class C { x: number; constructor() { this!.x = 1; } }",
+    // Field already has an initializer / definite-assignment assertion.
+     "class C { x: number = 0; constructor() {} }", "class C { x!: number; constructor() {} }",
+  ]
+  for src in srcs {
+    @test.assert_eq(ts2564_flagged(src).length(), 0)
+  }
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -7427,3 +7427,48 @@ test "expr_check: this-type-guard narrows the receiver (method and arrow field)"
   let missing = issues.filter(fn(i) { i.message.contains("does not exist") })
   @test.assert_eq(missing.length(), 0)
 }
+
+///|
+// TS2728 ("Property 'X' is used before its initialization"): an instance
+// field initializer that reads `this.Y` before `Y` has its own initializer
+// is flagged, while references to already-initialized fields, methods, and
+// later-declared methods stay silent. Regression cover for Issue #60; the
+// behaviour is otherwise only exercised through the conformance corpus,
+// which is an optional git submodule.
+test "expr_check: TS2728 flags field init reading a not-yet-initialized field" {
+  let src =
+    #|class C {
+    #|  x = this.y;
+    #|  y = 5;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_class_property_init_order(module_)
+  let hits = issues.filter(fn(i) {
+    i.message.contains("`y` is used before its initialization")
+  })
+  @test.assert_eq(hits.length(), 1)
+}
+
+///|
+test "expr_check: TS2728 silent when referenced field is already initialized" {
+  let src =
+    #|class C {
+    #|  x = 5;
+    #|  y = this.x;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_class_property_init_order(module_)
+  @test.assert_eq(issues.length(), 0)
+}
+
+///|
+test "expr_check: TS2728 silent for method references from a field init" {
+  let src =
+    #|class C {
+    #|  x = this.m();
+    #|  m(): number { return 5; }
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_class_property_init_order(module_)
+  @test.assert_eq(issues.length(), 0)
+}

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -504,6 +504,25 @@ fn append_module_decls(
 }
 
 ///|
+/// Recursively collect every `enum` / `const enum` declaration reachable
+/// through a module's nested namespaces into `out`. Used by the module-block
+/// parser, which can only retain a flat `enums` list (`TsModuleBlock` has no
+/// `namespaces` field) but must not silently drop enums declared inside a
+/// `namespace N { ... }` / `declare namespace N { ... }` body — the bridge
+/// const-table pass and downstream type resolution read `block.enums`.
+fn collect_enums_recursive(
+  module_ : @ast.TsModule,
+  out : Array[@ast.TsEnumDecl],
+) -> Unit {
+  for enum_ in module_.enums {
+    out.push(enum_)
+  }
+  for ns in module_.namespaces {
+    collect_enums_recursive(ns.module_, out)
+  }
+}
+
+///|
 fn append_ambient_external_module_exports(
   module_ : @ast.TsModule,
   exports : Array[@ast.TsExportSpec],
@@ -3506,11 +3525,14 @@ fn Parser::parse_module_block_with_const_values(
                 append_ambient_external_module_exports(module_, exports)
               None => ()
             }
-          } else if name == "namespace" ||
-            name == "module" ||
-            name == "global" ||
-            name == "enum" ||
-            name == "class" {
+          } else if name == "namespace" || name == "module" || name == "global" {
+            // `declare namespace N { ... }` — not retained on the block, but
+            // hoist any nested enums so they aren't silently dropped.
+            match self.parse_namespace_decl() {
+              Some((_, Some(ns))) => collect_enums_recursive(ns.module_, enums)
+              _ => ()
+            }
+          } else if name == "enum" || name == "class" {
             self.skip_declaration_block()
           } else {
             raise ParseError("Unexpected identifier after declare: \{name}")
@@ -3538,7 +3560,13 @@ fn Parser::parse_module_block_with_const_values(
       continue
     }
     if self.is_namespace_decl_start() {
-      self.skip_declaration_block()
+      // Namespaces aren't retained on `TsModuleBlock`, but enums declared
+      // inside them must still be registered. Parse the body and hoist any
+      // nested enums rather than dropping the whole block.
+      match self.parse_namespace_decl_runtime() {
+        Some((_, Some(ns))) => collect_enums_recursive(ns.module_, enums)
+        _ => ()
+      }
       continue
     }
     if self.is_const_enum_decl_start() {

--- a/src/parser/parser_wbtest.mbt
+++ b/src/parser/parser_wbtest.mbt
@@ -2648,6 +2648,33 @@ test "parser: parse export const numeric enum in ts module" {
 }
 
 ///|
+// Issue #43: the module-block parser used to `skip_declaration_block()` on
+// namespaces, dropping any enum declared inside. They are now hoisted into
+// `block.enums` (the flat list the bridge const-table pass reads), covering
+// `namespace`, `declare namespace`, nested namespaces, and `const enum`.
+test "parser: hoists enums declared inside namespaces in a module block" {
+  let cases : Array[(String, String, Bool)] = [
+    ("namespace N { export enum E { A, B } }", "E", false),
+    ("namespace N { enum E { A } }", "E", false),
+    ("declare namespace N { enum E { A } }", "E", false),
+    ("namespace N { namespace M { enum E { A } } }", "E", false),
+    ("namespace N { const enum E { A } }", "E", true),
+  ]
+  for c in cases {
+    let (src, expected_name, expected_const) = c
+    let block = parse_module_block_from_source(src) catch {
+      e => {
+        fail("Parse error for `\{src}`: \{e}")
+        return
+      }
+    }
+    assert_eq(block.enums.length(), 1)
+    assert_eq(block.enums[0].name, expected_name)
+    assert_eq(block.enums[0].is_const, expected_const)
+  }
+}
+
+///|
 test "parser: marks non-literal enum initializers as computed" {
   let src =
     #|export declare enum ComputedKind {


### PR DESCRIPTION
## Summary

Works through four open issues. Two were already implemented and only needed regression coverage; two needed real fixes.

| Issue | Title | Action |
|---|---|---|
| #60 | TS2728 — property used before its initialization | already implemented (T17); added white-box regression tests |
| #49 | mapped types `{ [K in keyof T]: U }` | already implemented; verified end-to-end, closed (no code change) |
| #43 | enum / const enum skipped in module-block parser | **fixed**: hoist namespace-nested enums |
| #64 | TS2564 — track `this.x =` in constructor body | **fixed**: walk the constructor body |

## Changes

### #60 — TS2728 regression tests
`check_class_property_init_order` was already wired in and gated on `useDefineForClassFields`, but only exercised through the conformance corpus (an optional submodule). Added three white-box tests so the behaviour is locked in without the submodule.

### #43 — namespace-nested enums in the module-block parser
`parse_module_block_with_const_values` skipped namespaces wholesale via `skip_declaration_block()`, dropping any `enum` / `const enum` declared inside a `namespace N { … }` / `declare namespace N { … }` body. `TsModuleBlock` keeps only a flat `enums` list (no `namespaces` field), and the bridge const-table pass, transform/bundle, and `mtsc` all read it — so those enums were lost. Now the namespace body is parsed and its nested enums are hoisted into `block.enums` (recursively, via the new `collect_enums_recursive`). The runtime statement stream is unchanged — strictly additive. The two originally-cited *direct* enum-skip paths were already fixed in a prior refactor.

### #64 — TS2564 constructor-body walk
`check_native_class_property_initializers` skipped any class declaring a constructor, so `class D { x: number; constructor() {} }` (a genuine uninitialized field) was a false negative. Using the `constructor_body` retained by #99, the body is now walked to collect every field referenced as `this.<name>`; a field the constructor never mentions is reported.

False-positive-free design: assignment is over-approximated by presence (a read-only mention also suppresses), receivers are unwrapped through `as` / `!` / `satisfies` / optional-chain, parameter properties are seeded, and forms that can't be modelled precisely (dynamic `this[expr]`, destructuring assignment, nested classes, or a constructor with params but no retained body) mark the class opaque and skip it. Every `TsExpr` / `TsStmt` variant is matched explicitly so a future AST addition fails to compile rather than going silently untraversed.

## Testing
- `moon check` — 0 errors
- `moon test --target native` — **2279 tests pass**
- `moon fmt` applied

Closes #60, #49, #43, #64.

https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco

---
_Generated by [Claude Code](https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco)_