### PR TITLE
checker: bind object-destructuring rest pattern (#47)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -8185,6 +8185,33 @@ fn bind_object_pattern(
     let field_ty = apply_binding_default(env, ctx, field_ty, prop.default)
     bind_pattern(env, ctx, prop.binding, field_ty)
   }
+  // Rest pattern `{ a, b, ...rest }`: `rest` takes an object type with the
+  // source's remaining (non-destructured) fields. Mirror the object-spread
+  // path — build from `collect_declared_fields`. When the source shape is
+  // unknown (no declared fields, e.g. `any` / an opaque generic) keep `rest`
+  // permissive as `Any` rather than synthesising an empty object that would
+  // make every `rest.x` access a false "property does not exist".
+  match ob.rest {
+    Some(rest_name) => {
+      let declared = collect_declared_fields(source, ctx.resolver)
+      if declared.length() == 0 {
+        env.bind(rest_name, @ast.TsType::Any)
+      } else {
+        let taken : Map[String, Unit] = {}
+        for prop in ob.props {
+          taken[prop.key] = ()
+        }
+        let rest_fields : Array[(@ast.TsType, @ast.TsType)] = []
+        for f in declared {
+          if !taken.contains(f.0) {
+            rest_fields.push((@ast.TsType::Literal(f.0), f.1))
+          }
+        }
+        env.bind(rest_name, @ast.TsType::Object(rest_fields))
+      }
+    }
+    None => ()
+  }
 }
 
 ///|

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -7528,3 +7528,30 @@ test "expr_check: TS2564 silent when the constructor assigns the field" {
     @test.assert_eq(ts2564_flagged(src).length(), 0)
   }
 }
+
+///|
+// Issue #47: object-destructuring rest pattern `{ a, ...rest }` binds `rest`
+// to an object type carrying the source's remaining fields. A read of a
+// retained field resolves; a read of a destructured-out field is a real
+// "property does not exist" (matching TS), and an unknown source keeps
+// `rest` permissive.
+test "expr_check: destructuring rest pattern carries the remaining fields" {
+  let src =
+    #|interface P { a: number; b: string; c: boolean }
+    #|function f(p: P): void {
+    #|  const { a, ...rest } = p;
+    #|  const x: string = rest.b;
+    #|  const y: boolean = rest.c;
+    #|  const bad: number = rest.a;
+    #|}
+  let module_ = parse_module_or_empty(src)
+  let issues = check_module_function_bodies(module_)
+  let missing = issues.filter(fn(i) { i.message.contains("`a` does not exist") })
+  // Only `rest.a` is rejected — `a` was destructured out of `rest`.
+  @test.assert_eq(missing.length(), 1)
+  // `rest.b` / `rest.c` must not produce any "does not exist" diagnostic.
+  let other_missing = issues.filter(fn(i) {
+    i.message.contains("does not exist") && not(i.message.contains("`a`"))
+  })
+  @test.assert_eq(other_missing.length(), 0)
+}


### PR DESCRIPTION
## Summary

Implements the remaining gap in issue #47: object-destructuring **rest patterns** (`const { a, ...rest } = obj`).

`bind_object_pattern` walked `ob.props` but never bound `ob.rest`, so `rest` was left unbound (effectively `any`) and member accesses on it went unchecked. It now binds `rest` to an object type built from the source's remaining (non-destructured) fields, mirroring the object-spread path via `collect_declared_fields`. When the source shape is unknown (no declared fields — `any` / an opaque generic), `rest` stays permissive as `Any` to avoid synthesising an empty object that would make every `rest.x` a false "property does not exist".

The union-receiver field distribution the issue also describes was already implemented.

```ts
interface P { a: number; b: string; c: boolean }
function f(p: P): void {
  const { a, ...rest } = p;
  const x: string = rest.b;   // OK
  const y: boolean = rest.c;  // OK
  const bad: number = rest.a; // error — `a` was destructured out (matches tsc)
}
```

## Testing
- `moon check` — 0 errors
- `moon test --target native` — **2281 tests pass**
- Added a white-box regression test.

Closes #47.

While verifying the surrounding issues I also confirmed #44 (NewExpr nested `PropAccess` chains), #46 (object spread field merge) and #65 (compound-shape TS2322 via the relaxed `is_reliable_mismatch_pair`) are already implemented; those issues are closed separately with explanations.

https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco

---
_Generated by [Claude Code](https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco)_