### PR TITLE
parser: JSDoc type-overlay cleanup + coverage (#26)

### DIFF
--- a/src/parser/jsdoc_wbtest.mbt
+++ b/src/parser/jsdoc_wbtest.mbt
@@ -287,3 +287,43 @@ test "jsdoc: ?{x:number} translates to ({x:number} | null)" {
     _ => fail("expected Let / FuncExpr")
   }
 }
+
+///|
+// Issue #26: remaining JSDoc-specific scalar translations and the
+// inline-TS-wins rule, complementing the `?T` / function-type cases above.
+test "jsdoc: !T strips non-null, Object<K,V> becomes Record, inline TS wins" {
+  let src =
+    #|/**
+    #| * @param {!number} a
+    #| * @param {Object<string, number>} b
+    #| * @param {string} c
+    #| * @returns {!boolean}
+    #| */
+    #|function f(a, b, c: boolean) { return true; }
+  let block = parse_block_from_source(src)
+  match block.stmts[0] {
+    Let(_, _, @ast.TsExpr::FuncExpr(f)) => {
+      // `!number` → number (non-null marker stripped).
+      match f.params[0].type_ {
+        @ast.TsType::Number => ()
+        other => fail("expected Number for a, got \{other}")
+      }
+      // `Object<string, number>` → Record<string, number>.
+      match f.params[1].type_ {
+        @ast.TsType::Applied("Record", _) => ()
+        other => fail("expected Record for b, got \{other}")
+      }
+      // Inline `: boolean` annotation wins over the `@param {string} c`.
+      match f.params[2].type_ {
+        @ast.TsType::Boolean => ()
+        other => fail("expected Boolean (inline wins) for c, got \{other}")
+      }
+      // `!boolean` return → boolean.
+      match f.return_type {
+        @ast.TsType::Boolean => ()
+        other => fail("expected Boolean return, got \{other}")
+      }
+    }
+    _ => fail("expected Let / FuncExpr")
+  }
+}

--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -456,14 +456,6 @@ fn translate_jsdoc_type(raw : String) -> String {
       None => ()
     }
   }
-  // `function(T1, T2): R` → `(_0: T1, _1: T2) => R`
-  // `function(): R` → `() => R`
-  if s.has_prefix("function(") {
-    match translate_jsdoc_function_type(s) {
-      Some(ts) => return ts
-      None => ()
-    }
-  }
   s
 }
 


### PR DESCRIPTION
## Summary

Issue #26 (consume JSDoc `@param`/`@returns` types for untyped JS) is already implemented end-to-end:

- `@param {T} name` / `@returns {T}` brace contents are parsed and spliced into JS function declarations whose parameters/return are untyped (`Any`), via `apply_jsdoc_param_overlay` / `apply_jsdoc_return_overlay`.
- `translate_jsdoc_type` maps the JSDoc-specific forms the issue lists: `*` → `any`, `?T` → `T | null`, `!T` → `T`, `Object<K,V>` → `Record<K,V>`, `function(P…): R` → `(_0: P…) => R`.
- The overlay only fills `Any` slots, so inline TS annotations win.

Verified end-to-end:
```ts
/** @param {string} name @param {number} count @returns {boolean} */
function isValid(name, count) { … }   // name:string, count:number, ret:boolean
```

## Change

This PR is a small quality pass on the existing implementation:
- **Removed a dead duplicate** `function(` branch in `translate_jsdoc_type` (the second copy was unreachable).
- **Added a regression test** for the `!T`, `Object<K,V>`, and inline-TS-precedence translations, which lacked direct coverage (the basic overlay, `?T`, and function-type cases were already tested).

`@typedef` / `@template` import resolution remains out of scope per the issue (follow-up).

## Testing
- `moon check` — 0 errors
- `moon test --target native` — **2283 tests pass**

Closes #26.

https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco

---
_Generated by [Claude Code](https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco)_