### PR TITLE
checker: union bare type params across argument positions (#62, partial)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -4903,6 +4903,68 @@ fn infer_param_bindings(
 }
 
 ///|
+/// Whether the type parameter `tp` appears anywhere inside `t`. Exhaustive
+/// over every `TsType` variant so a future addition fails to compile rather
+/// than silently under-reporting (which would let `solve_generic_bindings`
+/// widen a parameter it shouldn't).
+fn type_param_occurs(tp : String, t : @ast.TsType) -> Bool {
+  match t {
+    Number
+    | Int
+    | Boolean
+    | String_
+    | Void
+    | BigInt
+    | Symbol
+    | UniqueSymbol(_)
+    | Any
+    | Unknown
+    | Never
+    | Null
+    | Undefined
+    | Literal(_)
+    | NumberLiteral(_)
+    | BigIntLiteral(_)
+    | BooleanLiteral(_)
+    | TypeOf(_) => false
+    Named(n) => n == tp
+    Array(e) | Rest(e) | Keyof(e) => type_param_occurs(tp, e)
+    Tuple(items) | Union(items) | Intersection(items) =>
+      items.iter().any(fn(it) { type_param_occurs(tp, it) })
+    Object(pairs) =>
+      pairs
+      .iter()
+      .any(fn(p) { type_param_occurs(tp, p.0) || type_param_occurs(tp, p.1) })
+    Struct(_, fields) => fields.iter().any(fn(f) { type_param_occurs(tp, f.1) })
+    Func(ps, r) | Constructor(ps, r, _) =>
+      ps.iter().any(fn(p) { type_param_occurs(tp, p) }) ||
+      type_param_occurs(tp, r)
+    Conditional(a, b, c, d) =>
+      type_param_occurs(tp, a) ||
+      type_param_occurs(tp, b) ||
+      type_param_occurs(tp, c) ||
+      type_param_occurs(tp, d)
+    Applied(name, args) =>
+      name == tp || args.iter().any(fn(a) { type_param_occurs(tp, a) })
+    IndexedAccess(a, b) => type_param_occurs(tp, a) || type_param_occurs(tp, b)
+    TemplateLiteralType(_, args) =>
+      args.iter().any(fn(a) { type_param_occurs(tp, a) })
+    MappedType(_, src, val, _) =>
+      type_param_occurs(tp, src) || type_param_occurs(tp, val)
+    MappedTypeRemap(_, src, remap, val, _) =>
+      type_param_occurs(tp, src) ||
+      type_param_occurs(tp, remap) ||
+      type_param_occurs(tp, val)
+    TypePredicate(_, pt) => type_param_occurs(tp, pt)
+    AssertsPredicate(_, opt) =>
+      match opt {
+        Some(pt) => type_param_occurs(tp, pt)
+        None => false
+      }
+  }
+}
+
+///|
 /// Compute type-parameter bindings at a call site by unifying each
 /// argument's inferred type against the corresponding formal parameter.
 /// Type parameters that remain unbound fall back to `Any`.
@@ -4917,6 +4979,27 @@ fn solve_generic_bindings(
   let bindings : Map[String, @ast.TsType] = {}
   for tp in type_params {
     bindings[tp] = @ast.TsType::Any
+  }
+  // A type parameter that appears *only* as a bare top-level parameter
+  // (`f<T>(x: T, y: T)`) — never nested inside an array / generic /
+  // structural shape — is inferred from every such argument as a union,
+  // matching TS (`f("a", 1)` gives `T = string | number`, not an error).
+  // When the same `T` also appears nested (`g<T>(arr: T[], x: T)`) we keep
+  // the first-wins inference so a genuine mismatch (`g([1,2,3], "abc")`) is
+  // still reported — the nested position pins `T` and the bare one is then
+  // a real assignability check.
+  let widen_safe : Map[String, Unit] = {}
+  for tp in type_params {
+    let mut nested = false
+    for p in params {
+      if type_param_occurs(tp, p) && !(p is Named(_) && p == Named(tp)) {
+        nested = true
+        break
+      }
+    }
+    if !nested {
+      widen_safe[tp] = ()
+    }
   }
   fn is_rest_at(i : Int) -> Bool {
     if params[i] is Rest(_) {
@@ -4954,7 +5037,13 @@ fn solve_generic_bindings(
     }
     if i < args.length() {
       let actual = infer_expr(env, resolver, args[i])
-      infer_param_bindings(type_params, params[i], actual, bindings, false)
+      // Widen (union across positions) only for a bare type parameter that
+      // is never nested elsewhere; otherwise keep first-wins.
+      let soft = match params[i] {
+        Named(n) => widen_safe.contains(n)
+        _ => false
+      }
+      infer_param_bindings(type_params, params[i], actual, bindings, soft)
     }
     i = i + 1
   }

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -7555,3 +7555,47 @@ test "expr_check: destructuring rest pattern carries the remaining fields" {
   })
   @test.assert_eq(other_missing.length(), 0)
 }
+
+///|
+// Issue #62: a type parameter that appears only as a bare top-level
+// parameter is inferred as the union of its argument positions (matching
+// tsc), so `f<T>(x: T, y: T)` called with mixed types is not a false
+// positive. A type parameter that also appears nested (`g<T>(arr: T[], x:
+// T)`) keeps first-wins inference so a genuine mismatch is still caught.
+fn ts62_issue_count(src : String) -> Int {
+  let module_ = parse_module_or_empty(src)
+  check_module_function_bodies(module_).length()
+}
+
+///|
+test "expr_check: bare type param unions across argument positions (no FP)" {
+  // All-bare `T` — `string | number`, accepted by tsc.
+  @test.assert_eq(
+    ts62_issue_count(
+      "function f<T>(x: T, y: T): T { return x; }\n" +
+      "function g(): void { f(\"a\", 1); }",
+    ),
+    0,
+  )
+  // Three bare positions union too.
+  @test.assert_eq(
+    ts62_issue_count(
+      "function pick<T>(a: T, b: T, c: T): T { return a; }\n" +
+      "function g(): void { pick(1, \"x\", true); }",
+    ),
+    0,
+  )
+}
+
+///|
+test "expr_check: nested type param keeps first-wins so mismatch is caught" {
+  // `T` is pinned to `number` by `arr: T[]`; `"abc"` against `T` is a real
+  // error — recall must be preserved, not widened away.
+  assert_true(
+    ts62_issue_count(
+      "function h<T>(arr: T[], x: T): void {}\n" +
+      "function g(): void { h([1, 2, 3], \"abc\"); }",
+    ) >=
+    1,
+  )
+}


### PR DESCRIPTION
## Summary

Addresses one false-positive class of issue #62: a generic type parameter inferred from multiple argument positions used **first-wins** inference, so

```ts
function f<T>(x: T, y: T): T { return x; }
f("a", 1);   // bound T = "a", then flagged `1` — false positive
```

tsc infers `T = string | number` here and accepts it.

## Change

Widen (union) the inference **only** when the type parameter appears *exclusively* as a bare top-level parameter and is never nested inside an array / generic / structural shape. That is precisely the covariant case tsc unions, so there is **no recall tradeoff**:

```ts
function g<T>(arr: T[], x: T): void {}
g([1, 2, 3], "abc");  // T pinned to number by arr; "abc" still reported (recall preserved)
```

Detection uses a new exhaustive `type_param_occurs` (every `TsType` variant matched explicitly, so a future variant fails to compile rather than silently mis-classifying).

## Testing
- `moon check` — 0 errors
- `moon test --target native` — **2283 tests pass**
- Added regression tests: 2- and 3-position bare unions (FP fixed) + nested-mismatch (recall preserved).

## Scope
Partial progress on #62 — issue stays open. The constraint-structural case (`len<T extends { length: number }>("s")`, where `string` / arrays structurally satisfy the constraint) and full tsc inference-priority modelling remain (and are best validated against the conformance corpus).

https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco

---
_Generated by [Claude Code](https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco)_