### PR TITLE
checker: rest-aware arity for function-value calls (#63)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -730,7 +730,9 @@ fn required_arity_from_types(params : Array[@ast.TsType]) -> Int {
   let mut last_required = 0
   let mut i = 0
   while i < params.length() {
-    if !type_accepts_undefined_param(params[i]) {
+    // A rest parameter (`...args: T[]`, stored as `Rest(...)`) accepts zero
+    // arguments, so it never raises the required count.
+    if !(params[i] is Rest(_)) && !type_accepts_undefined_param(params[i]) {
       last_required = i + 1
     }
     i = i + 1
@@ -7900,14 +7902,25 @@ fn check_arguments_with_sig(
       let max_ = if has_rest { -1 } else { ps.length() }
       (min_, max_)
     }
-    None =>
+    None => {
       // No rich `TsParam` metadata (e.g. calling a value typed as
       // `Func([...], _)` — a variable, method, or call-signature). We can
       // still recover optionality from the parameter *types*: the parser
       // widens `x?: T` to `T | undefined`, so a trailing param whose type
       // accepts `undefined` is omittable. This drives the min count down
-      // without needing the declaration's `TsParam` list.
-      (required_arity_from_types(params), params.length())
+      // without needing the declaration's `TsParam` list. A function-type
+      // rest param is wrapped in `Rest(...)`, so scan for it to lift the
+      // arity cap — `(a: number, ...c: boolean[]) => void` accepts any
+      // count >= 1, not exactly 2.
+      let mut has_rest_ty = false
+      for p in params {
+        if p is Rest(_) {
+          has_rest_ty = true
+        }
+      }
+      let max_ = if has_rest_ty { -1 } else { params.length() }
+      (required_arity_from_types(params), max_)
+    }
   }
   if !has_spread {
     let n = args.length()

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -7599,3 +7599,54 @@ test "expr_check: nested type param keeps first-wins so mismatch is caught" {
     1,
   )
 }
+
+///|
+// Issue #63: a function *value* with a rest parameter (`(a: number, ...c:
+// boolean[]) => void`, stored with the rest param wrapped in `Rest(...)`)
+// accepts any argument count >= the fixed-param count, and each trailing
+// argument is checked against the rest *element* type — no spurious arity
+// diagnostic, and genuinely-too-few / wrong-element calls are still caught.
+fn ts63_messages(src : String) -> Array[String] {
+  let module_ = parse_module_or_empty(src)
+  let out : Array[String] = []
+  for i in check_module_function_bodies(module_) {
+    out.push(i.message)
+  }
+  out
+}
+
+///|
+test "expr_check: function-value rest param accepts variable arity" {
+  let decl = "declare let f: (a: number, ...c: boolean[]) => void;\n"
+  // Extra rest arguments of the right element type — no diagnostic.
+  @test.assert_eq(
+    ts63_messages(decl + "function g(): void { f(1, true, false); }").length(),
+    0,
+  )
+  // Only the fixed param supplied (rest empty) — OK.
+  @test.assert_eq(
+    ts63_messages(decl + "function g(): void { f(1); }").length(),
+    0,
+  )
+  // Rest-only signature with several args — OK.
+  @test.assert_eq(
+    ts63_messages(
+      "declare let h: (...n: number[]) => void;\n" +
+      "function g(): void { h(1, 2, 3); }",
+    ).length(),
+    0,
+  )
+}
+
+///|
+test "expr_check: function-value rest param still flags real errors" {
+  let decl = "declare let f: (a: number, ...c: boolean[]) => void;\n"
+  // A rest argument of the wrong element type is reported (against the
+  // element, not the array).
+  let elem = ts63_messages(decl + "function g(): void { f(1, true, 5); }")
+  assert_true(elem.iter().any(fn(m) { m.contains("got `number`") }))
+  assert_true(not(elem.iter().any(fn(m) { m.contains("argument(s)") })))
+  // Missing the required fixed param is still a too-few arity error.
+  let few = ts63_messages(decl + "function g(): void { f(); }")
+  assert_true(few.iter().any(fn(m) { m.contains("at least 1 argument(s)") }))
+}


### PR DESCRIPTION
## Summary

Fixes issue #63: a function **value** whose type carries a rest parameter — `(a: number, ...c: boolean[]) => void` — was rejected for any argument count other than the fixed-param count (`f(1, true, false)` → "expected 2 argument(s), got 3"; `f(1)` → "got 1").

## Approach

No `Func` arity change was needed. The function-type parser already wraps rest params in the existing `Rest(...)` type marker, so the AST does carry the rest info, and the per-position element check was already `Rest`-aware. The only bug was the **arity computation** in the no-rich-sig branch of `check_arguments_with_sig`, which counted a `Rest(...)` param as one required argument and capped the maximum at `params.length()`.

- `required_arity_from_types` no longer counts a `Rest(...)` param toward the minimum (rest accepts zero arguments).
- The no-sig arity branch lifts the maximum to unbounded when a `Rest(...)` param is present.

## Behavior

| call | before | after |
|---|---|---|
| `f(1, true, false)` | FP "expected 2, got 3" | OK |
| `f(1)` | FP "expected 2, got 1" | OK |
| `(...n: number[]) => void` `h(1,2,3)` | FP "expected 1, got 3" | OK |
| `f(1, true, 5)` | element error (+ FP arity) | element error only (`boolean` vs `number`) |
| `f()` | — | "at least 1 argument(s), got 0" (recall preserved) |

This is the root fix the `is_rest_param_residue` symptomatic suppression was standing in for.

## Testing
- `moon check` — 0 errors
- `moon test --target native` — **2285 tests pass**
- Added regression tests for the accepted variable-arity calls and the still-flagged wrong-element / too-few cases.

Closes #63.

https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco

---
_Generated by [Claude Code](https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco)_