### PR TITLE
checker: primitive/array structurally satisfies object target (#62, constraint slice)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -5844,6 +5844,15 @@ fn check_expr_against(
     if structural_oneway_assignable(inferred_u, expected_u, ctx.resolver) {
       return
     }
+    // A primitive / array / tuple source can structurally satisfy an object
+    // target through its intrinsic prototype members — `string` and arrays
+    // have `length: number`, etc. — so `const o: { length: number } = "hi"`
+    // and `f<T extends { length: number }>("hi")` are valid. The
+    // resolver-free `is_assignable_to` has no primitive-member table, so
+    // prove it here via `lookup_field`.
+    if intrinsic_source_satisfies_object(inferred_u, expected_u, ctx.resolver) {
+      return
+    }
     // Class inheritance: `Derived is_a Base` when `class Derived extends
     // Base`. The resolver-free `is_assignable_to` is nominal so a pure
     // subtype assignment was previously flagged. Walk the source's class
@@ -6619,6 +6628,68 @@ fn structural_oneway_assignable(
     }
     _ => is_structurally_assignable_named(source, target, resolver)
   }
+}
+
+///|
+/// A primitive / array / tuple source can structurally satisfy an object
+/// *target* through its intrinsic prototype members — `string` and arrays
+/// expose `length: number`, strings expose the `String.prototype` methods,
+/// etc. TypeScript accepts `const o: { length: number } = "hi"`, but the
+/// resolver-free `is_assignable_to` has no primitive-member table. Prove it
+/// here via `lookup_field`, which already resolves primitive / array members.
+///
+/// Conservative and false-positive-free: engages only for intrinsic-membered
+/// sources against an object-shape target whose *every* required field is
+/// present on the source with an assignable type. A field the source lacks
+/// (and that isn't optional) makes this `false`, so a genuine mismatch
+/// (`number` against `{ length: number }`, or `{ length: number; foo: string }`
+/// against `string`) still falls through to the diagnostic.
+fn intrinsic_source_satisfies_object(
+  source : @ast.TsType,
+  target : @ast.TsType,
+  resolver : Resolver,
+) -> Bool {
+  let s = resolver.unwrap(source)
+  let intrinsic = match s {
+    String_
+    | Number
+    | Int
+    | Boolean
+    | BigInt
+    | Symbol
+    | Literal(_)
+    | NumberLiteral(_)
+    | BigIntLiteral(_)
+    | BooleanLiteral(_)
+    | Array(_)
+    | Tuple(_) => true
+    Applied(n, _) => is_array_like_iterable_name(n)
+    _ => false
+  }
+  if !intrinsic {
+    return false
+  }
+  let t = resolver.unwrap(target)
+  let target_fields = match t {
+    Object(_) | Struct(_, _) => collect_declared_fields(t, resolver)
+    _ => return false
+  }
+  if target_fields.length() == 0 {
+    return false
+  }
+  for f in target_fields {
+    let want = resolver.unwrap(f.1)
+    match resolver.lookup_field(s, f.0) {
+      Some(have) =>
+        if !is_assignable_to(resolver.unwrap(have), want) {
+          return false
+        }
+      // A required target member the source lacks → not assignable. An
+      // optional member (type accepts `undefined`) may legitimately be absent.
+      None => if !type_accepts_undefined(want) { return false }
+    }
+  }
+  true
 }
 
 ///|

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -7650,3 +7650,50 @@ test "expr_check: function-value rest param still flags real errors" {
   let few = ts63_messages(decl + "function g(): void { f(); }")
   assert_true(few.iter().any(fn(m) { m.contains("at least 1 argument(s)") }))
 }
+
+///|
+// Issue #62 (constraint-structural): a primitive / array source structurally
+// satisfies an object target through its intrinsic members — `string` and
+// arrays have `length: number` — so `f<T extends { length: number }>("s")`
+// and `const o: { length: number } = "hi"` are valid (matching tsc). A source
+// that genuinely lacks a required member (`number`, or a target with an extra
+// field) is still reported.
+test "expr_check: primitive/array satisfies object target via intrinsic members" {
+  let len_decl = "function len<T extends { length: number }>(x: T): number { return x.length; }\n"
+  // string / array have length:number — accepted.
+  @test.assert_eq(
+    ts63_messages(len_decl + "function g(): void { len(\"s\"); }").length(),
+    0,
+  )
+  @test.assert_eq(
+    ts63_messages(len_decl + "function g(): void { len([1, 2]); }").length(),
+    0,
+  )
+  // Direct assignment of a string to a structural object target.
+  @test.assert_eq(
+    ts63_messages(
+      "function g(): void { const o: { length: number } = \"hi\"; }",
+    ).length(),
+    0,
+  )
+}
+
+///|
+test "expr_check: intrinsic-source object check still flags real mismatches" {
+  // `number` has no `length` — still reported (recall preserved).
+  assert_true(
+    ts63_messages(
+      "function len<T extends { length: number }>(x: T): number { return x.length; }\n" +
+      "function g(): void { len(42); }",
+    ).length() >=
+    1,
+  )
+  // A target field the source lacks (`foo`) keeps the mismatch.
+  assert_true(
+    ts63_messages(
+      "function f<T extends { length: number; foo: string }>(x: T): void {}\n" +
+      "function g(): void { f(\"s\"); }",
+    ).length() >=
+    1,
+  )
+}


### PR DESCRIPTION
## Summary

Resolves the **constraint-structural** false-positive class of issue #62.

```ts
function len<T extends { length: number }>(x: T): number { return x.length; }
len("s");    // was: "expected { length: number } but got string"
len([1, 2]); // was: "expected { length: number } but got number[]"
const o: { length: number } = "hi"; // was flagged too
```

The resolver-free `is_assignable_to` has no primitive-member table, so it reports `string` / arrays as not assignable to a structural object type. tsc accepts these — `string` and arrays expose `length: number`.

## Change

Add `intrinsic_source_satisfies_object`: for an intrinsic-membered source (string / number / boolean / bigint / symbol / array / tuple / literal) against an object-shape target, prove assignability via `lookup_field` (which already resolves primitive / array members), requiring **every** target field to be present-and-assignable on the source.

**False-positive-free, no recall loss** — a field the source lacks (and that isn't optional) makes it `false`, so genuine mismatches still surface:

| case | result |
|---|---|
| `len("s")`, `len([1,2])`, `const o: {length:number} = "hi"` | OK (FP fixed) |
| `len(42)` — number has no `length` | still flagged |
| `f<T extends {length:number; foo:string}>("s")` — string lacks `foo` | still flagged |
| `const o: {length:number} = 42` | still flagged |

## Testing
- `moon check` — 0 errors
- `moon test --target native` — **2287 tests pass**
- Added regression tests for the fixed FPs and the preserved-recall cases.

## Scope
Partial progress on #62 (constraint-structural slice). The remaining tsc inference-priority work (`genericCallWithGenericSignatureArguments`, `genericCallTypeArgumentInference`) is best validated against the conformance corpus; #62 stays open.

https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco

---
_Generated by [Claude Code](https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco)_