### PR TITLE
checker: TS18010 — accessibility modifier on a private identifier

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -12667,6 +12667,35 @@ fn check_class_member_structure(
 ) -> Array[ExprIssue] {
   let issues : Array[ExprIssue] = []
   for decl in module_.classes {
+    // --- TS18010: an accessibility modifier (`public` / `private` /
+    // `protected`) cannot be used with a private identifier (`private #x`,
+    // `protected #y`). The parser mangles a `#x` name to a
+    // `__private_brand__N__x` symbol and records an explicit accessibility
+    // modifier by pushing that mangled name into `private_members` /
+    // `protected_members` (a plain `#x` with no modifier is *not* added).
+    // So a branded name in either list is exactly a modifier-on-`#name`
+    // declaration, which TS rejects unconditionally — false-positive-free.
+    let reported_brand_modifier : Map[String, Unit] = {}
+    for name in decl.private_members {
+      if name.has_prefix("__private_brand__") &&
+        !reported_brand_modifier.contains(name) {
+        reported_brand_modifier[name] = ()
+        issues.push({
+          path: "class \{decl.name}",
+          message: "an accessibility modifier cannot be used with a private identifier",
+        })
+      }
+    }
+    for name in decl.protected_members {
+      if name.has_prefix("__private_brand__") &&
+        !reported_brand_modifier.contains(name) {
+        reported_brand_modifier[name] = ()
+        issues.push({
+          path: "class \{decl.name}",
+          message: "an accessibility modifier cannot be used with a private identifier",
+        })
+      }
+    }
     // --- TS2506: a class directly references itself in its own base
     // expression (`class C extends C {}`, `class D<T> extends D<T> {}`).
     // `base_names` carries the bare extended name, so a self-reference is

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -7697,3 +7697,29 @@ test "expr_check: intrinsic-source object check still flags real mismatches" {
     1,
   )
 }
+
+///|
+// TS18010: an accessibility modifier (`public` / `private` / `protected`)
+// cannot be used with a private identifier (`private #x`). The parser brands
+// a `#x` member and records an explicit modifier in private/protected lists,
+// so the check is purely structural and false-positive-free — a plain `#x`,
+// a `readonly #x`, or a regular `private y` (no `#`) is not flagged.
+test "expr_check: TS18010 flags accessibility modifier on a private identifier" {
+  let flagged = fn(src : String) -> Int {
+    let module_ = parse_module_or_empty(src)
+    check_module_function_bodies(module_)
+    .filter(fn(i) {
+      i.message.contains("accessibility modifier cannot be used with a private")
+    })
+    .length()
+  }
+  // `private #bar` and `protected #baz` are both rejected; `readonly #qux` ok.
+  @test.assert_eq(
+    flagged(
+      "class A { private #bar = 2; protected #baz = 3; readonly #qux = 4; }",
+    ),
+    2,
+  )
+  // A plain `#x` (no modifier), and a regular `private y` (no `#`), are legal.
+  @test.assert_eq(flagged("class C { #x = 1; private y = 2; }"), 0)
+}


### PR DESCRIPTION
## Summary

First bounded, measured step into the ECMAScript `#private` conformance cluster (`classes/members`). Implements **TS18010** — an accessibility modifier (`public` / `private` / `protected`) cannot be combined with a private identifier:

```ts
class A {
  private #bar = 3;    // TS18010
  protected #baz = 3;  // TS18010
  readonly #qux = 3;   // ok (not an accessibility modifier)
  #plain = 3;          // ok
}
```

## Why it's false-positive-free

The parser brands a `#x` member to a `__private_brand__N__x` symbol and only pushes it into `private_members` / `protected_members` when an explicit accessibility modifier was present (a plain `#x` is *not* added). So a branded name in either list is exactly a modifier-on-`#name` declaration — TS rejects it unconditionally. A plain `#x`, a `readonly #x`, or a regular `private y` (no `#`) is never flagged. (`public #x` is currently a benign false negative — `public` isn't tracked — but the file still flips to a recall hit via the `private`/`protected` cases.)

## Measurement

| | recall | precision | FP |
|---|---|---|---|
| before | 538/815 | 414/414 | 0 |
| **after** | **539/815** | 414/414 | **0** |

Measured with `tsacc` against the conformance corpus. Full unit suite green (2289 tests); added a unit test.

This is step 1 of the `#private` surface; subsequent rules (TS18013 "not accessible outside class", TS18014 shadowing, etc.) can follow the same measurement-first, FP-gated approach.

https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco

---
_Generated by [Claude Code](https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco)_