### PR TITLE
checker: TS18012 — `#constructor` is a reserved word

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -12696,6 +12696,34 @@ fn check_class_member_structure(
         })
       }
     }
+    // --- TS18012: `#constructor` is a reserved word — a `#`-private member
+    // may not be named `constructor`. The parser brands such a member to
+    // `__private_brand__N__constructor`, so a branded name ending in
+    // `__constructor` is exactly a `#constructor` declaration (field, method,
+    // or accessor). Always an error, never a legal shape — false-positive-free.
+    let mut reported_hash_ctor = false
+    fn is_brand_constructor(n : String) -> Bool {
+      n.has_prefix("__private_brand__") && n.has_suffix("__constructor")
+    }
+
+    for p in decl.properties {
+      if is_brand_constructor(p.name) && !reported_hash_ctor {
+        reported_hash_ctor = true
+        issues.push({
+          path: "class \{decl.name}",
+          message: "`#constructor` is a reserved word",
+        })
+      }
+    }
+    for m in decl.methods {
+      if is_brand_constructor(m.name) && !reported_hash_ctor {
+        reported_hash_ctor = true
+        issues.push({
+          path: "class \{decl.name}",
+          message: "`#constructor` is a reserved word",
+        })
+      }
+    }
     // --- TS2506: a class directly references itself in its own base
     // expression (`class C extends C {}`, `class D<T> extends D<T> {}`).
     // `base_names` carries the bare extended name, so a self-reference is

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -7723,3 +7723,21 @@ test "expr_check: TS18010 flags accessibility modifier on a private identifier" 
   // A plain `#x` (no modifier), and a regular `private y` (no `#`), are legal.
   @test.assert_eq(flagged("class C { #x = 1; private y = 2; }"), 0)
 }
+
+///|
+// TS18012: `#constructor` is a reserved word — a `#`-private member may not be
+// named `constructor` (field, method, or accessor). The parser brands it to
+// `__private_brand__N__constructor`; a normal `constructor` is not branded and
+// stays legal.
+test "expr_check: TS18012 flags `#constructor` private member" {
+  let flagged = fn(src : String) -> Int {
+    let module_ = parse_module_or_empty(src)
+    check_module_function_bodies(module_)
+    .filter(fn(i) { i.message.contains("`#constructor` is a reserved word") })
+    .length()
+  }
+  @test.assert_eq(flagged("class A { #constructor() {} }"), 1)
+  @test.assert_eq(flagged("class B { #constructor = 1; }"), 1)
+  // A normal constructor and an ordinary `#` member are legal.
+  @test.assert_eq(flagged("class C { constructor() {} #foo() {} }"), 0)
+}


### PR DESCRIPTION
## Summary

Second `#private` structural rule (after TS18010, PR #106). Implements **TS18012** — `#constructor` is a reserved word; a `#`-private member may not be named `constructor`:

```ts
class A { #constructor() {} }   // TS18012
class B { #constructor = 1; }   // TS18012
class C { constructor() {} #foo() {} }  // ok
```

## Why it's false-positive-free

The parser brands a `#x` member to `__private_brand__N__x`, so a branded name ending in `__constructor` (field, method, or accessor) is exactly a `#constructor` declaration — always an error, never legal. A normal `constructor` isn't branded, so it's never flagged.

## Measurement

| | recall | precision | FP |
|---|---|---|---|
| before | 539/815 | 414/414 | 0 |
| **after** | **540/815** | 414/414 | **0** |

`tsacc` against the conformance corpus. Full unit suite green (2290 tests); added a unit test.

https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco

---
_Generated by [Claude Code](https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco)_