### PR TITLE
checker: TS18006 — class field named `constructor`

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -12724,6 +12724,25 @@ fn check_class_member_structure(
         })
       }
     }
+    // --- TS18006: a class may not have a (data) field named `constructor`
+    // (`class C { constructor: number }` / `class C { "constructor" = 3 }`).
+    // The real constructor is parsed as a method / `constructor_body`, never
+    // as a `properties` entry, and a computed `["constructor"]` key parses to
+    // `<computed>` — so a non-static, non-accessor property literally named
+    // `constructor` is exactly the illegal field form. False-positive-free.
+    let mut reported_ctor_field = false
+    for p in decl.properties {
+      if p.name == "constructor" &&
+        !p.is_static &&
+        !p.is_accessor &&
+        !reported_ctor_field {
+        reported_ctor_field = true
+        issues.push({
+          path: "class \{decl.name}",
+          message: "classes may not have a field named `constructor`",
+        })
+      }
+    }
     // --- TS2506: a class directly references itself in its own base
     // expression (`class C extends C {}`, `class D<T> extends D<T> {}`).
     // `base_names` carries the bare extended name, so a self-reference is

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -7741,3 +7741,25 @@ test "expr_check: TS18012 flags `#constructor` private member" {
   // A normal constructor and an ordinary `#` member are legal.
   @test.assert_eq(flagged("class C { constructor() {} #foo() {} }"), 0)
 }
+
+///|
+// TS18006: a class may not have a data field named `constructor`
+// (`constructor: T` / `"constructor" = 3`). The real constructor parses as a
+// method / `constructor_body` (never a `properties` entry), a computed
+// `["constructor"]` key parses to `<computed>`, and a `static constructor`
+// field is allowed — so only a non-static, non-accessor property literally
+// named `constructor` is flagged.
+test "expr_check: TS18006 flags a field named constructor" {
+  let flagged = fn(src : String) -> Int {
+    let module_ = parse_module_or_empty(src)
+    check_module_function_bodies(module_)
+    .filter(fn(i) { i.message.contains("field named `constructor`") })
+    .length()
+  }
+  @test.assert_eq(flagged("class A { constructor: number; m() {} }"), 1)
+  @test.assert_eq(flagged("class B { \"constructor\" = 3; }"), 1)
+  // A real constructor, a computed key, and a static field are all legal.
+  @test.assert_eq(flagged("class C { constructor() {} }"), 0)
+  @test.assert_eq(flagged("class D { [\"constructor\"] = 3; }"), 0)
+  @test.assert_eq(flagged("class E { static constructor = 3; }"), 0)
+}


### PR DESCRIPTION
## Summary

Third bounded class-member structural rule (after TS18010 / TS18012). Implements **TS18006** — a class may not have a data field named `constructor`:

```ts
class A { constructor: number; }   // TS18006
class B { "constructor" = 3; }     // TS18006
class C { constructor() {} }       // ok (the real constructor)
class D { ["constructor"] = 3; }   // ok (computed key)
class E { static constructor = 3; }// ok (static)
```

## Why it's false-positive-free

The real constructor parses as a method / `constructor_body` (never a `properties` entry), a computed `["constructor"]` key parses to `<computed>`, and a `static constructor` field is allowed — so a **non-static, non-accessor** property literally named `constructor` is exactly the illegal field form.

## Measurement

| | recall | precision | FP |
|---|---|---|---|
| before | 540/815 | 414/414 | 0 |
| **after** | **541/815** | 414/414 | **0** |

`tsacc` against the conformance corpus. Full unit suite green (2291 tests); added a unit test. Target identified from a fresh miss-scan on current `main`.

https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco

---
_Generated by [Claude Code](https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco)_