### PR TITLE
checker: TS2335 — super in a class with no base

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -12659,6 +12659,92 @@ fn check_native_class_property_initializers(
 ///     changes the get/set-vs-data shape of an inherited member. TS only
 ///     reports these under `useDefineForClassFields`, so we gate on that
 ///     flag to stay false-positive-free.
+///
+/// Whether `expr` references `super` (a `super(...)` call, `super.x`, or
+/// `super.m(...)`). Used by the TS2335 check below.
+fn expr_mentions_super(expr : @ast.TsExpr) -> Bool {
+  match expr {
+    Var("super") => true
+    Call("super", _) => true
+    PropAccess(inner, _) => expr_mentions_super(inner)
+    IndexAccess(a, b) => expr_mentions_super(a) || expr_mentions_super(b)
+    CallExpr(callee, args) | NewExpr(callee, args) =>
+      expr_mentions_super(callee) ||
+      args.iter().any(fn(a) { expr_mentions_super(a) })
+    Call(_, args) | New(_, args) =>
+      args.iter().any(fn(a) { expr_mentions_super(a) })
+    MethodCall(recv, _, args) =>
+      expr_mentions_super(recv) ||
+      args.iter().any(fn(a) { expr_mentions_super(a) })
+    BinOp(_, a, b) | Seq(a, b) =>
+      expr_mentions_super(a) || expr_mentions_super(b)
+    UnaryOp(_, a)
+    | Spread(a)
+    | PureCall(a)
+    | Await(a)
+    | NonNull(a)
+    | OptionalChain(a)
+    | As(a, _)
+    | Satisfies(a, _) => expr_mentions_super(a)
+    Cond(a, b, c) =>
+      expr_mentions_super(a) || expr_mentions_super(b) || expr_mentions_super(c)
+    AssignExpr(_, v) => expr_mentions_super(v)
+    PropAssignExpr(r, _, v) => expr_mentions_super(r) || expr_mentions_super(v)
+    CompoundAssignExpr(t, _, v) =>
+      expr_mentions_super(t) || expr_mentions_super(v)
+    _ => false
+  }
+}
+
+///|
+fn block_mentions_super(block : @ast.TsBlock) -> Bool {
+  block.stmts.iter().any(fn(s) { stmt_mentions_super(s) })
+}
+
+///|
+fn stmt_mentions_super(stmt : @ast.TsStmt) -> Bool {
+  match stmt {
+    Expr(e) | Throw(e) => expr_mentions_super(e)
+    Return(opt) =>
+      match opt {
+        Some(e) => expr_mentions_super(e)
+        None => false
+      }
+    Var(_, _, e) | Let(_, _, e) | Const(_, _, e) => expr_mentions_super(e)
+    PropAssign(r, _, v) => expr_mentions_super(r) || expr_mentions_super(v)
+    Block(b) => block_mentions_super(b)
+    If(c, t, e) =>
+      expr_mentions_super(c) ||
+      block_mentions_super(t) ||
+      (match e {
+        Some(eb) => block_mentions_super(eb)
+        None => false
+      })
+    While(c, b) | DoWhile(c, b) =>
+      expr_mentions_super(c) || block_mentions_super(b)
+    For(_, _, _, b) => block_mentions_super(b)
+    ForOf(_, _, _, it, b)
+    | ForAwaitOf(_, _, _, it, b)
+    | ForIn(_, _, _, it, b) =>
+      expr_mentions_super(it) || block_mentions_super(b)
+    Try(b, _, c, f) =>
+      block_mentions_super(b) ||
+      (match c {
+        Some(cb) => block_mentions_super(cb)
+        None => false
+      }) ||
+      (match f {
+        Some(fb) => block_mentions_super(fb)
+        None => false
+      })
+    Switch(e, cases) =>
+      expr_mentions_super(e) ||
+      cases.iter().any(fn(cse) { block_mentions_super(cse.body) })
+    _ => false
+  }
+}
+
+///|
 fn check_class_member_structure(
   module_ : @ast.TsModule,
   resolver : Resolver,
@@ -12741,6 +12827,24 @@ fn check_class_member_structure(
           path: "class \{decl.name}",
           message: "classes may not have a field named `constructor`",
         })
+      }
+    }
+    // --- TS2335: `super` can only be referenced in a derived class. A class
+    // with no base (`base_names` empty and no expression-base) whose
+    // constructor body references `super` (`super()`, `super.x`,
+    // `super.m()`) is an error. Derived classes carry a base name (or the
+    // `<expr-base>` sentinel with `base_expr` set), so this is
+    // false-positive-free.
+    if decl.base_names.length() == 0 && decl.base_expr is None {
+      match decl.constructor_body {
+        Some(body) =>
+          if block_mentions_super(body) {
+            issues.push({
+              path: "class \{decl.name}",
+              message: "`super` can only be referenced in a derived class",
+            })
+          }
+        None => ()
       }
     }
     // --- TS2506: a class directly references itself in its own base

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -7763,3 +7763,30 @@ test "expr_check: TS18006 flags a field named constructor" {
   @test.assert_eq(flagged("class D { [\"constructor\"] = 3; }"), 0)
   @test.assert_eq(flagged("class E { static constructor = 3; }"), 0)
 }
+
+///|
+// TS2335: `super` can only be referenced in a derived class. A class with no
+// base whose constructor references `super` (`super()`, `super.x`) is an
+// error; a derived class (or one with no `super` reference) is not flagged.
+test "expr_check: TS2335 flags super in a class with no base" {
+  let flagged = fn(src : String) -> Int {
+    let module_ = parse_module_or_empty(src)
+    check_module_function_bodies(module_)
+    .filter(fn(i) { i.message.contains("can only be referenced in a derived") })
+    .length()
+  }
+  @test.assert_eq(flagged("class C { constructor() { super(); } }"), 1)
+  @test.assert_eq(
+    flagged("class C2 { x = 1; constructor() { let y = super.foo; } }"),
+    1,
+  )
+  // Derived class, and a base-less class without `super`, are both legal.
+  @test.assert_eq(
+    flagged("class B {}\nclass D extends B { constructor() { super(); } }"),
+    0,
+  )
+  @test.assert_eq(
+    flagged("class E { x: number; constructor() { this.x = 1; } }"),
+    0,
+  )
+}


### PR DESCRIPTION
## Summary

Implements **TS2335** — `super` can only be referenced in a derived class:

```ts
class C { constructor() { super(); } }          // TS2335
class C2 { x = 1; constructor() { super.foo; } } // TS2335
class B {}
class D extends B { constructor() { super(); } } // ok (derived)
class E { constructor() { this.x = 1; } }        // ok (no super)
```

## Why it's false-positive-free

A class with no base has `base_names` empty *and* no expression-base (`base_expr`). Derived classes carry a base name (or the `<expr-base>` sentinel with `base_expr` set). So a base-less class whose constructor references `super` is unconditionally an error. The constructor body is walked recursively, so `super` inside a nested `if`/loop is also caught.

## Measurement

| | recall | precision | FP |
|---|---|---|---|
| before | 541/815 | 414/414 | 0 |
| **after** | **542/815** | 414/414 | **0** |

`tsacc` against the conformance corpus. Full unit suite green (2292 tests); added a unit test. Target from a fresh `constructorDeclarations` miss-scan.

https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco

---
_Generated by [Claude Code](https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco)_