### PR TITLE
checker: infer generic params through object-typed parameters (#62)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -4887,6 +4887,39 @@ fn infer_param_bindings(
       }
       infer_param_bindings(type_params, f_ret, a_ret, bindings, true)
     }
+    // Object / interface-shaped parameters: match fields by name and infer
+    // recursively. `foo<T>(x: { bar: T; baz: T })` called with `{ bar: 1,
+    // baz: "" }` infers `T = number` from `bar` (first-wins for a nested
+    // position), so the later `baz: ""` is then checked against `number` and
+    // the mismatch surfaces — matching tsc's object-literal inference.
+    (Object(f_fields), Object(a_fields)) =>
+      infer_object_field_bindings(
+        type_params,
+        object_fields_by_name(f_fields),
+        object_fields_by_name(a_fields),
+        bindings,
+        soft,
+      )
+    (Struct(_, f_fields), Object(a_fields)) =>
+      infer_object_field_bindings(
+        type_params,
+        f_fields,
+        object_fields_by_name(a_fields),
+        bindings,
+        soft,
+      )
+    (Object(f_fields), Struct(_, a_fields)) =>
+      infer_object_field_bindings(
+        type_params,
+        object_fields_by_name(f_fields),
+        a_fields,
+        bindings,
+        soft,
+      )
+    (Struct(_, f_fields), Struct(_, a_fields)) =>
+      infer_object_field_bindings(
+        type_params, f_fields, a_fields, bindings, soft,
+      )
     (Union(f_parts), _) =>
       // Best-effort: try the first part that isn't a bare type parameter
       // (matching a concrete shape generally yields more information). If
@@ -4901,6 +4934,42 @@ fn infer_param_bindings(
         }
       }
     _ => ()
+  }
+}
+
+///|
+/// Extract `(name, type)` pairs from an `Object` field list. Object keys are
+/// stored as `Literal(name)`; non-literal / computed keys are skipped.
+fn object_fields_by_name(
+  fields : Array[(@ast.TsType, @ast.TsType)],
+) -> Array[(String, @ast.TsType)] {
+  let out : Array[(String, @ast.TsType)] = []
+  for f in fields {
+    match f.0 {
+      Literal(name) => out.push((name, f.1))
+      _ => ()
+    }
+  }
+  out
+}
+
+///|
+/// Infer type-parameter bindings by matching formal/actual object fields by
+/// name, recursing into each shared field's types. Used for object / struct
+/// shaped parameters in `infer_param_bindings`.
+fn infer_object_field_bindings(
+  type_params : Array[String],
+  formal_fields : Array[(String, @ast.TsType)],
+  actual_fields : Array[(String, @ast.TsType)],
+  bindings : Map[String, @ast.TsType],
+  soft : Bool,
+) -> Unit {
+  for ff in formal_fields {
+    for af in actual_fields {
+      if af.0 == ff.0 {
+        infer_param_bindings(type_params, ff.1, af.1, bindings, soft)
+      }
+    }
   }
 }
 

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -7790,3 +7790,25 @@ test "expr_check: TS2335 flags super in a class with no base" {
     0,
   )
 }
+
+///|
+// Issue #62 (object-typed argument inference): a type parameter nested in an
+// object-shaped parameter (`foo<T>(x: { bar: T; baz: T })`) is inferred from
+// the matching fields of an object-literal argument. `{ bar: 1, baz: "" }`
+// pins `T = number` from `bar`, so the later `baz: ""` mismatch surfaces;
+// consistent field types stay silent.
+test "expr_check: generic inference through object-typed parameter fields" {
+  let count = fn(src : String) -> Int {
+    check_module_function_bodies(parse_module_or_empty(src)).length()
+  }
+  let decl = "function foo<T>(x: { bar: T; baz: T }) { return x; }\n"
+  // bar pins T = number; baz: "" is then a real mismatch.
+  assert_true(
+    count(decl + "function g(): void { foo({ bar: 1, baz: '' }); }") >= 1,
+  )
+  // Consistent field types — no diagnostic.
+  @test.assert_eq(
+    count(decl + "function g(): void { foo({ bar: 1, baz: 2 }); }"),
+    0,
+  )
+}


### PR DESCRIPTION
## Summary

First increment of the **#62** higher-order generic-inference work (target found via the new `tsacc --list-misses`).

`infer_param_bindings` had no Object/Struct case, so a type parameter nested in an object-shaped parameter was never inferred from an object-literal argument:

```ts
function foo<T>(x: { bar: T; baz: T }) { return x; }
foo({ bar: 1, baz: "" }); // was: not checked → miss
```

## Change

Add field-by-name matching for Object/Struct formals against Object/Struct arguments (`infer_object_field_bindings` + `object_fields_by_name`), recursing into each shared field. Nested positions keep **first-wins** inference, so `{ bar: 1, baz: "" }` pins `T = number` from `bar` and the later `baz: ""` mismatch surfaces (TS2322); consistent field types (`{ bar: 1, baz: 2 }`) stay silent — matching tsc's object-literal inference.

## Measurement

| | recall | precision | FP |
|---|---|---|---|
| before | 542/815 | 414/414 | 0 |
| **after** | **543/815** | 414/414 | **0** |

The new inference introduced **no precision regression**. Clears `genericCallWithObjectLiteralArgs`. Full unit suite green (2293 tests); added a unit test.

https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco

---
_Generated by [Claude Code](https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco)_