### PR TITLE
checker: null/undefined not assignable to a bare type parameter under strict (#62)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1360,6 +1360,12 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-05 (T50)   559/815 (69 %)        394/414 (20 FP)
 2026-06-05 (T51)   560/815 (69 %)        394/414 (20 FP)
 2026-06-08 (T52)   (corpus sweep deferred — see note)
+2026-06-15 (RB)    538/815 (66 %)        414/414 ( 0 FP)
+2026-06-15 (T53)   539/815 (66 %)        414/414 ( 0 FP)
+2026-06-15 (T54)   540/815 (66 %)        414/414 ( 0 FP)
+2026-06-15 (T55)   541/815 (66 %)        414/414 ( 0 FP)
+2026-06-15 (T56)   542/815 (67 %)        414/414 ( 0 FP)
+2026-06-15 (T57)   543/815 (67 %)        414/414 ( 0 FP)
 
   Toolchain note (2026-06-08): the native parser-package whitebox test
   generates a ~25 MB C unit that this session's `tcc` could not compile in
@@ -1400,6 +1406,42 @@ conformance sources (`.errors.txt` baseline = ground truth):
     FP steady 20. A future session should re-run the parser accuracy test
     (use `-f "*accuracy*"` to skip the slow full-TS smoke-run) and fill in
     the table row.
+
+  RB / T53-T57 (2026-06-15) -- corpus re-measured via `tsacc` after the
+  2026-06-12 soundness pass drove whole-corpus FP to 0 (which suppressed the
+  ~20 FP-causing emissions logged through T51, re-baselining recall down to
+  538/815 @ 0 FP). The TypeScript submodule was re-initialised this session so
+  `moon run src/cmd/tsacc --target native` measures again. Precision held at
+  414/414 (0 FP) across every step below.
+
+    RB  -- re-baseline: 538/815 @ 0 FP.
+    T53 -- TS18010 ("an accessibility modifier cannot be used with a private
+      identifier"): a `#`-private member declared `private`/`protected`.
+      Structural, FP-free (brand-mangled name in the private/protected list).
+      recall 538 -> 539.
+    T54 -- TS18012 ("`#constructor` is a reserved word"): a `#`-private member
+      named `constructor`. recall 539 -> 540.
+    T55 -- TS18006 ("classes may not have a field named `constructor`"): a
+      non-static, non-accessor data field literally named `constructor`.
+      recall 540 -> 541.
+    T56 -- TS2335 ("`super` can only be referenced in a derived class"): a
+      base-less class whose constructor body references `super`. recall
+      541 -> 542.
+    T57 -- generic inference through object-typed parameters (#62): a type
+      parameter nested in an object-shaped parameter (`foo<T>(x: { bar: T;
+      baz: T })`) is now inferred from an object-literal argument's matching
+      fields (first-wins for nested positions), so `foo({ bar: 1, baz: "" })`
+      flags the `baz` mismatch. recall 542 -> 543. Clears
+      `genericCallWithObjectLiteralArgs`.
+
+    Tooling: `tsacc` gained `--list-misses [substr]`, which prints one
+    `RECALL_MISS <case>` line per recall miss (optionally path-filtered) for
+    triaging targets without ad-hoc instrumentation.
+
+    Remaining typeInference misses are the hard higher-order cases
+    (body-internal `null`-vs-bare-`T`, construct-signature inference, nested
+    function-type variance, mapped-type inference) — no bounded increment
+    left; each is deliberate multi-step work with FP risk to manage.
 
   T51 -- argument checking for union construct signatures (TS2345). recall
   +1. The `new`-call analog of T50.

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -5745,6 +5745,26 @@ fn check_expr_against(
     )
     return
   }
+  // Under strict null checks, a literal `null` / `undefined` is *not*
+  // assignable to a bare in-scope type parameter (`function f<T>(...)` body /
+  // a generic call's `T`): `T` could be instantiated to a non-nullable type,
+  // so tsc reports TS2345 / TS2322. Without strict mode null/undefined flow
+  // to everything (the suppression below), so gate this on the strict flag.
+  // Restricted to a target that is exactly an in-scope type-parameter name.
+  if ctx.strict_property_init && is_null_or_undefined_literal_expr(expr) {
+    match expected_u {
+      Named(n) =>
+        if ctx.in_scope_type_params.contains(n) {
+          record(
+            ctx,
+            sub_path,
+            "`null` / `undefined` is not assignable to type parameter `\{n}`",
+          )
+          return
+        }
+      _ => ()
+    }
+  }
   // Without `strictNullChecks`, a literal `null` / `undefined` is assignable
   // to every type (`var b: number = null`). The conformance corpus runs
   // largely under `@strict: false` and we have no per-file strict-mode

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -7812,3 +7812,37 @@ test "expr_check: generic inference through object-typed parameter fields" {
     0,
   )
 }
+
+///|
+// Issue #62 (null/undefined vs a bare type parameter): under strict null
+// checks, passing `null` / `undefined` where a bare in-scope type parameter
+// `T` is expected is a TS2345 (`T` could be instantiated to a non-nullable
+// type). Non-strict files keep the permissive null rule.
+test "expr_check: null/undefined is not assignable to a bare type parameter (strict)" {
+  let count = fn(src : String) -> Int {
+    check_module_function_bodies(parse_module_or_empty(src))
+    .filter(fn(i) { i.message.contains("not assignable to type parameter") })
+    .length()
+  }
+  // Default (strict): `arg.cb(null)` with `cb: (t: T) => U` is flagged.
+  assert_true(
+    count(
+      "function foo<T, U>(arg: { cb: (t: T) => U }) { return arg.cb(null); }",
+    ) >=
+    1,
+  )
+  // Passing a real `T` value is fine.
+  @test.assert_eq(
+    count(
+      "function foo<T, U>(arg: { cb: (t: T) => U }, v: T) { return arg.cb(v); }",
+    ),
+    0,
+  )
+  // `@strict: false` keeps the permissive null rule — not flagged.
+  @test.assert_eq(
+    count(
+      "// @strict: false\nfunction foo<T, U>(arg: { cb: (t: T) => U }) { return arg.cb(null); }",
+    ),
+    0,
+  )
+}


### PR DESCRIPTION
## Summary

Continues #62. Under **strict null checks**, passing a literal `null` / `undefined` where a bare in-scope type parameter `T` is expected (a generic function body, or a generic call's `T`) is a real TS2345/TS2322 — `T` could be instantiated to a non-nullable type, so tsc rejects it:

```ts
function foo<T, U>(arg: { cb: (t: T) => U }) { return arg.cb(null); } // TS2345
```

The checker previously suppressed all literal null/undefined as universally assignable.

## Change

Flag it in `check_expr_against` when the target unwraps to an in-scope type-parameter name — **gated on `ctx.strict_property_init`**. Without strict mode, null/undefined legitimately flow to everything, so the existing permissive rule is kept.

The strict gate is what makes this false-positive-free: an earlier *ungated* attempt produced 12 FPs, all in `@strict: false` files where tsc allows the assignment. Gating on the strict flag distinguishes them — so this recovers the recall **without** the type-parameter-bounds AST foundation that was thought to be required.

## Measurement

| | recall | precision | FP |
|---|---|---|---|
| before | 543/815 | 414/414 | 0 |
| **after** | **547/815** | 414/414 | **0** |

Full unit suite green (2294 tests); added a test covering strict (flagged), real-value (not flagged), and `@strict: false` (not flagged).

https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco

---
_Generated by [Claude Code](https://claude.ai/code/session_01W33XpkB7eVD1rDGSiQUPco)_