### PR TITLE
checker: a literal is not assignable to a bare type parameter (#62)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -5785,6 +5785,31 @@ fn check_expr_against(
   if expected_u is Never {
     return
   }
+  // A *literal* value is never assignable to a bare in-scope type parameter
+  // `T`: `T` could be instantiated with an arbitrary type unrelated to the
+  // value, so `function f<T>() { var x: T = 1 }` and
+  // `function f<T>(): T { return 1 }` are TS2322 / TS2345 regardless of strict
+  // mode (unlike `null` / `undefined`, which non-strict allows everywhere —
+  // handled above). Gated on the *expression* being a literal (not merely the
+  // inferred type being primitive): a variable typed `T` that flow-narrows to
+  // `string` (`if (typeof x === "string") { let v: T = x }`) keeps the
+  // intersection `T & string`, which IS assignable to `T` — flagging its
+  // inferred `string` would be a false positive.
+  if precise_literal_type(expr) is Some(_) {
+    match expected_u {
+      Named(n) =>
+        if ctx.in_scope_type_params.contains(n) &&
+          is_concrete_primitive_or_literal(inferred_u) {
+          record(
+            ctx,
+            sub_path,
+            "type `\{type_display(inferred_u)}` is not assignable to type parameter `\{n}`",
+          )
+          return
+        }
+      _ => ()
+    }
+  }
   // If the expected type is a `Named` reference that the resolver can't expand
   // (e.g. a generic type parameter like `T`, or a qualified name like
   // `Intl.NumberFormatPartTypes` that isn't in the module's declaration list),
@@ -12276,6 +12301,29 @@ fn check_module_function_bodies_layered(
     }
   }
   all
+}
+
+///|
+/// True when `ty` is a fully-concrete primitive or literal type with no type
+/// parameters, `any`, `unknown`, or `never` inside it. Used to decide that a
+/// value is genuinely incompatible with a bare in-scope type parameter `T`
+/// (`var x: T = 1`): only such unambiguously-concrete sources are flagged, so
+/// an imprecisely-inferred object / union / generic instantiation can never
+/// false-flag against `T`.
+fn is_concrete_primitive_or_literal(ty : @ast.TsType) -> Bool {
+  match ty {
+    Number
+    | Int
+    | String_
+    | Boolean
+    | BigInt
+    | Symbol
+    | Literal(_)
+    | NumberLiteral(_)
+    | BigIntLiteral(_)
+    | BooleanLiteral(_) => true
+    _ => false
+  }
 }
 
 ///|

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -7846,3 +7846,42 @@ test "expr_check: null/undefined is not assignable to a bare type parameter (str
     0,
   )
 }
+
+///|
+// Issue #62 (a concrete literal vs a bare type parameter): a literal value is
+// never assignable to a bare in-scope type parameter `T` — `T` could be
+// instantiated with an arbitrary type unrelated to the literal, so this is a
+// TS2322 / TS2345 regardless of strict mode. The complement of the
+// null/undefined rule above; together they cover "non-`T` value -> bare `T`".
+test "expr_check: a literal is not assignable to a bare type parameter" {
+  let count = fn(src : String) -> Int {
+    check_module_function_bodies(parse_module_or_empty(src))
+    .filter(fn(i) { i.message.contains("not assignable to type parameter") })
+    .length()
+  }
+  // `var x: T = 1` in a generic body — flagged (literal source).
+  assert_true(count("function f<T>(): T { var x: T = 1; return x; }") >= 1)
+  // `return 1` where the return annotation is the bare type parameter.
+  assert_true(count("function f<T>(): T { return 1; }") >= 1)
+  // String literal likewise.
+  assert_true(count("function f<T>(): T { return \"s\"; }") >= 1)
+  // A value already typed as `T` is fine — not flagged.
+  @test.assert_eq(
+    count("function f<T>(t: T): T { var x: T = t; return x; }"),
+    0,
+  )
+  // An `any`-typed source flows to everything — not flagged.
+  @test.assert_eq(
+    count("function f<T>(a: any): T { var x: T = a; return x; }"),
+    0,
+  )
+  // Flow-narrowing residue: a `T`-typed variable narrowed to a primitive by a
+  // `typeof` guard keeps the intersection `T & string`, which IS assignable to
+  // `T`. The source is a variable (not a literal), so the rule stays silent.
+  @test.assert_eq(
+    count(
+      "function f<T>(x: T): void { if (typeof x === \"string\") { let v: T = x; } }",
+    ),
+    0,
+  )
+}


### PR DESCRIPTION
## 概要

Issue #62 の継続。902c7f8 の「null/undefined → bare `T`」ルールの補完として、**「リテラル値 → bare 型パラメータ `T`」**の検出を追加します。両ルールで「`T` でない値 → bare `T`」を網羅します。

`function f<T>(): T { return 1 }` / `var x: T = 1` は `T` が無関係な型にインスタンス化され得るため、strict 非依存で TS2322 / TS2345。`check_expr_against` で target が in-scope 型パラメータ名に unwrap され、**式がリテラル**(`precise_literal_type is Some`)のときに flag します。

## FP 回避の要点

ゲートを「inferred 型がプリミティブ」ではなく「**式がリテラル**」にしたのが FP-free の鍵です。`T` 型変数が `typeof x === "string"` で narrow された場合、実型は交差型 `T & string`(= `T` に代入可)を保ちますが、その source は変数でリテラルではないため沈黙します。inferred ベースの初版は `typeGuardsTypeParameters.ts` で FP を出していました。

## 計測

- 全 4091 ファイルの conformance corpus で **precision 0 FP 維持**。
- 全 **2296 テスト green**(回帰 wbtest 追加)。
- corpus はこのエラーを **call-site の明示的型引数**経由でしか露出しておらず(AST が型引数を保持していない)、standalone の recall delta は 0。ただし健全・FP0 でジェネリック本体の実バグ類を捕捉する正当な gap closure。

## 残（#62 は open 継続）

1. 明示的型引数を AST に載せて substitute する path(`foo<Date,Date>(1)` 等)。`Call` / `CallExpr` / `MethodCall` の variant 拡張は `src/transform/*` 含む ~28 ファイルの網羅 match に波及するため、段階導入が適切。
2. construct-signature 推論 / overload-pairwise 推論 / `NoInfer<T>` / index-signature 推論 など inference-priority の深いモデル化。

https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx)_