### PR TITLE
checker: detect out-of-scope single-letter type parameters (TS2304) (#62)

### DIFF
--- a/src/ast/types.mbt
+++ b/src/ast/types.mbt
@@ -42,6 +42,15 @@ pub(all) enum TsType {
   Object(Array[(TsType, TsType)]) // { key: value } - key is Literal for property names
   Struct(String, Array[(String, TsType)]) // name, fields (for codegen)
   Func(Array[TsType], TsType) // params, return
+  // A function type that declares its own generic type parameters:
+  // `<S>(x: S) => T`. Wraps the underlying `Func` (or `Constructor`) and
+  // carries the bound type-parameter names so the checker can add them to
+  // scope. Type-parameter names are erased everywhere the function type's
+  // *value* shape matters (assignability, emit, bridge), so those consumers
+  // peel the wrapper to the inner callable; only scope-aware checks read the
+  // names. Kept as a wrapper (rather than a field on `Func`) so the pervasive
+  // `Func(params, ret)` match sites stay unchanged.
+  GenericFunc(Array[String], TsType)
   // Constructor type: `new (...args) => T` or `abstract new (...) => T`.
   // Stored separately from `Func` so utility passes (`ConstructorParameters`,
   // `InstanceType`) can pattern-match on the call form, and so a bridge

--- a/src/bridge/moonbit_decl.mbt
+++ b/src/bridge/moonbit_decl.mbt
@@ -3289,6 +3289,7 @@ fn utility_record_type_suffix(type_ : @ast.TsType) -> String {
     }
     Func(_, return_type) =>
       "FunctionTo" + utility_record_type_suffix(return_type)
+    GenericFunc(_, inner) => utility_record_type_suffix(inner)
     Union(items) => {
       let parts : Array[String] = []
       for item in items {

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -930,6 +930,13 @@ fn Resolver::unwrap(self : Resolver, ty : @ast.TsType) -> @ast.TsType {
           _ => cur = simplified
         }
       }
+      // A generic function type erases to its underlying callable for every
+      // value-shape decision (assignability, member lookup, inference): the
+      // declared type-parameter names matter only to scope-aware checks that
+      // read the wrapper directly. Peel it here so the rest of the resolver
+      // sees the plain `Func` / `Constructor` exactly as before this variant
+      // existed.
+      GenericFunc(_, inner) => cur = inner
       _ => keep_going = false
     }
   }
@@ -5010,6 +5017,10 @@ fn type_param_occurs(tp : String, t : @ast.TsType) -> Bool {
     Func(ps, r) | Constructor(ps, r, _) =>
       ps.iter().any(fn(p) { type_param_occurs(tp, p) }) ||
       type_param_occurs(tp, r)
+    // A generic function type shadows `tp` when it re-declares the same name;
+    // otherwise `tp` may occur free in the underlying callable.
+    GenericFunc(names, inner) =>
+      !names.contains(tp) && type_param_occurs(tp, inner)
     Conditional(a, b, c, d) =>
       type_param_occurs(tp, a) ||
       type_param_occurs(tp, b) ||
@@ -11673,6 +11684,279 @@ fn check_structural_duplicates(module_ : @ast.TsModule) -> Array[ExprIssue] {
 }
 
 ///|
+/// True when `name` is a single uppercase ASCII letter (`T`, `U`, `K`, …).
+/// Such names are, by overwhelming convention, generic type parameters —
+/// never library / global types — so an *unresolved* one is reliably an
+/// out-of-scope type parameter rather than a type we merely fail to model.
+fn is_single_upper_letter(name : String) -> Bool {
+  if name.length() != 1 {
+    return false
+  }
+  let c = name[0]
+  c >= 'A' && c <= 'Z'
+}
+
+///|
+/// TS2304 ("Cannot find name") for the false-positive-free slice: a *single
+/// uppercase letter* type reference used in a function / method / property /
+/// interface-field / value signature that is neither declared anywhere in the
+/// module tree nor in scope as a type parameter of an enclosing function /
+/// method / class / interface / generic function type
+/// (`function foo<T>(b: (x: U) => U)` references the undeclared `U`).
+///
+/// Restricting to the single-letter lexical shape sidesteps the incomplete
+/// library-type registry that makes general unresolved-name reporting unsound
+/// here. The type parameters bound by a nested generic function type
+/// (`<S>(x: S) => T`) are tracked via the `GenericFunc` wrapper and added to
+/// scope, so they are not mistaken for out-of-scope references. Binder /
+/// computed forms that do *not* surface their binders (`Conditional` with
+/// `infer`, `MappedType`, `Keyof`, `IndexedAccess`, `TemplateLiteralType`)
+/// are not descended into.
+fn check_undeclared_type_parameters(
+  module_ : @ast.TsModule,
+) -> Array[ExprIssue] {
+  let declared : Map[String, Unit] = {}
+  collect_declared_type_names(module_, declared)
+  let issues : Array[ExprIssue] = []
+  walk_module_undeclared_tps(module_, [], declared, issues)
+  issues
+}
+
+///|
+/// Collect every type-name declaration (interface / alias / class / enum /
+/// namespace) across the whole module tree into `out`. Over-approximating
+/// visibility (a name declared in any namespace suppresses the report
+/// everywhere) keeps the check false-positive-free at the cost of a few
+/// missed reports — the safe direction.
+fn collect_declared_type_names(
+  module_ : @ast.TsModule,
+  out : Map[String, Unit],
+) -> Unit {
+  for iface in module_.interfaces {
+    out[iface.name] = ()
+  }
+  for ta in module_.type_aliases {
+    out[ta.name] = ()
+  }
+  for c in module_.classes {
+    out[c.name] = ()
+  }
+  for e in module_.enums {
+    out[e.name] = ()
+  }
+  for ns in module_.namespaces {
+    out[ns.name] = ()
+    collect_declared_type_names(ns.module_, out)
+  }
+}
+
+///|
+/// Walk a module's signatures looking for single-letter unresolved type
+/// parameters. `tp_scope` is the chain of type parameters in scope from
+/// enclosing functions / classes / interfaces (namespaces are not generic).
+fn walk_module_undeclared_tps(
+  module_ : @ast.TsModule,
+  tp_scope : Array[String],
+  declared : Map[String, Unit],
+  issues : Array[ExprIssue],
+) -> Unit {
+  for f in module_.funcs {
+    let scope = scope_extend(tp_scope, f.type_params)
+    for p in f.params {
+      check_type_undeclared_tps(
+        p.type_,
+        scope,
+        declared,
+        issues,
+        "function \{f.name}",
+      )
+    }
+    check_type_undeclared_tps(
+      f.return_type,
+      scope,
+      declared,
+      issues,
+      "function \{f.name}",
+    )
+  }
+  for imp in module_.imports {
+    let scope = scope_extend(tp_scope, imp.type_params)
+    for p in imp.params {
+      check_type_undeclared_tps(
+        p.1,
+        scope,
+        declared,
+        issues,
+        "function \{imp.name}",
+      )
+    }
+    check_type_undeclared_tps(
+      imp.return_type,
+      scope,
+      declared,
+      issues,
+      "function \{imp.name}",
+    )
+  }
+  for iface in module_.interfaces {
+    let iscope = scope_extend(tp_scope, iface.type_params)
+    for field in iface.fields {
+      // Call / construct / index signatures (`<T>(x: T): T`) declare their own
+      // generic parameters under a sentinel field name that doesn't key into
+      // `method_type_params`, so their binders aren't recoverable as scope —
+      // skip them to stay false-positive-free.
+      if is_signature_sentinel(field.0) {
+        continue
+      }
+      // A generic method field carries its own fresh type parameters.
+      let mut mscope = iscope
+      for entry in iface.method_type_params {
+        if entry.0 == field.0 {
+          mscope = scope_extend(iscope, entry.1)
+        }
+      }
+      check_type_undeclared_tps(
+        field.1,
+        mscope,
+        declared,
+        issues,
+        "interface \{iface.name}",
+      )
+    }
+  }
+  for c in module_.classes {
+    let cscope = scope_extend(tp_scope, c.type_params)
+    for prop in c.properties {
+      check_type_undeclared_tps(
+        prop.type_,
+        cscope,
+        declared,
+        issues,
+        "class \{c.name}",
+      )
+    }
+    for m in c.methods {
+      let mscope = scope_extend(cscope, m.type_params)
+      for p in m.params {
+        check_type_undeclared_tps(
+          p.1,
+          mscope,
+          declared,
+          issues,
+          "class \{c.name}",
+        )
+      }
+      check_type_undeclared_tps(
+        m.return_type,
+        mscope,
+        declared,
+        issues,
+        "class \{c.name}",
+      )
+    }
+  }
+  for v in module_.values {
+    check_type_undeclared_tps(
+      v.type_,
+      tp_scope,
+      declared,
+      issues,
+      "value \{v.name}",
+    )
+  }
+  for ns in module_.namespaces {
+    walk_module_undeclared_tps(ns.module_, tp_scope, declared, issues)
+  }
+}
+
+///|
+/// Concatenate `extra` onto `base`, returning `base` unchanged when `extra`
+/// is empty (the common non-generic case).
+fn scope_extend(base : Array[String], extra : Array[String]) -> Array[String] {
+  if extra.length() == 0 {
+    return base
+  }
+  let out : Array[String] = []
+  for b in base {
+    out.push(b)
+  }
+  for e in extra {
+    out.push(e)
+  }
+  out
+}
+
+///|
+/// Recurse a type position, reporting single-letter type references that are
+/// neither in `scope` nor `declared`. Binder / computed forms are not
+/// descended into (see `check_undeclared_type_parameters`).
+fn check_type_undeclared_tps(
+  ty : @ast.TsType,
+  scope : Array[String],
+  declared : Map[String, Unit],
+  issues : Array[ExprIssue],
+  path : String,
+) -> Unit {
+  fn report(n : String) -> Unit {
+    if is_single_upper_letter(n) &&
+      !scope.contains(n) &&
+      !(declared.get(n) is Some(_)) {
+      issues.push({ path, message: "cannot find name `\{n}`" })
+    }
+  }
+
+  match ty {
+    Named(n) => report(n)
+    Applied(n, args) => {
+      report(n)
+      for a in args {
+        check_type_undeclared_tps(a, scope, declared, issues, path)
+      }
+    }
+    Array(e) | Rest(e) =>
+      check_type_undeclared_tps(e, scope, declared, issues, path)
+    Tuple(items) | Union(items) | Intersection(items) =>
+      for it in items {
+        check_type_undeclared_tps(it, scope, declared, issues, path)
+      }
+    Object(pairs) =>
+      for p in pairs {
+        // Object-literal call / construct signatures (`{ <T>(x: T): T }`)
+        // bind their own generics under a sentinel key that doesn't surface
+        // the binder names, so skip them to stay false-positive-free.
+        match p.0 {
+          Literal(key) if is_signature_sentinel(key) => continue
+          _ => ()
+        }
+        check_type_undeclared_tps(p.1, scope, declared, issues, path)
+      }
+    Struct(_, fields) =>
+      for f in fields {
+        check_type_undeclared_tps(f.1, scope, declared, issues, path)
+      }
+    Func(params, ret) | Constructor(params, ret, _) => {
+      for p in params {
+        check_type_undeclared_tps(p, scope, declared, issues, path)
+      }
+      check_type_undeclared_tps(ret, scope, declared, issues, path)
+    }
+    // A generic function type binds its own type parameters: add them to
+    // scope before descending so `<S>(x: S) => T` does not flag `S`.
+    GenericFunc(names, inner) => {
+      let inner_scope = scope_extend(scope, names)
+      check_type_undeclared_tps(inner, inner_scope, declared, issues, path)
+    }
+    TypePredicate(_, pt) =>
+      check_type_undeclared_tps(pt, scope, declared, issues, path)
+    // Binder-introducing / computed forms are intentionally not descended
+    // into — `Conditional` (with `infer`), `MappedType`, `MappedTypeRemap`,
+    // `Keyof`, `IndexedAccess`, `TemplateLiteralType`, `AssertsPredicate`,
+    // and all primitive / literal leaves.
+    _ => ()
+  }
+}
+
+///|
 /// TS2374 ("Duplicate index signature for type 'string' / 'number'"): a
 /// single object type (interface or class body) may declare at most one
 /// string index signature and at most one numeric index signature. Two of
@@ -12186,6 +12470,14 @@ fn check_module_function_bodies_layered(
   }
   for issue in check_structural_duplicates(module_) {
     all.push(issue)
+  }
+  // TS2304 for single-letter out-of-scope type parameters. Run once at the
+  // top level — the walker recurses into namespaces itself, so calling it per
+  // layered namespace would double-report.
+  if outer_modules.length() == 0 {
+    for issue in check_undeclared_type_parameters(module_) {
+      all.push(issue)
+    }
   }
   for issue in check_var_redeclaration_types(module_, resolver) {
     all.push(issue)

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -7885,3 +7885,35 @@ test "expr_check: a literal is not assignable to a bare type parameter" {
     0,
   )
 }
+
+///|
+// Issue #62 (TS2304 for out-of-scope single-letter type parameters): a single
+// uppercase-letter type reference that is not declared and not in scope as a
+// type parameter is a `cannot find name` error. The generic parameters bound
+// by a nested generic function / constructor type, by interface call / index
+// signatures, and by object-literal call signatures are NOT mistaken for
+// out-of-scope references — keeping the check false-positive-free.
+test "expr_check: out-of-scope single-letter type parameter (TS2304)" {
+  let count = fn(src : String) -> Int {
+    check_module_function_bodies(parse_module_or_empty(src))
+    .filter(fn(i) { i.message.contains("cannot find name") })
+    .length()
+  }
+  // `b: (y: U) => U` references the undeclared `U` (only `<T>` is in scope).
+  assert_true(count("function f<T>(x: T, b: (y: U) => U): void {}") >= 1)
+  // A bound type parameter of the function itself is fine.
+  @test.assert_eq(count("function f<T>(x: T, b: (y: T) => T): void {}"), 0)
+  // A nested generic function type binds its own `<S>` — not flagged.
+  @test.assert_eq(count("function f(cb: <S>(x: S) => S): void {}"), 0)
+  // A nested generic constructor type binds its own `<S>` — not flagged.
+  @test.assert_eq(count("function f(cb: new <S>(x: S) => S[]): void {}"), 0)
+  // Interface call / index signatures declare their own generics — not flagged.
+  @test.assert_eq(count("interface I { <U>(x: U): U; }"), 0)
+  // Object-literal call signatures declare their own generics — not flagged.
+  @test.assert_eq(count("declare function g(o: { <T>(x: T): T }): void;"), 0)
+  // A declared type alias named with a single letter is in scope everywhere.
+  @test.assert_eq(
+    count("type T = number;\nfunction f(x: T): T { return x; }"),
+    0,
+  )
+}

--- a/src/checker/generics.mbt
+++ b/src/checker/generics.mbt
@@ -374,6 +374,16 @@ fn substitute_params(
       }
       TemplateLiteralType(parts, new_args)
     }
+    // A generic function type's own type parameters shadow the substitution:
+    // drop them from the bindings before recursing into the callable so an
+    // outer `T` substitution doesn't capture an inner `<T>`.
+    GenericFunc(names, inner) => {
+      let mut inner_bindings = bindings
+      for n in names {
+        inner_bindings = scoped_without(inner_bindings, n)
+      }
+      GenericFunc(names, substitute_params(inner, inner_bindings))
+    }
     _ => type_
   }
 }

--- a/src/parser/parser_type.mbt
+++ b/src/parser/parser_type.mbt
@@ -74,8 +74,14 @@ fn Parser::parse_constructor_tail(
   self : Parser,
   is_abstract : Bool,
 ) -> @ast.TsType raise ParseError {
-  if self.check(Lt) {
-    self.skip_type_args()
+  // Capture the constructor type's own generic parameters (`new <T>(x: T) =>
+  // T`) so scope-aware checks can see the binder; the names are erased for
+  // the value shape (see `GenericFunc`).
+  let tp_names = if self.check(Lt) {
+    let (names, _) = self.parse_type_param_names_and_bounds()
+    names
+  } else {
+    []
   }
   if !self.check(LParen) {
     return Any
@@ -119,7 +125,12 @@ fn Parser::parse_constructor_tail(
     return Any
   }
   let ret = self.parse_type()
-  Constructor(param_types, ret, is_abstract)
+  let ctor = @ast.TsType::Constructor(param_types, ret, is_abstract)
+  if tp_names.length() > 0 {
+    GenericFunc(tp_names, ctor)
+  } else {
+    ctor
+  }
 }
 
 ///|
@@ -776,10 +787,15 @@ fn Parser::parse_primary_type(self : Parser) -> @ast.TsType raise ParseError {
   let tok = self.peek()
   let base_type : @ast.TsType = match tok.kind {
     Lt => {
-      self.skip_type_args()
+      let (tp_names, _bounds) = self.parse_type_param_names_and_bounds()
       if self.check(LParen) {
         match self.parse_paren_or_function_type() {
-          Func(_, _) as func_type => func_type
+          Func(_, _) | Constructor(_, _, _) as func_type =>
+            if tp_names.length() > 0 {
+              @ast.TsType::GenericFunc(tp_names, func_type)
+            } else {
+              func_type
+            }
           _ => Any
         }
       } else {

--- a/src/parser/parser_wbtest.mbt
+++ b/src/parser/parser_wbtest.mbt
@@ -4207,9 +4207,12 @@ test "parser: parse generic function property type" {
   }
   assert_eq(module_.interfaces.length(), 1)
   assert_eq(module_.interfaces[0].fields.length(), 1)
+  // A function-type property that declares its own generic parameters
+  // (`<E>(expected: E) => void`) now lowers to `GenericFunc` carrying the
+  // bound names, wrapping the underlying `Func`.
   match module_.interfaces[0].fields[0].1 {
-    Func(params, Void) => assert_eq(params.length(), 1)
-    _ => fail("expected generic function property to lower to Func")
+    GenericFunc(["E"], Func(params, Void)) => assert_eq(params.length(), 1)
+    _ => fail("expected generic function property to lower to GenericFunc")
   }
 }
 

--- a/src/transform/dts_emit.mbt
+++ b/src/transform/dts_emit.mbt
@@ -480,6 +480,9 @@ fn emit_type(buf : StringBuilder, ty : @ast.TsType) -> Unit {
       buf.write_string(") => ")
       emit_type(buf, ret)
     }
+    // Emit the underlying callable; the generic binder prefix is dropped (as
+    // it was before the `GenericFunc` wrapper existed).
+    GenericFunc(_, inner) => emit_type(buf, inner)
     Constructor(params, ret, is_abstract) => {
       if is_abstract {
         buf.write_string("abstract ")


### PR DESCRIPTION
## 概要

#62 の継続。ユーザー方針に従い**基盤的 AST 変更**に着手し、スコープ外の型パラメータ参照(TS2304)を検出します。recall +5、新規 FP ゼロ。

## 基盤(挙動保存)

自身のジェネリックを宣言する関数型 / コンストラクタ型 `<S>(x: S) => T` / `new <S>(...) => T` を、bound 名を保持する新ラッパー `GenericFunc(names, inner)` に lower します。名前は値の形には無関係なので、既存 consumer はラッパーを peel して従来通り `Func` / `Constructor` を見ます:
- `Resolver::unwrap`
- `substitute_params`(binder シャドーイング対応)
- `type_param_occurs`
- `.d.ts` / bridge emit

→ 基盤だけでは conformance precision/recall・全テストとも完全に不変。

## detector

`function foo<T>(b: (x: U) => U)` は未宣言の `U` を参照 → TypeScript は TS2304。**単一大文字**は慣習上必ず型パラメータで lib 型ではないため、未解決なら確実にスコープ外。この字句形に限定することで、不完全な lib 型レジストリに依存せず健全に検出できます。

walker は、囲む関数/メソッド/クラス/インターフェース及びネストした `GenericFunc` の binder からスコープ内型パラメータを追跡し、宣言済み型名は木全体から over-approximate、binder を surface しない形(interface/object の call/construct/index signature、`infer` 付き `Conditional`、`MappedType`、`Keyof`、`IndexedAccess`、`TemplateLiteralType`)には降りません。

## 計測

- conformance recall **1505 → 1510 TP**、precision **全 4091 ファイルで 0 FP 維持**。
- 初期の inferred-only 版は generic 関数型 binder(AST 未モデル化)由来で 14 FP を出していたが、基盤 + binder-aware scope で解消。
- 全 **2297 テスト green**(回帰 wbtest 追加)。

## 残（#62 は open 継続）

generic-function assignability の contravariance 系 MISS(`genericCallWithGenericSignatureArguments2/3` の TS2345 等)— 今回の `GenericFunc` 基盤が将来の足がかりになる。

https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx)_