### PR TITLE
checker: detect function-type parameter incompatibility (#62)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -5893,6 +5893,36 @@ fn check_expr_against(
   if tuples_differ_only_in_named(inferred_u, expected_u, ctx.resolver) {
     return
   }
+  // Plain function-type vs function-type: check assignability before the
+  // broad callable bail below. Parameters are compared *bivariantly* — that
+  // matches the conformance corpus default (`strictFunctionTypes: false`) and
+  // is the permissive choice, so we never FP on a case a stricter
+  // contravariant rule would reject. A clear incompatibility
+  // (`(x: string) => string` assigned where `(x: number) => number` is
+  // expected) is then a real TS2322 / TS2345.
+  //
+  // Restricted to cases where neither side is a *generic* function type
+  // (`GenericFunc`) — those can be made compatible by instantiating their
+  // type parameters, which we don't attempt here — and where neither inner
+  // shape carries an unresolved / in-scope type-parameter reference (the
+  // source side is already cleared by the unresolved-`Named` bail above; this
+  // guards the expected side).
+  if not_generic_func(inferred) &&
+    not_generic_func(expected) &&
+    inferred_u is Func(_, _) &&
+    expected_u is Func(_, _) &&
+    !func_type_mentions_type_param(inferred_u, ctx) &&
+    !func_type_mentions_type_param(expected_u, ctx) &&
+    !type_contains_unresolved_named(expected_u, ctx.resolver) {
+    if !is_assignable_to_bivariant(inferred_u, expected_u) {
+      record(
+        ctx,
+        sub_path,
+        "expected `\{type_display(expected_u)}` but got `\{type_display(inferred_u)}`",
+      )
+    }
+    return
+  }
   // Callable / constructable interfaces & objects (`<call>` / `<new>`
   // signatures, often `extends Function`, with overloaded methods like
   // `foo("hi"): Derived1; foo("bye"): Derived2`) match other call signatures
@@ -7932,6 +7962,26 @@ fn check_arrow_with_context(
       formal_params[i]
     } else {
       p.type_
+    }
+    // When the arrow param carries an *explicit* annotation, it must be
+    // compatible with the contextual (formal) parameter type. Parameters are
+    // compared bivariantly (matching `strictFunctionTypes: false`, the corpus
+    // default): a clear incompatibility (`(x: string) => …` passed where
+    // `(x: number) => …` is expected) is a real TS2345 / TS2322. Skipped when
+    // either side is non-checkable (`any`) or mentions an in-scope type
+    // parameter (instantiation could reconcile them).
+    if is_checkable(p.type_) &&
+      i < formal_params.length() &&
+      is_checkable(formal_params[i]) &&
+      reliable_func_param_operand(p.type_, ctx) &&
+      reliable_func_param_operand(formal_params[i], ctx) &&
+      !(is_assignable_to_bivariant(p.type_, formal_params[i]) ||
+      is_assignable_to_bivariant(formal_params[i], p.type_)) {
+      record(
+        ctx,
+        "\{sub_path} param `\{p.name}`",
+        "expected `\{type_display(formal_params[i])}` but got `\{type_display(p.type_)}`",
+      )
     }
     env.bind(p.name, ty)
     param_names.push(p.name)
@@ -12616,6 +12666,69 @@ fn is_concrete_primitive_or_literal(ty : @ast.TsType) -> Bool {
     | BooleanLiteral(_) => true
     _ => false
   }
+}
+
+///|
+/// True when `ty` is *not* a generic function type. Used to keep the
+/// function-type assignability check away from `<S>(...) => T` shapes, which
+/// can be made compatible by instantiating their type parameters.
+fn not_generic_func(ty : @ast.TsType) -> Bool {
+  !(ty is GenericFunc(_, _))
+}
+
+///|
+/// True when any param / return position of a function type references an
+/// in-scope type parameter (`(x: T) => T` inside `function f<T>(...)`). Such a
+/// function type's assignability depends on how `T` is instantiated, so the
+/// concrete function-type check stays silent. Only the immediate param /
+/// return positions are inspected — enough for the shapes the check handles.
+fn func_type_mentions_type_param(ty : @ast.TsType, ctx : CheckCtx) -> Bool {
+  match ty {
+    Func(params, ret) | Constructor(params, ret, _) =>
+      params.iter().any(fn(p) { type_mentions_in_scope_type_param(p, ctx) }) ||
+      type_mentions_in_scope_type_param(ret, ctx)
+    _ => false
+  }
+}
+
+///|
+/// True when a type is a *reliable* operand for the bivariant function-type
+/// parameter check: a concrete type whose comparison we trust. Excludes
+/// - in-scope type parameters (`T`) and generic function types — instantiation
+///   could reconcile them;
+/// - unresolved `Named` references (an arrow's own dropped generic `<U>`, or a
+///   library type we don't model) — we can't compare them soundly;
+/// - `Union` types — these are usually the artifact of our generic
+///   type-argument inference (which diverges from tsc), so a strict param
+///   comparison against them false-flags.
+fn reliable_func_param_operand(ty : @ast.TsType, ctx : CheckCtx) -> Bool {
+  if type_mentions_in_scope_type_param(ty, ctx) {
+    return false
+  }
+  if !not_generic_func(ty) {
+    return false
+  }
+  if type_contains_unresolved_named(ty, ctx.resolver) {
+    return false
+  }
+  match ty {
+    Union(_) => false
+    _ => true
+  }
+}
+
+///|
+/// True when `ty` references any type parameter currently in scope.
+fn type_mentions_in_scope_type_param(ty : @ast.TsType, ctx : CheckCtx) -> Bool {
+  if ctx.in_scope_type_params.length() == 0 {
+    return false
+  }
+  for tp in ctx.in_scope_type_params {
+    if type_param_occurs(tp, ty) {
+      return true
+    }
+  }
+  false
 }
 
 ///|

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -7917,3 +7917,62 @@ test "expr_check: out-of-scope single-letter type parameter (TS2304)" {
     0,
   )
 }
+
+///|
+// Issue #62 (function-type parameter assignability): a function-typed value /
+// argument whose explicit parameter types are incompatible with the expected
+// function type is a TS2322 / TS2345. Parameters are compared bivariantly
+// (matching `strictFunctionTypes: false`). Generic function types, in-scope
+// type parameters, unresolved names, and inference-union formals are skipped
+// to stay false-positive-free.
+test "expr_check: function-type parameter mismatch (contravariance)" {
+  let count = fn(src : String) -> Int {
+    check_module_function_bodies(parse_module_or_empty(src))
+    .filter(fn(i) { i.message.contains("expected") })
+    .length()
+  }
+  // Assignment: `(x: string) => string` is not assignable to
+  // `(x: number) => number` (param `string` vs `number`).
+  assert_true(
+    count(
+      "declare var g: (x: string) => string;\nvar f: (x: number) => number = g;",
+    ) >=
+    1,
+  )
+  // Function-typed argument: same mismatch at a call site.
+  assert_true(
+    count(
+      "declare function take(cb: (x: number) => number): void;\ndeclare var g: (x: string) => string;\ntake(g);",
+    ) >=
+    1,
+  )
+  // Arrow argument with an explicit, incompatible param annotation.
+  assert_true(
+    count(
+      "declare function take(cb: (x: number) => number): void;\ntake((x: string) => x.length);",
+    ) >=
+    1,
+  )
+  // Compatible (same param type) — not flagged.
+  @test.assert_eq(
+    count(
+      "declare var g: (x: number) => number;\nvar f: (x: number) => number = g;",
+    ),
+    0,
+  )
+  // A generic arrow (`<U extends string>(x: U) => x`) can be instantiated to
+  // satisfy the constraint — not flagged.
+  @test.assert_eq(
+    count(
+      "function foo<T extends (x: string) => string>(x: T): T { return x; }\nvar r = foo(<U extends string>(x: U) => x);",
+    ),
+    0,
+  )
+  // Unannotated arrow params take the contextual type — not flagged.
+  @test.assert_eq(
+    count(
+      "declare function take(cb: (x: number) => number): void;\ntake((x) => x + 1);",
+    ),
+    0,
+  )
+}


### PR DESCRIPTION
## 概要

#62 の継続(contravariance 系)。関数型同士の代入で**パラメータ型の非互換**を検出します(TS2322 / TS2345)。recall +6、新規 FP ゼロ。

`var f: (x: number) => number = g`(`g: (x: string) => string`)、呼び出しサイトの関数型引数、明示注釈付き arrow 引数の不一致を検出。従来は `shape_is_callable` の広い bail で関数型代入が全て抑制されていました。

## bivariance

パラメータは **bivariant** に比較(`is_assignable_to_bivariant`)。conformance corpus の既定 `strictFunctionTypes: false` に一致し、contravariant より permissive なので「より厳しい規則なら弾く」ケースで FP しません。`string` vs `number` のような明確な非互換は双方向不成立で真のエラー。

## FP ガード(`reliable_func_param_operand`)

以下の場合スキップ:
- generic 関数型(`GenericFunc`)— instantiation で互換になり得る
- in-scope 型パラメータ参照
- unresolved `Named`(arrow 自身の落とされた `<U>`、未モデル化 lib 型)
- `Union`(我々の generic 型引数推論の産物で tsc と乖離)

ガードなし版が出した2 FP — `functionConstraintSatisfaction3`(generic arrow `<U extends string>(x: U) => x`)と `genericCallWithGenericSignatureArguments`(推論 T の union formal)— はこれで解消。

## 計測

- conformance recall **1510 → 1516 TP**、precision **全 4091 ファイルで 0 FP 維持**
- 全 **2298 テスト green**(回帰 wbtest 追加)

## このセッションの #62 進捗(累積)

| PR | 内容 | recall |
|----|------|--------|
| #113 | literal → bare `T` | ±0 |
| #114 | スコープ外単一大文字 TS2304 + `GenericFunc` 基盤 | +5 |
| 本PR | 関数型パラメータ非互換 | +6 |

precision は全工程で **0 FP** 維持。

https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx)_