### PR TITLE
checker: extend function-type assignability to constructor types (#62)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -5893,13 +5893,14 @@ fn check_expr_against(
   if tuples_differ_only_in_named(inferred_u, expected_u, ctx.resolver) {
     return
   }
-  // Plain function-type vs function-type: check assignability before the
-  // broad callable bail below. Parameters are compared *bivariantly* — that
-  // matches the conformance corpus default (`strictFunctionTypes: false`) and
-  // is the permissive choice, so we never FP on a case a stricter
-  // contravariant rule would reject. A clear incompatibility
-  // (`(x: string) => string` assigned where `(x: number) => number` is
-  // expected) is then a real TS2322 / TS2345.
+  // Plain function- / constructor-type vs the same: check assignability
+  // before the broad callable bail below. Parameters are compared
+  // *bivariantly* — that matches the conformance corpus default
+  // (`strictFunctionTypes: false`) and is the permissive choice, so we never
+  // FP on a case a stricter contravariant rule would reject. A clear
+  // incompatibility (`(x: string) => string` assigned where `(x: number) =>
+  // number` is expected, or `new (x: number) => string` where `new (x:
+  // number) => number` is expected) is then a real TS2322 / TS2345.
   //
   // Restricted to cases where neither side is a *generic* function type
   // (`GenericFunc`) — those can be made compatible by instantiating their
@@ -5909,8 +5910,8 @@ fn check_expr_against(
   // guards the expected side).
   if not_generic_func(inferred) &&
     not_generic_func(expected) &&
-    inferred_u is Func(_, _) &&
-    expected_u is Func(_, _) &&
+    is_plain_callable(inferred_u) &&
+    is_plain_callable(expected_u) &&
     !func_type_mentions_type_param(inferred_u, ctx) &&
     !func_type_mentions_type_param(expected_u, ctx) &&
     !type_contains_unresolved_named(expected_u, ctx.resolver) {
@@ -12674,6 +12675,16 @@ fn is_concrete_primitive_or_literal(ty : @ast.TsType) -> Bool {
 /// can be made compatible by instantiating their type parameters.
 fn not_generic_func(ty : @ast.TsType) -> Bool {
   !(ty is GenericFunc(_, _))
+}
+
+///|
+/// True when `ty` is a plain callable type — a bare function or constructor
+/// type. Used to gate the bivariant function-type assignability check, which
+/// `is_assignable_to_bivariant` handles for `Func` / `Constructor` (and the
+/// `Constructor` -> `Func` direction) but not for interface / object call
+/// signatures (those keep going through the `shape_is_callable` bail).
+fn is_plain_callable(ty : @ast.TsType) -> Bool {
+  ty is (Func(_, _) | Constructor(_, _, _))
 }
 
 ///|

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -7976,3 +7976,29 @@ test "expr_check: function-type parameter mismatch (contravariance)" {
     0,
   )
 }
+
+///|
+// Issue #62 (constructor-type assignability): a constructor type whose
+// parameter / return types are incompatible with the expected constructor
+// type is flagged, mirroring the function-type check.
+test "expr_check: constructor-type return mismatch" {
+  let count = fn(src : String) -> Int {
+    check_module_function_bodies(parse_module_or_empty(src))
+    .filter(fn(i) { i.message.contains("expected") })
+    .length()
+  }
+  // Return mismatch: `new (x: number) => string` vs `new (x: number) => number`.
+  assert_true(
+    count(
+      "declare var g: new (x: number) => string;\nvar f: new (x: number) => number = g;",
+    ) >=
+    1,
+  )
+  // Compatible — not flagged.
+  @test.assert_eq(
+    count(
+      "declare var g: new (x: number) => number;\nvar f: new (x: number) => number = g;",
+    ),
+    0,
+  )
+}


### PR DESCRIPTION
## 概要

#62 の継続。前PR(#115)の関数型 bivariant assignability チェックを **constructor 型**にも拡張します。recall +1、新規 FP ゼロ。

`var f: new (x: number) => number = g`(`g: new (x: number) => string`)のような construct signature の戻り値/パラメータ非互換を TS2322 として検出。呼び出しサイトも同様。

## 実装

`is_assignable_to_bivariant` は既に `Constructor` vs `Constructor`(および `Constructor` → `Func`)をモデル化済み。`check_expr_against` のゲートが `Func` 限定だっただけなので、新 predicate `is_plain_callable`(= `Func` or `Constructor`)で両 callable 形に広げました。interface / object の call signature は従来通り `shape_is_callable` の bail に残します。

FP ガード(generic callable / in-scope 型パラメータ / unresolved Named / 推論 union)は #115 と共通。

## 戻り値の非互換について

関数型の**戻り値**非互換は #115 の func-vs-func チェック(`is_assignable_to_bivariant` が return を covariant に検査)+ 既存の arrow body 検査で既にカバー済みであることを確認済み:
- `var f: (x: number) => number = g`(`g: (x: number) => string`)→ 検出
- arrow body の戻り値型不一致 → 検出
- ネスト関数型 / func を返す arrow → 検出

本PRはそのうち未対応だった constructor 形を埋めるもの。

## 計測

- conformance recall **1516 → 1517 TP**、precision **全 4091 ファイルで 0 FP 維持**
- 全 **2299 テスト green**

https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx)_