### PR TITLE
checker: detect assignment between unrelated type parameters (#62)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -5821,6 +5821,28 @@ fn check_expr_against(
       _ => ()
     }
   }
+  // Assignment between two *distinct* in-scope type parameters (`function
+  // foo<T, U>(t: T, u: U) { t = u }`) is a TS2322: type parameters are
+  // unrelated unless one is constrained to the other. Constraint relationships
+  // are already resolved by the parser, which inlines a constrained type
+  // parameter to its (transitive) bound — so a reference that is *still* a
+  // bare in-scope type parameter here is genuinely unconstrained relative to
+  // the target, and `<T, U extends T>` / `<T, V extends T, U extends V>` have
+  // their `U` rewritten to `T` and never reach this flag.
+  match (inferred_u, expected_u) {
+    (Named(s), Named(t)) =>
+      if s != t &&
+        ctx.in_scope_type_params.contains(s) &&
+        ctx.in_scope_type_params.contains(t) {
+        record(
+          ctx,
+          sub_path,
+          "expected `\{type_display(expected_u)}` but got `\{type_display(inferred_u)}`",
+        )
+        return
+      }
+    _ => ()
+  }
   // If the expected type is a `Named` reference that the resolver can't expand
   // (e.g. a generic type parameter like `T`, or a qualified name like
   // `Intl.NumberFormatPartTypes` that isn't in the module's declaration list),

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8002,3 +8002,28 @@ test "expr_check: constructor-type return mismatch" {
     0,
   )
 }
+
+///|
+// Issue #62 (type-parameter assignability): two distinct, unrelated in-scope
+// type parameters are not assignable to one another (TS2322). Constraint
+// relationships — including transitive ones — are resolved by the parser
+// (which inlines a constrained type parameter to its ultimate bound), so a
+// reference that is still a bare type parameter here is genuinely unrelated.
+test "expr_check: unrelated type-parameter assignment (TS2322)" {
+  let count = fn(src : String) -> Int {
+    check_module_function_bodies(parse_module_or_empty(src))
+    .filter(fn(i) { i.message.contains("expected") })
+    .length()
+  }
+  // Unconstrained, unrelated `T` and `U` — not assignable.
+  assert_true(count("function f<T, U>(t: T, u: U) { t = u; }") >= 1)
+  // `U extends T` — `U` is assignable to `T`, so `t = u` is fine.
+  @test.assert_eq(count("function f<T, U extends T>(t: T, u: U) { t = u; }"), 0)
+  // Transitive: `U extends V extends T` — `t = u` is fine (no FP).
+  @test.assert_eq(
+    count("function f<T, V extends T, U extends V>(t: T, u: U) { t = u; }"),
+    0,
+  )
+  // Same type parameter — fine.
+  @test.assert_eq(count("function f<T>(a: T, b: T) { a = b; }"), 0)
+}

--- a/src/parser/parser_type.mbt
+++ b/src/parser/parser_type.mbt
@@ -770,15 +770,40 @@ fn Parser::parse_named_type_tail(
 
 ///|
 fn Parser::local_type_param_bound(self : Parser, name : String) -> @ast.TsType? {
-  let mut idx = self.local_type_param_bounds.length()
-  while idx > 0 {
-    idx -= 1
-    let (param_name, bound) = self.local_type_param_bounds[idx]
-    if param_name == name {
-      return Some(bound)
+  fn direct(n : String) -> @ast.TsType? {
+    let mut idx = self.local_type_param_bounds.length()
+    while idx > 0 {
+      idx -= 1
+      let (param_name, bound) = self.local_type_param_bounds[idx]
+      if param_name == n {
+        return Some(bound)
+      }
+    }
+    None
+  }
+
+  match direct(name) {
+    None => None
+    Some(bound) => {
+      // Follow chains of type-parameter constraints to their ultimate bound:
+      // `<T, V extends T, U extends V>` resolves `U` to `T`, not just `V`.
+      // This keeps the inlined form transitively faithful so downstream
+      // structural checks (e.g. type-parameter assignability) don't treat
+      // `U` and `T` as unrelated. A visited set guards malformed cycles
+      // (`<A extends B, B extends A>`).
+      let mut cur = bound
+      let seen : Map[String, Bool] = {}
+      seen[name] = true
+      while cur is Named(n) && !seen.contains(n) {
+        seen[n] = true
+        match direct(n) {
+          Some(next) => cur = next
+          None => break
+        }
+      }
+      Some(cur)
     }
   }
-  None
 }
 
 ///|


### PR DESCRIPTION
## 概要

#62 の継続(inference 系)。**無関係な型パラメータ間の代入**を検出します(TS2322)。recall +2、新規 FP ゼロ。

`function foo<T, U>(t: T, u: U) { t = u }` — 制約で関連付けられていない型パラメータ同士は代入不可。従来は「expected が展開不能 `Named`」の bail で silent でした。

## 制約はパーサーで解決

制約付き型パラメータはパーサーが **bound に inline** します(`<T, U extends T>` の `U` → `T`)。よって新しい flag に到達した時点で bare な型パラメータなら、対象に対して本当に無制約。

本PRでこの inline を**推移的**にしました(`<T, V extends T, U extends V>` で `U` を最終 bound `T` まで解決、循環ガード付き)。これにより:
1. 制約チェーンで **FP しない**(`U extends V extends T` の `t = u` は受理)
2. inline 形が推移的に正確になり、下流の全構造チェックが恩恵を受ける

## 調査メモ

検討の結果、以下は割に合わず見送り:
- **明示型引数の不一致**(`foo<Date>(1)`): AST `Call` が型引数を捨てているため AST 拡張が必要だが、真の利回りは事実上1ファイル。
- **関数型引数からのジェネリック推論**(`genericCallWithFunctionTypedArguments2` 等): tsc の inference-priority の完全モデル化が必要で FP リスク大。

型パラメータ間代入は、パーサーの既存 bound-inline 機構に乗ることで AST 変更なし・FP=0 で実装できる点が決め手でした。

## 計測

- conformance recall **1517 → 1519 TP**(`typeParameterAssignability`, `typeParameterAssignability2`)、precision **全 4091 ファイルで 0 FP 維持**
- 全 **2300 テスト green**

https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx)_