### PR TITLE
checker: capture call/new type arguments and report TS2558 (#62)

### DIFF
--- a/src/ast/types.mbt
+++ b/src/ast/types.mbt
@@ -139,6 +139,16 @@ pub(all) enum TsExpr {
   // function
   Call(String, Array[TsExpr])
 
+  // A call / new / method-call carrying explicit type arguments
+  // (`foo<number>(x)`, `new C<string>()`, `obj.m<T>(a)`). Wraps the
+  // underlying call expression; the type arguments are erased for every
+  // value-level consumer (JS emission, inlining, flow analysis), which peel
+  // to the inner call. Only type-checking reads the arguments — e.g. to
+  // report supplying type arguments to a non-generic callee (TS2558). Kept
+  // as a wrapper so the pervasive `Call` / `New` / `MethodCall` match sites
+  // stay unchanged.
+  TypeArgs(Array[TsType], TsExpr)
+
   // function (expression)
   CallExpr(TsExpr, Array[TsExpr])
 

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -4236,6 +4236,9 @@ fn infer_expr(
   expr : @ast.TsExpr,
 ) -> @ast.TsType {
   match expr {
+    // Explicit type arguments are erased for inference: the call's value
+    // type is the inner call's type.
+    TypeArgs(_, inner) => infer_expr(env, resolver, inner)
     NumberLit(_) | IntLit(_) => @ast.TsType::Number
     BigIntLit(_) => @ast.TsType::BigInt
     BoolLit(_) => @ast.TsType::Boolean
@@ -10495,12 +10498,69 @@ fn check_undefined_name(env : ExprEnv, ctx : CheckCtx, name : String) -> Unit {
 }
 
 ///|
+
+///|
+/// TS2558 ("Expected N type arguments, but got M") for explicit type arguments
+/// supplied to a callee that is *confidently* non-generic: a declared class or
+/// function that declares zero type parameters. Restricted to that case to
+/// stay false-positive-free — when the callee can't be resolved, or is generic
+/// / `any` / a callable interface whose type-parameter count we don't model,
+/// the check stays silent.
+fn check_explicit_type_args(
+  ctx : CheckCtx,
+  targs : Array[@ast.TsType],
+  inner : @ast.TsExpr,
+) -> Unit {
+  if targs.length() == 0 {
+    return
+  }
+  // Returns `Some(count)` when `name` is a declared callee whose type-parameter
+  // count is known, `None` when it can't be determined (stay silent).
+  fn declared_type_param_count(name : String) -> Int? {
+    match ctx.resolver.classes.get(name) {
+      Some(cls) => Some(cls.type_params.length())
+      None =>
+        match ctx.resolver.func_type_params.get(name) {
+          Some(tps) => Some(tps.length())
+          None => None
+        }
+    }
+  }
+
+  let callee_name = match inner {
+    Call(name, _) => Some(name)
+    New(name, _) => Some(name)
+    _ => None
+  }
+  match callee_name {
+    Some(name) =>
+      match declared_type_param_count(name) {
+        Some(0) =>
+          record(
+            ctx,
+            "call `\{name}`",
+            "expected 0 type arguments, but got \{targs.length()}",
+          )
+        _ => ()
+      }
+    None => ()
+  }
+}
+
+///|
 fn check_call_args_in_expr(
   env : ExprEnv,
   expr : @ast.TsExpr,
   ctx : CheckCtx,
 ) -> Unit {
   match expr {
+    // A call carrying explicit type arguments: first validate the type-argument
+    // list against the callee, then descend into the underlying call so its
+    // arguments are still checked.
+    TypeArgs(targs, inner) => {
+      check_explicit_type_args(ctx, targs, inner)
+      check_call_args_in_expr(env, inner, ctx)
+    }
     Call(name, args) => {
       // TS2304: calling a name declared nowhere and not a standard global.
       check_undefined_name(env, ctx, name)
@@ -12943,6 +13003,7 @@ fn collect_ctor_this_members_expr(
     | ArrayHole
     | Var(_)
     | ImportMeta => ()
+    TypeArgs(_, inner) => collect_ctor_this_members_expr(inner, members, opaque)
     PropAccess(recv, name) =>
       if expr_is_this(recv) {
         members[name] = ()

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8027,3 +8027,40 @@ test "expr_check: unrelated type-parameter assignment (TS2322)" {
   // Same type parameter — fine.
   @test.assert_eq(count("function f<T>(a: T, b: T) { a = b; }"), 0)
 }
+
+///|
+// Issue #62 (TS2558): supplying explicit type arguments to a callee that is
+// confidently non-generic (a declared class / function with zero type
+// parameters) is an error. Generic callees and ones we can't resolve stay
+// silent. Relies on the parser capturing call/new type arguments in a
+// `TypeArgs` wrapper.
+test "expr_check: type arguments on non-generic callee (TS2558)" {
+  let count = fn(src : String) -> Int {
+    check_module_function_bodies(parse_module_or_empty(src))
+    .filter(fn(i) { i.message.contains("type argument") })
+    .length()
+  }
+  // `new C<number>()` where `C` is a non-generic class.
+  assert_true(
+    count("class C {}\nfunction f() { var c = new C<number>(); }") >= 1,
+  )
+  // `new Foo<number>()` where `Foo` is a non-generic function.
+  assert_true(
+    count(
+      "function Foo(): void {}\nfunction f() { var r = new Foo<number>(); }",
+    ) >=
+    1,
+  )
+  // Generic function called with type arguments — fine.
+  @test.assert_eq(
+    count(
+      "function g<T>(x: T): T { return x; }\nfunction f() { g<number>(1); }",
+    ),
+    0,
+  )
+  // Generic class instantiated with type arguments — fine.
+  @test.assert_eq(
+    count("class Box<T> { v!: T; }\nfunction f() { new Box<number>(); }"),
+    0,
+  )
+}

--- a/src/parser/parser_core.mbt
+++ b/src/parser/parser_core.mbt
@@ -46,6 +46,11 @@ pub struct Parser {
   // `extends make(ast)`). Callers drain this immediately after the
   // call to stash it on the resulting `TsClassDecl.base_expr`.
   mut pending_class_base_expr : @ast.TsExpr?
+  // Explicit type arguments captured by `try_skip_call_type_args` for the
+  // call that immediately follows (`foo<number>(x)`). Drained by `parse_call`
+  // when it builds the `Call` / `New` / `MethodCall` so the result can be
+  // wrapped in `TypeArgs`. Empty when the following call had none.
+  mut pending_call_type_args : Array[@ast.TsType]
   local_type_param_bounds : Array[(String, @ast.TsType)]
   // Decorator expressions parsed at the statement level that should be
   // attached to the next class declaration. The class parsers drain
@@ -116,6 +121,7 @@ pub fn Parser::new_with_strict_and_jsx(
     pos: 0,
     pending_gt: 0,
     pending_gt_pos: 0,
+    pending_call_type_args: [],
     in_generator: false,
     in_async: false,
     temp_index: 0,
@@ -168,6 +174,7 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
     pos: 0,
     pending_gt: 0,
     pending_gt_pos: 0,
+    pending_call_type_args: [],
     in_generator: false,
     in_async: false,
     temp_index: 0,

--- a/src/parser/parser_expr.mbt
+++ b/src/parser/parser_expr.mbt
@@ -1031,13 +1031,22 @@ fn Parser::try_skip_call_type_args(self : Parser, expr : @ast.TsExpr) -> Bool {
     return false
   }
   let saved_pos = self.pos
+  self.pending_call_type_args = []
+  // Capture the type arguments when they parse cleanly so a following call
+  // can be wrapped in `TypeArgs`; otherwise fall back to the balanced skip.
   // Require a balanced `<...>` — otherwise `S<N;…` happily scans to
   // EOF, the caller treats it as a successful generic-instantiation,
   // and everything after the misread `<` disappears. (Real cases:
   // for-cond `S<N;++S`, ternary `S<N?a:b`.)
-  if !self.try_skip_type_args() {
-    self.pos = saved_pos
-    return false
+  match self.try_parse_simple_type_args() {
+    Some(args) => self.pending_call_type_args = args
+    None => {
+      self.pos = saved_pos
+      if !self.try_skip_type_args() {
+        self.pos = saved_pos
+        return false
+      }
+    }
   }
   if self.check(LParen) {
     return true
@@ -1058,6 +1067,7 @@ fn Parser::try_skip_call_type_args(self : Parser, expr : @ast.TsExpr) -> Bool {
     return true
   }
   self.pos = saved_pos
+  self.pending_call_type_args = []
   false
 }
 
@@ -2253,6 +2263,9 @@ fn Parser::parse_call(self : Parser) -> @ast.TsExpr raise ParseError {
   // followed — bare `parse_primary()` results (`x` alone, no
   // `(args)`) shouldn't be tagged pure.
   let mut saw_call_in_chain = false
+  // Explicit type arguments captured for the call about to be built
+  // (`foo<number>(x)`). Reset after each call form consumes them.
+  let mut pending_type_args : Array[@ast.TsType] = []
 
   // operatorcheck
   while true {
@@ -2263,6 +2276,9 @@ fn Parser::parse_call(self : Parser) -> @ast.TsExpr raise ParseError {
       continue
     }
     if self.try_skip_call_type_args(expr) {
+      // Stash the captured type args; the next loop iteration builds the
+      // actual call and wraps it (see the `LParen` branch below).
+      pending_type_args = self.pending_call_type_args
       continue
     }
     if self.check(Question) && self.peek_at(1).kind == Dot {
@@ -2317,12 +2333,20 @@ fn Parser::parse_call(self : Parser) -> @ast.TsExpr raise ParseError {
       let args = self.parse_args()
       let _ = self.expect(RParen)
       saw_call_in_chain = true
-      match expr {
-        Var(name) => expr = Call(name, args)
+      let call : @ast.TsExpr = match expr {
+        Var(name) => Call(name, args)
         PropAccess(receiver, method_name) =>
           // method: receiver.method(args)
-          expr = MethodCall(receiver, method_name, args)
-        _ => expr = CallExpr(expr, args)
+          MethodCall(receiver, method_name, args)
+        _ => CallExpr(expr, args)
+      }
+      // Re-attach explicit type arguments captured just before the `(`.
+      expr = if pending_type_args.length() > 0 {
+        let wrapped = @ast.TsExpr::TypeArgs(pending_type_args, call)
+        pending_type_args = []
+        wrapped
+      } else {
+        call
       }
     } else if self.match_(LBracket) {
       // array
@@ -3010,6 +3034,9 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
       }
       let mut type_name = ""
       let mut callee_expr : @ast.TsExpr? = None
+      // Explicit constructor type arguments (`new C<number>()`); captured so
+      // the result can be wrapped in `TypeArgs` for type-checking.
+      let mut new_type_args : Array[@ast.TsType] = []
       match self.peek().kind {
         Ident(_) => {
           let first = match self.advance().kind {
@@ -3080,7 +3107,10 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
           callee_expr = Some(expr)
           // typeparameter (simpleimplementation)
           if self.check(Lt) {
-            self.skip_type_args()
+            match self.try_parse_simple_type_args() {
+              Some(targs) => new_type_args = targs
+              None => self.skip_type_args()
+            }
           }
         }
         NumberType => {
@@ -3154,13 +3184,18 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
       } else {
         []
       }
-      match callee_expr {
+      let new_expr : @ast.TsExpr = match callee_expr {
         Some(expr) =>
           match expr {
             Var(_) => New(type_name, args)
             _ => NewExpr(expr, args)
           }
         None => New(type_name, args)
+      }
+      if new_type_args.length() > 0 {
+        @ast.TsExpr::TypeArgs(new_type_args, new_expr)
+      } else {
+        new_expr
       }
     }
     LBrace => {

--- a/src/parser/parser_wbtest.mbt
+++ b/src/parser/parser_wbtest.mbt
@@ -782,8 +782,8 @@ test "parser: parse new array" {
   let parser = Parser::from_source("new Array<number>(10)")
   let expr = parser.parse_expr()
   match expr {
-    New("Array", args) => assert_eq(args.length(), 1)
-    _ => fail("expected New, got \{expr}")
+    TypeArgs([Number], New("Array", args)) => assert_eq(args.length(), 1)
+    _ => fail("expected TypeArgs-wrapped New, got \{expr}")
   }
 }
 
@@ -3840,17 +3840,25 @@ test "parser: parse bare import type annotation" {
 
 ///|
 test "parser: parse new expression with multiple generic type args" {
+  // Explicit constructor type arguments are now captured in a `TypeArgs`
+  // wrapper around the underlying `New`.
   match parse_expr_from("new Map<string, string>()") {
-    New("Map", args) => assert_eq(args.length(), 0)
-    _ => fail("expected generic New(Map), got different expression")
+    TypeArgs(targs, New("Map", args)) => {
+      assert_eq(targs.length(), 2)
+      assert_eq(args.length(), 0)
+    }
+    _ => fail("expected TypeArgs-wrapped New(Map), got different expression")
   }
 }
 
 ///|
 test "parser: parse new expression with private constructor property and type args" {
   match parse_expr_from("new this.#mapCtor<string, DataValue>()") {
-    NewExpr(_, args) => assert_eq(args.length(), 0)
-    _ => fail("expected NewExpr with private constructor property")
+    TypeArgs(targs, NewExpr(_, args)) => {
+      assert_eq(targs.length(), 2)
+      assert_eq(args.length(), 0)
+    }
+    _ => fail("expected TypeArgs-wrapped NewExpr with private constructor")
   }
 }
 
@@ -3880,8 +3888,9 @@ test "parser: parse module block type re-export metadata" {
 ///|
 test "parser: parse generic call with array type arg" {
   match parse_expr_from("signal<number[]>([])") {
-    Call("signal", args) => assert_eq(args.length(), 1)
-    _ => fail("expected generic call expression")
+    TypeArgs([Array(Number)], Call("signal", args)) =>
+      assert_eq(args.length(), 1)
+    _ => fail("expected TypeArgs-wrapped generic call expression")
   }
 }
 

--- a/src/transform/emit.mbt
+++ b/src/transform/emit.mbt
@@ -1648,6 +1648,8 @@ fn emit_expr(e : Emitter, expr : @ast.TsExpr, parent_prec : Int) -> Unit {
 ///|
 fn emit_expr_body(e : Emitter, expr : @ast.TsExpr) -> Unit {
   match expr {
+    // Type arguments are erased in JS output — emit the underlying call.
+    TypeArgs(_, inner) => emit_expr_body(e, inner)
     NumberLit(n) =>
       if e.pretty {
         // Use JS-valid names for special floating-point values.
@@ -3354,6 +3356,7 @@ fn compound_op_str(op : @ast.TsCompoundOp) -> String {
 ///|
 fn expr_precedence(expr : @ast.TsExpr) -> Int {
   match expr {
+    TypeArgs(_, inner) => expr_precedence(inner)
     NumberLit(_)
     | IntLit(_)
     | BigIntLit(_)

--- a/src/transform/mangle.mbt
+++ b/src/transform/mangle.mbt
@@ -1548,6 +1548,7 @@ fn collect_var_refs_stmt(stmt : @ast.TsStmt, out : Map[String, Bool]) -> Unit {
 ///|
 fn collect_var_refs_expr(expr : @ast.TsExpr, out : Map[String, Bool]) -> Unit {
   match expr {
+    TypeArgs(_, inner) => collect_var_refs_expr(inner, out)
     Var(name) => out[name] = true
     BinOp(_, a, b) => {
       collect_var_refs_expr(a, out)

--- a/src/transform/purity.mbt
+++ b/src/transform/purity.mbt
@@ -860,6 +860,7 @@ fn signature_pure_stmt(stmt : @ast.TsStmt, locals : Map[String, Bool]) -> Bool {
 ///|
 fn signature_pure_expr(expr : @ast.TsExpr, locals : Map[String, Bool]) -> Bool {
   match expr {
+    TypeArgs(_, inner) => signature_pure_expr(inner, locals)
     NumberLit(_)
     | IntLit(_)
     | BigIntLit(_)


### PR DESCRIPTION
## 概要

#62 の継続。ユーザー方針に従い **explicit type arguments の AST 拡張**に着手し、非ジェネリックな callee への型引数(TS2558)を検出します。recall +3、新規 FP ゼロ。

## 基盤(挙動保存)

`foo<number>(x)` / `new C<string>()` / `obj.m<T>(a)` を、型引数を捨てずに新ラッパー `TypeArgs(args, inner)` に lower します。型引数は値レベルでは無関係なので全 consumer が peel:
- JS emit / precedence / var-ref 収集 / purity(mtsc transform パイプライン)
- 型推論 / call 引数チェック(checker)

→ emit 出力・conformance とも基盤だけでは不変(検証: `new Map<string, number>()` → `new Map()`、checker の `check_call_args_in_expr` で peel 後 TP/FP 不変)。

網羅 match の破綻は checker 2 + transform 4(emit/mangle/purity)のみで、全て inner に peel。

## TS2558 検出

callee が**確実に非ジェネリック**(型パラメータ0個の宣言済みクラス/関数)の場合に「Expected 0 type arguments, but got N」:
- `new C<number>()`(非ジェネリッククラス)
- `new Foo<number>()`(非ジェネリック関数)
- `f<number>()`(非ジェネリック関数呼び出し)

ジェネリック callee / `any` / 型パラメータ数不明の callee は silent → FP-safe。

## 経緯メモ

調査時に「Call 型引数 AST 拡張は mtsc transform パイプライン(27ファイル)に影響し利回り低」と判明し方針確認しましたが、ユーザー選択により強行。実際は wrapper + peel 方式で:
- 網羅 match 破綻は6箇所のみ
- 非網羅 `_` skip による checker 回帰(TP 1519→1511)は `check_call_args_in_expr` の peel で解消
- mtsc emit 回帰なし(全 2301 テスト green)

と安全に着地。foundation は将来の TS2344(型引数制約違反)等にも再利用可能。

## 計測

- conformance recall **1519 → 1522 TP**、precision **全 4091 ファイルで 0 FP 維持**
- 全 **2301 テスト green**

https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx)_