### PR TITLE
checker: generalize TS2558 to any excess type arguments (#62)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -10535,13 +10535,21 @@ fn check_explicit_type_args(
   match callee_name {
     Some(name) =>
       match declared_type_param_count(name) {
-        Some(0) =>
-          record(
-            ctx,
-            "call `\{name}`",
-            "expected 0 type arguments, but got \{targs.length()}",
-          )
-        _ => ()
+        // Supplying *more* type arguments than the callee declares is always an
+        // error, regardless of any trailing defaults — defaults make trailing
+        // parameters optional but never raise the maximum. (The "too few"
+        // direction is left silent: without default-parameter info we can't
+        // tell a required parameter from a defaulted one, so flagging it would
+        // risk false positives.)
+        Some(count) =>
+          if targs.length() > count {
+            record(
+              ctx,
+              "call `\{name}`",
+              "expected \{count} type arguments, but got \{targs.length()}",
+            )
+          }
+        None => ()
       }
     None => ()
   }

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8064,3 +8064,33 @@ test "expr_check: type arguments on non-generic callee (TS2558)" {
     0,
   )
 }
+
+///|
+test "expr_check: too many type arguments on generic callee (TS2558)" {
+  let count = fn(src : String) -> Int {
+    check_module_function_bodies(parse_module_or_empty(src))
+    .filter(fn(i) { i.message.contains("type argument") })
+    .length()
+  }
+  // generic function with 1 type param, given 2 → too many.
+  assert_true(
+    count(
+      "function g<T>(x: T): T { return x; }\nfunction f() { g<number, string>(1); }",
+    ) >=
+    1,
+  )
+  // generic class with 1 type param, given 2 → too many.
+  assert_true(
+    count(
+      "class Box<T> { v!: T; }\nfunction f() { new Box<number, string>(); }",
+    ) >=
+    1,
+  )
+  // exact arity → fine.
+  @test.assert_eq(
+    count(
+      "function g<T>(x: T): T { return x; }\nfunction f() { g<number>(1); }",
+    ),
+    0,
+  )
+}


### PR DESCRIPTION
## 概要

#118 の継続。TS2558 を「型パラメータ0個の callee」特殊ケースから「**宣言数を超える型引数**」一般へ拡張します。

## 変更

`new C<number>()`(非ジェネリック)に加え、`g<number, string>(x)`(`g<T>`)や `new Box<number, string>()`(`Box<T>`)のような**型引数過多**も検出。デフォルトは引数を増やさず上限は常に `type_params.length()` なので、超過は必ずエラー → FP-safe。

「不足」方向は silent のまま: `type_params` は名前のみ(デフォルト情報なし)で必須/デフォルト引数を区別できず、flag すると FP リスク。

## 計測

- conformance **1522 TP / 0 FP 維持**(corpus に過多形が無いため横ばいだが、チェックが0個特殊ケースから一般化され完全化)
- 全 **2302 テスト green**(+1: ジェネリック過多ケース)

https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx)_