### PR TITLE
checker: flag undefined names in class method computed keys (#62)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -12713,6 +12713,43 @@ fn check_module_function_bodies_layered(
       all.push(issue)
     }
   }
+  // Computed member keys on class methods / accessors (`class C { [e]() {} }`).
+  // The key is an ordinary value expression, so an undefined name in it is a
+  // TS2304 like any other reference. Walked with `in_computed_key` set so the
+  // TS2454 used-before-assigned read-check stays suppressed for `var` reads.
+  for cls in module_.classes {
+    let has_computed_key = cls.methods
+      .iter()
+      .any(fn(m) { m.key_expr is Some(_) })
+    if !has_computed_key {
+      continue
+    }
+    let key_ctx : CheckCtx = {
+      path_prefix: "function \{cls.name}.<member-key>",
+      return_type: @ast.TsType::Void,
+      yield_type: @ast.TsType::Any,
+      resolver,
+      issues: [],
+      in_scope_type_params: cls.type_params,
+      permissive,
+      unassigned: {},
+      strict_property_init,
+      in_computed_key: true,
+    }
+    let env = ExprEnv::new()
+    for v in module_.values {
+      env.bind(v.name, v.type_)
+    }
+    for meth in cls.methods {
+      match meth.key_expr {
+        Some(key) => check_call_args_in_expr(env, key, key_ctx)
+        None => ()
+      }
+    }
+    for issue in key_ctx.issues {
+      all.push(issue)
+    }
+  }
   // Top-level statements (const/let/var with explicit type annotations).
   // Walk them in a module-scope env so local names resolve correctly.
   if module_.top_level_stmts.length() > 0 {

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8176,3 +8176,27 @@ test "expr_check: class field initializer type mismatch" {
   assert_true(issues("class C { x: number = \"s\"; }").length() >= 1)
   @test.assert_eq(issues("class C { x: number = 5; }").length(), 0)
 }
+
+///|
+// Issue #62: an undefined name in a class method's computed key
+// (`class C { [e]() {} }`) is a TS2304, like object-literal computed keys.
+test "expr_check: class method computed key references" {
+  let issues = fn(src : String) -> Array[String] {
+    check_module_function_bodies(parse_module_or_empty(src)).map(fn(i) {
+      i.message
+    })
+  }
+  assert_true(
+    issues("class C { [missingName]() {} }").any(fn(m) {
+      m.contains("cannot find name")
+    }),
+  )
+  // Getter / setter computed keys too.
+  assert_true(
+    issues("class C { get [missingName]() { return 1; } }").any(fn(m) {
+      m.contains("cannot find name")
+    }),
+  )
+  // Defined key — no diagnostic.
+  @test.assert_eq(issues("const k = \"m\";\nclass C { [k]() {} }").length(), 0)
+}


### PR DESCRIPTION
## 概要

#121 の自然な延長。クラスメソッド/アクセサの計算キー(`class C { [e]() {} }`、`get [e]() {}`)内の未定義名を TS2304 として検出。recall **1531 → 1537 TP(+6)、FP 0 維持**。

## 実装

メソッドの `key_expr`(parser は populate するが checker は未読だった)を `check_call_args_in_expr` で walk。`in_computed_key` フラグを立てるので `var` の TS2454 read-check は抑制(#121 と同様)。

## 未対応(parser AST 変更が必要なため見送り)

- クラス**フィールド**の計算キー(`class C { [e] = 1 }`)— フィールドは key expr を保持しない
- **interface / 型リテラル**メンバの計算キー(`{ [e](): number }`)— メンバは (name, type) で key expr なし
- **declare class** メンバ — parser がブラケットキーを skip して破棄

各々少数ファイルのため AST 変更は見送り。

## 計測

- conformance recall **1531 → 1537 TP**、precision **0 FP 維持**
- 全 **2306 テスト green**(+1)

https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx)_