### PR TITLE
checker: flag array-destructuring of an object literal (TS2488) (#62)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -9984,6 +9984,20 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
     | Let(@ast.TsBinding::Array(ab), declared, init)
     | Const(@ast.TsBinding::Array(ab), declared, init) => {
       check_call_args_in_expr(env, init, ctx)
+      // TS2488: an array-destructuring pattern requires an iterable, but a
+      // plain object literal (`var [a, b] = { 0: "", 1: true }`) has no
+      // `[Symbol.iterator]()`. Object literals are never iterable, so this is
+      // false-positive-free — unless the literal carries a computed key that
+      // could itself be `[Symbol.iterator]`, in which case we stay silent.
+      match init {
+        ObjectLit(entries) =>
+          if not(entries.iter().any(fn(e) { e.1 is ComputedProp(_, _) })) {
+            record(
+              ctx, "destructuring init", "object literal must have a `[Symbol.iterator]()` method to be destructured as an array",
+            )
+          }
+        _ => ()
+      }
       if is_checkable(declared) {
         check_expr_against(env, init, declared, ctx, "destructuring init")
       }

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8200,3 +8200,34 @@ test "expr_check: class method computed key references" {
   // Defined key — no diagnostic.
   @test.assert_eq(issues("const k = \"m\";\nclass C { [k]() {} }").length(), 0)
 }
+
+///|
+// Issue #62 (TS2488): array-destructuring a plain object literal is an error —
+// an object literal has no `[Symbol.iterator]()`. False-positive-free unless
+// the literal carries a computed key that could be `[Symbol.iterator]`.
+test "expr_check: array-destructure of object literal (TS2488)" {
+  let issues = fn(src : String) -> Array[String] {
+    check_module_function_bodies(parse_module_or_empty(src)).map(fn(i) {
+      i.message
+    })
+  }
+  assert_true(
+    issues("var [a, b] = { x: 1, y: 2 };").any(fn(m) {
+      m.contains("Symbol.iterator")
+    }),
+  )
+  // Array initializer is iterable — fine.
+  @test.assert_eq(
+    issues("var [a, b] = [1, 2];")
+    .filter(fn(m) { m.contains("Symbol.iterator") })
+    .length(),
+    0,
+  )
+  // Object literal with a computed key (could be `[Symbol.iterator]`) — silent.
+  @test.assert_eq(
+    issues("var [a] = { [Symbol.iterator]() { return null as any; } };")
+    .filter(fn(m) { m.contains("Symbol.iterator") })
+    .length(),
+    0,
+  )
+}


### PR DESCRIPTION
## 概要

MISS 分析の続き。配列デストラクチャリングでオブジェクトリテラル(非イテラブル)を分解する **TS2488** を検出。recall **1537 → 1540 TP(+3)、FP 0 維持**。

## 実装

`var [a, b] = { 0: "", 1: true }` — 配列パターンはイテラブルを要求するが、オブジェクトリテラルは `[Symbol.iterator]()` を持たない。オブジェクトリテラルは決してイテラブルにならないため FP-safe。ただし**計算キー(`[Symbol.iterator]` の可能性)を含む場合は silent** にガード。

宣言形(`var`/`let`/`const [pattern] = {…}`)をカバー。代入形(`[a, b] = {…}`)は別の AST 形状のため follow-up。

## 計測

- conformance recall **1537 → 1540 TP**、precision **0 FP 維持**
- 全 **2307 テスト green**(+1)

https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx)_