### PR TITLE
checker: flag literal assignment targets (TS2364)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -11164,6 +11164,23 @@ fn check_call_args_in_expr(
     CompoundAssignExpr(target, op, v) => {
       check_call_args_in_expr(env, target, ctx)
       check_call_args_in_expr(env, v, ctx)
+      // TS2364: the left-hand side of an assignment must be a variable or a
+      // property access. A literal LHS (`1 >>= 2`) is never assignable. Only
+      // literals are flagged — every reference-shaped target (`Var`, member /
+      // index access, and anything we can't classify) is left silent, so the
+      // check is false-positive-free.
+      match target {
+        NumberLit(_)
+        | IntLit(_)
+        | BigIntLit(_)
+        | BoolLit(_)
+        | StringLit(_)
+        | NullLit =>
+          record(
+            ctx, "assignment", "the left-hand side of an assignment expression must be a variable or a property access",
+          )
+        _ => ()
+      }
       // TS2454: a compound assignment (`x += …`) settles `x` after
       // the rhs walk above (which still flags the implicit read).
       match target {

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8249,3 +8249,17 @@ test "expr_check: class field computed key references" {
   )
   @test.assert_eq(issues("const k = \"x\";\nclass C { [k] = 1; }").length(), 0)
 }
+
+///|
+// TS2364: the left-hand side of a (compound) assignment must be a variable or
+// property access. A literal LHS (`1 >>= 2`) is flagged; reference targets and
+// property/index accesses are left silent.
+test "expr_check: TS2364 literal assignment target" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies(parse_module_or_empty(src)).length()
+  }
+  assert_true(issues("1 >>= 2;") > 0)
+  assert_true(issues("\"x\" += 2;") > 0)
+  @test.assert_eq(issues("let y = 0;\ny >>= 2;"), 0)
+  @test.assert_eq(issues("let o = { p: 0 };\no.p >>= 2;"), 0)
+}

--- a/src/parser/parser_expr.mbt
+++ b/src/parser/parser_expr.mbt
@@ -363,7 +363,11 @@ fn Parser::parse_assignment(self : Parser) -> @ast.TsExpr raise ParseError {
         CompoundAssignExpr(PropAccess(obj, prop), AddAssign, right)
       IndexAccess(obj, index) =>
         CompoundAssignExpr(IndexAccess(obj, index), AddAssign, right)
-      _ => right
+      // A non-reference LHS (`1 += 2`) is never a valid assignment
+      // target (TS2364). Preserve the node instead of discarding it so
+      // the checker sees the invalid target; pre-existing reference
+      // targets above are unaffected.
+      _ => CompoundAssignExpr(left, AddAssign, right)
     }
   } else if self.match_(MinusEq) {
     let right = self.parse_assignment()
@@ -373,7 +377,7 @@ fn Parser::parse_assignment(self : Parser) -> @ast.TsExpr raise ParseError {
         CompoundAssignExpr(PropAccess(obj, prop), SubAssign, right)
       IndexAccess(obj, index) =>
         CompoundAssignExpr(IndexAccess(obj, index), SubAssign, right)
-      _ => right
+      _ => CompoundAssignExpr(left, SubAssign, right)
     }
   } else if self.match_(StarEq) {
     let right = self.parse_assignment()
@@ -383,7 +387,7 @@ fn Parser::parse_assignment(self : Parser) -> @ast.TsExpr raise ParseError {
         CompoundAssignExpr(PropAccess(obj, prop), MulAssign, right)
       IndexAccess(obj, index) =>
         CompoundAssignExpr(IndexAccess(obj, index), MulAssign, right)
-      _ => right
+      _ => CompoundAssignExpr(left, MulAssign, right)
     }
   } else if self.match_(SlashEq) {
     let right = self.parse_assignment()
@@ -393,7 +397,7 @@ fn Parser::parse_assignment(self : Parser) -> @ast.TsExpr raise ParseError {
         CompoundAssignExpr(PropAccess(obj, prop), DivAssign, right)
       IndexAccess(obj, index) =>
         CompoundAssignExpr(IndexAccess(obj, index), DivAssign, right)
-      _ => right
+      _ => CompoundAssignExpr(left, DivAssign, right)
     }
   } else if self.match_(PercentEq) {
     let right = self.parse_assignment()
@@ -403,7 +407,7 @@ fn Parser::parse_assignment(self : Parser) -> @ast.TsExpr raise ParseError {
         CompoundAssignExpr(PropAccess(obj, prop), ModAssign, right)
       IndexAccess(obj, index) =>
         CompoundAssignExpr(IndexAccess(obj, index), ModAssign, right)
-      _ => right
+      _ => CompoundAssignExpr(left, ModAssign, right)
     }
   } else if self.match_(AmpEq) {
     let right = self.parse_assignment()
@@ -413,7 +417,7 @@ fn Parser::parse_assignment(self : Parser) -> @ast.TsExpr raise ParseError {
         CompoundAssignExpr(PropAccess(obj, prop), BitAndAssign, right)
       IndexAccess(obj, index) =>
         CompoundAssignExpr(IndexAccess(obj, index), BitAndAssign, right)
-      _ => right
+      _ => CompoundAssignExpr(left, BitAndAssign, right)
     }
   } else if self.match_(PipeEq) {
     let right = self.parse_assignment()
@@ -423,7 +427,7 @@ fn Parser::parse_assignment(self : Parser) -> @ast.TsExpr raise ParseError {
         CompoundAssignExpr(PropAccess(obj, prop), BitOrAssign, right)
       IndexAccess(obj, index) =>
         CompoundAssignExpr(IndexAccess(obj, index), BitOrAssign, right)
-      _ => right
+      _ => CompoundAssignExpr(left, BitOrAssign, right)
     }
   } else if self.match_(CaretEq) {
     let right = self.parse_assignment()
@@ -433,7 +437,7 @@ fn Parser::parse_assignment(self : Parser) -> @ast.TsExpr raise ParseError {
         CompoundAssignExpr(PropAccess(obj, prop), BitXorAssign, right)
       IndexAccess(obj, index) =>
         CompoundAssignExpr(IndexAccess(obj, index), BitXorAssign, right)
-      _ => right
+      _ => CompoundAssignExpr(left, BitXorAssign, right)
     }
   } else if self.match_(LtLtEq) {
     let right = self.parse_assignment()
@@ -443,7 +447,7 @@ fn Parser::parse_assignment(self : Parser) -> @ast.TsExpr raise ParseError {
         CompoundAssignExpr(PropAccess(obj, prop), ShlAssign, right)
       IndexAccess(obj, index) =>
         CompoundAssignExpr(IndexAccess(obj, index), ShlAssign, right)
-      _ => right
+      _ => CompoundAssignExpr(left, ShlAssign, right)
     }
   } else if self.match_(GtGtEq) {
     let right = self.parse_assignment()
@@ -453,7 +457,7 @@ fn Parser::parse_assignment(self : Parser) -> @ast.TsExpr raise ParseError {
         CompoundAssignExpr(PropAccess(obj, prop), ShrAssign, right)
       IndexAccess(obj, index) =>
         CompoundAssignExpr(IndexAccess(obj, index), ShrAssign, right)
-      _ => right
+      _ => CompoundAssignExpr(left, ShrAssign, right)
     }
   } else if self.match_(GtGtGtEq) {
     let right = self.parse_assignment()
@@ -463,7 +467,7 @@ fn Parser::parse_assignment(self : Parser) -> @ast.TsExpr raise ParseError {
         CompoundAssignExpr(PropAccess(obj, prop), UShrAssign, right)
       IndexAccess(obj, index) =>
         CompoundAssignExpr(IndexAccess(obj, index), UShrAssign, right)
-      _ => right
+      _ => CompoundAssignExpr(left, UShrAssign, right)
     }
   } else if self.match_(StarStarEq) {
     let right = self.parse_assignment()
@@ -473,7 +477,7 @@ fn Parser::parse_assignment(self : Parser) -> @ast.TsExpr raise ParseError {
         CompoundAssignExpr(PropAccess(obj, prop), PowAssign, right)
       IndexAccess(obj, index) =>
         CompoundAssignExpr(IndexAccess(obj, index), PowAssign, right)
-      _ => right
+      _ => CompoundAssignExpr(left, PowAssign, right)
     }
   } else if self.match_(AmpAmpEq) {
     let right = self.parse_assignment()
@@ -483,7 +487,7 @@ fn Parser::parse_assignment(self : Parser) -> @ast.TsExpr raise ParseError {
         CompoundAssignExpr(PropAccess(obj, prop), AndAssign, right)
       IndexAccess(obj, index) =>
         CompoundAssignExpr(IndexAccess(obj, index), AndAssign, right)
-      _ => right
+      _ => CompoundAssignExpr(left, AndAssign, right)
     }
   } else if self.match_(PipePipeEq) {
     let right = self.parse_assignment()
@@ -493,7 +497,7 @@ fn Parser::parse_assignment(self : Parser) -> @ast.TsExpr raise ParseError {
         CompoundAssignExpr(PropAccess(obj, prop), OrAssign, right)
       IndexAccess(obj, index) =>
         CompoundAssignExpr(IndexAccess(obj, index), OrAssign, right)
-      _ => right
+      _ => CompoundAssignExpr(left, OrAssign, right)
     }
   } else if self.match_(QuestionQuestionEq) {
     let right = self.parse_assignment()
@@ -503,7 +507,7 @@ fn Parser::parse_assignment(self : Parser) -> @ast.TsExpr raise ParseError {
         CompoundAssignExpr(PropAccess(obj, prop), CoalesceAssign, right)
       IndexAccess(obj, index) =>
         CompoundAssignExpr(IndexAccess(obj, index), CoalesceAssign, right)
-      _ => right
+      _ => CompoundAssignExpr(left, CoalesceAssign, right)
     }
   } else {
     left


### PR DESCRIPTION
## 概要

代入式の左辺が変数/プロパティでない場合(`1 >>= 2`)を **TS2364** として検出。conformance **1550 → 1554 TP(+4)、FP 0 維持**。

## 背景(調査で判明)

複合代入パーサが無効な左辺を **破棄** していた(`_ => right` で LHS と演算子を捨て RHS だけ返す)ため、不正なターゲットが AST に残らず checker から見えなかった。

## 実装

- **parser**: 非参照な左辺で複合代入ノードを保持(`_ => CompoundAssignExpr(left, op, right)`)。15 個の複合演算子すべてに適用。参照ターゲット(`Var`/プロパティ/インデックスアクセス)は不変
- **checker**: リテラルターゲット(`NumberLit`/`IntLit`/`BigIntLit`/`BoolLit`/`StringLit`/`NullLit`)のみ flag。参照型・分類不能なターゲットはすべて silent → FP-free

下流の `CompoundAssignExpr` consumer(infer / value-name 収集 / super 検出)はすべて target に generic に再帰するため、リテラル target でも安全。

## 計測

- conformance **1550 → 1554 TP**、precision **0 FP 維持**
- 全 **2309 テスト green**(+1)
- 4 つの `parserGreaterThanTokenAmbiguity` MISS を解消

https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx)_