### PR TITLE
checker: flag `typeof X` over undefined value name (TS2304)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -12912,6 +12912,13 @@ fn check_module_function_bodies_layered(
         all.push({ path: issue.name, message: issue.detail })
       }
     }
+    // TS2304 for `typeof X` over an undefined value name. Distinct from the
+    // (excluded) `UnresolvedReference` type-name check: this resolves the
+    // *value* namespace against the comprehensive lib-globals registry, so it
+    // is false-positive-free — only a provably undeclared `typeof` base fires.
+    for n in unresolved_typeof_references(module_) {
+      all.push({ path: "typeof \{n}", message: "cannot find name `\{n}`" })
+    }
   }
   // Recurse into namespace bodies. Each level threads its own ancestor
   // chain so a nested namespace can reference parent-scope types by their

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8263,3 +8263,21 @@ test "expr_check: TS2364 literal assignment target" {
   @test.assert_eq(issues("let y = 0;\ny >>= 2;"), 0)
   @test.assert_eq(issues("let o = { p: 0 };\no.p >>= 2;"), 0)
 }
+
+///|
+// TS2304: a `typeof X` query over an undefined value name is flagged
+// (`var v: typeof A`). Declared values, function parameters, declared type
+// names (a field-only class lowers to an interface in our parser), lib globals,
+// and value keywords (`undefined`, `this`) are all left silent — the check
+// only fires for a provably undeclared base.
+test "expr_check: TS2304 typeof over undefined name" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies(parse_module_or_empty(src)).length()
+  }
+  assert_true(issues("var v: typeof A;") > 0)
+  assert_true(issues("var v: typeof A.B;") > 0)
+  @test.assert_eq(issues("const A = 1;\nvar v: typeof A;"), 0)
+  @test.assert_eq(issues("function f() {}\nvar v: typeof f;"), 0)
+  @test.assert_eq(issues("var v: typeof undefined;"), 0)
+  @test.assert_eq(issues("var v: typeof Math;"), 0)
+}

--- a/src/checker/validate.mbt
+++ b/src/checker/validate.mbt
@@ -46,6 +46,125 @@ pub fn unresolved_type_references(module_ : @ast.TsModule) -> Array[String] {
 }
 
 ///|
+// Return the base names of `typeof X` queries in `module_` that resolve to no
+// known value. A value is "known" when it is declared in the module (function,
+// ambient import, value, class, enum, namespace, or a top-level binding) or is
+// a standard-library ambient global (`is_lib_global_value`, the generated
+// 1000-name registry). Only `typeof` over a *provably* undeclared name is
+// returned, so the check is false-positive-free: any name we cannot account
+// for as a value is assumed known and left silent.
+//
+// Kept separate from `unresolved_type_references` (which resolves *type*
+// names) because a `typeof` query references the *value* namespace; the two
+// scopes differ (e.g. a `const` is a value but not a type).
+pub fn unresolved_typeof_references(module_ : @ast.TsModule) -> Array[String] {
+  // Gather every `typeof` base across all type positions.
+  let bases : Array[String] = []
+  for v in module_.values {
+    collect_typeof_bases(v.type_, bases)
+  }
+  for iface in module_.interfaces {
+    for field in iface.fields {
+      collect_typeof_bases(field.1, bases)
+    }
+  }
+  for ta in module_.type_aliases {
+    collect_typeof_bases(ta.type_, bases)
+  }
+  for f in module_.funcs {
+    for param in f.params {
+      collect_typeof_bases(param.type_, bases)
+    }
+    collect_typeof_bases(f.return_type, bases)
+  }
+  for i in module_.imports {
+    for param in i.params {
+      collect_typeof_bases(param.1, bases)
+    }
+    collect_typeof_bases(i.return_type, bases)
+  }
+  for stmt in module_.top_level_stmts {
+    match stmt {
+      Var(_, declared, _) | Let(_, declared, _) | Const(_, declared, _) =>
+        collect_typeof_bases(declared, bases)
+      _ => ()
+    }
+  }
+  if bases.length() == 0 {
+    return []
+  }
+  // Build the in-scope name set. Maximally conservative: a `typeof` base is
+  // left silent unless we can *prove* it undeclared, so the set folds in every
+  // namespace a value could plausibly live in. Besides the obvious value
+  // declarations it includes function / import parameters (`[T, typeof obj]`),
+  // every declared *type* name (our parser lowers a field-only class to an
+  // interface, erasing its value side — treating the type name as in scope
+  // avoids a false positive there), and the value keywords (`undefined`,
+  // `this`, …) that are not in the lib-globals registry.
+  let values : Map[String, Bool] = {}
+  for f in module_.funcs {
+    values[f.name] = true
+    for param in f.params {
+      values[param.name] = true
+    }
+  }
+  for i in module_.imports {
+    values[i.name] = true
+    for param in i.params {
+      values[param.0] = true
+    }
+  }
+  for v in module_.values {
+    values[v.name] = true
+  }
+  for c in module_.classes {
+    values[c.name] = true
+  }
+  for e in module_.enums {
+    values[e.name] = true
+  }
+  for ns in module_.namespaces {
+    values[ns.name] = true
+  }
+  for n in module_declared_names(module_) {
+    values[n] = true
+  }
+  for stmt in module_.top_level_stmts {
+    collect_stmt_value_names(stmt, values)
+  }
+  let acc : Array[String] = []
+  for base in bases {
+    if !values.contains(base) &&
+      !is_typeof_value_keyword(base) &&
+      !is_lib_global_value(base) &&
+      !acc.contains(base) {
+      acc.push(base)
+    }
+  }
+  acc
+}
+
+///|
+// Global value keywords that a `typeof` query may target but which are not in
+// the standard-library ambient-globals registry (they are language keywords /
+// contextual values, not declared identifiers).
+fn is_typeof_value_keyword(name : String) -> Bool {
+  match name {
+    "undefined"
+    | "null"
+    | "this"
+    | "globalThis"
+    | "NaN"
+    | "Infinity"
+    | "arguments"
+    | "true"
+    | "false"
+    | "import" => true
+    _ => false
+  }
+}
+
+///|
 fn scope_with(
   declared : Array[String],
   type_params : Array[String],
@@ -146,6 +265,68 @@ fn is_well_known_type_name(name : String) -> Bool {
     | "AsyncIterator"
     | "IterableIterator" => true
     _ => false
+  }
+}
+
+///|
+// Collect the base identifier of every `typeof X` query reachable in `type_`
+// (`typeof A` -> "A", `typeof A.B` -> "A"). `typeof import("…")` queries are
+// skipped — they reference an external module, not a local value. Used to
+// flag a `typeof` over an undefined name (TS2304). Mirrors `check_type`'s
+// structural recursion so the query is found in every nested position.
+fn collect_typeof_bases(type_ : @ast.TsType, acc : Array[String]) -> Unit {
+  match type_ {
+    TypeOf(query) => {
+      if query.has_prefix("import(") {
+        return
+      }
+      let base = match query.find(".") {
+        Some(i) => query.substring(start=0, end=i)
+        None => query
+      }
+      if base != "" && !acc.contains(base) {
+        acc.push(base)
+      }
+    }
+    Array(inner) => collect_typeof_bases(inner, acc)
+    Applied(_, args) =>
+      for a in args {
+        collect_typeof_bases(a, acc)
+      }
+    Tuple(items) =>
+      for it in items {
+        collect_typeof_bases(it, acc)
+      }
+    Object(fields) =>
+      for f in fields {
+        collect_typeof_bases(f.0, acc)
+        collect_typeof_bases(f.1, acc)
+      }
+    Struct(_, fields) =>
+      for f in fields {
+        collect_typeof_bases(f.1, acc)
+      }
+    Func(params, ret) => {
+      for p in params {
+        collect_typeof_bases(p, acc)
+      }
+      collect_typeof_bases(ret, acc)
+    }
+    Union(members) | Intersection(members) =>
+      for m in members {
+        collect_typeof_bases(m, acc)
+      }
+    Conditional(check_t, extends, t_branch, f_branch) => {
+      collect_typeof_bases(check_t, acc)
+      collect_typeof_bases(extends, acc)
+      collect_typeof_bases(t_branch, acc)
+      collect_typeof_bases(f_branch, acc)
+    }
+    IndexedAccess(base, key) => {
+      collect_typeof_bases(base, acc)
+      collect_typeof_bases(key, acc)
+    }
+    _ => ()
   }
 }
 


### PR DESCRIPTION
## 概要

`var v: typeof A`(`A` が未定義の値名)を **TS2304** として検出。conformance **1554 → 1562 TP(+8)、FP 0 維持**。`parserTypeQuery1-9` クラスタを解消。

## 背景

型ウォーカの catch-all が `TypeOf` ノードを黙って無視していたため、`typeof <未定義名>` を見逃していた。

## 実装

型名前空間用の `unresolved_type_references` に対する **値名前空間版** `unresolved_typeof_references` を追加:
- 全型ポジションから `typeof` ベース名を収集(`typeof A` → "A"、`typeof A.B` → "A"、`typeof import("…")` は除外)
- **証明可能に未宣言**なベースのみ flag

### FP-safety(最重要)

in-scope セットを**意図的に最大限**保守的に:
- モジュールの function / import / value / class / enum / namespace 名
- function・import の**パラメータ名**(`[T, typeof obj]`)
- **すべての宣言された型名**(本パーサは field-only class を interface に lower し値側が消えるため)
- 生成済み 1000 名 lib-globals レジストリ
- 値キーワード(`undefined` / `null` / `this` / `globalThis` / …)

→ positively に説明できない名前は「既知」とみなし silent。除外されている `UnresolvedReference` 型チェックとは別系統で FP-free。

緩めの初期スコープでは `typeof undefined` / `typeof this` / `typeof <param>` / field-only-class で **4 FP** が出たが、上記の保守的スコープで全て解消(TP 1566/FP4 → 1562/FP0 を選択 — FP-free が絶対要件)。

## 計測

- conformance **1554 → 1562 TP**、precision **0 FP 維持**
- 全 **2310 テスト green**(+1)

https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx)_