### PR TITLE
checker: flag literal assigned to non-matching literal target (TS2322)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -6093,7 +6093,28 @@ fn check_expr_against(
     // Display the widened form of the inferred type (`number` rather than the
     // precise `42`) so the message reads naturally; the precise literal was
     // only needed for the assignability decision above.
-    let shown = widen_literal(inferred_u)
+    //
+    // Exception: when the *source expression* is itself a literal (`let x: "a"
+    // = "b"`), keep the precise literal in the message. A direct literal that
+    // is not assignable to a literal target is an unambiguous TS2322 — widening
+    // it to the bare primitive (`string`) would make the message look like a
+    // const-widening residue and get suppressed by the permissive filter
+    // (`is_widening_direction_mismatch`), masking a real error. A *variable*
+    // source (which may have been const-widened) still widens and stays
+    // conservatively suppressed.
+    // Gated tightly to stay false-positive-free: the source must be a literal
+    // expression, the target a literal (or literal union) of matching kind, and
+    // the context a single-target assignment — never a call argument
+    // (`… arg[i]`), where overload / specialized-signature resolution can
+    // legitimately accept a literal that the checked signature rejects.
+    let precise_literal_mismatch = precise_literal_type(expr) is Some(_) &&
+      literal_union_members(expected_u) is Some(_) &&
+      not(sub_path.contains("arg["))
+    let shown = if precise_literal_mismatch {
+      inferred_u
+    } else {
+      widen_literal(inferred_u)
+    }
     let exp_str = type_display(expected)
     let detail = "expected `\{exp_str}` but got `\{type_display(shown)}`"
     record(ctx, sub_path, detail)

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8281,3 +8281,21 @@ test "expr_check: TS2304 typeof over undefined name" {
   @test.assert_eq(issues("var v: typeof undefined;"), 0)
   @test.assert_eq(issues("var v: typeof Math;"), 0)
 }
+
+///|
+// TS2322: a literal value assigned to a literal (or literal-union) target it
+// is not a member of (`let x: "a" = "b"`, `let x: 1 = 2`). Same-literal
+// assignment, const-widened variables, and call arguments (overload-prone)
+// are left silent.
+test "expr_check: TS2322 literal not assignable to literal target" {
+  // Permissive helper: matches the CLI / conformance path, where the
+  // widening-suppression this feature works around is active.
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  assert_true(issues("let x: \"a\" = \"b\";") > 0)
+  assert_true(issues("let x: 1 = 2;") > 0)
+  assert_true(issues("let x: \"a\" | \"b\" = \"c\";") > 0)
+  @test.assert_eq(issues("let x: \"a\" = \"a\";"), 0)
+  @test.assert_eq(issues("const c = \"b\";\nlet y: \"a\" = c;"), 0)
+}


### PR DESCRIPTION
## 概要

リテラル値を非一致のリテラル型(または リテラル union)に代入する場合(`let x: "a" = "b"`、`let x: 1 = 2`)を **TS2322** として検出。conformance **1562 → 1564 TP(+2)、FP 0 維持**。

## 背景(調査で判明した根因)

ミスマッチ自体は正しく**計算**されていた(`is_assignable_to(Literal("b"), Literal("a"))` は false で診断は `record` まで到達)が、permissive フィルタが落としていた:

メッセージが推論型を primitive に**ワイドニング**して表示(`string`)していたため、`is_widening_direction_mismatch` が「const-widening の残渣」と誤認して抑制していた(`const c = "b"; let y: "a" = c` の FP を防ぐための抑制)。

## 実装

ソースがリテラル**式**の場合、メッセージに精密なリテラルを表示してフィルタを通す。

**FP-safety のための厳格なゲート**:
- ソースがリテラル式
- ターゲットがリテラル or リテラル union
- 文脈が単一ターゲット代入(`… arg[i]` の呼び出し引数は**除外** — オーバーロード/特殊化シグネチャ解決が、検査中のシグネチャが拒否するリテラルを正当に受理しうるため)

変数ソース(const-widening の可能性)は従来通りワイドニングして抑制を維持。

緩い初期版(任意のリテラルソースで精密表示)では specialized-call-signature / spread-call のオーバーロードで **2 FP** が発生。non-argument + literal-target ゲートで解消。

## 計測

- conformance **1562 → 1564 TP**、precision **0 FP 維持**
- 全 **2311 テスト green**(+1)

https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx)_