### PR TITLE
checker: arg-check computed method calls `recv["m"](args)` (TS2345)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -10798,8 +10798,30 @@ fn check_call_args_in_expr(
             None => ()
           }
         other =>
-          if is_definitely_not_callable(other) {
-            record(ctx, "call", "`\{type_display(other)}` is not callable")
+          // `recv["method"](args)` is a method call with a computed
+          // string-literal key — semantically identical to `recv.method(args)`.
+          // We don't resolve computed-member types, so the indexed access
+          // infers as `Any` and the arg types would go unchecked. Route it
+          // through the same method-signature lookup the dotted `MethodCall`
+          // path uses so a wrong-typed argument (`"".charAt("x")` written as
+          // `""["charAt"]("x")`) is still flagged. Only fires when the method
+          // signature resolves concretely, so it stays false-positive-free.
+          match callee {
+            IndexAccess(recv, StringLit(meth)) => {
+              let recv_ty = prune_nullish(
+                ctx.resolver,
+                infer_expr(env, ctx.resolver, recv),
+              )
+              match ctx.resolver.lookup_method_sig(recv_ty, meth) {
+                Some((params, _)) =>
+                  check_arguments(env, params, args, ctx, "call `\{meth}`")
+                None => ()
+              }
+            }
+            _ =>
+              if is_definitely_not_callable(other) {
+                record(ctx, "call", "`\{type_display(other)}` is not callable")
+              }
           }
       }
       check_call_args_in_expr(env, callee, ctx)

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8299,3 +8299,18 @@ test "expr_check: TS2322 literal not assignable to literal target" {
   @test.assert_eq(issues("let x: \"a\" = \"a\";"), 0)
   @test.assert_eq(issues("const c = \"b\";\nlet y: \"a\" = c;"), 0)
 }
+
+///|
+// TS2345: a computed (string-literal) method call `recv["m"](args)` is checked
+// against the resolved method signature, just like the dotted `recv.m(args)`
+// form. A wrong-typed argument to a known primitive method is flagged; correct
+// args and unknown (`any`) receivers stay silent.
+test "expr_check: TS2345 computed method-call argument" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  assert_true(issues("var x = \"\";\nx[\"charAt\"](\"bad\");") > 0)
+  assert_true(issues("var a = [1];\na[\"slice\"](\"bad\");") > 0)
+  @test.assert_eq(issues("var x = \"\";\nx[\"charAt\"](0);"), 0)
+  @test.assert_eq(issues("declare var o: any;\no[\"foo\"](\"x\");"), 0)
+}


### PR DESCRIPTION
## 概要

計算プロパティ経由のメソッド呼び出し `recv["m"](args)` の引数を、ドット形式 `recv.m(args)` と同様にメソッド署名と照合。conformance **1564 → 1565 TP(+1)、FP 0 維持**。

## 背景(調査で判明)

`string=>number` クラスタ(5件)を狙ったが、実態は heterogeneous:
- `stringPropertyAccessWithError` — 真の lib-method ケース(`x['charAt']('invalid')`)
- `jsdocTypeFromChainedAssignment*` — JSDoc + chained assignment(`.js`、別機構)
- `overloadResolutionConstructors` — オーバーロード解決(FP-prone)

調査の結果、**lib メソッド署名レジストリは既に存在**(`lookup_method_sig` 経由で `x.charAt("bad")` は既に検出済み)。唯一のギャップは**計算/要素アクセス形式** `x["charAt"](arg)` で、indexed-access callee が `Any` に推論され引数チェックがスキップされていた。

## 実装

`CallExpr(IndexAccess(recv, StringLit(meth)), args)` を、ドット形式の `MethodCall` パスと同じ `lookup_method_sig` に通す。

**FP-safety**: メソッドが具体的に解決できる場合(既知のプリミティブ/宣言済みシェイプ)のみ発火。未知・`any` レシーバは署名なし → silent。

## 計測

- conformance **1564 → 1565 TP**、precision **0 FP 維持**
- 全 **2312 テスト green**(+1)
- `stringPropertyAccessWithError` MISS を解消

https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx)_