### PR TITLE
checker: explicit type-arg inference + primitive-vs-lib-type (TS2345/TS2322)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -5868,7 +5868,18 @@ fn check_expr_against(
     Named(n) =>
       if ctx.resolver.type_aliases.get(n) is None &&
         ctx.resolver.interfaces.get(n) is None &&
-        ctx.resolver.classes.get(n) is None {
+        ctx.resolver.classes.get(n) is None &&
+        // A well-known standard-library type name (`Date`, `RegExp`, …) is
+        // resolvable enough to decide assignability against a *concrete
+        // primitive / literal* source: `number` is never a `Date`. The
+        // assignability table already accepts the legitimate primitive→wrapper
+        // widenings (`number`→`Number`, `string`→`String`) and `Object` /
+        // `Function` are guarded as universal targets below, so letting these
+        // through stays false-positive-free while catching e.g. `foo<Date>(1)`.
+        not(
+          is_well_known_type_name(n) &&
+          is_concrete_primitive_or_literal(inferred_u),
+        ) {
         return
       }
     _ => ()
@@ -10575,6 +10586,7 @@ fn check_undefined_name(env : ExprEnv, ctx : CheckCtx, name : String) -> Unit {
 /// / `any` / a callable interface whose type-parameter count we don't model,
 /// the check stays silent.
 fn check_explicit_type_args(
+  env : ExprEnv,
   ctx : CheckCtx,
   targs : Array[@ast.TsType],
   inner : @ast.TsExpr,
@@ -10623,6 +10635,50 @@ fn check_explicit_type_args(
       "expected \{params.length()} type arguments, but got \{targs.length()}",
     )
     return
+  }
+  // TS2345: with explicit type arguments the formal parameters are pinned to
+  // the supplied types — inference plays no part — so `foo<string>(1)` rejects
+  // the numeric argument. The inner call's own pass *infers* `T` from the
+  // arguments and so never observes the mismatch; substitute the explicit
+  // arguments here and re-check each argument against the resulting concrete
+  // parameter. Functions only, exact type-argument arity (so substitution is
+  // well defined), and rest-free signatures (positional alignment) — and the
+  // per-argument `check_expr_against` is itself false-positive-free, so this
+  // stays sound. Spread arguments are skipped (their count is unknown).
+  if targs.length() == params.length() {
+    match inner {
+      Call(_, call_args) =>
+        match ctx.resolver.signatures.get(name) {
+          Some(sig) =>
+            if not(sig.iter().any(fn(p) { p.is_rest })) {
+              let bindings : Map[String, @ast.TsType] = {}
+              for i in 0..<params.length() {
+                bindings[params[i]] = targs[i]
+              }
+              let substituted = substitute_params_array(
+                sig.map(fn(p) { p.type_ }),
+                bindings,
+              )
+              for i in 0..<call_args.length() {
+                if i < substituted.length() {
+                  match call_args[i] {
+                    Spread(_) => ()
+                    arg =>
+                      check_expr_against(
+                        env,
+                        arg,
+                        substituted[i],
+                        ctx,
+                        "call `\{name}` arg[\{i}]",
+                      )
+                  }
+                }
+              }
+            }
+          None => ()
+        }
+      _ => ()
+    }
   }
   // TS2344: a type argument that doesn't satisfy its parameter's `extends`
   // constraint. Mirrors the type-position check in `check_constraints`:
@@ -10685,7 +10741,7 @@ fn check_call_args_in_expr(
     // list against the callee, then descend into the underlying call so its
     // arguments are still checked.
     TypeArgs(targs, inner) => {
-      check_explicit_type_args(ctx, targs, inner)
+      check_explicit_type_args(env, ctx, targs, inner)
       check_call_args_in_expr(env, inner, ctx)
     }
     Call(name, args) => {

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8314,3 +8314,30 @@ test "expr_check: TS2345 computed method-call argument" {
   @test.assert_eq(issues("var x = \"\";\nx[\"charAt\"](0);"), 0)
   @test.assert_eq(issues("declare var o: any;\no[\"foo\"](\"x\");"), 0)
 }
+
+///|
+// Generic inference: explicit type arguments pin the formal parameters, so an
+// argument incompatible with the supplied type is a TS2345 — independent of
+// what inference would have derived from the arguments.
+test "expr_check: explicit type-argument call argument mismatch" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  assert_true(issues("function f<T>(t: T) { return t; }\nf<string>(1);") > 0)
+  assert_true(issues("function f<T>(a: T, b: T) {}\nf<string>(\"a\", 1);") > 0)
+  @test.assert_eq(issues("function f<T>(t: T) { return t; }\nf<number>(1);"), 0)
+}
+
+///|
+// A concrete primitive / literal is never assignable to a well-known
+// class-like standard-library type (`Date`, `RegExp`), but still widens to its
+// wrapper interface (`Number`, `String`) and into the universal `Object`.
+test "expr_check: primitive not assignable to lib class type" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  assert_true(issues("let x: Date = 1;") > 0)
+  assert_true(issues("let x: RegExp = \"s\";") > 0)
+  @test.assert_eq(issues("let x: Number = 5;"), 0)
+  @test.assert_eq(issues("let x: Object = 1;"), 0)
+}


### PR DESCRIPTION
## 概要

generics 推論の強化として、関連する2つの改善を実装。conformance **1565 → 1568 TP(+3)、FP 0 維持**。

## 実装

### 1. 明示的型引数による引数チェック(TS2345)
明示的型引数 `f<string>(1)` は仮引数を**固定**する(推論は関与しない)ため、数値引数は拒否されるべき。だが内側の call は引数から `T` を**推論**してしまいミスマッチを見逃していた。

`check_explicit_type_args` で明示型引数を仮引数に代入し、各引数を再チェック。ゲート: 関数のみ・型引数 arity 厳密一致・rest なし・spread 引数除外。per-argument の `check_expr_against` 自体が FP-free。

### 2. プリミティブ vs lib クラス型(TS2322)
具体的なプリミティブ/リテラルは well-known 標準ライブラリ型名に対して判定可能(`number` は決して `Date` でない)。`check_expr_against` は resolver が展開できない `Named` ターゲット(lib 型含む)で従来 bail していたため、これらのミスマッチを見逃していた。

ソースが具体プリミティブ/リテラルの場合のみ well-known ターゲットを通すように変更。

**FP-safety**: assignability テーブルは既にプリミティブ→ラッパー widening(`number`→`Number`)を受理し、`Object` は universal ターゲットとして guard 済み → FP-free。検証:
- `let x: Date = 1` / `let x: RegExp = "s"` → flag ✓
- `let x: Number = 5` / `let x: Object = 1` / `new Date()` → silent ✓

## 計測

- conformance **1565 → 1568 TP**、precision **0 FP 維持**
- 全 **2314 テスト green**(+2)
- `foo<Date, Date>(1)` および直接代入ミスマッチを解消

https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx)_