### PR TITLE
checker: extend explicit type-argument arg-check to constructors (TS2345)

### DIFF
--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -10637,43 +10637,61 @@ fn check_explicit_type_args(
     return
   }
   // TS2345: with explicit type arguments the formal parameters are pinned to
-  // the supplied types — inference plays no part — so `foo<string>(1)` rejects
-  // the numeric argument. The inner call's own pass *infers* `T` from the
-  // arguments and so never observes the mismatch; substitute the explicit
-  // arguments here and re-check each argument against the resulting concrete
-  // parameter. Functions only, exact type-argument arity (so substitution is
-  // well defined), and rest-free signatures (positional alignment) — and the
-  // per-argument `check_expr_against` is itself false-positive-free, so this
-  // stays sound. Spread arguments are skipped (their count is unknown).
+  // the supplied types — inference plays no part — so `foo<string>(1)` (and the
+  // constructor form `new C<string>(1)`) rejects the numeric argument. The
+  // inner call's own pass *infers* the type parameter from the arguments and so
+  // never observes the mismatch; substitute the explicit arguments here and
+  // re-check each argument against the resulting concrete parameter. Requires
+  // exact type-argument arity (so substitution is well defined) and a rest-free
+  // signature (positional alignment); the per-argument `check_expr_against` is
+  // itself false-positive-free. Spread arguments are skipped (count unknown).
   if targs.length() == params.length() {
+    // Shared per-argument re-check against `formal_types` with the explicit
+    // type arguments substituted in.
+    let check_against = fn(
+      formal_types : Array[@ast.TsType],
+      call_args : Array[@ast.TsExpr],
+      path : String,
+    ) -> Unit {
+      let bindings : Map[String, @ast.TsType] = {}
+      for i in 0..<params.length() {
+        bindings[params[i]] = targs[i]
+      }
+      let substituted = substitute_params_array(formal_types, bindings)
+      for i in 0..<call_args.length() {
+        if i < substituted.length() {
+          match call_args[i] {
+            Spread(_) => ()
+            arg =>
+              check_expr_against(
+                env,
+                arg,
+                substituted[i],
+                ctx,
+                "\{path} arg[\{i}]",
+              )
+          }
+        }
+      }
+    }
     match inner {
       Call(_, call_args) =>
         match ctx.resolver.signatures.get(name) {
           Some(sig) =>
             if not(sig.iter().any(fn(p) { p.is_rest })) {
-              let bindings : Map[String, @ast.TsType] = {}
-              for i in 0..<params.length() {
-                bindings[params[i]] = targs[i]
-              }
-              let substituted = substitute_params_array(
+              check_against(
                 sig.map(fn(p) { p.type_ }),
-                bindings,
+                call_args,
+                "call `\{name}`",
               )
-              for i in 0..<call_args.length() {
-                if i < substituted.length() {
-                  match call_args[i] {
-                    Spread(_) => ()
-                    arg =>
-                      check_expr_against(
-                        env,
-                        arg,
-                        substituted[i],
-                        ctx,
-                        "call `\{name}` arg[\{i}]",
-                      )
-                  }
-                }
-              }
+            }
+          None => ()
+        }
+      New(_, call_args) =>
+        match ctx.resolver.lookup_constructor_sig(name) {
+          Some((formal_types, sig)) =>
+            if not(sig.iter().any(fn(p) { p.is_rest })) {
+              check_against(formal_types, call_args, "new `\{name}`")
             }
           None => ()
         }

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8341,3 +8341,24 @@ test "expr_check: primitive not assignable to lib class type" {
   @test.assert_eq(issues("let x: Number = 5;"), 0)
   @test.assert_eq(issues("let x: Object = 1;"), 0)
 }
+
+///|
+// Generic inference: explicit type arguments on a `new` expression pin the
+// constructor's parameters just as they do for a function call, so
+// `new C<string>(1)` rejects the numeric constructor argument.
+test "expr_check: explicit type-argument constructor argument mismatch" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  assert_true(
+    issues("class C<T> { constructor(x: T) {} }\nnew C<string>(1);") > 0,
+  )
+  @test.assert_eq(
+    issues("class C<T> { constructor(x: T) {} }\nnew C<string>(\"s\");"),
+    0,
+  )
+  @test.assert_eq(
+    issues("class C<T> { constructor(x: T) {} }\nnew C<number>(1);"),
+    0,
+  )
+}


### PR DESCRIPTION
## 概要

明示的型引数の引数チェックを**コンストラクタ**にも拡張(#129 の Call/New 対称性を完成)。`new C<string>(1)` が数値引数を拒否。**conformance は 1568/0 のまま変化なし** — 正当性の地固め(unit test でカバー)であり recall gain ではありません(後述)。

## 実装

`check_explicit_type_args` は既にクラス型パラメータを解決済み(TS2344 bound チェック用)。これに加えて、明示型引数をコンストラクタ署名(`lookup_constructor_sig` 経由)に代入し各引数を再チェック。関数版と同じ FP-free ゲート(型引数 arity 厳密一致・rest なし・spread 除外・per-argument `check_expr_against`)。共通の substitute+check ロジックを local closure に切り出し、`Call`/`New` 両 arm で再利用。

## 透明性: なぜ recall gain が 0 か

`new C<string>(1)`(解決可能な generic class + ミスマッチ明示型引数)は検出できるようになりましたが、**コーパスにこの形のケースが存在しない**ため conformance は変化しません。これは #129 の part 1(明示型引数・関数版)が単独では 0 gain だったのと同じ構図です。

### option 1(object-literal generic 推論)の調査結果
- **インライン object 型**経由の推論は既に動作(`f({a:1,b:"s"})` を flag 済み)
- 残る MISS は **named generic interface** 経由(`foo<T>(x: Computed<T>)`)で、`infer_param_bindings` への resolver スレッディング、または `check_expr_against` の広範な `Applied` bail の緩和が必要
- 後者は共変 generic(`Box<Dog>` → `Box<Animal>`)で FP リスクが高く、安全なスライスではないため見送り

## 計測

- conformance **1568 TP / 0 FP 維持**(groundwork)
- 全 **2315 テスト green**(+1)

https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKDgGi3gCa3gt63Kepjvqx)_