### PR TITLE
checker: sound assignability / nominality / signature-subtyping recall (FP 0)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1374,6 +1374,8 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-18 (T62)   567/815 (69 %)        414/414 ( 0 FP)
 2026-06-18 (T63)   569/815 (70 %)        414/414 ( 0 FP)
 2026-06-18 (T64)   570/815 (70 %)        414/414 ( 0 FP)
+2026-06-18 (T65)   571/815 (70 %)        414/414 ( 0 FP)
+2026-06-18 (T66)   572/815 (70 %)        414/414 ( 0 FP)
 
   RB2 (2026-06-18) -- re-baseline after the intervening checker commits
   (through f545849) lifted measured recall 543 -> 563 @ 0 FP. Toolchain note:
@@ -1469,6 +1471,36 @@ conformance sources (`.errors.txt` baseline = ground truth):
   Tooling: `tsacc --list-misses` now also prints `FALSE_POS <case> :: <path>
   :: <msg>`, which made the arity quality assessment and the variance-safety
   audits above mechanical.
+
+  T65 / T66 -- overloaded function- and constructor-typed argument arity
+    (TS2345), the "overloaded function-typed arguments machinery" follow-up.
+    A function / constructor *value* passed for a (possibly overloaded) call-
+    or construct-signature parameter must be callable with the arguments every
+    target signature would pass it. When the value *requires* more parameters
+    than a signature *provides*, it can never implement that signature; for an
+    overload set the value must satisfy every signature, so any signature with
+    fewer parameters than the value requires is flagged. The source arity comes
+    from a function literal (`function_value_required_arity`) or the value's
+    single call / construct signature (`single_signature_required_arity`);
+    targets are enumerated by `collect_call_signatures` / `collect_construct_signatures`
+    (every `<call>` / `<new>` overload on object / interface types, plus bare
+    `Func` / `Constructor`). Checked ahead of the single-signature contextual-
+    typing routes, which never enforce this minimum.
+      T65: recall 570 -> 571, clears genericCallWithOverloadedFunctionTypedArguments2
+        (`foo(<T>(x, y) => '')` vs `{ (x: T): string; (x: T, y?: T): string }`).
+      T66: recall 571 -> 572, clears genericCallWithOverloadedConstructorTypedArguments2
+        (`foo(b)`, `b: { new <T>(x, y): string }` vs an overloaded `<new>` set).
+    Not covered by the arity mechanism (separate, larger machinery):
+      - genericCallToOverloadedMethodWithOverloadedArguments -- overload
+        *resolution* of an overloaded callback argument plus generic return
+        (`U`) inference through `(x: T) => Promise<U>`; arities match, so this
+        is TS2769 overload selection, not an arity verdict.
+      - The call/construct-signature *subtyping* families
+        (subtypingWith{Call,Construct}Signatures*, TS2430 interface-extends;
+        assignmentCompatWith{Construct,GenericCall}Signatures, TS2322 type-vs-
+        type) need full signature structural comparison (kind + arity + param
+        bivariance + covariant return), a broader relaxation than the arity
+        rule -- a candidate next slice if directed.
 
   Boundary (2026-06-18): the named higher-order MISS clusters remain
   single-recall-point, bespoke-machinery cases (overloaded construct-signature

--- a/TODO.md
+++ b/TODO.md
@@ -1376,6 +1376,8 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-18 (T64)   570/815 (70 %)        414/414 ( 0 FP)
 2026-06-18 (T65)   571/815 (70 %)        414/414 ( 0 FP)
 2026-06-18 (T66)   572/815 (70 %)        414/414 ( 0 FP)
+2026-06-18 (T67)   576/815 (71 %)        414/414 ( 0 FP)
+2026-06-18 (T68)   581/815 (71 %)        414/414 ( 0 FP)
 
   RB2 (2026-06-18) -- re-baseline after the intervening checker commits
   (through f545849) lifted measured recall 543 -> 563 @ 0 FP. Toolchain note:
@@ -1501,6 +1503,27 @@ conformance sources (`.errors.txt` baseline = ground truth):
         type) need full signature structural comparison (kind + arity + param
         bivariance + covariant return), a broader relaxation than the arity
         rule -- a candidate next slice if directed.
+
+  T67 / T68 -- signature subtyping in interface-extends (TS2430). recall
+    572 -> 576 -> 581. `check_interface_extends_compat` previously compared only
+    optionality and scalar-vs-object for redeclared members. Now a callable
+    member (or a derived interface's own `<call>` / `<new>` signature, which
+    lives as a member) must be assignable to the base's:
+      T67 -- arity-only first (`callable_member_arity_incompatible`): a derived
+        signature requiring more args than the base provides. To make this
+        sound the parser now widens optional function-/constructor-*type*
+        parameters (`(x?: T) => R`) to `T | undefined` like declaration
+        parameters -- previously the `?` was consumed and discarded, so an
+        optional trailing parameter looked required (also corrected bridge FFI
+        emission to render such a parameter as `T?`). Cleared the four
+        subtypingWith{Call,Construct,GenericCall,GenericConstruct}SignaturesWithOptionalParameters.
+      T68 -- generalized to full `is_assignable_to_bivariant` (bivariant
+        params per `strictFunctionTypes: false`, covariant return) for plain
+        non-generic `Func` / `Constructor` members (`callable_member_incompatible`).
+        Catches incompatible parameter types (`(...xs: string[])` over
+        `(...xs: number[])`), returns, and interface call/construct signatures.
+        Cleared call/constructSignatureAssignabilityInInheritance and the
+        Call/ConstructSignaturesWithSpecializedSignatures pair.
 
   Boundary (2026-06-18): the named higher-order MISS clusters remain
   single-recall-point, bespoke-machinery cases (overloaded construct-signature

--- a/TODO.md
+++ b/TODO.md
@@ -1379,6 +1379,7 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-18 (T67)   576/815 (71 %)        414/414 ( 0 FP)
 2026-06-18 (T68)   581/815 (71 %)        414/414 ( 0 FP)
 2026-06-18 (T69)   583/815 (72 %)        414/414 ( 0 FP)
+2026-06-18 (T70)   584/815 (72 %)        414/414 ( 0 FP)
 
   RB2 (2026-06-18) -- re-baseline after the intervening checker commits
   (through f545849) lifted measured recall 543 -> 563 @ 0 FP. Toolchain note:
@@ -1535,13 +1536,18 @@ conformance sources (`.errors.txt` baseline = ground truth):
     signatures containing intersections / generic `Applied`
     (`type_has_intersection_or_applied`, which removed the lone FP) abstain.
     Cleared assignmentCompatWithGenericCallSignatures2, genericCallWithFunctionTypedArguments2.
-    Still out of reach in this family: the remaining generic-call-signature
-    files (assignmentCompatWithGenericCallSignatures4 / ...WithOptionalParameters,
-    126 errors) need generic-signature instantiation, and the overloaded-value
-    assignments (stringLiteralTypesOverloadAssignability*) need overload-set
-    comparison.
 
-  Session total 2026-06-18: recall 563 -> 583 (+20) at a steady 0 FP, all via
+  T70 -- enforce function-value arity against a bare `Func` target too (TS2322).
+    recall 583 -> 584. `collect_call_signatures` now treats a bare `Func` as a
+    single call signature, so the arity rule fires for `this.a = (x: T) => null`
+    where `a: () => T` (not only object/interface call-signature targets).
+    Cleared assignmentCompatWithGenericCallSignaturesWithOptionalParameters (126
+    errors). Still out of reach in the signature family: the remaining
+    generic-call-signature files (assignmentCompatWithGenericCallSignatures4)
+    need generic-signature instantiation, and the overloaded-value assignments
+    (stringLiteralTypesOverloadAssignability*) need overload-set comparison.
+
+  Session total 2026-06-18: recall 563 -> 584 (+21) at a steady 0 FP, all via
   sound relaxations (the authorized temporary-FP budget was never spent). The
   clusters cleared: enum nominality; covariant generic assignability;
   primitive-vs-callable / -overload / -object-part; intersection-target;
@@ -1557,9 +1563,12 @@ conformance sources (`.errors.txt` baseline = ground truth):
   inference; `typeof Class` constructor-accessibility; mapped-type
   instantiation; static-/prototype-member function-assignment target
   resolution; lowercase `object` is currently parsed as `Any`, so the
-  non-primitive rule has nothing to fire on). Each needs its own resolver
-  threading or signature machinery; the clean structural relaxations are now
-  largely harvested. Sound, FP-0 recall went 563 -> 570 (+7) this session.
+  non-primitive rule has nothing to fire on; abstract-member implementation
+  TS2515 and parameter-property TS2369 would need new AST/parser fields tracked
+  across every `TsClassDecl` construction site). Each needs its own resolver
+  threading, AST extension, or generic / overload machinery; the clean
+  structural relaxations are now largely harvested. Sound, FP-0 recall went
+  563 -> 584 (+21) this session.
 
   Toolchain note (2026-06-08): the native parser-package whitebox test
   generates a ~25 MB C unit that this session's `tcc` could not compile in

--- a/TODO.md
+++ b/TODO.md
@@ -1378,6 +1378,7 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-18 (T66)   572/815 (70 %)        414/414 ( 0 FP)
 2026-06-18 (T67)   576/815 (71 %)        414/414 ( 0 FP)
 2026-06-18 (T68)   581/815 (71 %)        414/414 ( 0 FP)
+2026-06-18 (T69)   583/815 (72 %)        414/414 ( 0 FP)
 
   RB2 (2026-06-18) -- re-baseline after the intervening checker commits
   (through f545849) lifted measured recall 543 -> 563 @ 0 FP. Toolchain note:
@@ -1524,6 +1525,31 @@ conformance sources (`.errors.txt` baseline = ground truth):
         `(...xs: number[])`), returns, and interface call/construct signatures.
         Cleared call/constructSignatureAssignabilityInInheritance and the
         Call/ConstructSignaturesWithSpecializedSignatures pair.
+
+  T69 -- bivariant single-signature comparison for callable *value*
+    assignment (TS2322). recall 581 -> 583. The value-assignment analog of
+    T68: `check_expr_against` relaxes its `shape_is_callable` bail so that when
+    source and target each expose exactly one comparable call (or construct)
+    signature, it is compared via `is_assignable_to_bivariant`
+    (`single_signature_of`). Overloaded shapes, generic signatures, and
+    signatures containing intersections / generic `Applied`
+    (`type_has_intersection_or_applied`, which removed the lone FP) abstain.
+    Cleared assignmentCompatWithGenericCallSignatures2, genericCallWithFunctionTypedArguments2.
+    Still out of reach in this family: the remaining generic-call-signature
+    files (assignmentCompatWithGenericCallSignatures4 / ...WithOptionalParameters,
+    126 errors) need generic-signature instantiation, and the overloaded-value
+    assignments (stringLiteralTypesOverloadAssignability*) need overload-set
+    comparison.
+
+  Session total 2026-06-18: recall 563 -> 583 (+20) at a steady 0 FP, all via
+  sound relaxations (the authorized temporary-FP budget was never spent). The
+  clusters cleared: enum nominality; covariant generic assignability;
+  primitive-vs-callable / -overload / -object-part; intersection-target;
+  private/protected nominality; logical-operator contextual typing; overloaded
+  function-/constructor-typed argument arity; and the call/construct-signature
+  subtyping family at both interface-extends and value-assignment levels (which
+  also drove a parser fix: optional function-/constructor-type parameters now
+  widen to `T | undefined`).
 
   Boundary (2026-06-18): the named higher-order MISS clusters remain
   single-recall-point, bespoke-machinery cases (overloaded construct-signature

--- a/TODO.md
+++ b/TODO.md
@@ -1366,6 +1366,75 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-15 (T55)   541/815 (66 %)        414/414 ( 0 FP)
 2026-06-15 (T56)   542/815 (67 %)        414/414 ( 0 FP)
 2026-06-15 (T57)   543/815 (67 %)        414/414 ( 0 FP)
+2026-06-18 (RB2)   563/815 (69 %)        414/414 ( 0 FP)
+2026-06-18 (T58)   564/815 (69 %)        414/414 ( 0 FP)
+2026-06-18 (T59)   564/815 (69 %)        414/414 ( 0 FP)
+
+  RB2 (2026-06-18) -- re-baseline after the intervening checker commits
+  (through f545849) lifted measured recall 543 -> 563 @ 0 FP. Toolchain note:
+  this session's container had no MoonBit toolchain or `typescript` submodule
+  checked out; both were provisioned (`scripts/patch_async_dep.sh` is still
+  required for the bleeding-edge compiler to accept moonbitlang/async). `moon
+  run --target native src/cmd/tsacc` compiles + runs in ~9s here.
+
+  Decision (2026-06-18): per direction to pursue the "real type-system" path
+  with a *small* FP budget for covariant generic assignability, this session
+  targeted the three remaining higher-order clusters the prior triage named:
+  named-interface object inference, multi-source `T` inference + enum
+  nominality, and overloaded constructor types.
+
+  T58 -- enum nominality on assignment targets (TS2322). recall 563 -> 564.
+    A numeric enum is nominal: a concrete non-numeric primitive / literal or a
+    plain object value is not assignable to an enum-typed target (`var e: E;
+    e = ''` / `e = {}` / `e = true`). Numeric values, the same enum,
+    `any` / `unknown`, and non-strict `null` / `undefined` stay silent. Added
+    ahead of the unresolved-`Named` bail in `check_expr_against`, which
+    previously skipped enum targets entirely (enums live in `resolver.enums`,
+    not the alias / interface / class tables). Cross-enum member assignment
+    (`e = E2.A`) loses its enum provenance through member access (it resolves
+    to a bare numeric literal) and is deliberately not caught -- modelling that
+    needs a nominal enum-typed value representation. Clears
+    `invalidEnumAssignments`. FP-safe by soundness (these shapes are never
+    assignable to a numeric enum). The remaining enum misses are strict-mode-
+    only (`validEnumAssignments`: `e = null` / `e = -1` need
+    strictNullChecks / numeric-literal-vs-member) or different diagnostics
+    (`enumAssignabilityInInheritance` is TS2403, `assignmentCompatWithEnumIndexer`
+    is TS2741 over `Record<E, any>`).
+
+  T59 -- covariant generic assignability (relax the `Applied` bail). recall
+    steady 564, FP steady 0.
+    `check_expr_against` bailed unconditionally whenever either side was an
+    `Applied(...)` instantiation. Relaxed to a variance-safe covariant
+    best-effort comparison (`applied_generic_mismatch`): two instantiations of
+    the *same* generic with the *same* arity are a mismatch when some
+    type-argument pair is bidirectionally incompatible (`Box<string>` vs
+    `Box<number>`; `Box<P>` vs `Box<Q>` for distinct shape-incompatible user
+    classes). Bidirectional incompatibility keeps covariant / contravariant
+    subtype directions silent, so it is sound; argument pairs are only judged
+    when both are concrete primitives / literals or distinct resolvable nominal
+    references. +0 on the measured corpus: every conformance generic-mismatch
+    lives at a *call-argument inference* site, not an assignment / return one,
+    so this strengthens the synthesized-bridge `@checker.check_module` gate
+    without moving the conformance metric.
+
+  Boundary reached (2026-06-18): the named MISS clusters that remain are
+  single-recall-point, high-FP-risk higher-order cases, exactly as the prior
+  triage warned:
+    - `genericCallWithOverloadedConstructorTypedArguments2` (the "overloaded
+      constructor" target): its lone baseline error is an arity mismatch
+      *across an overloaded construct-signature set* fed a *generic*
+      constructor (`{ new(x:T):string; new(x:T,y?:T):string }` vs `new
+      <T>(x:T,y:T)=>string`). Needs quadratic-pairwise overload matching with
+      generic-constructor instantiation -- a large machine for +1.
+    - The "multi-source `T`" shape (`foo<T>(x:T, y:T)`) is already inferred via
+      `infer_param_bindings` (first-wins + per-arg assignability), and its
+      representative file (`genericCallWithNonSymmetricSubtypes`) is already a
+      hit; the open variants are overloaded / function-typed-argument cases
+      (`genericCallWith{Overloaded,Function}*TypedArguments2`).
+    Wiring the covariant comparison into the call-argument conflict path is the
+    next lever for these, but each remaining file needs bespoke higher-order
+    overload machinery whose FP exposure exceeds the small budget; recommend an
+    explicit per-case go-ahead before building it.
 
   Toolchain note (2026-06-08): the native parser-package whitebox test
   generates a ~25 MB C unit that this session's `tcc` could not compile in

--- a/TODO.md
+++ b/TODO.md
@@ -1369,6 +1369,11 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-18 (RB2)   563/815 (69 %)        414/414 ( 0 FP)
 2026-06-18 (T58)   564/815 (69 %)        414/414 ( 0 FP)
 2026-06-18 (T59)   564/815 (69 %)        414/414 ( 0 FP)
+2026-06-18 (T60)   565/815 (69 %)        414/414 ( 0 FP)
+2026-06-18 (T61)   566/815 (69 %)        414/414 ( 0 FP)
+2026-06-18 (T62)   567/815 (69 %)        414/414 ( 0 FP)
+2026-06-18 (T63)   569/815 (70 %)        414/414 ( 0 FP)
+2026-06-18 (T64)   570/815 (70 %)        414/414 ( 0 FP)
 
   RB2 (2026-06-18) -- re-baseline after the intervening checker commits
   (through f545849) lifted measured recall 543 -> 563 @ 0 FP. Toolchain note:
@@ -1417,24 +1422,63 @@ conformance sources (`.errors.txt` baseline = ground truth):
     so this strengthens the synthesized-bridge `@checker.check_module` gate
     without moving the conformance metric.
 
-  Boundary reached (2026-06-18): the named MISS clusters that remain are
-  single-recall-point, high-FP-risk higher-order cases, exactly as the prior
-  triage warned:
-    - `genericCallWithOverloadedConstructorTypedArguments2` (the "overloaded
-      constructor" target): its lone baseline error is an arity mismatch
-      *across an overloaded construct-signature set* fed a *generic*
-      constructor (`{ new(x:T):string; new(x:T,y?:T):string }` vs `new
-      <T>(x:T,y:T)=>string`). Needs quadratic-pairwise overload matching with
-      generic-constructor instantiation -- a large machine for +1.
-    - The "multi-source `T`" shape (`foo<T>(x:T, y:T)`) is already inferred via
-      `infer_param_bindings` (first-wins + per-arg assignability), and its
-      representative file (`genericCallWithNonSymmetricSubtypes`) is already a
-      hit; the open variants are overloaded / function-typed-argument cases
-      (`genericCallWith{Overloaded,Function}*TypedArguments2`).
-    Wiring the covariant comparison into the call-argument conflict path is the
-    next lever for these, but each remaining file needs bespoke higher-order
-    overload machinery whose FP exposure exceeds the small budget; recommend an
-    explicit per-case go-ahead before building it.
+  Follow-up decision (2026-06-18): direction updated to "increase recall, a
+  temporary rise in FP is acceptable." In practice every gain below was still
+  found as a *sound* relaxation that holds FP at 0 -- the FP budget was never
+  spent. The one broad heuristic that does trade FP (emit unreliable arity for
+  `sig`-less calls: +7 recall / +8 FP) was rejected on *quality*: 6 of its 7
+  "gains" were spurious arity diagnostics that merely happened to land on
+  files carrying some other baseline error (the file-level metric rewards any
+  diagnostic on a baseline-positive file), and the 8 FP were our own lib /
+  call-signature param models lacking optional / rest markers. So arity stays
+  suppressed for `sig`-less calls; `arity_reliable` was instead broadened to
+  *every* `sig is Some` declaration (rest-bearing included -- `required_arity`
+  is exact), a correctness improvement (+0).
+
+  T60 -- primitive-vs-callable mismatch + precise rest-arity. recall 564 ->
+    565. A concrete primitive / literal is never a function or constructor, so
+    assigning one to a callable target (`var f: () => void = 5`, `var k: new ()
+    => A = "asdf"`) is a real TS2322. Checked ahead of the structural
+    `shape_is_callable` bail. Clears classAbstractAssignabilityConstructorFunction.
+
+  T61 -- intersection-target assignability. recall 565 -> 566. A value inhabits
+    `A & B` only when it satisfies every part; a source that provably fails an
+    object-like part (a primitive, or an object missing the part's members) is
+    a mismatch (`intersection_target_mismatch`). Intersection *source* still
+    bails. Clears nonPrimitiveUnionIntersection.
+
+  T62 -- primitive vs overload-bearing interface. recall 566 -> 567. A concrete
+    primitive / literal is never an object shape, including an overloaded-method
+    interface, so the overloaded-shape bail now flags a primitive source.
+    Clears assignFromStringInterface2.
+
+  T63 -- private / protected members are nominal. recall 567 -> 569.
+    `nominal_private_blocks` short-circuits the structural accept-fallbacks: a
+    class carrying a private/protected member is only assignable to/from the
+    same class or its sub/superclass (inheritance via `class_extends`). Clears
+    assignmentCompatWithObjectMembersAccessibility (a 72-error file) and
+    objectRest.
+
+  T64 -- contextual type through `&&` / `||` / `??`. recall 569 -> 570. The
+    expected type now flows to a logical operator's *right* operand (its result
+    / fallback), mirroring the ternary path, so `x = cond && (a => …)` types
+    the arrow's params and surfaces body errors. The left operand is not
+    checked (for `||` / `??` it is the guarded nullable value -- checking it
+    cost 1 FP in an earlier attempt). Clears contextuallyTypeLogicalAnd02.
+
+  Tooling: `tsacc --list-misses` now also prints `FALSE_POS <case> :: <path>
+  :: <msg>`, which made the arity quality assessment and the variance-safety
+  audits above mechanical.
+
+  Boundary (2026-06-18): the named higher-order MISS clusters remain
+  single-recall-point, bespoke-machinery cases (overloaded construct-signature
+  arity with generic constructors; overloaded / function-typed argument
+  inference; `typeof Class` constructor-accessibility; mapped-type
+  instantiation; static-/prototype-member function-assignment target
+  resolution; lowercase `object` is currently parsed as `Any`, so the
+  non-primitive rule has nothing to fire on). Each needs its own resolver
+  threading or signature machinery; the clean structural relaxations are now
+  largely harvested. Sound, FP-0 recall went 563 -> 570 (+7) this session.
 
   Toolchain note (2026-06-08): the native parser-package whitebox test
   generates a ~25 MB C unit that this session's `tcc` could not compile in

--- a/TODO.md
+++ b/TODO.md
@@ -1380,6 +1380,7 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-18 (T68)   581/815 (71 %)        414/414 ( 0 FP)
 2026-06-18 (T69)   583/815 (72 %)        414/414 ( 0 FP)
 2026-06-18 (T70)   584/815 (72 %)        414/414 ( 0 FP)
+2026-06-18 (T71)   589/815 (72 %)        414/414 ( 0 FP)
 
   RB2 (2026-06-18) -- re-baseline after the intervening checker commits
   (through f545849) lifted measured recall 543 -> 563 @ 0 FP. Toolchain note:
@@ -1547,7 +1548,18 @@ conformance sources (`.errors.txt` baseline = ground truth):
     need generic-signature instantiation, and the overloaded-value assignments
     (stringLiteralTypesOverloadAssignability*) need overload-set comparison.
 
-  Session total 2026-06-18: recall 563 -> 584 (+21) at a steady 0 FP, all via
+  T71 -- non-abstract class must implement inherited abstract members
+    (TS2515). recall 584 -> 589. Added an `abstract_members` name list to
+    `TsClassDecl` (populated by the runtime-class and ambient-`declare class`
+    parsers, like the private/protected lists). `check_abstract_implementation`
+    walks a concrete class's single-inheritance base chain, gathers every
+    abstract member an ancestor declares, and flags any not implemented
+    concretely anywhere in the chain; abstains on an unresolved base. Cleared
+    classAbstractExtends, classAbstractGeneric, classAbstractInheritance1/2,
+    classAbstractUsingAbstractMethods2. (This is the one change that touched
+    the AST -- threaded through all nine `TsClassDecl` construction sites.)
+
+  Session total 2026-06-18: recall 563 -> 589 (+26) at a steady 0 FP, all via
   sound relaxations (the authorized temporary-FP budget was never spent). The
   clusters cleared: enum nominality; covariant generic assignability;
   primitive-vs-callable / -overload / -object-part; intersection-target;
@@ -1568,7 +1580,7 @@ conformance sources (`.errors.txt` baseline = ground truth):
   across every `TsClassDecl` construction site). Each needs its own resolver
   threading, AST extension, or generic / overload machinery; the clean
   structural relaxations are now largely harvested. Sound, FP-0 recall went
-  563 -> 584 (+21) this session.
+  563 -> 589 (+26) this session.
 
   Toolchain note (2026-06-08): the native parser-package whitebox test
   generates a ~25 MB C unit that this session's `tcc` could not compile in

--- a/src/ast/types.mbt
+++ b/src/ast/types.mbt
@@ -749,6 +749,12 @@ pub(all) struct TsClassDecl {
   // changing the member-decl structs. Empty for fully-public classes.
   private_members : Array[String]
   protected_members : Array[String]
+  // Names of members declared `abstract` (`abstract foo(): void;` /
+  // `abstract x: number;`). A non-abstract class extending a class that has
+  // abstract members must implement each of them (TS2515). Stored as a name
+  // list for the same reason as the visibility lists above. Empty unless the
+  // class is `abstract` and declares abstract members.
+  abstract_members : Array[String]
   // Member names the parser saw declared in two incompatible ways within
   // this class body -- a data field colliding with a method / accessor of
   // the same name, or a duplicated getter / setter. TypeScript reports

--- a/src/bridge/moonbit_decl.mbt
+++ b/src/bridge/moonbit_decl.mbt
@@ -8991,6 +8991,7 @@ fn clone_exported_class(
     is_declare: false,
     private_members: exported.class_.private_members,
     protected_members: exported.class_.protected_members,
+    abstract_members: exported.class_.abstract_members,
     duplicate_member_names: exported.class_.duplicate_member_names,
   }
 }

--- a/src/bridge/moonbit_js_ffi_wbtest.mbt
+++ b/src/bridge/moonbit_js_ffi_wbtest.mbt
@@ -1133,7 +1133,7 @@ async test "bridge: emit callable wrappers for natural function-valued const exp
   )
   assert_true(
     bundle.ffi_mbt.contains(
-      "pub extern \"js\" fn has_magic(arg0 : String, arg1 : GlobOptions) -> Bool = \"__ts_mbt_has_magic\"",
+      "pub extern \"js\" fn has_magic(arg0 : String, arg1 : GlobOptions?) -> Bool = \"__ts_mbt_has_magic\"",
     ),
   )
   // The full `hasMagic` wrapper now routes the `string | string[]`

--- a/src/bridge/moonbit_js_ffi_wbtest.mbt
+++ b/src/bridge/moonbit_js_ffi_wbtest.mbt
@@ -4998,6 +4998,7 @@ test "bridge: FFI class methods unwrap optional arguments" {
     is_declare: false,
     private_members: [],
     protected_members: [],
+    abstract_members: [],
     duplicate_member_names: [],
   }
   let class_method : @ast.TsClassMethodDecl = {

--- a/src/checker/check_module_wbtest.mbt
+++ b/src/checker/check_module_wbtest.mbt
@@ -175,6 +175,7 @@ test "check_module: detects duplicate class instance properties" {
     is_declare: false,
     private_members: [],
     protected_members: [],
+    abstract_members: [],
     duplicate_member_names: [],
   })
   let report = check_module(m)
@@ -229,6 +230,7 @@ test "check_module: instance and static with same name is OK" {
     is_declare: false,
     private_members: [],
     protected_members: [],
+    abstract_members: [],
     duplicate_member_names: [],
   })
   let report = check_module(m)

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -6062,7 +6062,19 @@ fn check_expr_against(
     return
   }
   match (inferred_u, expected_u) {
-    (Applied(_, _), _) | (_, Applied(_, _)) => return
+    (Applied(_, _), _) | (_, Applied(_, _)) => {
+      // Covariant best-effort: same generic, same arity, a type-argument pair
+      // that is bidirectionally incompatible (`Box<string>` vs `Box<number>`)
+      // is a real mismatch. Everything else keeps the conservative bail.
+      if applied_generic_mismatch(inferred_u, expected_u, ctx) {
+        record(
+          ctx,
+          sub_path,
+          "expected `\{type_display(expected_u)}` but got `\{type_display(inferred_u)}`",
+        )
+      }
+      return
+    }
     // Intersections on either side (`PartialStepState & { repo: any }`,
     // `ComponentType<any> & ComponentType<RouteComponentProps>`, `A & A`):
     // intersection assignability (a value of the intersection satisfies each
@@ -13143,6 +13155,70 @@ fn check_module_function_bodies_layered(
 /// (`var x: T = 1`): only such unambiguously-concrete sources are flagged, so
 /// an imprecisely-inferred object / union / generic instantiation can never
 /// false-flag against `T`.
+/// Covariant best-effort generic-instantiation mismatch. Two `Applied`
+/// instantiations of the *same* generic with the *same* arity are a genuine
+/// type error when some type-argument pair is bidirectionally incompatible
+/// (`Box<string>` vs `Box<number>`). Requiring incompatibility in *both*
+/// directions keeps the check variance-safe: a covariant widening
+/// (`Box<"a">` -> `Box<string>`) or a contravariant one leaves one direction
+/// assignable, so it is not flagged. Type-argument pairs are only judged when
+/// both sides are concrete primitives / literals; anything else (type
+/// parameters, object shapes, nested generics, `any`) abstains. This is the
+/// relaxation of the blanket `Applied` bail in `check_expr_against`.
+fn applied_generic_mismatch(
+  source : @ast.TsType,
+  target : @ast.TsType,
+  ctx : CheckCtx,
+) -> Bool {
+  match (source, target) {
+    (Applied(s_name, s_args), Applied(t_name, t_args)) => {
+      if s_name != t_name || s_args.length() != t_args.length() {
+        return false
+      }
+      if s_args.length() == 0 {
+        return false
+      }
+      for i in 0..<s_args.length() {
+        let sa = ctx.resolver.unwrap(s_args[i])
+        let ta = ctx.resolver.unwrap(t_args[i])
+        if is_concrete_primitive_or_literal(sa) &&
+          is_concrete_primitive_or_literal(ta) {
+          if not(is_assignable_to(sa, ta)) && not(is_assignable_to(ta, sa)) {
+            return true
+          }
+          continue
+        }
+        // Both args are distinct user-declared nominal references
+        // (`X<Foo>` vs `X<Bar>`) that are bidirectionally structurally
+        // incompatible. Bidirectional incompatibility keeps the covariant /
+        // contravariant subtype directions silent.
+        match (sa, ta) {
+          (Named(sn), Named(tn)) =>
+            if sn != tn &&
+              is_resolvable_nominal_name(ctx.resolver, sn) &&
+              is_resolvable_nominal_name(ctx.resolver, tn) &&
+              not(is_structurally_assignable_named(sa, ta, ctx.resolver)) &&
+              not(is_structurally_assignable_named(ta, sa, ctx.resolver)) {
+              return true
+            }
+          _ => ()
+        }
+      }
+      false
+    }
+    _ => false
+  }
+}
+
+///|
+/// True when `name` resolves to a user-declared class or interface — a
+/// nominal reference whose member shape the structural-assignability relation
+/// can compare.
+fn is_resolvable_nominal_name(resolver : Resolver, name : String) -> Bool {
+  resolver.classes.get(name) is Some(_) || resolver.interfaces.get(name) is Some(_)
+}
+
+///|
 fn is_concrete_primitive_or_literal(ty : @ast.TsType) -> Bool {
   match ty {
     Number

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -6093,13 +6093,25 @@ fn check_expr_against(
       }
       return
     }
-    // Intersections on either side (`PartialStepState & { repo: any }`,
-    // `ComponentType<any> & ComponentType<RouteComponentProps>`, `A & A`):
-    // intersection assignability (a value of the intersection satisfies each
-    // part, and an object satisfying every part inhabits the intersection) is
-    // something we don't model structurally, so comparing nominally yields
-    // false mismatches. Stay silent.
-    (Intersection(_), _) | (_, Intersection(_)) => return
+    // Intersection *target*: a value inhabits `A & B` only when it satisfies
+    // every part. When the source is a concrete shape we can compare (object /
+    // struct / nominal / primitive) and it provably fails one object-like
+    // part, the assignment is a real mismatch (`var y: {a}&{b} = a` where `a:
+    // {a}`). Bidirectional / nominal-only parts and unmodeled shapes abstain.
+    (_, Intersection(parts)) =>
+      if intersection_target_mismatch(inferred_u, parts, ctx.resolver) {
+        record(
+          ctx,
+          sub_path,
+          "expected `\{type_display(expected_u)}` but got `\{type_display(inferred_u)}`",
+        )
+        return
+      } else {
+        return
+      }
+    // Intersection *source*: still modelled too coarsely structurally — stay
+    // silent.
+    (Intersection(_), _) => return
     // Bare callable / constructable shapes match other call signatures
     // structurally in ways we don't model — stay silent.
     (Func(_, _), _)
@@ -13219,6 +13231,49 @@ fn applied_generic_mismatch(
     }
     _ => false
   }
+}
+
+///|
+/// Intersection-target assignability: a value inhabits `A & B` only when it
+/// satisfies *every* part. Returns true when the source is a shape we can
+/// compare and it provably fails an object-like part -- a concrete primitive
+/// can never satisfy an object part, and a structural object / nominal source
+/// that lacks a part's members is a real mismatch. Parts that are primitives,
+/// type parameters, generics, callables, or unresolved names abstain (so the
+/// surrounding caller keeps bailing on those).
+fn intersection_target_mismatch(
+  source : @ast.TsType,
+  parts : Array[@ast.TsType],
+  resolver : Resolver,
+) -> Bool {
+  let source_concrete = is_concrete_primitive_or_literal(source)
+  let source_shape = match source {
+    Object(_) | Struct(_, _) => true
+    Named(n) => is_resolvable_nominal_name(resolver, n)
+    _ => false
+  }
+  if not(source_concrete) && not(source_shape) {
+    return false
+  }
+  for part in parts {
+    let p = resolver.unwrap(part)
+    let object_like = match p {
+      Object(_) | Struct(_, _) => true
+      Named(n) => is_resolvable_nominal_name(resolver, n)
+      _ => false
+    }
+    if not(object_like) {
+      continue
+    }
+    if source_concrete {
+      return true
+    }
+    if not(is_assignable_to(source, p)) &&
+      not(is_structurally_assignable_named(source, p, resolver)) {
+      return true
+    }
+  }
+  false
 }
 
 ///|

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -2966,6 +2966,67 @@ fn class_extends(resolver : Resolver, sub : String, base : String) -> Bool {
 }
 
 ///|
+/// True when class `name` declares any `private` / `protected` member. Such a
+/// member is nominal in TypeScript: only the same class declaration (or a
+/// subclass, which inherits it) can satisfy the type.
+fn class_has_private_member(resolver : Resolver, name : String) -> Bool {
+  match resolver.classes.get(name) {
+    Some(decl) =>
+      decl.private_members.length() > 0 || decl.protected_members.length() > 0
+    None => false
+  }
+}
+
+///|
+/// Private / protected members must originate from the same class declaration,
+/// so assignability is blocked when:
+///  - the *target* is a class with a private/protected member and the source
+///    is neither that class nor a subclass of it (which inherits the member);
+///  - or the *source* is a class with a private/protected member and the
+///    target is neither that class nor a superclass of it -- a structural
+///    object / interface / unrelated class can never supply the private
+///    member.
+/// Returns true when the assignment must be flagged. Only fires when the
+/// relevant side resolves to a known class; everything else abstains. Callers
+/// reach this only after the nominal `is_assignable_to` already returned false
+/// (so same-class and `any` / universal targets never get here).
+fn nominal_private_blocks(
+  source : @ast.TsType,
+  target : @ast.TsType,
+  resolver : Resolver,
+) -> Bool {
+  let s_class = match resolver.unwrap(source) {
+    Named(n) => if resolver.classes.get(n) is Some(_) { Some(n) } else { None }
+    _ => None
+  }
+  let t_class = match resolver.unwrap(target) {
+    Named(n) => if resolver.classes.get(n) is Some(_) { Some(n) } else { None }
+    _ => None
+  }
+  match t_class {
+    Some(tn) =>
+      if class_has_private_member(resolver, tn) {
+        match s_class {
+          Some(sn) => if not(class_extends(resolver, sn, tn)) { return true }
+          None => return true
+        }
+      }
+    None => ()
+  }
+  match s_class {
+    Some(sn) =>
+      if class_has_private_member(resolver, sn) {
+        match t_class {
+          Some(tn) => if not(class_extends(resolver, sn, tn)) { return true }
+          None => return true
+        }
+      }
+    None => ()
+  }
+  false
+}
+
+///|
 /// TS2341 / TS2445: accessing a `private` / `protected` class member from
 /// outside the scope that's allowed to see it. The receiver's class is
 /// resolved (instance type or a static `Class.member` reference); a
@@ -6149,6 +6210,19 @@ fn check_expr_against(
     _ => ()
   }
   if !is_assignable_to(inferred_u, expected_u) {
+    // Private / protected members are nominal: a class carrying one is only
+    // assignable to / from the same class (or its sub- / super-class via
+    // inheritance). This must short-circuit the structural accept-fallbacks
+    // below, which would otherwise match the private member as an ordinary
+    // field (`var a: { foo: string } = e` where `class E { private foo }`).
+    if nominal_private_blocks(inferred_u, expected_u, ctx.resolver) {
+      record(
+        ctx,
+        sub_path,
+        "expected `\{type_display(expected_u)}` but got `\{type_display(inferred_u)}`",
+      )
+      return
+    }
     // Class / interface references are nominal in `is_assignable_to`
     // (Named(A) == Named(B) iff A == B), but TypeScript types are
     // structural: two distinct classes / interfaces with the same

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -14589,30 +14589,30 @@ fn check_class_implements(
 }
 
 ///|
-/// True when a derived callable member cannot be assignable to the base
-/// callable member purely on *arity*: the derived signature requires more
-/// arguments than the base provides, so a base-typed caller would invoke it
-/// with too few. Arity-only (no return / parameter-type variance), so it is a
-/// sound, false-positive-free subset of full signature subtyping. A base with
-/// a rest parameter provides unbounded arity and never triggers this.
-fn callable_member_arity_incompatible(
+/// True when a derived callable member is not assignable to the base callable
+/// member (`interface I extends Base` requires `I`'s member to be a subtype of
+/// `Base`'s). Both must be plain, non-generic `Func` / `Constructor` of the
+/// same kind; assignability is bivariant in parameters (matching the
+/// conformance corpus' `strictFunctionTypes: false`) and covariant in the
+/// return type, via `is_assignable_to_bivariant`. This catches a derived
+/// signature that requires more arguments than the base provides (the surplus
+/// non-optional parameter fails), an incompatible parameter type (`(...args:
+/// string[])` over `(...args: number[])`), and an incompatible return.
+/// Generic signatures (`<T>(x: T): U`) abstain -- instantiation would need the
+/// full machinery.
+fn callable_member_incompatible(
   derived : @ast.TsType,
   base : @ast.TsType,
 ) -> Bool {
-  fn arity_exceeds(dp : Array[@ast.TsType], bp : Array[@ast.TsType]) -> Bool {
-    for p in bp {
-      if p is Rest(_) {
-        return false
-      }
-    }
-    required_arity_from_types(dp) > bp.length()
-  }
-
-  match (derived, base) {
-    (Func(dp, _), Func(bp, _)) => arity_exceeds(dp, bp)
-    (Constructor(dp, _, _), Constructor(bp, _, _)) => arity_exceeds(dp, bp)
+  let same_kind = match (derived, base) {
+    (Func(_, _), Func(_, _)) => true
+    (Constructor(_, _, _), Constructor(_, _, _)) => true
     _ => false
   }
+  same_kind &&
+  not_generic_func(derived) &&
+  not_generic_func(base) &&
+  not(is_assignable_to_bivariant(derived, base))
 }
 
 ///|
@@ -14757,13 +14757,13 @@ fn check_interface_extends_compat(
                 path: "interface \{iface.name}",
                 message: "interface incorrectly extends `\{base_name}`: property `\{df.0}` of type `\{type_display(df.1)}` is not assignable to the base type `\{type_display(btype)}`",
               })
-            } else if callable_member_arity_incompatible(
+            } else if callable_member_incompatible(
                 resolver.unwrap(d_payload),
                 resolver.unwrap(b_payload),
               ) {
               issues.push({
                 path: "interface \{iface.name}",
-                message: "interface incorrectly extends `\{base_name}`: member `\{df.0}` requires more arguments than the base signature provides",
+                message: "interface incorrectly extends `\{base_name}`: member `\{df.0}` signature is not assignable to the base signature",
               })
             } else if d_optional && !b_optional {
               issues.push({

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -3992,6 +3992,55 @@ fn enum_integer_values(decl : @ast.TsEnumDecl) -> Array[Int]? {
 }
 
 ///|
+/// True when `decl` is a purely numeric enum: every member is either
+/// auto-incremented (no initializer, so numeric) or has a numeric
+/// initializer. String / heterogeneous enums return false. Unlike
+/// `enum_integer_values`, this accepts auto-incremented members (`enum E { A,
+/// B }`) since their runtime values are still numbers. Used by the
+/// enum-nominality assignment rule, which only reasons about numeric enums.
+fn is_numeric_enum(decl : @ast.TsEnumDecl) -> Bool {
+  for m in decl.members {
+    match m.value {
+      None => ()
+      Some(Number(_)) => ()
+      _ => return false
+    }
+  }
+  decl.members.length() > 0
+}
+
+///|
+/// True when `name` resolves to a purely numeric enum declaration.
+fn is_numeric_enum_name(resolver : Resolver, name : String) -> Bool {
+  match resolver.enums.get(name) {
+    Some(decl) => is_numeric_enum(decl)
+    None => false
+  }
+}
+
+///|
+/// Enum nominality: a value of these shapes is provably *not* assignable to a
+/// numeric enum target. Numeric sources (`number` / numeric literal), the same
+/// enum, `any` / `unknown`, and `null` / `undefined` are all accepted
+/// elsewhere; what remains here is a concrete non-numeric primitive / literal
+/// or a plain object value (`var e: E; e = ''` / `e = {}` is TS2322). Enums
+/// are nominal, so rejecting these is sound and false-positive-free.
+fn enum_incompatible_source(ty : @ast.TsType) -> Bool {
+  match ty {
+    String_
+    | Literal(_)
+    | Boolean
+    | BooleanLiteral(_)
+    | BigInt
+    | BigIntLiteral(_)
+    | Symbol
+    | Object(_)
+    | Struct(_, _) => true
+    _ => false
+  }
+}
+
+///|
 /// The integer value of a literal expression / type, if it is one.
 fn expr_integer_literal(e : @ast.TsExpr, t : @ast.TsType) -> Int? {
   match e {
@@ -5851,6 +5900,28 @@ fn check_expr_against(
       if s != t &&
         ctx.in_scope_type_params.contains(s) &&
         ctx.in_scope_type_params.contains(t) {
+        record(
+          ctx,
+          sub_path,
+          "expected `\{type_display(expected_u)}` but got `\{type_display(inferred_u)}`",
+        )
+        return
+      }
+    _ => ()
+  }
+  // Enum nominality: a numeric enum target accepts numeric values, the same
+  // enum, `any` / `unknown`, and `null` / `undefined` (all handled above or
+  // not matched below). A concrete non-numeric primitive / literal or a plain
+  // object value is not assignable to it -- `var e: E; e = ''` / `e = {}` is
+  // TS2322. Cross-enum member assignment (`e = E2.A`) loses its enum
+  // provenance through member access (it resolves to a bare numeric literal)
+  // and is deliberately not caught here. Placed ahead of the unresolved-Named
+  // bail below, which would otherwise skip enum targets entirely (enums live
+  // in `resolver.enums`, not the alias / interface / class tables).
+  match expected_u {
+    Named(n) =>
+      if is_numeric_enum_name(ctx.resolver, n) &&
+        enum_incompatible_source(inferred_u) {
         record(
           ctx,
           sub_path,

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -5760,6 +5760,21 @@ fn check_expr_against(
       check_expr_against(env, else_, expected, ctx, sub_path + " (else)")
       return
     }
+    // Logical operators propagate the contextual type to their *right*
+    // operand, mirroring TS: `x && f` yields `f` when truthy, and the fallback
+    // of `a || b` / `a ?? b` is `b`. The right operand must therefore be
+    // assignable to the expected type, so checking it flows a function /
+    // object context inward (`x = y && (a => …)` types the arrow's params),
+    // surfacing body errors a bare inference would miss. The left operand is
+    // deliberately *not* checked: for `||` / `??` it is the value being
+    // guarded (`const xs: string[] = maybe || []` has `maybe: string[] |
+    // undefined`), and for `&&` it is the boolean-ish guard.
+    (BinOp(And, _, r), _)
+    | (BinOp(Or, _, r), _)
+    | (BinOp(Coalesce, _, r), _) => {
+      check_expr_against(env, r, expected, ctx, sub_path + " (logical)")
+      return
+    }
     // Contextual typing for array literals: `[a, b]` against a tuple type
     // `[T1, T2]` checks each element against the corresponding slot. Without
     // this hop the array literal would infer as `Array<elem>` and fail

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -14589,6 +14589,33 @@ fn check_class_implements(
 }
 
 ///|
+/// True when a derived callable member cannot be assignable to the base
+/// callable member purely on *arity*: the derived signature requires more
+/// arguments than the base provides, so a base-typed caller would invoke it
+/// with too few. Arity-only (no return / parameter-type variance), so it is a
+/// sound, false-positive-free subset of full signature subtyping. A base with
+/// a rest parameter provides unbounded arity and never triggers this.
+fn callable_member_arity_incompatible(
+  derived : @ast.TsType,
+  base : @ast.TsType,
+) -> Bool {
+  fn arity_exceeds(dp : Array[@ast.TsType], bp : Array[@ast.TsType]) -> Bool {
+    for p in bp {
+      if p is Rest(_) {
+        return false
+      }
+    }
+    required_arity_from_types(dp) > bp.length()
+  }
+
+  match (derived, base) {
+    (Func(dp, _), Func(bp, _)) => arity_exceeds(dp, bp)
+    (Constructor(dp, _, _), Constructor(bp, _, _)) => arity_exceeds(dp, bp)
+    _ => false
+  }
+}
+
+///|
 /// TS2430 ("Interface incorrectly extends interface"): a derived
 /// interface redeclares an inherited member with an incompatible shape.
 /// We report only the two reliably-detectable shapes (no structural
@@ -14729,6 +14756,14 @@ fn check_interface_extends_compat(
               issues.push({
                 path: "interface \{iface.name}",
                 message: "interface incorrectly extends `\{base_name}`: property `\{df.0}` of type `\{type_display(df.1)}` is not assignable to the base type `\{type_display(btype)}`",
+              })
+            } else if callable_member_arity_incompatible(
+                resolver.unwrap(d_payload),
+                resolver.unwrap(b_payload),
+              ) {
+              issues.push({
+                path: "interface \{iface.name}",
+                message: "interface incorrectly extends `\{base_name}`: member `\{df.0}` requires more arguments than the base signature provides",
               })
             } else if d_optional && !b_optional {
               issues.push({

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -807,19 +807,82 @@ fn collect_call_signatures(
 }
 
 ///|
-/// The finite parameter count of a call signature `Func(params, ret)`, or
-/// `None` when it has a rest parameter (its arity is unbounded, so it can
-/// never be invoked with too few arguments for a function value).
-fn call_signature_param_count(sig : @ast.TsType) -> Int? {
-  match sig {
-    Func(params, _) => {
-      for p in params {
-        if p is Rest(_) {
-          return None
+/// Collect every construct signature (`<new>`) declared on `t` -- one entry
+/// per overload -- from structural object types and interface declarations,
+/// plus a bare `Constructor` type.
+fn collect_construct_signatures(
+  t : @ast.TsType,
+  resolver : Resolver,
+) -> Array[@ast.TsType] {
+  let out : Array[@ast.TsType] = []
+  match resolver.unwrap(t) {
+    Constructor(_, _, _) as c => out.push(c)
+    Object(fields) =>
+      for f in fields {
+        match f.0 {
+          Literal(k) => if k == "<new>" { out.push(f.1) }
+          _ => ()
         }
       }
-      Some(params.length())
+    Named(n) =>
+      match resolver.interfaces.get(n) {
+        Some(iface) =>
+          for f in iface.fields {
+            if f.0 == "<new>" {
+              out.push(f.1)
+            }
+          }
+        None => ()
+      }
+    _ => ()
+  }
+  out
+}
+
+///|
+/// The finite parameter count of a call / construct signature (`Func` /
+/// `Constructor`), or `None` when it has a rest parameter (unbounded arity,
+/// so it can never be invoked with too few arguments).
+fn call_signature_param_count(sig : @ast.TsType) -> Int? {
+  let params = match sig {
+    Func(params, _) => params
+    Constructor(params, _, _) => params
+    _ => return None
+  }
+  for p in params {
+    if p is Rest(_) {
+      return None
     }
+  }
+  Some(params.length())
+}
+
+///|
+/// Required arity of a value whose type carries *exactly one* signature of the
+/// requested kind (`<call>` when `want_new` is false, `<new>` when true). An
+/// overloaded source (more than one matching signature) is itself flexible, so
+/// returns `None`; bare `Func` / `Constructor` types count as a single
+/// signature.
+fn single_signature_required_arity(
+  ty : @ast.TsType,
+  want_new : Bool,
+  resolver : Resolver,
+) -> Int? {
+  let sigs = if want_new {
+    collect_construct_signatures(ty, resolver)
+  } else {
+    let direct = match resolver.unwrap(ty) {
+      Func(_, _) as f => [f]
+      _ => collect_call_signatures(ty, resolver)
+    }
+    direct
+  }
+  if sigs.length() != 1 {
+    return None
+  }
+  match sigs[0] {
+    Func(params, _) | Constructor(params, _, _) =>
+      Some(required_arity_from_types(params))
     _ => None
   }
 }
@@ -5781,7 +5844,20 @@ fn check_expr_against(
   // than the value requires is a real TS2345. Checked ahead of the
   // contextual-typing routes below (which only fire for a single call
   // signature and never enforce this minimum).
-  match function_value_required_arity(expr) {
+  // The same applies to construct signatures (`new (x): T`): a constructor
+  // value that requires more parameters than a `<new>` overload provides can't
+  // implement it (`foo6(b)` where `b: { new <T>(x: T, y: T): string }` against
+  // `{ new (x: T): string; new (x: T, y?: T): string }`). The source arity is
+  // read from a function literal directly, otherwise from the value's own
+  // single call / construct signature.
+  let call_arity = match function_value_required_arity(expr) {
+    Some(m) => Some(m)
+    None =>
+      single_signature_required_arity(
+        infer_expr(env, ctx.resolver, expr), false, ctx.resolver,
+      )
+  }
+  match call_arity {
     Some(m) =>
       for sig in collect_call_signatures(expected_shape, ctx.resolver) {
         match call_signature_param_count(sig) {
@@ -5791,6 +5867,27 @@ fn check_expr_against(
                 ctx,
                 sub_path,
                 "expected `\{type_display(expected)}` but the function value requires \{m} argument(s); a target call signature accepts only \{n}",
+              )
+              return
+            }
+          None => ()
+        }
+      }
+    None => ()
+  }
+  match
+    single_signature_required_arity(
+      infer_expr(env, ctx.resolver, expr), true, ctx.resolver,
+    ) {
+    Some(m) =>
+      for sig in collect_construct_signatures(expected_shape, ctx.resolver) {
+        match call_signature_param_count(sig) {
+          Some(n) =>
+            if m > n {
+              record(
+                ctx,
+                sub_path,
+                "expected `\{type_display(expected)}` but the constructor value requires \{m} argument(s); a target construct signature accepts only \{n}",
               )
               return
             }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -3124,6 +3124,7 @@ fn check_abstract_instantiation(ctx : CheckCtx, class_name : String) -> Unit {
 /// "simple" type (primitive / literal / `T[]` / single Named) is
 /// reliable enough to keep -- those cases are picked up by the
 /// strict mode anyway and contribute recall without inflating FP.
+///|
 fn is_permissively_suppressed(sub_path : String, message : String) -> Bool {
   if message.has_prefix("expected `") && message.contains("but got `") {
     // Compatibility goal: a type mismatch is a real TS error, so emit it
@@ -3188,11 +3189,12 @@ fn is_permissively_suppressed(sub_path : String, message : String) -> Bool {
     return false
   }
   if message.contains("argument(s), got ") {
-    // Arity diagnostics are suppressed by default in permissive mode
-    // (overloads / optional / builtin signatures we don't fully model make
-    // them false-positive-prone). The reliable cases -- constructor calls
-    // and direct calls to rest-free top-level function declarations -- are
-    // emitted via `record_unfiltered`, so they never reach this filter.
+    // Arity diagnostics are suppressed by default in permissive mode: with no
+    // rich `TsParam` list (builtin lib methods, call-signature-typed values)
+    // optional / default / rest parameters aren't modelled accurately, so the
+    // count is unreliable in both directions. Reliable cases (constructors,
+    // direct calls to function declarations -- `sig is Some`) bypass this
+    // filter via `record_unfiltered`.
     return true
   }
   if message.contains("is not callable") {
@@ -6043,6 +6045,22 @@ fn check_expr_against(
         "expected `\{type_display(expected_u)}` but got `\{type_display(inferred_u)}`",
       )
     }
+    return
+  }
+  // Callable vs concrete-scalar: a primitive / literal value is never a
+  // function or constructor (and vice versa), so this is a real, unambiguous
+  // mismatch -- `var f: () => void = 5`, `var k: new () => A = "asdf"`. Checked
+  // ahead of the structural callable bail below, which would otherwise swallow
+  // it (a `Func` / `Constructor` is `shape_is_callable`).
+  if (shape_is_callable(expected_u, ctx.resolver) &&
+      is_concrete_primitive_or_literal(inferred_u)) ||
+    (shape_is_callable(inferred_u, ctx.resolver) &&
+      is_concrete_primitive_or_literal(expected_u)) {
+    record(
+      ctx,
+      sub_path,
+      "expected `\{type_display(expected_u)}` but got `\{type_display(inferred_u)}`",
+    )
     return
   }
   // Callable / constructable interfaces & objects (`<call>` / `<new>`
@@ -10893,24 +10911,17 @@ fn check_call_args_in_expr(
             params
           }
           // A direct call to a top-level function *declaration* (present in
-          // `signatures`) with no rest parameter has an exact, reliable
-          // arity -- safe to report even in permissive mode. Call-signature
-          // -typed variables, inferred function values, and rest-bearing
-          // signatures are not in `signatures` (or carry a rest) and stay
-          // suppressed. (`this` parameters are stripped during resolver
-          // construction, so they no longer skew the count.)
-          let arity_reliable = match sig {
-            Some(ps) => {
-              let mut ok = true
-              for p in ps {
-                if p.is_rest {
-                  ok = false
-                }
-              }
-              ok
-            }
-            None => false
-          }
+          // `signatures`) has an exact, reliable arity -- safe to report even
+          // in permissive mode. The rich `TsParam` list models optional /
+          // default / rest parameters precisely (`required_arity` excludes
+          // optionals and rest; a rest param lifts the upper bound to
+          // unbounded), so even rest-bearing declarations are reliable. Call-
+          // signature-typed variables, inferred function values, and builtin
+          // lib methods have no `sig` and stay suppressed -- their lib param
+          // models don't mark optional / rest accurately, which is where the
+          // arity false positives come from. (`this` parameters are stripped
+          // during resolver construction, so they no longer skew the count.)
+          let arity_reliable = sig is Some(_)
           check_arguments_with_sig(
             env,
             substituted_params,

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -858,6 +858,56 @@ fn call_signature_param_count(sig : @ast.TsType) -> Int? {
 }
 
 ///|
+/// The single call (`want_new` false) or construct (`want_new` true)
+/// signature of `ty`, or `None` when it has zero or several (an overloaded
+/// shape is not a single comparable signature). A bare `Func` counts as one
+/// call signature.
+fn single_signature_of(
+  ty : @ast.TsType,
+  want_new : Bool,
+  resolver : Resolver,
+) -> @ast.TsType? {
+  let sigs = if want_new {
+    collect_construct_signatures(ty, resolver)
+  } else {
+    match resolver.unwrap(ty) {
+      Func(_, _) as f => [f]
+      _ => collect_call_signatures(ty, resolver)
+    }
+  }
+  if sigs.length() == 1 {
+    Some(sigs[0])
+  } else {
+    None
+  }
+}
+
+///|
+/// True when a type contains an `Intersection` or a generic `Applied`
+/// instantiation anywhere -- shapes that the resolver-free
+/// `is_assignable_to_bivariant` compares nominally and so cannot reliably
+/// judge. Used to keep the bivariant single-signature comparison
+/// false-positive-free.
+fn type_has_intersection_or_applied(t : @ast.TsType) -> Bool {
+  match t {
+    Intersection(_) | Applied(_, _) => true
+    Array(e) | Rest(e) => type_has_intersection_or_applied(e)
+    Union(parts) => parts.iter().any(type_has_intersection_or_applied)
+    Tuple(items) => items.iter().any(type_has_intersection_or_applied)
+    Func(params, ret) =>
+      params.iter().any(type_has_intersection_or_applied) ||
+      type_has_intersection_or_applied(ret)
+    Constructor(params, ret, _) =>
+      params.iter().any(type_has_intersection_or_applied) ||
+      type_has_intersection_or_applied(ret)
+    Object(fields) => fields.iter().any(fn(f) {
+      type_has_intersection_or_applied(f.1)
+    })
+    _ => false
+  }
+}
+
+///|
 /// Required arity of a value whose type carries *exactly one* signature of the
 /// requested kind (`<call>` when `want_new` is false, `<new>` when true). An
 /// overloaded source (more than one matching signature) is itself flexible, so
@@ -6323,6 +6373,35 @@ fn check_expr_against(
       "expected `\{type_display(expected_u)}` but got `\{type_display(inferred_u)}`",
     )
     return
+  }
+  // Value assignment between callable shapes: when the source and target each
+  // expose exactly one comparable call signature (or each exactly one
+  // construct signature), compare it bivariantly (params bivariant per
+  // `strictFunctionTypes: false`, return covariant) -- `var f: (x: number) =>
+  // string = g` where `g: (x: number) => number`. Overloaded shapes and
+  // generic signatures abstain, falling through to the structural callable
+  // bail below.
+  for want_new in [false, true] {
+    match
+      (
+        single_signature_of(inferred_u, want_new, ctx.resolver),
+        single_signature_of(expected_u, want_new, ctx.resolver),
+      ) {
+      (Some(s), Some(t)) =>
+        if not_generic_func(s) &&
+          not_generic_func(t) &&
+          not(type_has_intersection_or_applied(s)) &&
+          not(type_has_intersection_or_applied(t)) &&
+          not(is_assignable_to_bivariant(s, t)) {
+          record(
+            ctx,
+            sub_path,
+            "expected `\{type_display(expected_u)}` but got `\{type_display(inferred_u)}`",
+          )
+          return
+        }
+      _ => ()
+    }
   }
   // Callable / constructable interfaces & objects (`<call>` / `<new>`
   // signatures, often `extends Function`, with overloaded methods like

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -14585,6 +14585,84 @@ fn check_class_member_structure(
   for issue in check_class_implements(module_, resolver) {
     issues.push(issue)
   }
+  for issue in check_abstract_implementation(module_, resolver) {
+    issues.push(issue)
+  }
+  issues
+}
+
+///|
+/// TS2515: a non-abstract class that (transitively) extends a class declaring
+/// `abstract` members must implement each of them. Walks the single-
+/// inheritance base chain; abstains when any base in the chain is not a
+/// resolvable class declaration (an unresolved base could supply the
+/// implementation, so flagging would risk a false positive). Member identity
+/// is by name -- enough to detect a wholly-missing implementation, which is
+/// what TS2515 reports.
+fn check_abstract_implementation(
+  module_ : @ast.TsModule,
+  resolver : Resolver,
+) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  for cls in module_.classes {
+    // Only concrete (non-abstract), non-ambient classes must implement.
+    if cls.is_abstract || cls.is_declare {
+      continue
+    }
+    // name -> the abstract base that declared the still-unimplemented member.
+    let abstract_needed : Map[String, String] = {}
+    let concrete : Map[String, Unit] = {}
+    fn add_concrete(c : @ast.TsClassDecl) -> Unit {
+      let abs : Map[String, Unit] = {}
+      for a in c.abstract_members {
+        abs[a] = ()
+      }
+      for p in c.properties {
+        if not(abs.contains(p.name)) {
+          concrete[p.name] = ()
+        }
+      }
+      for m in c.methods {
+        if not(abs.contains(m.name)) {
+          concrete[m.name] = ()
+        }
+      }
+    }
+
+    add_concrete(cls)
+    let mut current = cls
+    let mut resolvable = true
+    let mut depth = 0
+    while current.base_names.length() > 0 && depth < 64 {
+      depth = depth + 1
+      match resolver.classes.get(current.base_names[0]) {
+        Some(base) => {
+          for a in base.abstract_members {
+            if not(abstract_needed.contains(a)) {
+              abstract_needed[a] = base.name
+            }
+          }
+          add_concrete(base)
+          current = base
+        }
+        None => {
+          resolvable = false
+          break
+        }
+      }
+    }
+    if not(resolvable) {
+      continue
+    }
+    for name, from_class in abstract_needed {
+      if not(concrete.contains(name)) {
+        issues.push({
+          path: "class \{cls.name}",
+          message: "non-abstract class `\{cls.name}` does not implement inherited abstract member `\{name}` from class `\{from_class}`",
+        })
+      }
+    }
+  }
   issues
 }
 

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -6074,9 +6074,19 @@ fn check_expr_against(
   }
   // Overloaded-method shapes (the same member name declared several times with
   // different signatures) don't match structurally under our single-type-per-
-  // member model. Stay silent.
+  // member model. Stay silent -- except a concrete primitive / literal source,
+  // which is never any object shape (overloaded or not), so a primitive
+  // assigned to an overload-bearing interface target is a real mismatch.
   if shape_has_overloads(inferred_u, ctx.resolver) ||
     shape_has_overloads(expected_u, ctx.resolver) {
+    if shape_has_overloads(expected_u, ctx.resolver) &&
+      is_concrete_primitive_or_literal(inferred_u) {
+      record(
+        ctx,
+        sub_path,
+        "expected `\{type_display(expected_u)}` but got `\{type_display(inferred_u)}`",
+      )
+    }
     return
   }
   match (inferred_u, expected_u) {

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -765,6 +765,66 @@ fn type_accepts_undefined_param(ty : @ast.TsType) -> Bool {
 }
 
 ///|
+/// Required argument count of a function *value* -- an arrow or function
+/// expression. `None` for any other expression.
+fn function_value_required_arity(expr : @ast.TsExpr) -> Int? {
+  match expr {
+    ArrowFunc(params, _, _, _) => Some(required_arity(params))
+    FuncExpr(f) => Some(required_arity(f.params))
+    _ => None
+  }
+}
+
+///|
+/// Collect every call signature (`<call>`) declared on `t` -- one entry per
+/// overload -- from both structural object types and interface declarations.
+fn collect_call_signatures(
+  t : @ast.TsType,
+  resolver : Resolver,
+) -> Array[@ast.TsType] {
+  let out : Array[@ast.TsType] = []
+  match resolver.unwrap(t) {
+    Object(fields) =>
+      for f in fields {
+        match f.0 {
+          Literal(k) => if k == "<call>" { out.push(f.1) }
+          _ => ()
+        }
+      }
+    Named(n) =>
+      match resolver.interfaces.get(n) {
+        Some(iface) =>
+          for f in iface.fields {
+            if f.0 == "<call>" {
+              out.push(f.1)
+            }
+          }
+        None => ()
+      }
+    _ => ()
+  }
+  out
+}
+
+///|
+/// The finite parameter count of a call signature `Func(params, ret)`, or
+/// `None` when it has a rest parameter (its arity is unbounded, so it can
+/// never be invoked with too few arguments for a function value).
+fn call_signature_param_count(sig : @ast.TsType) -> Int? {
+  match sig {
+    Func(params, _) => {
+      for p in params {
+        if p is Rest(_) {
+          return None
+        }
+      }
+      Some(params.length())
+    }
+    _ => None
+  }
+}
+
+///|
 fn param_is_optional(p : @ast.TsParam) -> Bool {
   if p.is_rest {
     return true
@@ -5711,6 +5771,34 @@ fn check_expr_against(
   // x + 1)` flows the element type into `x` so the body's `x + 1` is
   // properly typed instead of falling through to `Any`.
   let expected_shape = ctx.resolver.unwrap(expected)
+  // Function-typed-argument arity (contravariant): a function *value* must be
+  // callable with the arguments any target call signature would pass it. If
+  // the value *requires* more parameters than a call signature *provides*, it
+  // can never implement that signature -- `foo6(<T>(x, y) => '')` against
+  // `{ (x: T): string; (x: T, y?: T): string }`, where the 1-parameter
+  // overload would call the value with no `y`. For an overload set the value
+  // must satisfy *every* signature, so any signature with fewer parameters
+  // than the value requires is a real TS2345. Checked ahead of the
+  // contextual-typing routes below (which only fire for a single call
+  // signature and never enforce this minimum).
+  match function_value_required_arity(expr) {
+    Some(m) =>
+      for sig in collect_call_signatures(expected_shape, ctx.resolver) {
+        match call_signature_param_count(sig) {
+          Some(n) =>
+            if m > n {
+              record(
+                ctx,
+                sub_path,
+                "expected `\{type_display(expected)}` but the function value requires \{m} argument(s); a target call signature accepts only \{n}",
+              )
+              return
+            }
+          None => ()
+        }
+      }
+    None => ()
+  }
   // A call-signature interface / object type (`interface I { (): T }`,
   // `type F = { (x): T }`) is callable. Route a function / arrow value
   // through that call signature so it gets contextual typing and skips

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -777,13 +777,15 @@ fn function_value_required_arity(expr : @ast.TsExpr) -> Int? {
 
 ///|
 /// Collect every call signature (`<call>`) declared on `t` -- one entry per
-/// overload -- from both structural object types and interface declarations.
+/// overload -- from both structural object types and interface declarations,
+/// plus a bare `Func` type (a single call signature).
 fn collect_call_signatures(
   t : @ast.TsType,
   resolver : Resolver,
 ) -> Array[@ast.TsType] {
   let out : Array[@ast.TsType] = []
   match resolver.unwrap(t) {
+    Func(_, _) as f => out.push(f)
     Object(fields) =>
       for f in fields {
         match f.0 {

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8485,6 +8485,11 @@ test "expr_check: function value arity vs overloaded call signature" {
     issues("function g(cb: { (x: number): string }) { return cb }\ng((x, y) => '');") >
     0,
   )
+  // A bare function-typed target enforces the same minimum arity: assigning an
+  // arrow that requires an argument to a `() => T` field is too many params.
+  assert_true(
+    issues("var f: () => number;\nf = (x: number) => 1;") > 0,
+  )
 }
 
 ///|

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8546,6 +8546,32 @@ test "expr_check: interface extends with too many required params" {
 }
 
 ///|
+// TS2322: assigning between callable values compares their single call /
+// construct signatures bivariantly. An incompatible parameter or return type
+// is flagged; a compatible signature stays silent. Signatures involving
+// intersections / generic instantiations abstain.
+test "expr_check: callable value assignment compares signatures" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Return-type mismatch between two function-typed values.
+  assert_true(
+    issues("declare var g: (x: number) => number;\nvar f: (x: number) => string;\nf = g;") >
+    0,
+  )
+  // Parameter-type mismatch.
+  assert_true(
+    issues("declare var g: (x: string) => number;\nvar f: (x: number) => number;\nf = g;") >
+    0,
+  )
+  // Compatible signature stays silent.
+  @test.assert_eq(
+    issues("declare var g: (x: number) => number;\nvar f: (x: number) => number;\nf = g;"),
+    0,
+  )
+}
+
+///|
 // TS2345: a computed (string-literal) method call `recv["m"](args)` is checked
 // against the resolved method signature, just like the dotted `recv.m(args)`
 // form. A wrong-typed argument to a known primitive method is flagged; correct

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8577,6 +8577,27 @@ test "expr_check: callable value assignment compares signatures" {
 }
 
 ///|
+// TS2515: a non-abstract class extending a class with abstract members must
+// implement each of them. An abstract subclass, or a concrete class that
+// implements the member, stays silent.
+test "expr_check: non-abstract class must implement abstract members" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  let base = "abstract class B { abstract foo(): void; bar(): void {} }\n"
+  // C does not implement abstract `foo`.
+  assert_true(issues(base + "class C extends B {}") > 0)
+  // D implements `foo` -> ok.
+  @test.assert_eq(issues(base + "class D extends B { foo(): void {} }"), 0)
+  // An abstract subclass need not implement it.
+  @test.assert_eq(issues(base + "abstract class E extends B {}"), 0)
+  // Transitive: a concrete grandchild of an abstract class must implement.
+  assert_true(
+    issues(base + "abstract class M extends B {}\nclass N extends M {}") > 0,
+  )
+}
+
+///|
 // TS2345: a computed (string-literal) method call `recv["m"](args)` is checked
 // against the resolved method signature, just like the dotted `recv.m(args)`
 // form. A wrong-typed argument to a known primitive method is flagged; correct

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8419,6 +8419,30 @@ test "expr_check: primitive not assignable to overloaded interface" {
 }
 
 ///|
+// TS2322: private / protected members are nominal -- a class carrying one is
+// only assignable to / from the same class (or via inheritance). A distinct
+// structural / nominal type can never satisfy it.
+test "expr_check: private member makes a class nominal" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Source class with a private member -> structural object target: error.
+  assert_true(
+    issues("class E { private foo: string }\nvar a: { foo: string };\na = new E();") >
+    0,
+  )
+  // Distinct classes, one private: not mutually assignable.
+  let two = "class D { foo: string = \"\" }\nclass E { private foo: string = \"\" }\n"
+  assert_true(issues(two + "var d: D = new D();\nd = new E();") > 0)
+  // Same class stays silent; a public-only class is still structural.
+  @test.assert_eq(issues("class E { private foo: string = \"\" }\nvar e: E = new E();\ne = new E();"), 0)
+  @test.assert_eq(
+    issues("class P { foo: string = \"\" }\nvar a: { foo: string };\na = new P();"),
+    0,
+  )
+}
+
+///|
 // TS2345: a computed (string-literal) method call `recv["m"](args)` is checked
 // against the resolved method signature, just like the dotted `recv.m(args)`
 // form. A wrong-typed argument to a known primitive method is flagged; correct

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8301,6 +8301,30 @@ test "expr_check: TS2322 literal not assignable to literal target" {
 }
 
 ///|
+// Enum nominality (TS2322): a numeric enum is nominal, so a concrete
+// non-numeric primitive / literal or a plain object value is not assignable to
+// an enum-typed target. Numeric values, the same enum, and `null` /
+// `undefined` (non-strict) stay silent.
+test "expr_check: enum nominality assignment target" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  let prelude = "enum E { A, B }\nvar e: E;\n"
+  assert_true(issues(prelude + "e = '';") > 0)
+  assert_true(issues(prelude + "e = {};") > 0)
+  assert_true(issues(prelude + "e = true;") > 0)
+  // Numeric values, the same enum member, and a number variable stay silent.
+  @test.assert_eq(issues(prelude + "e = 1;"), 0)
+  @test.assert_eq(issues(prelude + "e = E.A;"), 0)
+  @test.assert_eq(issues(prelude + "declare var n: number;\ne = n;"), 0)
+  // A string enum is not numeric, so the rule does not fire on it.
+  @test.assert_eq(
+    issues("enum S { A = \"a\" }\nvar s: S;\ns = 'x';"),
+    0,
+  )
+}
+
+///|
 // TS2345: a computed (string-literal) method call `recv["m"](args)` is checked
 // against the resolved method signature, just like the dotted `recv.m(args)`
 // form. A wrong-typed argument to a known primitive method is flagged; correct

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8508,6 +8508,29 @@ test "expr_check: constructor value arity vs overloaded construct signature" {
 }
 
 ///|
+// TS2430: a derived interface that redeclares an inherited callable member
+// requiring more arguments than the base signature provides incorrectly
+// extends it (a base-typed caller would invoke it with too few args).
+test "expr_check: interface extends with too many required params" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  let base = "interface Base { a: () => number }\n"
+  // Derived `a` requires 1 arg; base provides 0 -> incompatible.
+  assert_true(issues(base + "interface I extends Base { a: (x: number) => number }") > 0)
+  // Same number of required params (optional second) -> ok.
+  @test.assert_eq(
+    issues(base + "interface I extends Base { a: (x?: number) => number }"),
+    0,
+  )
+  // Construct-signature member analog.
+  let cbase = "interface CB { a: new () => number }\n"
+  assert_true(
+    issues(cbase + "interface I extends CB { a: new (x: number) => number }") > 0,
+  )
+}
+
+///|
 // TS2345: a computed (string-literal) method call `recv["m"](args)` is checked
 // against the resolved method signature, just like the dotted `recv.m(args)`
 // form. A wrong-typed argument to a known primitive method is flagged; correct

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8381,6 +8381,31 @@ test "expr_check: primitive not assignable to callable type" {
 }
 
 ///|
+// TS2322: a value inhabits an intersection `A & B` only when it satisfies
+// every part. A source that provably fails an object-like part (a concrete
+// primitive, or an object missing a part's members) is a real mismatch; a
+// source satisfying all parts stays silent.
+test "expr_check: intersection target requires every part" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  let pre = "declare var a: { a: string };\n"
+  // `a` lacks `b`, so it cannot inhabit `{ a } & { b }`.
+  assert_true(
+    issues(pre + "var y: { a: string } & { b: string };\ny = a;") > 0,
+  )
+  // A primitive can never satisfy an object part of the intersection.
+  assert_true(issues("var y: { a: string } & { b: string };\ny = 5;") > 0)
+  // A source carrying both members satisfies the intersection.
+  @test.assert_eq(
+    issues(
+      "declare var x: { a: string, b: string };\nvar y: { a: string } & { b: string };\ny = x;",
+    ),
+    0,
+  )
+}
+
+///|
 // TS2345: a computed (string-literal) method call `recv["m"](args)` is checked
 // against the resolved method signature, just like the dotted `recv.m(args)`
 // form. A wrong-typed argument to a known primitive method is flagged; correct

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8466,6 +8466,28 @@ test "expr_check: logical operator propagates contextual type to rhs" {
 }
 
 ///|
+// TS2345: a function value passed for a (possibly overloaded) call-signature
+// parameter must be callable with every signature's arguments. A value that
+// *requires* more parameters than a signature provides can't implement it
+// (`foo(<T>(x, y) => '')` against `{ (x: T): string; (x: T, y?: T): string }`
+// -- the 1-param overload supplies no `y`).
+test "expr_check: function value arity vs overloaded call signature" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  let overloaded = "function foo<T>(cb: { (x: T): string; (x: T, y?: T): string }) { return cb }\n"
+  // Arrow requires 2 args; the 1-param overload can't supply the second.
+  assert_true(issues(overloaded + "foo((x, y) => '');") > 0)
+  // A 1-param arrow satisfies both overloads.
+  @test.assert_eq(issues(overloaded + "foo(x => '');"), 0)
+  // Single call signature: arrow needing more args than provided is an error.
+  assert_true(
+    issues("function g(cb: { (x: number): string }) { return cb }\ng((x, y) => '');") >
+    0,
+  )
+}
+
+///|
 // TS2345: a computed (string-literal) method call `recv["m"](args)` is checked
 // against the resolved method signature, just like the dotted `recv.m(args)`
 // form. A wrong-typed argument to a known primitive method is flagged; correct

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8528,6 +8528,21 @@ test "expr_check: interface extends with too many required params" {
   assert_true(
     issues(cbase + "interface I extends CB { a: new (x: number) => number }") > 0,
   )
+  // Incompatible rest-parameter element type (`string[]` over `number[]`).
+  assert_true(
+    issues(
+      "interface B { a: (...xs: number[]) => number }\ninterface I extends B { a: (...xs: string[]) => number }",
+    ) >
+    0,
+  )
+  // A derived interface whose own call signature has an incompatible
+  // parameter type incorrectly extends the base's call signature.
+  assert_true(
+    issues(
+      "interface B { (x: number): number }\ninterface I extends B { (x: string): number }",
+    ) >
+    0,
+  )
 }
 
 ///|

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8488,6 +8488,26 @@ test "expr_check: function value arity vs overloaded call signature" {
 }
 
 ///|
+// TS2345: the call-signature arity rule extends to construct signatures. A
+// constructor value that requires more parameters than a `<new>` overload
+// provides can't implement it.
+test "expr_check: constructor value arity vs overloaded construct signature" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  let pre = "function foo<T>(cb: { new (x: T): string; new (x: T, y?: T): string }) { return cb }\n"
+  // `b` needs 2 construct args; the 1-param overload supplies none for `y`.
+  assert_true(
+    issues(pre + "declare var b: { new <T>(x: T, y: T): string };\nfoo(b);") > 0,
+  )
+  // A 1-param constructor satisfies both overloads.
+  @test.assert_eq(
+    issues(pre + "declare var a: { new <T>(x: T): T };\nfoo(a);"),
+    0,
+  )
+}
+
+///|
 // TS2345: a computed (string-literal) method call `recv["m"](args)` is checked
 // against the resolved method signature, just like the dotted `recv.m(args)`
 // form. A wrong-typed argument to a known primitive method is flagged; correct

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8406,6 +8406,19 @@ test "expr_check: intersection target requires every part" {
 }
 
 ///|
+// TS2322: a concrete primitive / literal is never an object shape, including
+// an overload-bearing interface, so assigning one to such a target is a real
+// mismatch (the overloaded-shape bail otherwise stays silent).
+test "expr_check: primitive not assignable to overloaded interface" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  let pre = "interface I { f(x: string): string; f(x: number): number }\n"
+  assert_true(issues(pre + "var i: I;\ni = 5;") > 0)
+  assert_true(issues(pre + "var i: I;\ni = \"s\";") > 0)
+}
+
+///|
 // TS2345: a computed (string-literal) method call `recv["m"](args)` is checked
 // against the resolved method signature, just like the dotted `recv.m(args)`
 // form. A wrong-typed argument to a known primitive method is flagged; correct

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8325,6 +8325,36 @@ test "expr_check: enum nominality assignment target" {
 }
 
 ///|
+// Covariant generic assignability (TS2322): two instantiations of the same
+// generic with a bidirectionally-incompatible type argument (`Box<string>` vs
+// `Box<number>`) are a real mismatch. Covariant widening (`Box<"x">` ->
+// `Box<string>`) and identical instantiations stay silent. This relaxes the
+// blanket `Applied` bail in `check_expr_against`.
+test "expr_check: covariant generic instantiation mismatch" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  let pre = "interface Box<T> { v: T }\n"
+  assert_true(
+    issues(pre + "declare var a: Box<string>;\nvar b: Box<number> = a;") > 0,
+  )
+  @test.assert_eq(
+    issues(pre + "declare var a: Box<\"x\">;\nvar b: Box<string> = a;"),
+    0,
+  )
+  @test.assert_eq(
+    issues(pre + "declare var a: Box<number>;\nvar b: Box<number> = a;"),
+    0,
+  )
+  // Distinct user classes with incompatible shapes as the type argument are a
+  // mismatch; a shared shape (bidirectionally assignable) stays silent.
+  let pre2 = "class P { x: number }\nclass Q { y: string }\ninterface Box<T> { v: T }\n"
+  assert_true(
+    issues(pre2 + "declare var a: Box<P>;\nvar b: Box<Q> = a;") > 0,
+  )
+}
+
+///|
 // TS2345: a computed (string-literal) method call `recv["m"](args)` is checked
 // against the resolved method signature, just like the dotted `recv.m(args)`
 // form. A wrong-typed argument to a known primitive method is flagged; correct

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -353,25 +353,35 @@ test "expr_check: permissive flags constructor arity for a base-less class" {
 
 ///|
 test "expr_check: permissive flags direct call arity for top-level functions" {
-  // A rest-free top-level function declaration has an exact arity, reliable
-  // even in permissive mode. A rest-bearing function is not flagged.
+  // A top-level function declaration carries a rich `TsParam` list, so its
+  // arity is modelled precisely (optionals / defaults / rest) and is reliable
+  // even in permissive mode. A rest-bearing declaration still has a hard
+  // *minimum* arity: `variadic()` omits the required leading `a`, so it is
+  // flagged ("at least 1"); extra trailing args (`variadic(1, 2, 3)`) are not.
   let src =
     #|function add(a: number, b: number): number { return a + b }
     #|function variadic(a: number, ...rest: number[]): void {}
     #|function caller(): void {
     #|  add(1)
     #|  variadic()
+    #|  variadic(1, 2, 3)
     #|}
   let module_ = parse_module_or_empty(src)
   let issues = check_module_function_bodies_permissive(module_)
   let mut saw_add = false
+  let mut saw_variadic_too_few = false
   for i in issues {
     if i.path.contains("call `add`") && i.message.contains("argument(s), got 1") {
       saw_add = true
     }
-    assert_true(!i.path.contains("call `variadic`"))
+    if i.path.contains("call `variadic`") && i.message.contains("got 0") {
+      saw_variadic_too_few = true
+    }
+    // The valid `variadic(1, 2, 3)` over-application is never flagged.
+    assert_true(!i.message.contains("got 3"))
   }
   assert_true(saw_add)
+  assert_true(saw_variadic_too_few)
 }
 
 ///|
@@ -8352,6 +8362,22 @@ test "expr_check: covariant generic instantiation mismatch" {
   assert_true(
     issues(pre2 + "declare var a: Box<P>;\nvar b: Box<Q> = a;") > 0,
   )
+}
+
+///|
+// TS2322: a concrete primitive / literal is never a function or constructor,
+// so assigning one to a callable-typed target (`() => void`, `new () => A`) is
+// a real mismatch. Callable-to-callable shapes still stay silent.
+test "expr_check: primitive not assignable to callable type" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  assert_true(issues("var f: () => void;\nf = 5;") > 0)
+  assert_true(
+    issues("class A {}\nvar k: new () => A;\nk = \"asdf\";") > 0,
+  )
+  // A matching callable value stays silent.
+  @test.assert_eq(issues("var f: () => void;\nf = () => {};"), 0)
 }
 
 ///|

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -8443,6 +8443,29 @@ test "expr_check: private member makes a class nominal" {
 }
 
 ///|
+// TS2322: a logical operator propagates the contextual type to its right
+// operand, so a function value there is checked against the expected
+// signature (`x = cond && (a => …)` types the arrow's params). The left
+// operand of `||` / `??` is the guarded value and is not checked.
+test "expr_check: logical operator propagates contextual type to rhs" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // The arrow body assigns its (contextually `string`) param to a `number`.
+  assert_true(
+    issues(
+      "let x: (a: string) => string;\nlet y = true;\nx = y && (a => { const b: number = a; return b; });",
+    ) >
+    0,
+  )
+  // `||` left operand may be the guarded (nullable) value — not flagged.
+  @test.assert_eq(
+    issues("declare var xs: string[] | undefined;\nvar r: string[] = xs || [];"),
+    0,
+  )
+}
+
+///|
 // TS2345: a computed (string-literal) method call `recv["m"](args)` is checked
 // against the resolved method signature, just like the dotted `recv.m(args)`
 // form. A wrong-typed argument to a known primitive method is flagged; correct

--- a/src/cmd/tsacc/main.mbt
+++ b/src/cmd/tsacc/main.mbt
@@ -8,6 +8,7 @@
 //
 //   tsacc                       # walks the pinned conformance dirs, prints the 2x2 table
 //   tsacc --list-misses         # also print every recall miss (`RECALL_MISS <case>`)
+//                               # and every false positive (`FALSE_POS <case> :: <path> :: <message>`)
 //   tsacc --list-misses <substr> # ...restricted to paths containing <substr>
 
 ///|
@@ -173,6 +174,11 @@ async fn main {
         } else {
           precision_miss += 1
           d_pm += 1
+          if list_misses && (miss_filter == "" || path.contains(miss_filter)) {
+            for iss in issues {
+              println("FALSE_POS \{case_name} :: \{iss.path} :: \{iss.message}")
+            }
+          }
         }
       } else if has_baseline {
         recall_miss += 1

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -58,6 +58,7 @@ fn build_runtime_class_decl(
   is_abstract : Bool,
   private_members : Array[String],
   protected_members : Array[String],
+  abstract_members : Array[String],
   implements_names : Array[String],
 ) -> @ast.TsClassDecl {
   let properties : Array[@ast.TsClassPropertyDecl] = []
@@ -344,6 +345,7 @@ fn build_runtime_class_decl(
     is_declare: false,
     private_members,
     protected_members,
+    abstract_members,
     duplicate_member_names,
   }
 }
@@ -1022,7 +1024,13 @@ fn Parser::inject_instance_field_assigns(
 ///|
 fn Parser::parse_class_body(
   self : Parser,
-) -> (@ast.TsFunc?, Array[ClassElement], Array[String], Array[String]) raise ParseError {
+) -> (
+  @ast.TsFunc?,
+  Array[ClassElement],
+  Array[String],
+  Array[String],
+  Array[String],
+) raise ParseError {
   let _ = self.expect(LBrace)
   // Class body is implicitly strict mode
   let prev_strict = self.in_strict
@@ -1033,6 +1041,7 @@ fn Parser::parse_class_body(
   // can expose member visibility to the checker (TS2341 / TS2445).
   let private_members : Array[String] = []
   let protected_members : Array[String] = []
+  let abstract_members : Array[String] = []
   while !self.check(RBrace) && !self.check(Eof) {
     while self.check(At) {
       self.skip_decorator()
@@ -1047,6 +1056,7 @@ fn Parser::parse_class_body(
     let mut parsed_static_block = false
     let mut has_declare = false
     let mut visibility = "public"
+    let mut is_abstract_member = false
     while has_modifier {
       has_modifier = false
       match self.peek().kind {
@@ -1090,6 +1100,9 @@ fn Parser::parse_class_body(
             }
             if n == "declare" {
               has_declare = true
+            }
+            if n == "abstract" {
+              is_abstract_member = true
             }
           }
         Declare => {
@@ -1148,6 +1161,9 @@ fn Parser::parse_class_body(
         private_members.push(method_name)
       } else if visibility == "protected" {
         protected_members.push(method_name)
+      }
+      if is_abstract_member {
+        abstract_members.push(method_name)
       }
     }
     let is_optional = self.match_(Question)
@@ -1339,7 +1355,7 @@ fn Parser::parse_class_body(
   }
   let _ = self.expect(RBrace)
   self.in_strict = prev_strict
-  (ctor, elements, private_members, protected_members)
+  (ctor, elements, private_members, protected_members, abstract_members)
 }
 
 ///|
@@ -1383,7 +1399,7 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
   let brand = "__private_brand__" + brand_id.to_string()
   let prev_brand = self.current_class_brand
   self.current_class_brand = Some(brand)
-  let (ctor_opt, elements, private_members, protected_members) = self.parse_class_body()
+  let (ctor_opt, elements, private_members, protected_members, abstract_members) = self.parse_class_body()
   self.current_class_brand = prev_brand
   self.restore_local_type_param_bounds(class_type_param_bound_len)
   // Self-extending classes (`class C extends C {}`) intentionally
@@ -1421,7 +1437,7 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
     Some(base_name) => {
       let runtime_decl = build_runtime_class_decl(
         class_name, class_type_params, class_type_param_bounds, ctor_opt, elements,
-        false, private_members, protected_members, implements_names,
+        false, private_members, protected_members, abstract_members, implements_names,
       )
       let pending_base_expr = self.pending_class_base_expr
       self.pending_class_base_expr = None
@@ -1546,6 +1562,7 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
     false,
     private_members,
     protected_members,
+    abstract_members,
     implements_names,
   )
   // Attach any decorators accumulated via `skip_decorator` before this
@@ -1574,6 +1591,7 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
     is_declare: false,
     private_members: runtime_decl.private_members,
     protected_members: runtime_decl.protected_members,
+    abstract_members: runtime_decl.abstract_members,
     duplicate_member_names: runtime_decl.duplicate_member_names,
   }
   self.last_runtime_class_decl = Some(decorated)
@@ -2024,12 +2042,12 @@ fn Parser::parse_class_decl_with_abstract(
   let brand = "__private_brand__" + brand_id.to_string()
   let prev_brand = self.current_class_brand
   self.current_class_brand = Some(brand)
-  let (ctor_opt, elements, private_members, protected_members) = self.parse_class_body()
+  let (ctor_opt, elements, private_members, protected_members, abstract_members) = self.parse_class_body()
   self.current_class_brand = prev_brand
   self.restore_local_type_param_bounds(class_type_param_bound_len)
   let runtime_decl = build_runtime_class_decl(
     name, class_type_params, class_type_param_bounds, ctor_opt, elements, is_abstract,
-    private_members, protected_members, implements_names,
+    private_members, protected_members, abstract_members, implements_names,
   )
   self.last_runtime_class_decl = Some(runtime_decl)
   // When the class extends another class, the IIFE desugar below

--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -2201,6 +2201,7 @@ fn Parser::parse_declare_class(
   let methods : Array[@ast.TsClassMethodDecl] = []
   let private_members : Array[String] = []
   let protected_members : Array[String] = []
+  let abstract_members : Array[String] = []
   let index_signatures : Array[(@ast.TsType, @ast.TsType)] = []
   let static_blocks : Array[@ast.TsBlock] = []
   let mut constructor_params : Array[(String, @ast.TsType)]? = None
@@ -2228,6 +2229,7 @@ fn Parser::parse_declare_class(
     let mut is_public = true
     let mut visibility = "public"
     let mut is_accessor = false
+    let mut is_abstract_member = false
     let mut has_modifier = true
     while has_modifier {
       has_modifier = false
@@ -2269,6 +2271,9 @@ fn Parser::parse_declare_class(
             is_public = false
             visibility = mod
           }
+          if mod == "abstract" {
+            is_abstract_member = true
+          }
           has_modifier = true
         }
         _ => ()
@@ -2294,12 +2299,16 @@ fn Parser::parse_declare_class(
     }
     let member_name = self.parse_declare_class_member_name()
     match member_name {
-      Some(n) =>
+      Some(n) => {
         if visibility == "private" {
           private_members.push(n)
         } else if visibility == "protected" {
           protected_members.push(n)
         }
+        if is_abstract_member {
+          abstract_members.push(n)
+        }
+      }
       None => ()
     }
     let _ = self.match_(Question)
@@ -2455,6 +2464,7 @@ fn Parser::parse_declare_class(
     is_declare: true,
     private_members,
     protected_members,
+    abstract_members,
     duplicate_member_names: [],
   }
 }

--- a/src/parser/parser_type.mbt
+++ b/src/parser/parser_type.mbt
@@ -34,7 +34,7 @@ fn Parser::parse_paren_or_function_type(
         break
       }
     }
-    let _ = self.match_(Question)
+    let is_optional = self.match_(Question)
     // Type annotation on a function-type parameter is optional —
     // `(item) => T` is a valid TS arrow function type. A `...rest` param is
     // wrapped in `Rest(...)` so call-site checking treats each trailing
@@ -45,6 +45,10 @@ fn Parser::parse_paren_or_function_type(
     } else {
       @ast.TsType::Any
     }
+    // An optional function-type parameter (`(x?: T) => R`) widens to
+    // `T | undefined`, mirroring declaration parameters, so arity / required-
+    // param reasoning sees it as omittable.
+    let pty = if is_optional { wrap_optional_ts_type(pty) } else { pty }
     param_types.push(if is_rest { Rest(pty) } else { pty })
     if self.match_(Comma) {
       if self.check(RParen) {
@@ -99,12 +103,15 @@ fn Parser::parse_constructor_tail(
           break
         }
       }
-      let _ = self.match_(Question)
+      let is_optional = self.match_(Question)
       let pty = if self.match_(Colon) {
         self.parse_type()
       } else {
         @ast.TsType::Any
       }
+      // Optional constructor-type parameter widens to `T | undefined`, like
+      // function-type and declaration parameters.
+      let pty = if is_optional { wrap_optional_ts_type(pty) } else { pty }
       param_types.push(if is_rest { Rest(pty) } else { pty })
       if self.match_(Comma) {
         if self.check(RParen) {

--- a/src/transform/iife_class_lift.mbt
+++ b/src/transform/iife_class_lift.mbt
@@ -244,6 +244,7 @@ fn try_lift_iife_value(
     is_declare: false,
     private_members: [],
     protected_members: [],
+    abstract_members: [],
     duplicate_member_names: [],
   }
   // Emit closure-variable declarations before the class so the class


### PR DESCRIPTION
## Summary

Conformance-recall improvements to the declaration checker, all landed as **sound relaxations that hold whole-corpus false positives at 0**. Measured via `src/cmd/tsacc` over the pinned conformance dirs.

This session's contribution (on top of the accumulated checker work since `main`): **recall 563 → 589 (+26), precision 414/414 (0 FP)**.

### New checks / relaxations (each with whitebox tests, FP 0)

- **enum nominality** — a non-numeric primitive / object is not assignable to a numeric enum target (TS2322).
- **covariant generic assignability** — relaxes the blanket `Applied` bail; two instantiations of the same generic with a bidirectionally-incompatible type argument (`Box<string>` vs `Box<number>`) are flagged, variance-safe.
- **primitive-vs-callable / -overload-interface** — a concrete primitive is never a function / constructor / object shape.
- **intersection-target assignability** — a value must satisfy every part of `A & B`.
- **private / protected nominality** — a class carrying a private/protected member is only assignable to/from itself or its sub/superclass.
- **contextual typing through `&&` / `||` / `??`** — the expected type flows to the operator's right operand.
- **overloaded function- and constructor-typed argument arity** (TS2345) — a function/constructor value that requires more parameters than a target call/construct signature provides can't implement it.
- **call/construct-signature subtyping** at both interface-extends (TS2430) and value-assignment (TS2322) levels — full bivariant comparison (bivariant params per `strictFunctionTypes: false`, covariant return); plus a parser fix so optional function-/constructor-type parameters (`(x?: T) => R`) widen to `T | undefined` like declaration parameters (also corrects bridge FFI emission to render such a parameter as `T?`).
- **abstract member implementation** (TS2515) — a non-abstract class must implement inherited abstract members; adds an `abstract_members` list to `TsClassDecl`, threaded through all construction sites.

### Tooling

`tsacc --list-misses` now also prints `FALSE_POS <case> :: <path> :: <msg>` for triaging precision regressions.

### Verification

- `moon check`: clean.
- Tests: checker 666 / parser 471 / bridge 371 — all pass.
- Whole-corpus precision held at 414/414 (0 FP) across every increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRuChZzTMedfUFg8SvcGs8

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRuChZzTMedfUFg8SvcGs8)_