### PR TITLE
checker: possibly-undefined method calls (TS18048/TS2722) + template-literal typeof narrowing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1395,6 +1395,24 @@ conformance sources (`.errors.txt` baseline = ground truth):
 2026-06-22 (T87)   617/815 (76 %)        414/414 ( 0 FP)   whole-corpus TP 1629 -> 1640
 2026-06-22 (T88)   619/815 (76 %)        414/414 ( 0 FP)   whole-corpus TP 1640 -> 1643
 2026-06-22 (T89)   619/815 (76 %)        414/414 ( 0 FP)   narrowing-engine hardening (no corpus delta)
+2026-06-22 (T90)   619/815 (76 %)        414/414 ( 0 FP)   whole-corpus TP 1643 -> 1645
+
+  T90 -- possibly-undefined *method calls* (TS18048 / TS2722) + template-literal
+    typeof narrowing. Extended the T88 check to the `MethodCall` path: calling a
+    method on a `Var` receiver whose narrowed type still includes nullish (and
+    the method resolves on the pruned receiver) flags "object is possibly
+    undefined/null". Same `Var`-receiver gating as PropAccess. Broadening the
+    PropAccess check to `PropAccess`-chain receivers was tried first but gains 0
+    conformance recall and exposes correlated-union narrowing gaps
+    (intersectionOfUnionNarrowing: `q.a !== undefined` doesn't propagate to
+    `q.b` across an intersection-of-union), so it was reverted -- chains stay
+    `Var`-only. The method-call broadening surfaced one FP
+    (controlFlowWithTemplateLiterals) from `typeof x === \`string\`` using a
+    no-substitution *template literal* instead of a quoted string, so
+    `analyze_equality` now normalizes `TemplateLiteral([s], [])` to
+    `StringLit(s)` (fixes typeof / discriminant / literal narrowing uniformly).
+    Whole-corpus TP 1643 -> 1645 @ 0 FP, pinned 619 (the +2 land outside the
+    pinned dirs). Correct-reason against the TS18048/TS2722 baselines.
 
   T89 -- narrowing-engine hardening for the T88 possibly-undefined check.
     T88 was corpus-FP-0 but had *latent* FPs on ubiquitous guard forms the

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -10365,6 +10365,17 @@ fn analyze_equality(
   false_side : Array[(String, @ast.TsType)],
   loose : Bool,
 ) -> Unit {
+  // A template literal with no substitutions (`` `string` ``) is exactly the
+  // string literal `"string"`; normalize so `typeof x === \`string\`` and
+  // discriminant comparisons narrow the same as the quoted form.
+  let norm = fn(e : @ast.TsExpr) -> @ast.TsExpr {
+    match e {
+      TemplateLiteral([s], []) => StringLit(s)
+      _ => e
+    }
+  }
+  let left = norm(left)
+  let right = norm(right)
   // `typeof x === "string"` — canonical form.
   // `typeof <expr> === "string"` — accept any Var / PropAccess chain on
   // the operand position so `typeof c.a.b === "string"` narrows the
@@ -11567,6 +11578,24 @@ fn check_call_args_in_expr(
               "call `\{meth}`",
               "cannot call `.\{meth}()` — receiver may be null or undefined",
             )
+          } else if ctx.strict_null_checks &&
+            receiver is Var(_) &&
+            union_possibly_nullish(ctx.resolver.unwrap(recv_ty)) is Some(kind) &&
+            ctx.resolver.lookup_method_sig(
+              prune_nullish(ctx.resolver, recv_ty),
+              meth,
+            )
+            is Some(_) {
+            // TS18048 / TS2722: calling a method on a value whose narrowed type
+            // still includes `undefined` / `null` is an error under
+            // strictNullChecks. Same `Var`-receiver gating as the PropAccess
+            // case — the method must resolve on the pruned receiver, otherwise
+            // the "method does not exist" branch below is the right diagnostic.
+            record(
+              ctx,
+              "call `\{meth}`",
+              "object is possibly `\{type_display(kind)}`",
+            )
           } else {
             let pruned = prune_nullish(ctx.resolver, recv_ty)
             match ctx.resolver.lookup_method_sig(pruned, meth) {
@@ -11814,9 +11843,11 @@ fn check_call_args_in_expr(
         // purely nullish) is an error. Gated to a simple `Var` receiver — those
         // are the bindings the narrowing engine rewrites precisely (`if (x)`,
         // `if (x != null)`, `x === undefined` early returns, …), so a residual
-        // nullish union at the access site means no guard removed it. The
-        // property must exist on the pruned receiver, otherwise the
-        // "does not exist" branch below is the right diagnostic.
+        // nullish union at the access site means no guard removed it.
+        // (`PropAccess`-chain receivers were tried but gain no conformance
+        // recall and expose correlated-union narrowing gaps — see
+        // intersectionOfUnionNarrowing.) The property must exist on the pruned
+        // receiver, otherwise the "does not exist" branch below is right.
         record(
           ctx,
           "PropAccess `.\{prop}`",

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -9140,3 +9140,38 @@ test "expr_check: narrowing guards suppress possibly-undefined (TS18048)" {
   // The genuinely-unguarded access still flags.
   assert_true(issues("function f(x?: string) { return x.length; }") > 0)
 }
+
+///|
+// TS18048 / TS2722 also covers *method calls* on a possibly-undefined `Var`
+// receiver, and `typeof x === \`tmpl\`` (a no-substitution template literal)
+// narrows the same as the quoted string form.
+test "expr_check: possibly-undefined method call + template-literal typeof" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Method call on a possibly-undefined value -> flagged.
+  assert_true(
+    issues("function f(x?: { foo(): number }) { return x.foo(); }") > 0,
+  )
+  // Guards narrow the receiver -> silent.
+  @test.assert_eq(
+    issues(
+      "function f(x?: { foo(): number }) { if (x) return x.foo(); return 0; }",
+    ),
+    0,
+  )
+  @test.assert_eq(
+    issues("function f(x?: { foo(): number }) { return x && x.foo(); }"),
+    0,
+  )
+  // `typeof x === \`string\`` (template literal) narrows like `\"string\"`.
+  @test.assert_eq(
+    issues(
+      (
+        #|declare const e: string | undefined;
+        #|if (typeof e === `string`) { e.slice(0); }
+      ),
+    ),
+    0,
+  )
+}


### PR DESCRIPTION
## Summary

Extends the possibly-undefined check (TS18048 / TS2722) from property reads to **method calls**, and fixes a `typeof` narrowing gap for template literals.

Whole-corpus TP **1643 → 1645**, pinned recall **619/815**, FP held at **0**, tests **2343/2343**.

## Changes

- **Method-call receivers**: calling a method on a `Var` receiver whose narrowed type still includes `undefined`/`null` (and the method resolves on the pruned receiver) now flags "object is possibly undefined/null". Same `Var`-receiver gating as the existing PropAccess check.
- **Template-literal `typeof`**: `analyze_equality` now normalizes a no-substitution `TemplateLiteral([s], [])` to `StringLit(s)`, so `typeof x === ` + "`string`" + ` narrows the same as the quoted form (fixes typeof / discriminant / literal narrowing uniformly).

## Rejected (kept FP=0)

Broadening the PropAccess check to `PropAccess`-chain receivers gains **0** conformance recall and exposes correlated-union narrowing gaps (`intersectionOfUnionNarrowing`: `q.a !== undefined` doesn't propagate to `q.b` across an intersection-of-union), so chains stay `Var`-only.

Each step gated on the whole-corpus oracle (`--max-fp 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCtv8FXj9TSyrmx8fxi294)_