### PR TITLE
checker: TS2790 delete operand must be optional (recall 634→636)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1509,6 +1509,18 @@ conformance sources (`.errors.txt` baseline = ground truth):
     PropAssignExpr where the declared field type is `Any`. Whole-corpus 0 FP, TP
     +1; pinned recall 633 -> 634 (privateNameFieldsESNext). Whitebox-tested.
 
+2026-06-25 (T102)  636/815 (78 %)        414/414 ( 0 FP)   TS2790 delete operand must be optional
+
+  T102 -- TS2790 ("The operand of a 'delete' operator must be optional"). In the
+    `UnaryOp(Delete, PropAccess(recv, prop))` walk: deleting a *required* field
+    (its resolved type has no `undefined` member) under strictNullChecks is an
+    error, as is deleting a private name (`delete this.#x`, always illegal).
+    Optionality is read from the `| undefined` encoding, so an explicitly-
+    nullable-but-required `b: T | undefined` is conservatively treated as
+    optional (a miss, never an FP); the required-field case is gated on
+    `strict_null_checks` (non-strict code may delete freely -- objectRestReadonly
+    FP, fixed). Whole-corpus 0 FP; pinned recall 634 -> 636. Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -4104,6 +4104,22 @@ fn is_nullable_type(ty : @ast.TsType) -> Bool {
 // preferred). This is the "possibly undefined/null" shape that makes member
 // access an error under strictNullChecks (TS18048 / TS2532). A purely-nullish
 // type is handled by `is_nullable_type` separately, so it returns `None` here.
+///|
+/// True when `ty` includes an `undefined` member (directly or as a union part).
+/// Used by the TS2790 `delete` check: an optional property is encoded with an
+/// `undefined` member, so a field type *without* `undefined` is a required
+/// property that `delete` may not target. (An explicitly-nullable-but-required
+/// `b: T | undefined` is conservatively treated as optional here — a miss, not
+/// a false positive.)
+fn type_has_undefined(ty : @ast.TsType) -> Bool {
+  match ty {
+    Undefined => true
+    Union(parts) => parts.iter().any(fn(p) { p is Undefined })
+    _ => false
+  }
+}
+
+///|
 fn union_possibly_nullish(ty : @ast.TsType) -> @ast.TsType? {
   match ty {
     Union(members) => {
@@ -11972,6 +11988,38 @@ fn check_call_args_in_expr(
             )
           }
         }
+        // TS2790: the operand of `delete` must be an *optional* property. A
+        // `delete obj.prop` where `prop` resolves to a required field (its type
+        // carries no `undefined` member) is an error, as is deleting a private
+        // name (`delete this.#x`).
+        Delete =>
+          match inner {
+            PropAccess(recv, prop) =>
+              if prop.has_prefix("__private_brand__") {
+                record(
+                  ctx, "delete", "the operand of a `delete` operator cannot be a private name",
+                )
+              } else if ctx.strict_null_checks {
+                // TS2790 for a required field only fires under strictNullChecks;
+                // non-strict code may `delete` a required property freely.
+                let recv_ty = infer_expr(env, ctx.resolver, recv)
+                if is_checkable(recv_ty) &&
+                  !is_in_scope_type_param(ctx, recv_ty) &&
+                  !type_contains_unresolved_named(recv_ty, ctx.resolver) &&
+                  !member_recv_unmodeled(recv_ty, ctx.resolver) {
+                  match ctx.resolver.lookup_field(recv_ty, prop) {
+                    Some(ft) =>
+                      if is_checkable(ft) && not(type_has_undefined(ft)) {
+                        record(
+                          ctx, "delete", "the operand of a `delete` operator must be optional",
+                        )
+                      }
+                    None => ()
+                  }
+                }
+              }
+            _ => ()
+          }
         _ => ()
       }
     }

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -9645,3 +9645,37 @@ test "expr_check: inferred primitive field assignment (TS2322)" {
   // Non-primitive initializer -> not inferred -> silent (no FP).
   @test.assert_eq(issues("class C { a = {}; m() { this.a = 5; } }"), 0)
 }
+
+///|
+// TS2790: the operand of `delete` must be an optional property (under
+// strictNullChecks); deleting a private name is never allowed.
+test "expr_check: delete operand must be optional (TS2790)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Required field, strictNullChecks -> flagged.
+  assert_true(
+    issues(
+      "// @strictNullChecks: true\nfunction f(){ let x: {a?: number, b: number} = {b:1}; delete x.b; }",
+    ) >
+    0,
+  )
+  // Optional field -> silent.
+  @test.assert_eq(
+    issues(
+      "// @strictNullChecks: true\nfunction f(){ let x: {a?: number, b: number} = {b:1}; delete x.a; }",
+    ),
+    0,
+  )
+  // Non-strict: deleting a required field is allowed.
+  @test.assert_eq(
+    issues(
+      "// @strict: false\nfunction f(){ let x: {b: number} = {b:1}; delete x.b; }",
+    ),
+    0,
+  )
+  // Private name delete -> flagged regardless.
+  assert_true(
+    issues("class A { #v = 1; constructor(){ delete this.#v; } }") > 0,
+  )
+}


### PR DESCRIPTION
Follow-on to #134.

Adds **TS2790** ("The operand of a 'delete' operator must be optional"): in the `delete obj.prop` walk, deleting a required field (resolved type carries no `undefined` member) under strictNullChecks is flagged, as is deleting a private name (`delete this.#x`). Optionality is read from the `| undefined` encoding, so an explicitly-nullable-but-required field is conservatively treated as optional (a miss, never an FP); the required-field case is gated on `strict_null_checks` (non-strict code may delete freely — fixes the objectRestReadonly FP found by the oracle).

Conformance: whole-corpus 0 FP (oracle); **pinned recall 634 → 636**, precision 414/414 (0 FP). Whitebox-tested; full checker suite green (695 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_