### PR TITLE
checker: TS2322 null/undefined not assignable to enum (recall 636→637)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1521,6 +1521,15 @@ conformance sources (`.errors.txt` baseline = ground truth):
     `strict_null_checks` (non-strict code may delete freely -- objectRestReadonly
     FP, fixed). Whole-corpus 0 FP; pinned recall 634 -> 636. Whitebox-tested.
 
+2026-06-25 (T103)  637/815 (78 %)        414/414 ( 0 FP)   TS2322 null/undefined not assignable to enum
+
+  T103 -- TS2322: under strictNullChecks, `null` / `undefined` are not
+    assignable to an enum type. Interface / class targets already reject them
+    structurally, but an enum `Named` stays unresolved in the resolver-aware
+    assignability check and was conservatively treated as accepting null. Added
+    an explicit `expected` enum check in `check_expr_against`. Whole-corpus 0 FP;
+    pinned recall 636 -> 637 (validEnumAssignments). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -4104,6 +4104,7 @@ fn is_nullable_type(ty : @ast.TsType) -> Bool {
 // preferred). This is the "possibly undefined/null" shape that makes member
 // access an error under strictNullChecks (TS18048 / TS2532). A purely-nullish
 // type is handled by `is_nullable_type` separately, so it returns `None` here.
+
 ///|
 /// True when `ty` includes an `undefined` member (directly or as a union part).
 /// Used by the TS2790 `delete` check: an optional property is encoded with an
@@ -6492,6 +6493,21 @@ fn check_expr_against(
   // on every exhaustiveness assertion.
   if expected_u is Never {
     return
+  }
+  // TS2322: under strictNullChecks, `null` / `undefined` are not assignable to
+  // an enum type. Interface / class targets already reject them via the
+  // structural check, but an enum `Named` stays unresolved there and is treated
+  // conservatively as accepting null — so handle it explicitly.
+  if ctx.strict_null_checks && (expr is NullLit || expr is Var("undefined")) {
+    match expected_u {
+      Named(n) =>
+        if ctx.resolver.enums.get(n) is Some(_) {
+          let lit = if expr is NullLit { "null" } else { "undefined" }
+          record(ctx, sub_path, "`\{lit}` is not assignable to enum `\{n}`")
+          return
+        }
+      _ => ()
+    }
   }
   // A *literal* value is never assignable to a bare in-scope type parameter
   // `T`: `T` could be instantiated with an arbitrary type unrelated to the

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -9679,3 +9679,29 @@ test "expr_check: delete operand must be optional (TS2790)" {
     issues("class A { #v = 1; constructor(){ delete this.#v; } }") > 0,
   )
 }
+
+///|
+// TS2322: null / undefined are not assignable to an enum type under
+// strictNullChecks.
+test "expr_check: null/undefined to enum (TS2322)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  assert_true(
+    issues("// @strict: true\nenum E { A } function f(e: E) { e = null; }") > 0,
+  )
+  assert_true(
+    issues("// @strict: true\nenum E { A } function f(e: E) { e = undefined; }") >
+    0,
+  )
+  // A valid enum member assignment is silent.
+  @test.assert_eq(
+    issues("// @strict: true\nenum E { A } function f(e: E) { e = E.A; }"),
+    0,
+  )
+  // Non-strict allows nullish.
+  @test.assert_eq(
+    issues("// @strict: false\nenum E { A } function f(e: E) { e = null; }"),
+    0,
+  )
+}


### PR DESCRIPTION
Follow-on to #135. Under strictNullChecks, `null` / `undefined` are not assignable to an enum type — interface/class targets already reject them structurally, but an enum `Named` stayed unresolved in the resolver-aware assignability check. Adds an explicit enum-target check in `check_expr_against`.

Conformance: whole-corpus 0 FP (oracle); pinned recall 636 → 637 (validEnumAssignments), precision 414/414. Whitebox-tested; checker suite green (696).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_