### PR TITLE
checker: TS2322 unconstrained type param → object type (recall 637→638)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1530,6 +1530,17 @@ conformance sources (`.errors.txt` baseline = ground truth):
     an explicit `expected` enum check in `check_expr_against`. Whole-corpus 0 FP;
     pinned recall 636 -> 637 (validEnumAssignments). Whitebox-tested.
 
+2026-06-25 (T104)  638/815 (78 %)        414/414 ( 0 FP)   TS2322 unconstrained type param -> concrete object type
+
+  T104 -- TS2322: a bare *unconstrained* in-scope type parameter is effectively
+    `unknown`, so a `T`-typed value is not assignable to a concrete object type
+    (`var b: { s?: number } = a` where `a: T`). Threaded the function/class type-
+    parameter bounds into `CheckCtx.type_param_bounds`; the check fires only when
+    `T` has no bound (a constrained `T extends { … }` is skipped conservatively)
+    and the target is a structural object / named-interface (primitives, any,
+    other type params unaffected). Whole-corpus 0 FP, TP +2; pinned recall
+    637 -> 638 (subtypingWithOptionalProperties). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -3081,6 +3081,13 @@ priv struct CheckCtx {
   // property / method misses on named types that are *not* type
   // parameters at this point.
   in_scope_type_params : Array[String]
+  // Constraints (`(name, bound)`) for the in-scope type parameters that
+  // declared one (`<T extends X>`). Sparse — a type parameter absent here is
+  // *unconstrained*. Used to flag a bare unconstrained type parameter assigned
+  // to a concrete object type (TS2322): an unconstrained `T` is effectively
+  // `unknown`, so it is not assignable to `{ … }` (constrained ones are skipped
+  // conservatively).
+  type_param_bounds : Array[(String, @ast.TsType)]
   // Permissive mode for whole-corpus runs: when `true`, drop the
   // diagnostic families dominated by features we don't model (flow
   // narrowing, generic inference, builtin optional-arg tables). Set
@@ -6509,6 +6516,35 @@ fn check_expr_against(
       _ => ()
     }
   }
+  // TS2322: a bare *unconstrained* in-scope type parameter is effectively
+  // `unknown`, so a value of type `T` is not assignable to a concrete object
+  // type (`var b: { s?: number } = a` where `a: T`). Restricted to an
+  // unconstrained `T` (no entry in `type_param_bounds`) so a constrained
+  // `T extends { … }` — which may satisfy the target — is conservatively
+  // skipped, and to a structural object / interface target so primitives,
+  // `any` / `unknown`, and other type parameters are unaffected.
+  match inferred_u {
+    Named(tp) =>
+      if ctx.in_scope_type_params.contains(tp) &&
+        not(ctx.type_param_bounds.iter().any(fn(b) { b.0 == tp })) {
+        let target_is_concrete_object = match expected_u {
+          Object(_) | Struct(_, _) => true
+          Named(tn) =>
+            not(ctx.in_scope_type_params.contains(tn)) &&
+            ctx.resolver.interfaces.get(tn) is Some(_)
+          _ => false
+        }
+        if target_is_concrete_object {
+          record(
+            ctx,
+            sub_path,
+            "type parameter `\{tp}` is not assignable to type `\{type_display(expected_u)}`",
+          )
+          return
+        }
+      }
+    _ => ()
+  }
   // A *literal* value is never assignable to a bare in-scope type parameter
   // `T`: `T` could be instantiated with an arbitrary type unrelated to the
   // value, so `function f<T>() { var x: T = 1 }` and
@@ -8905,6 +8941,7 @@ fn check_arrow_with_context(
     resolver: ctx.resolver,
     issues: ctx.issues,
     in_scope_type_params: ctx.in_scope_type_params,
+    type_param_bounds: ctx.type_param_bounds,
     permissive: ctx.permissive,
     unassigned: unassigned_without(ctx.unassigned, param_names),
     strict_property_init: ctx.strict_property_init,
@@ -8996,6 +9033,7 @@ fn check_funcexpr_with_context(
     resolver: ctx.resolver,
     issues: ctx.issues,
     in_scope_type_params: ctx.in_scope_type_params,
+    type_param_bounds: ctx.type_param_bounds,
     permissive: ctx.permissive,
     // Parameters shadow outer bindings — drop them from the TS2454 set.
     unassigned: unassigned_without(ctx.unassigned, param_names),
@@ -12943,6 +12981,7 @@ fn check_function_body_with(
     resolver,
     issues,
     in_scope_type_params: func.type_params,
+    type_param_bounds: func.type_param_bounds,
     permissive,
     unassigned: {},
     strict_property_init,
@@ -15516,6 +15555,7 @@ fn check_module_function_bodies_layered(
       resolver,
       issues: [],
       in_scope_type_params: cls.type_params,
+      type_param_bounds: cls.type_param_bounds,
       permissive,
       unassigned: {},
       strict_property_init,
@@ -15582,6 +15622,7 @@ fn check_module_function_bodies_layered(
       resolver,
       issues: [],
       in_scope_type_params: cls.type_params,
+      type_param_bounds: cls.type_param_bounds,
       permissive,
       unassigned: {},
       strict_property_init,
@@ -15615,6 +15656,7 @@ fn check_module_function_bodies_layered(
       resolver,
       issues: [],
       in_scope_type_params: [],
+      type_param_bounds: [],
       permissive,
       unassigned: {},
       strict_property_init,

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -9705,3 +9705,27 @@ test "expr_check: null/undefined to enum (TS2322)" {
     0,
   )
 }
+
+///|
+// TS2322: a bare unconstrained type parameter is not assignable to a concrete
+// object type. Constrained type params / any / T-to-T stay silent.
+test "expr_check: unconstrained type param to object type (TS2322)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  assert_true(issues("function f<T>(a: T) { let b: { s: number } = a; }") > 0)
+  assert_true(
+    issues("interface I { x: number } function f<T>(a: T) { let b: I = a; }") >
+    0,
+  )
+  // Constrained type parameter may satisfy the target -> silent.
+  @test.assert_eq(
+    issues(
+      "function f<T extends { s: number }>(a: T) { let b: { s: number } = a; }",
+    ),
+    0,
+  )
+  // `any` / same type parameter targets -> silent.
+  @test.assert_eq(issues("function f<T>(a: T) { let b: any = a; }"), 0)
+  @test.assert_eq(issues("function f<T>(a: T) { let b: T = a; }"), 0)
+}


### PR DESCRIPTION
Follow-on to #136. A bare *unconstrained* in-scope type parameter is effectively `unknown`, so a `T`-typed value is not assignable to a concrete object type (`var b: { s?: number } = a` where `a: T`). Threads function/class type-parameter bounds into `CheckCtx.type_param_bounds`; fires only for unbounded `T` (constrained `T extends { … }` skipped) against a structural object / named-interface target.

Conformance: whole-corpus 0 FP (oracle), TP +2; pinned recall 637 → 638 (subtypingWithOptionalProperties), precision 414/414. Whitebox-tested; checker suite green (697).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_