### PR TITLE
checker: TS2322 residual nullish union → non-nullish target (recall 638→641)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1541,6 +1541,20 @@ conformance sources (`.errors.txt` baseline = ground truth):
     other type params unaffected). Whole-corpus 0 FP, TP +2; pinned recall
     637 -> 638 (subtypingWithOptionalProperties). Whitebox-tested.
 
+2026-06-25 (T105)  641/815 (79 %)        414/414 ( 0 FP)   TS2322 residual nullish union into non-nullish target
+
+  T105 -- TS2322: under strictNullChecks, a non-keyword source whose inferred
+    type is a union still carrying `undefined` / `null` (a residual nullish no
+    narrowing removed) is not assignable to a target that does not accept that
+    nullish member (`let y: string | number = x` where `x: string | undefined`).
+    The purely-nullish keyword forms are handled separately (T87); this covers a
+    variable / expression leaking nullish into a non-nullish location. Targets
+    that accept anything (`any` / `unknown` / `void` / `never`) or a type
+    parameter are excluded, as is a target carrying the same nullish member.
+    This is the inferred-nullish increment T87 flagged as needing its own FP
+    sweep — done via the oracle. Whole-corpus 0 FP, TP +3; pinned recall
+    638 -> 641. Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -4128,6 +4128,35 @@ fn type_has_undefined(ty : @ast.TsType) -> Bool {
 }
 
 ///|
+fn type_has_null(ty : @ast.TsType) -> Bool {
+  match ty {
+    Null => true
+    Union(parts) => parts.iter().any(fn(p) { p is Null })
+    _ => false
+  }
+}
+
+///|
+/// True when `ty` has at least one non-nullish member — distinguishes a
+/// "possibly nullish" union (`string | undefined`) from a purely-nullish type
+/// (whose keyword forms are handled by the dedicated strict-null path).
+fn type_has_non_nullish(ty : @ast.TsType) -> Bool {
+  match ty {
+    Null | Undefined => false
+    Union(parts) =>
+      parts
+      .iter()
+      .any(fn(p) {
+        match p {
+          Null | Undefined => false
+          _ => true
+        }
+      })
+    _ => true
+  }
+}
+
+///|
 fn union_possibly_nullish(ty : @ast.TsType) -> @ast.TsType? {
   match ty {
     Union(members) => {
@@ -6544,6 +6573,38 @@ fn check_expr_against(
         }
       }
     _ => ()
+  }
+  // TS2322: under strictNullChecks, a *non-keyword* source whose inferred type
+  // is a union that still carries `undefined` / `null` (a residual nullish that
+  // no narrowing removed) is not assignable to a target that does not accept
+  // that nullish member (`let y: string | number = x` where `x: string |
+  // undefined`). The purely-nullish keyword forms are handled above; this
+  // covers a variable / expression whose union leaks nullish into a
+  // non-nullish location. Targets that openly accept anything (`any` /
+  // `unknown` / `void`) or a type parameter (generic instantiation unknown) are
+  // excluded, as is a target that itself carries the same nullish member.
+  if ctx.strict_null_checks &&
+    type_has_non_nullish(inferred_u) &&
+    (type_has_undefined(inferred_u) || type_has_null(inferred_u)) {
+    let target_open = match expected_u {
+      Any | Unknown | Void | Never => true
+      Named(tn) => ctx.in_scope_type_params.contains(tn)
+      _ => false
+    }
+    if not(target_open) && is_checkable(expected_u) {
+      let leaks_undef = type_has_undefined(inferred_u) &&
+        not(type_has_undefined(expected_u))
+      let leaks_null = type_has_null(inferred_u) &&
+        not(type_has_null(expected_u))
+      if leaks_undef || leaks_null {
+        record(
+          ctx,
+          sub_path,
+          "type `\{type_display(inferred_u)}` is not assignable to type `\{type_display(expected_u)}`",
+        )
+        return
+      }
+    }
   }
   // A *literal* value is never assignable to a bare in-scope type parameter
   // `T`: `T` could be instantiated with an arbitrary type unrelated to the

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -9729,3 +9729,38 @@ test "expr_check: unconstrained type param to object type (TS2322)" {
   @test.assert_eq(issues("function f<T>(a: T) { let b: any = a; }"), 0)
   @test.assert_eq(issues("function f<T>(a: T) { let b: T = a; }"), 0)
 }
+
+///|
+// TS2322: under strictNullChecks, a union value still carrying undefined/null
+// is not assignable to a target that does not accept it.
+test "expr_check: residual nullish union not assignable (TS2322)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  assert_true(
+    issues(
+      "// @strict: true\nfunction f(x: string | undefined) { let y: string | number = x; }",
+    ) >
+    0,
+  )
+  assert_true(
+    issues(
+      "// @strict: true\nfunction f(x: string | null) { let y: string = x; }",
+    ) >
+    0,
+  )
+  // Target accepts the same nullish member -> silent.
+  @test.assert_eq(
+    issues(
+      "// @strict: true\nfunction f(x: string | undefined) { let y: string | undefined = x; }",
+    ),
+    0,
+  )
+  // any / unknown target -> silent.
+  @test.assert_eq(
+    issues(
+      "// @strict: true\nfunction f(x: string | undefined) { let y: unknown = x; }",
+    ),
+    0,
+  )
+}


### PR DESCRIPTION
Follow-on to #137. Under strictNullChecks, a non-keyword source whose inferred type is a union still carrying `undefined`/`null` (a residual no narrowing removed) is not assignable to a target that doesn't accept it (`let y: string | number = x` where `x: string | undefined`). Purely-nullish keyword forms are handled separately (T87); `any`/`unknown`/`void`/`never`/type-parameter targets and same-nullish targets are excluded. This is the inferred-nullish increment T87 flagged for a dedicated FP sweep — verified via the whole-corpus oracle.

Conformance: whole-corpus 0 FP (oracle), TP +3; pinned recall 638 → 641, precision 414/414. Whitebox-tested; checker suite green (698).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_