### PR TITLE
checker: TS2539 cannot assign to undefined + TS2322 unconstrained-T/nullish-union (recall 641→642)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1555,6 +1555,13 @@ conformance sources (`.errors.txt` baseline = ground truth):
     sweep — done via the oracle. Whole-corpus 0 FP, TP +3; pinned recall
     638 -> 641. Whitebox-tested.
 
+2026-06-25 (T106)  642/815 (79 %)        414/414 ( 0 FP)   TS2539 cannot assign to `undefined`
+
+  T106 -- TS2539: `undefined` is a global value, not an assignable variable, so
+    `undefined = x` is an error. Flagged in the `AssignExpr` walk, gated on the
+    name not being shadowed by a declared local. Whole-corpus 0 FP; pinned
+    recall 641 -> 642 (nullAssignedToUndefined). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -12357,6 +12357,14 @@ fn check_call_args_in_expr(
     }
     AssignExpr(name, v) => {
       check_call_args_in_expr(env, v, ctx)
+      // TS2539: `undefined` is a global value, not an assignable variable, so
+      // `undefined = x` is an error. Only when it is not shadowed by a declared
+      // local of that name (which would make it an ordinary variable).
+      if name == "undefined" && env.lookup_declared(name) is None {
+        record(
+          ctx, "assign `undefined`", "cannot assign to `undefined` because it is not a variable",
+        )
+      }
       // Assignment target is the *declared* type, not the narrowed
       // current type (same reasoning as the stmt-level `Assign`
       // case above). Falls back to `resolver.globals` for module-

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -9764,3 +9764,14 @@ test "expr_check: residual nullish union not assignable (TS2322)" {
     0,
   )
 }
+
+///|
+// TS2539: `undefined` is not an assignable variable.
+test "expr_check: cannot assign to undefined (TS2539)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  assert_true(issues("var x = undefined = null;") > 0)
+  // A normal variable assignment is silent.
+  @test.assert_eq(issues("let u: number = 0; u = 1;"), 0)
+}


### PR DESCRIPTION
Follow-on to #138. Adds **TS2539** (`undefined = x` — `undefined` is not an assignable variable), flagged in the `AssignExpr` walk, gated on the name not being a declared local.

Conformance: whole-corpus 0 FP (oracle); pinned recall 641 → 642 (nullAssignedToUndefined), precision 414/414. Whitebox-tested; checker suite green (699).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_