### PR TITLE
checker: TS1228 type predicate only allowed in return position

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1562,6 +1562,16 @@ conformance sources (`.errors.txt` baseline = ground truth):
     name not being shadowed by a declared local. Whole-corpus 0 FP; pinned
     recall 641 -> 642 (nullAssignedToUndefined). Whitebox-tested.
 
+2026-06-25 (T107)  644/815 (79 %)        414/414 ( 0 FP)   TS1228 type predicate only in return position
+
+  T107 -- TS1228 ("A type predicate is only allowed in return type position
+    for functions and methods"). `check_misplaced_type_predicates` scans
+    non-return-type positions for `TypePredicate(_, _)`: top-level
+    Var/Let/Const declared types, function & ambient-import params, interface
+    fields, and type-alias bodies. Return-type predicates stay silent. Whole-
+    corpus TP 1675 -> 1677, 0 FP; pinned recall 642 -> 644
+    (typePredicateOnVariableDeclaration01/02). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -14706,6 +14706,53 @@ fn check_rest_param_position(module_ : @ast.TsModule) -> Array[ExprIssue] {
 }
 
 ///|
+/// TS1228: a type predicate (`x is T`) is only allowed in the return-type
+/// position of a function or method. The parser models it as `TypePredicate`,
+/// so flag it anywhere we know is *not* a return type: a variable / parameter /
+/// field annotation or a type-alias body. (Return types are never routed
+/// through this pass.) Sound — a type predicate is never valid in these spots.
+fn check_misplaced_type_predicates(module_ : @ast.TsModule) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  let msg = "a type predicate is only allowed in return type position for functions and methods"
+  for stmt in module_.top_level_stmts {
+    match stmt {
+      Var(_, ty, _) | Let(_, ty, _) | Const(_, ty, _) =>
+        if ty is TypePredicate(_, _) {
+          issues.push({ path: "top-level", message: msg })
+        }
+      _ => ()
+    }
+  }
+  for f in module_.funcs {
+    for p in f.params {
+      if p.type_ is TypePredicate(_, _) {
+        issues.push({ path: "function \{f.name}", message: msg })
+      }
+    }
+  }
+  for imp in module_.imports {
+    for p in imp.params {
+      if p.1 is TypePredicate(_, _) {
+        issues.push({ path: "function \{imp.name}", message: msg })
+      }
+    }
+  }
+  for iface in module_.interfaces {
+    for fld in iface.fields {
+      if fld.1 is TypePredicate(_, _) {
+        issues.push({ path: "interface \{iface.name}", message: msg })
+      }
+    }
+  }
+  for ta in module_.type_aliases {
+    if ta.type_ is TypePredicate(_, _) {
+      issues.push({ path: "type \{ta.name}", message: msg })
+    }
+  }
+  issues
+}
+
+///|
 /// TS2414: a class name may not be one of the predefined type keywords. Mirrors
 /// `checkTypeNameIsReserved` in tsc — the exact reserved set is `any`,
 /// `unknown`, `never`, `number`, `bigint`, `boolean`, `string`, `symbol`,
@@ -15758,6 +15805,9 @@ fn check_module_function_bodies_layered(
     }
   }
   for issue in check_var_redeclaration_types(module_, resolver) {
+    all.push(issue)
+  }
+  for issue in check_misplaced_type_predicates(module_) {
     all.push(issue)
   }
   for issue in check_super_before_this(module_) {

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -9775,3 +9775,18 @@ test "expr_check: cannot assign to undefined (TS2539)" {
   // A normal variable assignment is silent.
   @test.assert_eq(issues("let u: number = 0; u = 1;"), 0)
 }
+
+///|
+// TS1228: a type predicate is only allowed in return-type position.
+test "expr_check: misplaced type predicate (TS1228)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  assert_true(issues("var x: this is string;") > 0)
+  assert_true(issues("var y: z is number;") > 0)
+  // A type predicate in return-type position is valid.
+  @test.assert_eq(
+    issues("function isStr(x: unknown): x is string { return true; }"),
+    0,
+  )
+}


### PR DESCRIPTION
A type predicate (`x is T`) is only valid in return-type position for functions and methods. `check_misplaced_type_predicates` scans the other positions — top-level `Var`/`Let`/`Const` declared types, function and ambient-import params, interface fields, and type-alias bodies — and flags any `TypePredicate(_, _)` found there. Return-type predicates remain silent.

## Validation
- Whole-corpus oracle (`scripts/checker_conformance_oracle.sh --max-fp 0`): TP 1675 → 1677, **0 false positives**.
- Pinned conformance recall: **642 → 644/815** (`typePredicateOnVariableDeclaration01`/`02`), precision 414/414 (0 FP).
- Full suite: 2361/2361 green. Whitebox-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_