### PR TITLE
parser: capture predefined-type-keyword class names (TS2414)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1572,6 +1572,18 @@ conformance sources (`.errors.txt` baseline = ground truth):
     corpus TP 1675 -> 1677, 0 FP; pinned recall 642 -> 644
     (typePredicateOnVariableDeclaration01/02). Whitebox-tested.
 
+2026-06-25 (T108)  646/815 (79 %)        414/414 ( 0 FP)   class named with predefined-type keyword
+
+  T108 -- a class whose name is a predefined-type keyword (`class void {}`,
+    `class string {}`, `class number {}`, `class boolean {}`) is always a TS
+    error (TS1005/TS2414). `void`/`string`/`number`/`boolean` tokenize as
+    dedicated `*Type` kinds, so `parse_class_decl_with_abstract` previously
+    lost the name to the `<class>` recovery fallback and the existing
+    `check_reserved_class_names` couldn't see it. Capture the keyword spelling
+    in the class-name position. Whole-corpus TP 1677 -> 1679, 0 FP; pinned
+    recall 644 -> 646 (classWithPredefinedTypesAsNames2,
+    objectTypesWithPredefinedTypesAsName2). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -9790,3 +9790,19 @@ test "expr_check: misplaced type predicate (TS1228)" {
     0,
   )
 }
+
+///|
+test "expr_check: class named with predefined-type keyword (TS2414)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A class whose name is a predefined-type keyword is always a TS error.
+  // These keywords tokenize as dedicated `*Type` kinds, so the parser must
+  // capture their spelling for the reserved-name check to fire.
+  assert_true(issues("class void {}") > 0)
+  assert_true(issues("class string {}") > 0)
+  assert_true(issues("class number {}") > 0)
+  assert_true(issues("class boolean {}") > 0)
+  // An ordinary class name is fine.
+  @test.assert_eq(issues("class Foo {}"), 0)
+}

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -2009,8 +2009,17 @@ fn Parser::parse_class_decl_with_abstract(
 ) -> @ast.TsStmt raise ParseError {
   self.last_runtime_class_decl = None
   let _ = self.expect(Class)
+  // A class named with a predefined-type keyword (`class void {}`,
+  // `class string {}`, …) is always a TS error (TS1005 / TS2414). These
+  // keywords tokenize as dedicated `*Type` kinds rather than `Ident`, so
+  // capture their spelling here — otherwise the name is lost to the
+  // `<class>` recovery fallback and the reserved-name check can't see it.
   let name = match self.advance().kind {
     Ident(n) => n
+    VoidType => "void"
+    StringType => "string"
+    NumberType => "number"
+    BooleanType => "boolean"
     _ => "<class>"
   }
   let mut class_type_params : Array[String] = []


### PR DESCRIPTION
A class whose name is a predefined-type keyword — `class void {}`, `class string {}`, `class number {}`, `class boolean {}` — is always a TS error (TS1005 / TS2414).

These keywords tokenize as dedicated `*Type` kinds rather than `Ident`, so `parse_class_decl_with_abstract` dropped the name into the `<class>` recovery fallback and the existing `check_reserved_class_names` never saw it. This captures the keyword spelling in the class-name position so the reserved-name check fires.

## Validation
- Whole-corpus oracle (`--max-fp 0`): TP 1677 → 1679, **0 false positives**.
- Pinned conformance recall: **644 → 646/815** (`classWithPredefinedTypesAsNames2`, `objectTypesWithPredefinedTypesAsName2`), precision 414/414 (0 FP).
- Full suite: 2361/2361 green. Whitebox-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_