### PR TITLE
checker: TS2457 type alias name cannot be a predefined-type keyword

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1584,6 +1584,16 @@ conformance sources (`.errors.txt` baseline = ground truth):
     recall 644 -> 646 (classWithPredefinedTypesAsNames2,
     objectTypesWithPredefinedTypesAsName2). Whitebox-tested.
 
+2026-06-25 (T109)  647/815 (79 %)        414/414 ( 0 FP)   type alias named with predefined-type keyword
+
+  T109 -- TS2457 ("Type alias name cannot be 'X'"). A type alias whose name is
+    a predefined-type keyword (`type any = …`, `type string = …`, `type void
+    = …`, `type object = …`) is always an error. The parser already lowers the
+    keyword tokens to their spelling via `parse_binding_ident`, so the alias
+    name is visible directly; added `check_reserved_type_alias_names` mirroring
+    `check_reserved_class_names`. Whole-corpus TP 1679 -> 1680, 0 FP; pinned
+    recall 646 -> 647 (reservedNamesInAliases). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -14782,6 +14782,35 @@ fn check_reserved_class_names(module_ : @ast.TsModule) -> Array[ExprIssue] {
 }
 
 ///|
+/// A type alias whose name is a predefined-type keyword (`type any = …`,
+/// `type string = …`) is always a TS error (TS2457, "Type alias name cannot
+/// be 'X'"). The parser already lowers these keyword tokens to their spelling
+/// (`parse_binding_ident`), so the alias name is visible here directly.
+fn check_reserved_type_alias_names(module_ : @ast.TsModule) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  for ta in module_.type_aliases {
+    match ta.name {
+      "any"
+      | "unknown"
+      | "never"
+      | "number"
+      | "bigint"
+      | "boolean"
+      | "string"
+      | "symbol"
+      | "void"
+      | "object" =>
+        issues.push({
+          path: "type \{ta.name}",
+          message: "type alias name cannot be `\{ta.name}`",
+        })
+      _ => ()
+    }
+  }
+  issues
+}
+
+///|
 /// Walk a class's `extends` ancestry (nearest first) looking for how `name`
 /// (matching `is_static`) was last declared. Returns `Some(true)` when the
 /// nearest ancestor declaration is a *data property*, `Some(false)` when it is
@@ -15814,6 +15843,9 @@ fn check_module_function_bodies_layered(
     all.push(issue)
   }
   for issue in check_reserved_class_names(module_) {
+    all.push(issue)
+  }
+  for issue in check_reserved_type_alias_names(module_) {
     all.push(issue)
   }
   for issue in check_property_overridden_as_accessor(module_, resolver) {

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -9806,3 +9806,17 @@ test "expr_check: class named with predefined-type keyword (TS2414)" {
   // An ordinary class name is fine.
   @test.assert_eq(issues("class Foo {}"), 0)
 }
+
+///|
+test "expr_check: type alias named with predefined-type keyword (TS2457)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A type alias whose name is a predefined-type keyword is always a TS error.
+  assert_true(issues("type any = number;") > 0)
+  assert_true(issues("type string = number;") > 0)
+  assert_true(issues("type void = number;") > 0)
+  assert_true(issues("type object = number;") > 0)
+  // An ordinary alias name is fine.
+  @test.assert_eq(issues("type Foo = number;"), 0)
+}


### PR DESCRIPTION
A type alias whose name is a predefined-type keyword — `type any = …`, `type string = …`, `type void = …`, `type object = …` — is always a TS error (TS2457, "Type alias name cannot be 'X'").

The parser already lowers these keyword tokens to their spelling via `parse_binding_ident`, so the alias name is visible directly. Added `check_reserved_type_alias_names`, mirroring the existing `check_reserved_class_names`.

## Validation
- Whole-corpus oracle (`--max-fp 0`): TP 1679 → 1680, **0 false positives**.
- Pinned conformance recall: **646 → 647/815** (`reservedNamesInAliases`), precision 414/414 (0 FP).
- Full suite: 2362/2362 green. Whitebox-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_