### PR TITLE
checker: TS1015 parameter cannot have question mark and initializer

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1594,6 +1594,17 @@ conformance sources (`.errors.txt` baseline = ground truth):
     `check_reserved_class_names`. Whole-corpus TP 1679 -> 1680, 0 FP; pinned
     recall 646 -> 647 (reservedNamesInAliases). Whitebox-tested.
 
+2026-06-25 (T110)  648/815 (79 %)        414/414 ( 0 FP)   TS1015 optional param + initializer
+
+  T110 -- TS1015 ("Parameter cannot have question mark and initializer"). A
+    parameter declared with both `?` and `= e` is always a syntax error. The
+    `?` is otherwise folded into the parameter type (`x?: T` -> `T | undefined`),
+    making it indistinguishable from a legal `x: T | undefined = e`, so the
+    conflict is recorded at parse time (new `param_optional_initializer_misuses`
+    on the Parser / TsModule, mirroring `parameter_property_misuses`) and
+    surfaced by the checker. Whole-corpus TP 1680 -> 1682, 0 FP; pinned recall
+    647 -> 648 (callSignatureWithOptionalParameterAndInitializer). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/ast/types.mbt
+++ b/src/ast/types.mbt
@@ -862,6 +862,11 @@ pub(all) struct TsModule {
   // Empty for any well-formed input (the modifier is always an error in
   // these positions), so it never costs precision.
   parameter_property_misuses : Array[String]
+  // Parameters declared with both an optional marker (`x?`) and an
+  // initializer (`x = e`) -- always a TS1015 syntax error. The parser
+  // records one parameter name per offending declaration; the checker
+  // surfaces one diagnostic per entry. Empty for well-formed input.
+  param_optional_initializer_misuses : Array[String]
 } derive(Debug)
 
 ///|

--- a/src/bridge/moonbit_decl.mbt
+++ b/src/bridge/moonbit_decl.mbt
@@ -419,6 +419,7 @@ async fn load_decl_module_info(
           use_define_for_class_fields: false,
           deprecated_compiler_options: [],
           parameter_property_misuses: [],
+          param_optional_initializer_misuses: [],
         }
       }
   }
@@ -9220,6 +9221,7 @@ pub async fn emit_moonbit_decl_from_entry_path(
     use_define_for_class_fields: false,
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
+    param_optional_initializer_misuses: [],
   }
   // Run the checker over the final module shape and surface anything it
   // catches as a generator-level note. The emit pipeline is internally

--- a/src/checker/check_module_wbtest.mbt
+++ b/src/checker/check_module_wbtest.mbt
@@ -15,6 +15,7 @@ fn empty_module_for_check() -> @ast.TsModule {
     use_define_for_class_fields: false,
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
+    param_optional_initializer_misuses: [],
     top_level_stmts: [],
   }
 }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -15945,6 +15945,15 @@ fn check_module_function_bodies_layered(
         message: "a parameter property is only allowed in a constructor implementation",
       })
     }
+    // TS1015: a parameter cannot have both an optional marker (`x?`) and an
+    // initializer (`x = e`). The parser records each offending parameter; this
+    // position is never valid TS, so it is false-positive-free.
+    for pname in module_.param_optional_initializer_misuses {
+      all.push({
+        path: "parameter `\{pname}`",
+        message: "parameter cannot have question mark and initializer",
+      })
+    }
     // TS2313: a type parameter with a circular constraint (`T extends T`, or an
     // indirect cycle). Walks declarations (and nested namespaces) once from the
     // top.

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -320,6 +320,7 @@ fn parse_module_or_empty(src : String) -> @ast.TsModule {
         use_define_for_class_fields: false,
         deprecated_compiler_options: [],
         parameter_property_misuses: [],
+        param_optional_initializer_misuses: [],
         top_level_stmts: [],
       }
   } noraise {
@@ -9819,4 +9820,18 @@ test "expr_check: type alias named with predefined-type keyword (TS2457)" {
   assert_true(issues("type object = number;") > 0)
   // An ordinary alias name is fine.
   @test.assert_eq(issues("type Foo = number;"), 0)
+}
+
+///|
+test "expr_check: parameter optional marker plus initializer (TS1015)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A parameter cannot be both optional and have an initializer.
+  assert_true(issues("function f(x?: number = 1) {}") > 0)
+  assert_true(issues("var g = (y?: string = \"a\") => {};") > 0)
+  // An optional parameter without an initializer is fine.
+  @test.assert_eq(issues("function h(x?: number) {}"), 0)
+  // An explicit `| undefined` type with an initializer is legal (no `?`).
+  @test.assert_eq(issues("function k(x: number | undefined = 1) {}"), 0)
 }

--- a/src/checker/generics_wbtest.mbt
+++ b/src/checker/generics_wbtest.mbt
@@ -103,6 +103,7 @@ test "module_alias_resolver: combines parsed aliases with stdlib utilities" {
     use_define_for_class_fields: false,
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
+    param_optional_initializer_misuses: [],
     top_level_stmts: [],
   }
   let resolve = module_alias_resolver(m)
@@ -141,6 +142,7 @@ test "module_alias_resolver: include_standard=false omits stdlib" {
     use_define_for_class_fields: false,
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
+    param_optional_initializer_misuses: [],
     top_level_stmts: [],
   }
   let resolve = module_alias_resolver(m, include_standard=false)
@@ -181,6 +183,7 @@ test "module_alias_resolver: module aliases shadow stdlib on name clash" {
     use_define_for_class_fields: false,
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
+    param_optional_initializer_misuses: [],
     top_level_stmts: [],
   }
   let resolve = module_alias_resolver(m)

--- a/src/checker/validate_wbtest.mbt
+++ b/src/checker/validate_wbtest.mbt
@@ -15,6 +15,7 @@ fn empty_module() -> @ast.TsModule {
     use_define_for_class_fields: false,
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
+    param_optional_initializer_misuses: [],
     top_level_stmts: [],
   }
 }

--- a/src/cmd/mtsc/main.mbt
+++ b/src/cmd/mtsc/main.mbt
@@ -423,6 +423,7 @@ async fn mtsc_load_bundle_files(
           use_define_for_class_fields: false,
           deprecated_compiler_options: [],
           parameter_property_misuses: [],
+          param_optional_initializer_misuses: [],
           top_level_stmts: [],
         }
     }
@@ -632,6 +633,7 @@ async fn main {
           use_define_for_class_fields: false,
           deprecated_compiler_options: [],
           parameter_property_misuses: [],
+          param_optional_initializer_misuses: [],
           top_level_stmts: [],
         })
         let local_names : Array[String] = []
@@ -744,6 +746,7 @@ async fn main {
             use_define_for_class_fields: false,
             deprecated_compiler_options: [],
             parameter_property_misuses: [],
+            param_optional_initializer_misuses: [],
             top_level_stmts: [],
           })
           // Filter exports through the entry's `@internal` set so

--- a/src/parser/parser_core.mbt
+++ b/src/parser/parser_core.mbt
@@ -73,6 +73,16 @@ pub struct Parser {
   // signature. TypeScript reports TS2369 for each. `parse_param` appends a
   // location string here; `parse_module` hands the list to the checker.
   param_property_misuses : Array[String]
+  // Parameters declared with *both* an optional marker (`x?`) and an
+  // initializer (`x = e`) -- always a TS1015 syntax error regardless of
+  // position. The `?` is otherwise folded into the parameter type
+  // (`x?: T` -> `T | undefined`), indistinguishable from an explicit
+  // `x: T | undefined = e` (which is legal), so the conflict must be
+  // recorded at parse time where both facts are still separate.
+  // `parse_param` appends the parameter name; `parse_module` hands the
+  // list to the checker. Empty for well-formed input, so it never costs
+  // precision.
+  param_optional_initializer_misuses : Array[String]
   // Token-position → "JSDoc `/* @__PURE__ */` annotation seen
   // just before this token". The lexer populates this when it
   // skips a block comment whose contents contain the literal
@@ -149,6 +159,7 @@ pub fn Parser::new_with_strict_and_jsx(
     pending_decorators: [],
     param_property_scopes: [],
     param_property_misuses: [],
+    param_optional_initializer_misuses: [],
     pure_marker_positions: {},
     internal_marker_positions: {},
     collected_internal_names: {},
@@ -203,6 +214,7 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
     pending_decorators: [],
     param_property_scopes: [],
     param_property_misuses: [],
+    param_optional_initializer_misuses: [],
     pure_marker_positions: lexer.pure_marker_positions,
     internal_marker_positions: lexer.internal_marker_positions,
     collected_internal_names: {},

--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -176,6 +176,12 @@ fn Parser::parse_param(self : Parser) -> @ast.TsParam raise ParseError {
   } else {
     None
   }
+  // TS1015: a parameter cannot be both optional (`x?`) and have an
+  // initializer (`x = e`). The `?` is otherwise lost into the parameter
+  // type below, so record the conflict here where both facts are visible.
+  if is_optional && not(default is None) {
+    self.param_optional_initializer_misuses.push(name)
+  }
   { name, binding: Some(binding), is_rest, type_, default }
 }
 

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -135,6 +135,7 @@ fn empty_ts_module() -> @ast.TsModule {
     top_level_stmts: [],
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
+    param_optional_initializer_misuses: [],
   }
 }
 
@@ -3272,6 +3273,7 @@ fn Parser::parse_module_with_seeded_const_values_internal(
     use_define_for_class_fields: detect_use_define_for_class_fields(self.src),
     deprecated_compiler_options: detect_deprecated_compiler_options(self.src),
     parameter_property_misuses: self.param_property_misuses,
+    param_optional_initializer_misuses: self.param_optional_initializer_misuses,
   }
 }
 


### PR DESCRIPTION
A parameter declared with both an optional marker (`x?`) and an initializer (`x = e`) is always a TS syntax error (TS1015).

The `?` is otherwise folded into the parameter type (`x?: T` → `T | undefined`), which is indistinguishable from a legal `x: T | undefined = e`, so the conflict is recorded at parse time via a new `param_optional_initializer_misuses` list on the Parser / TsModule (mirroring the existing `parameter_property_misuses`) and surfaced by the checker.

## Validation
- Whole-corpus oracle (`--max-fp 0`): TP 1680 → 1682, **0 false positives**.
- Pinned conformance recall: **647 → 648/815** (`callSignatureWithOptionalParameterAndInitializer`), precision 414/414 (0 FP).
- Full suite: 2363/2363 green. Whitebox-tested (optional+init flags; bare optional and explicit `| undefined = e` stay silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_