### PR TITLE
checker: TS2392 multiple constructor implementations are not allowed

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1605,6 +1605,18 @@ conformance sources (`.errors.txt` baseline = ground truth):
     surfaced by the checker. Whole-corpus TP 1680 -> 1682, 0 FP; pinned recall
     647 -> 648 (callSignatureWithOptionalParameterAndInitializer). Whitebox-tested.
 
+2026-06-25 (T111)  649/815 (79 %)        414/414 ( 0 FP)   TS2392 multiple constructor implementations
+
+  T111 -- TS2392 ("Multiple constructor implementations are not allowed"). A
+    class with two or more `constructor(...) { ... }` bodies (vs. bodyless
+    overload signatures) is an error. `parse_class_body` now counts
+    body-bearing constructors and, when >= 2, records a `<multiple-ctor-impl>`
+    sentinel in the class's existing duplicate-member channel; the checker maps
+    that sentinel to the dedicated diagnostic. A single implementation with any
+    number of bodyless overload signatures stays silent. Whole-corpus TP
+    1682 -> 1683, 0 FP; pinned recall 648 -> 649
+    (classWithTwoConstructorDefinitions). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -15246,10 +15246,18 @@ fn check_class_duplicate_members(module_ : @ast.TsModule) -> Array[ExprIssue] {
   let issues : Array[ExprIssue] = []
   for cls in module_.classes {
     for name in cls.duplicate_member_names {
-      issues.push({
-        path: "class \{cls.name}",
-        message: "duplicate identifier `\{name}`",
-      })
+      if name == "<multiple-ctor-impl>" {
+        // TS2392: the parser recorded two or more constructor implementations.
+        issues.push({
+          path: "class \{cls.name}",
+          message: "multiple constructor implementations are not allowed",
+        })
+      } else {
+        issues.push({
+          path: "class \{cls.name}",
+          message: "duplicate identifier `\{name}`",
+        })
+      }
     }
   }
   issues

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -9835,3 +9835,23 @@ test "expr_check: parameter optional marker plus initializer (TS1015)" {
   // An explicit `| undefined` type with an initializer is legal (no `?`).
   @test.assert_eq(issues("function k(x: number | undefined = 1) {}"), 0)
 }
+
+///|
+test "expr_check: multiple constructor implementations (TS2392)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Two constructor implementations (both with bodies) is an error.
+  assert_true(
+    issues("class C { constructor() {} constructor(x: number) {} }") > 0,
+  )
+  // A single implementation preceded by bodyless overload signatures is legal.
+  @test.assert_eq(
+    issues(
+      "class D { constructor(x: number); constructor(x: string); constructor(x: any) {} }",
+    ),
+    0,
+  )
+  // A single constructor is fine.
+  @test.assert_eq(issues("class E { constructor(x: number) {} }"), 0)
+}

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -1030,12 +1030,17 @@ fn Parser::parse_class_body(
   Array[String],
   Array[String],
   Array[String],
+  Int,
 ) raise ParseError {
   let _ = self.expect(LBrace)
   // Class body is implicitly strict mode
   let prev_strict = self.in_strict
   self.in_strict = true
   let mut ctor : @ast.TsFunc? = None
+  // Count constructor *implementations* (a `constructor(...) { ... }` with a
+  // real body). Two or more is TS2392 ("Multiple constructor implementations
+  // are not allowed").
+  let mut ctor_impl_count = 0
   let elements : Array[ClassElement] = []
   // Names declared `private` / `protected`, collected so the class decl
   // can expose member visibility to the checker (TS2341 / TS2445).
@@ -1216,7 +1221,12 @@ fn Parser::parse_class_body(
       } else {
         Any
       }
-      let body = if self.match_(Semicolon) {
+      let consumed_semi = self.match_(Semicolon)
+      // A real `{ ... }` body marks an *implementation* (vs. a bodyless
+      // overload signature). Used below to count constructor implementations
+      // for TS2392.
+      let has_body_block = not(consumed_semi) && self.check(LBrace)
+      let body = if consumed_semi {
         @ast.TsBlock::{ stmts: [], stmt_positions: [] }
       } else if !self.check(LBrace) {
         // Overload signature with no body and no trailing `;` (relying on
@@ -1288,6 +1298,9 @@ fn Parser::parse_class_body(
         is_async: is_async_method,
       }
       if accessor_kind is None && key is Name("constructor") && !is_static {
+        if has_body_block {
+          ctor_impl_count += 1
+        }
         ctor = Some(func)
         // Materialize TS "parameter properties" (`constructor(readonly x:
         // T)`) as real instance fields so the checker can see them — this
@@ -1355,7 +1368,9 @@ fn Parser::parse_class_body(
   }
   let _ = self.expect(RBrace)
   self.in_strict = prev_strict
-  (ctor, elements, private_members, protected_members, abstract_members)
+  (
+    ctor, elements, private_members, protected_members, abstract_members, ctor_impl_count,
+  )
 }
 
 ///|
@@ -1399,7 +1414,14 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
   let brand = "__private_brand__" + brand_id.to_string()
   let prev_brand = self.current_class_brand
   self.current_class_brand = Some(brand)
-  let (ctor_opt, elements, private_members, protected_members, abstract_members) = self.parse_class_body()
+  let (
+    ctor_opt,
+    elements,
+    private_members,
+    protected_members,
+    abstract_members,
+    _,
+  ) = self.parse_class_body()
   self.current_class_brand = prev_brand
   self.restore_local_type_param_bounds(class_type_param_bound_len)
   // Self-extending classes (`class C extends C {}`) intentionally
@@ -2051,13 +2073,27 @@ fn Parser::parse_class_decl_with_abstract(
   let brand = "__private_brand__" + brand_id.to_string()
   let prev_brand = self.current_class_brand
   self.current_class_brand = Some(brand)
-  let (ctor_opt, elements, private_members, protected_members, abstract_members) = self.parse_class_body()
+  let (
+    ctor_opt,
+    elements,
+    private_members,
+    protected_members,
+    abstract_members,
+    ctor_impl_count,
+  ) = self.parse_class_body()
   self.current_class_brand = prev_brand
   self.restore_local_type_param_bounds(class_type_param_bound_len)
   let runtime_decl = build_runtime_class_decl(
     name, class_type_params, class_type_param_bounds, ctor_opt, elements, is_abstract,
     private_members, protected_members, abstract_members, implements_names,
   )
+  // TS2392: two or more constructor implementations. Recorded via the class's
+  // duplicate-member channel with a sentinel name so the checker can surface
+  // the dedicated diagnostic. A single implementation (with any number of
+  // bodyless overload signatures) is legal and leaves the count at 1.
+  if ctor_impl_count >= 2 {
+    runtime_decl.duplicate_member_names.push("<multiple-ctor-impl>")
+  }
   self.last_runtime_class_decl = Some(runtime_decl)
   // When the class extends another class, the IIFE desugar below
   // produces a `super(…)` call outside a real class body — V8


### PR DESCRIPTION
A class with two or more constructor *implementations* (each a `constructor(...) { ... }` with a real body, as opposed to a bodyless overload signature) is a TS error (TS2392).

`parse_class_body` now counts body-bearing constructors and, when there are two or more, records a `<multiple-ctor-impl>` sentinel in the class's existing duplicate-member channel; the checker maps that sentinel to the dedicated diagnostic. A single implementation preceded by any number of bodyless overload signatures stays silent.

## Validation
- Whole-corpus oracle (`--max-fp 0`): TP 1682 → 1683, **0 false positives**.
- Pinned conformance recall: **648 → 649/815** (`classWithTwoConstructorDefinitions`), precision 414/414 (0 FP).
- Full suite: 2364/2364 green. Whitebox-tested (two impls flag; overload sigs + single impl stay silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_