### PR TITLE
checker: TS1245 abstract method cannot have an implementation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1628,6 +1628,17 @@ conformance sources (`.errors.txt` baseline = ground truth):
     Whole-corpus TP 1683 -> 1687, 0 FP; pinned recall 649 -> 651 (privateIndexer,
     publicIndexer). Whitebox-tested.
 
+2026-06-25 (T113)  652/815 (80 %)        414/414 ( 0 FP)   TS1245 abstract method with implementation
+
+  T113 -- TS1245 ("Method cannot have an implementation because it is marked
+    abstract"). A method/accessor with the `abstract` modifier and a real
+    `{ ... }` body (vs. the valid bodyless `abstract foo();`) is an error.
+    `parse_class_body` reuses the `has_body_block` signal (added for TS2392)
+    and records an `<abstract-impl>` sentinel in the duplicate-member channel
+    when an abstract member has a body. Whole-corpus TP 1687 -> 1688, 0 FP;
+    pinned recall 651 -> 652 (classAbstractMethodWithImplementation).
+    Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -15258,6 +15258,12 @@ fn check_class_duplicate_members(module_ : @ast.TsModule) -> Array[ExprIssue] {
           path: "class \{cls.name}",
           message: "accessibility modifier cannot appear on an index signature",
         })
+      } else if name == "<abstract-impl>" {
+        // TS1245: an abstract method cannot have an implementation.
+        issues.push({
+          path: "class \{cls.name}",
+          message: "an abstract method cannot have an implementation",
+        })
       } else {
         issues.push({
           path: "class \{cls.name}",

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -9868,3 +9868,16 @@ test "expr_check: accessibility modifier on index signature (TS1071)" {
   // A plain index signature is fine.
   @test.assert_eq(issues("class F { [x: string]: number; }"), 0)
 }
+
+///|
+test "expr_check: abstract method with implementation (TS1245)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // An abstract method that carries a body is always an error.
+  assert_true(issues("abstract class A { abstract foo() {} }") > 0)
+  // A bodyless abstract signature is the valid form.
+  @test.assert_eq(issues("abstract class B { abstract foo(): void; }"), 0)
+  // A concrete method with a body is fine.
+  @test.assert_eq(issues("class C { foo(): void {} }"), 0)
+}

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -1032,6 +1032,7 @@ fn Parser::parse_class_body(
   Array[String],
   Int,
   Bool,
+  Bool,
 ) raise ParseError {
   let _ = self.expect(LBrace)
   // Class body is implicitly strict mode
@@ -1045,6 +1046,10 @@ fn Parser::parse_class_body(
   // Set when an accessibility modifier (`public` / `private` / `protected`)
   // was written on an index signature -- always TS1071.
   let mut index_sig_modifier_misuse = false
+  // Set when an `abstract` method / accessor was given a real body -- always
+  // TS1245 ("Method cannot have an implementation because it is marked
+  // abstract").
+  let mut abstract_member_with_body = false
   let elements : Array[ClassElement] = []
   // Names declared `private` / `protected`, collected so the class decl
   // can expose member visibility to the checker (TS2341 / TS2445).
@@ -1348,6 +1353,12 @@ fn Parser::parse_class_body(
           }
         }
       } else {
+        // TS1245: an `abstract` method / accessor cannot carry a body. A
+        // bodyless `abstract foo();` is the valid form; a real `{ ... }` body
+        // is always an error.
+        if is_abstract_member && has_body_block {
+          abstract_member_with_body = true
+        }
         elements.push(Method(is_static, key, accessor_kind, func))
       }
     } else {
@@ -1388,7 +1399,7 @@ fn Parser::parse_class_body(
   self.in_strict = prev_strict
   (
     ctor, elements, private_members, protected_members, abstract_members, ctor_impl_count,
-    index_sig_modifier_misuse,
+    index_sig_modifier_misuse, abstract_member_with_body,
   )
 }
 
@@ -1439,6 +1450,7 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
     private_members,
     protected_members,
     abstract_members,
+    _,
     _,
     _,
   ) = self.parse_class_body()
@@ -2101,6 +2113,7 @@ fn Parser::parse_class_decl_with_abstract(
     abstract_members,
     ctor_impl_count,
     index_sig_modifier_misuse,
+    abstract_member_with_body,
   ) = self.parse_class_body()
   self.current_class_brand = prev_brand
   self.restore_local_type_param_bounds(class_type_param_bound_len)
@@ -2119,6 +2132,10 @@ fn Parser::parse_class_decl_with_abstract(
   // channel; always an error, so false-positive-free.
   if index_sig_modifier_misuse {
     runtime_decl.duplicate_member_names.push("<index-sig-modifier>")
+  }
+  // TS1245: an `abstract` method with a body. Same sentinel channel.
+  if abstract_member_with_body {
+    runtime_decl.duplicate_member_names.push("<abstract-impl>")
   }
   self.last_runtime_class_decl = Some(runtime_decl)
   // When the class extends another class, the IIFE desugar below


### PR DESCRIPTION
A method or accessor declared `abstract` with a real `{ ... }` body (as opposed to the valid bodyless `abstract foo();`) is a TS error (TS1245).

`parse_class_body` reuses the `has_body_block` signal added for TS2392 and records an `<abstract-impl>` sentinel in the class's duplicate-member channel when an abstract member carries a body; the checker maps it to the dedicated diagnostic.

## Validation
- Whole-corpus oracle (`--max-fp 0`): TP 1687 → 1688, **0 false positives**.
- Pinned conformance recall: **651 → 652/815** (`classAbstractMethodWithImplementation`), precision 414/414 (0 FP).
- Full suite: 2366/2366 green. Whitebox-tested (abstract+body flags; bodyless abstract sig and concrete method stay silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_