### PR TITLE
checker: TS2554 arity check for inherited constructors

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1639,6 +1639,19 @@ conformance sources (`.errors.txt` baseline = ground truth):
     pinned recall 651 -> 652 (classAbstractMethodWithImplementation).
     Whitebox-tested.
 
+2026-06-25 (T114)  654/815 (80 %)        414/414 ( 0 FP)   TS2554 inherited constructor arity
+
+  T114 -- TS2554 ("Expected N arguments, but got M") for an *inherited*
+    constructor. A derived class with no own constructor inherits the nearest
+    ancestor's signature; `lookup_constructor_sig` previously returned `None`
+    (skip) whenever a class had a base, so `new Derived()` against a base
+    `constructor(x)` went unchecked. Added `lookup_inherited_constructor_sig`,
+    which walks the named-base heritage chain to the nearest explicit
+    constructor (bailing to `None` on an expression base, unresolvable/external
+    ancestor, or cycle — never assuming zero args). Whole-corpus TP 1688 ->
+    1690, 0 FP; pinned recall 652 -> 654 (derivedClassWithoutExplicitConstructor,
+    derivedClassWithoutExplicitConstructor2). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -2930,14 +2930,71 @@ fn Resolver::lookup_constructor_sig(
         }
         // No explicit constructor. With no base class the constructor is the
         // implicit zero-arg one, so its arity is known exactly. With a base
-        // (named or expression heritage) the constructor is *inherited*, and
-        // we don't resolve the base's parameter list here -- return `None` so
-        // the call site skips arity / argument checks rather than assuming
-        // zero parameters (which would be a false positive on `new Derived(x)`
-        // when the base takes `x`).
-        None => if cls.base_names.length() == 0 { Some(([], [])) } else { None }
+        // the constructor is *inherited* from the nearest ancestor that
+        // declares one -- resolve it by walking the heritage chain so
+        // `new Derived()` is checked against the base's parameter list
+        // (TS2554). The walk bails to `None` (skip the check) on an expression
+        // base or an unresolvable / cyclic ancestor, never assuming zero args.
+        None =>
+          if cls.base_names.length() == 0 {
+            Some(([], []))
+          } else {
+            self.lookup_inherited_constructor_sig(cls.base_names[0], Map::new())
+          }
       }
     None => None
+  }
+}
+
+///|
+/// Walk the heritage chain (named bases only) to the nearest ancestor that
+/// declares an explicit constructor, returning its signature. Returns `None`
+/// — so the caller skips arity / argument checks — when the chain reaches an
+/// expression base, an unresolvable / external class, or a cycle. A *resolved*
+/// implicit zero-arg ancestor yields `Some(([], []))`, which correctly flags
+/// `new Derived(x)` on a zero-arg base. `seen` guards against an `extends`
+/// cycle.
+fn Resolver::lookup_inherited_constructor_sig(
+  self : Resolver,
+  class_name : String,
+  seen : Map[String, Unit],
+) -> (Array[@ast.TsType], Array[@ast.TsParam])? {
+  if seen.contains(class_name) {
+    return None
+  }
+  seen[class_name] = ()
+  let cls = match self.classes.get(class_name) {
+    Some(c) => c
+    None => return None
+  }
+  // An expression base (`extends mixin(Base)`) hides the real constructor.
+  if cls.base_names.contains("<expr-base>") {
+    return None
+  }
+  match cls.constructor_params {
+    Some(params) => {
+      let types : Array[@ast.TsType] = []
+      let sig : Array[@ast.TsParam] = []
+      for idx, p in params {
+        types.push(p.1)
+        let is_rest = idx < cls.constructor_param_is_rest.length() &&
+          cls.constructor_param_is_rest[idx]
+        sig.push({
+          name: p.0,
+          binding: None,
+          is_rest,
+          type_: p.1,
+          default: None,
+        })
+      }
+      Some((types, sig))
+    }
+    None =>
+      if cls.base_names.length() == 0 {
+        Some(([], []))
+      } else {
+        self.lookup_inherited_constructor_sig(cls.base_names[0], seen)
+      }
   }
 }
 

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -9881,3 +9881,30 @@ test "expr_check: abstract method with implementation (TS1245)" {
   // A concrete method with a body is fine.
   @test.assert_eq(issues("class C { foo(): void {} }"), 0)
 }
+
+///|
+test "expr_check: inherited constructor arity (TS2554)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A derived class with no own constructor inherits the base's signature;
+  // `new Derived()` with too few arguments is an error.
+  assert_true(
+    issues(
+      "class Base { constructor(x: number) {} } class Derived extends Base {} let d = new Derived();",
+    ) >
+    0,
+  )
+  // Supplying the inherited argument is fine.
+  @test.assert_eq(
+    issues(
+      "class Base { constructor(x: number) {} } class Derived extends Base {} let d = new Derived(1);",
+    ),
+    0,
+  )
+  // A zero-arg base inherited through a derived class stays silent.
+  @test.assert_eq(
+    issues("class Base {} class Derived extends Base {} let d = new Derived();"),
+    0,
+  )
+}


### PR DESCRIPTION
A derived class with no own constructor inherits the nearest ancestor's signature. `lookup_constructor_sig` previously returned `None` (skipping arity/argument checks) whenever a class had a base, so `new Derived()` against a base `constructor(x: number)` went unchecked (TS2554).

Added `lookup_inherited_constructor_sig`, which walks the named-base heritage chain to the nearest explicit constructor, bailing to `None` on an expression base, an unresolvable/external ancestor, or a cycle — never assuming zero arguments.

## Validation
- Whole-corpus oracle (`--max-fp 0`): TP 1688 → 1690, **0 false positives**.
- Pinned conformance recall: **652 → 654/815** (`derivedClassWithoutExplicitConstructor`, `*2`), precision 414/414 (0 FP).
- Full suite: 2367/2367 green. Whitebox-tested (too-few-args flags; correct arg count and zero-arg base stay silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_