### PR TITLE
checker: flag instance field initializer referencing constructor parameter

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1665,6 +1665,18 @@ conformance sources (`.errors.txt` baseline = ground truth):
     0 FP; pinned recall 654 -> 655 (classAbstractOverrideWithAbstract).
     Whitebox-tested.
 
+2026-06-25 (T116)  657/815 (81 %)        414/414 ( 0 FP)   TS2301/2663/2844 field init references ctor param
+
+  T116 -- TS2301 / TS2663 / TS2844: an instance member initializer (or its
+    `typeof` type annotation) may not reference a constructor parameter by its
+    bare name -- the parameter is not in scope where field initializers run
+    (`this.x` is required). `check_field_init_references_ctor_param` flags a
+    *direct* `field = x` initializer or `field: typeof x` annotation whose name
+    matches a constructor parameter; restricting to direct references means a
+    name shadowed by a nested binding in a compound initializer can never FP.
+    Whole-corpus TP 1691 -> 1693, 0 FP; pinned recall 655 -> 657
+    (initializerReferencingConstructorParameters, +1 more). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -15073,6 +15073,67 @@ fn check_unimplemented_abstract_members(
 }
 
 ///|
+/// TS2301 / TS2663 / TS2844: an instance member initializer (or its `typeof`
+/// type annotation) may not reference a constructor parameter by its bare name
+/// -- the parameter is not in scope where field initializers are evaluated
+/// (`this.x` is required instead). Restricted to a *direct* `x` initializer or
+/// `typeof x` annotation so a name shadowed by a nested binding inside a
+/// compound initializer can never produce a false positive.
+fn check_field_init_references_ctor_param(
+  module_ : @ast.TsModule,
+) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  for cls in module_.classes {
+    let params : Map[String, Unit] = {}
+    match cls.constructor_params {
+      Some(ps) =>
+        for p in ps {
+          params[p.0] = ()
+        }
+      None => continue
+    }
+    if params.is_empty() {
+      continue
+    }
+    // Direct value initializer `field = x`.
+    for fi in cls.instance_field_inits {
+      match fi.1 {
+        Var(n) =>
+          if params.contains(n) {
+            issues.push({
+              path: "class \{cls.name}.\{fi.0}",
+              message: "instance member initializer cannot reference constructor parameter `\{n}`",
+            })
+          }
+        _ => ()
+      }
+    }
+    // Direct `typeof x` type annotation on a non-static field.
+    for p in cls.properties {
+      if p.is_static {
+        continue
+      }
+      match p.type_ {
+        TypeOf(q) => {
+          let base = match q.find(".") {
+            Some(i) => q.substring(start=0, end=i)
+            None => q
+          }
+          if params.contains(base) {
+            issues.push({
+              path: "class \{cls.name}.\{p.name}",
+              message: "instance member type cannot reference constructor parameter `\{base}`",
+            })
+          }
+        }
+        _ => ()
+      }
+    }
+  }
+  issues
+}
+
+///|
 fn check_structural_duplicates(module_ : @ast.TsModule) -> Array[ExprIssue] {
   let issues : Array[ExprIssue] = []
   for e in module_.enums {
@@ -16051,6 +16112,9 @@ fn check_module_function_bodies_layered(
     all.push(issue)
   }
   for issue in check_unimplemented_abstract_members(module_, resolver) {
+    all.push(issue)
+  }
+  for issue in check_field_init_references_ctor_param(module_) {
     all.push(issue)
   }
   for issue in check_rest_param_position(module_) {

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -9934,3 +9934,24 @@ test "expr_check: unimplemented inherited abstract member (TS2515)" {
     0,
   )
 }
+
+///|
+test "expr_check: field initializer references constructor parameter (TS2301/2844)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A bare field initializer referencing a constructor parameter is an error.
+  assert_true(issues("class C { a = x; constructor(x: number) {} }") > 0)
+  // A `typeof x` field-type annotation referencing a parameter is an error.
+  assert_true(issues("class D { b: typeof x; constructor(x: number) {} }") > 0)
+  // `this.x` is the correct form and stays silent.
+  @test.assert_eq(
+    issues("class E { a = this.x; constructor(x: number) {} }"),
+    0,
+  )
+  // Referencing an outer binding (not a parameter) is fine.
+  @test.assert_eq(
+    issues("const y = 1; class G { a = y; constructor(z: number) {} }"),
+    0,
+  )
+}


### PR DESCRIPTION
An instance member initializer (`a = x`) or its `typeof` type annotation (`b: typeof x`) may not reference a constructor parameter by its bare name — the parameter is not in scope where field initializers are evaluated (`this.x` is required) (TS2301 / TS2663 / TS2844).

`check_field_init_references_ctor_param` flags a *direct* `field = x` initializer or `field: typeof x` annotation whose name matches a constructor parameter. Restricting to direct references keeps a name shadowed by a nested binding in a compound initializer from ever producing a false positive.

## Validation
- Whole-corpus oracle (`--max-fp 0`): TP 1691 → 1693, **0 false positives**.
- Pinned conformance recall: **655 → 657/815** (`initializerReferencingConstructorParameters`), precision 414/414 (0 FP).
- Full suite: 2369/2369 green. Whitebox-tested (`this.x` and outer-binding references stay silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_