### PR TITLE
checker: surface structural diagnostics from nested classes + private-name duplicates

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1677,6 +1677,19 @@ conformance sources (`.errors.txt` baseline = ground truth):
     Whole-corpus TP 1691 -> 1693, 0 FP; pinned recall 655 -> 657
     (initializerReferencingConstructorParameters, +1 more). Whitebox-tested.
 
+2026-06-25 (T117)  658/815 (81 %)        414/414 ( 0 FP)   nested-class structural diagnostics + private-name dups
+
+  T117 -- generalized the parse-time class-body structural checks (duplicate
+    members, `<multiple-ctor-impl>` / `<index-sig-modifier>` / `<abstract-impl>`
+    sentinels) to classes *nested* in function bodies, which the IIFE lowering
+    drops from `module_.classes`. The parser now collects every class's
+    `duplicate_member_names` into `collected_class_dups` -> `TsModule
+    .class_dup_diagnostics`; `check_class_duplicate_members` reads that superset
+    (dedup by class+name). Also restored private-name duplicate detection
+    (`#foo` declared twice; only a get/set pair is legal; private names share a
+    static/instance namespace). Whole-corpus TP 1693 -> 1694, 0 FP; pinned
+    recall 657 -> 658 (privateNameDuplicateField). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/ast/types.mbt
+++ b/src/ast/types.mbt
@@ -867,6 +867,13 @@ pub(all) struct TsModule {
   // records one parameter name per offending declaration; the checker
   // surfaces one diagnostic per entry. Empty for well-formed input.
   param_optional_initializer_misuses : Array[String]
+  // Class-body structural diagnostics for every class parsed (top-level *and*
+  // nested in function bodies). Each entry is `(class_name, names)` where
+  // `names` is the class's `duplicate_member_names` (duplicate members plus
+  // the `<multiple-ctor-impl>` / `<index-sig-modifier>` / `<abstract-impl>`
+  // sentinels). Lets the checker flag nested classes that the IIFE lowering
+  // drops from `classes`. Empty for well-formed input.
+  class_dup_diagnostics : Array[(String, Array[String])]
 } derive(Debug)
 
 ///|

--- a/src/bridge/moonbit_decl.mbt
+++ b/src/bridge/moonbit_decl.mbt
@@ -420,6 +420,7 @@ async fn load_decl_module_info(
           deprecated_compiler_options: [],
           parameter_property_misuses: [],
           param_optional_initializer_misuses: [],
+          class_dup_diagnostics: [],
         }
       }
   }
@@ -9222,6 +9223,7 @@ pub async fn emit_moonbit_decl_from_entry_path(
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
     param_optional_initializer_misuses: [],
+    class_dup_diagnostics: [],
   }
   // Run the checker over the final module shape and surface anything it
   // catches as a generator-level note. The emit pipeline is internally

--- a/src/checker/check_module_wbtest.mbt
+++ b/src/checker/check_module_wbtest.mbt
@@ -16,6 +16,7 @@ fn empty_module_for_check() -> @ast.TsModule {
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
     param_optional_initializer_misuses: [],
+    class_dup_diagnostics: [],
     top_level_stmts: [],
   }
 }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -15484,29 +15484,37 @@ fn check_type_undeclared_tps(
 /// accessor in one class body), so this is false-positive-free.
 fn check_class_duplicate_members(module_ : @ast.TsModule) -> Array[ExprIssue] {
   let issues : Array[ExprIssue] = []
-  for cls in module_.classes {
-    for name in cls.duplicate_member_names {
+  // `class_dup_diagnostics` carries every class parsed (top-level and nested);
+  // it is the superset of `module_.classes[].duplicate_member_names`, so it is
+  // the sole source. A `(class, name)` guard dedups in case the same class is
+  // recorded twice.
+  let seen : Map[String, Unit] = {}
+  for entry in module_.class_dup_diagnostics {
+    let cls_name = entry.0
+    for name in entry.1 {
+      let dedup_key = cls_name + "\u{0}" + name
+      if seen.contains(dedup_key) {
+        continue
+      }
+      seen[dedup_key] = ()
       if name == "<multiple-ctor-impl>" {
-        // TS2392: the parser recorded two or more constructor implementations.
         issues.push({
-          path: "class \{cls.name}",
+          path: "class \{cls_name}",
           message: "multiple constructor implementations are not allowed",
         })
       } else if name == "<index-sig-modifier>" {
-        // TS1071: an accessibility modifier on an index signature.
         issues.push({
-          path: "class \{cls.name}",
+          path: "class \{cls_name}",
           message: "accessibility modifier cannot appear on an index signature",
         })
       } else if name == "<abstract-impl>" {
-        // TS1245: an abstract method cannot have an implementation.
         issues.push({
-          path: "class \{cls.name}",
+          path: "class \{cls_name}",
           message: "an abstract method cannot have an implementation",
         })
       } else {
         issues.push({
-          path: "class \{cls.name}",
+          path: "class \{cls_name}",
           message: "duplicate identifier `\{name}`",
         })
       }
@@ -15514,6 +15522,8 @@ fn check_class_duplicate_members(module_ : @ast.TsModule) -> Array[ExprIssue] {
   }
   issues
 }
+
+///|
 
 ///|
 /// A type whose identity we can compare safely by structural / set equality:

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -321,6 +321,7 @@ fn parse_module_or_empty(src : String) -> @ast.TsModule {
         deprecated_compiler_options: [],
         parameter_property_misuses: [],
         param_optional_initializer_misuses: [],
+        class_dup_diagnostics: [],
         top_level_stmts: [],
       }
   } noraise {
@@ -9954,4 +9955,22 @@ test "expr_check: field initializer references constructor parameter (TS2301/284
     issues("const y = 1; class G { a = y; constructor(z: number) {} }"),
     0,
   )
+}
+
+///|
+test "expr_check: duplicate private name and nested-class duplicates" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A private name declared as both a field and a method is a duplicate
+  // (only a get/set pair is legal).
+  assert_true(issues("class C { #foo = 1; #foo() {} }") > 0)
+  // A get/set pair on the same private name is legal.
+  @test.assert_eq(
+    issues("class C { get #foo() { return 1 } set #foo(v: number) {} }"),
+    0,
+  )
+  // A duplicate member inside a class nested in a function body is still
+  // flagged (the IIFE lowering would otherwise drop it from `module.classes`).
+  assert_true(issues("function f() { class D { #foo = 1; #foo() {} } }") > 0)
 }

--- a/src/checker/generics_wbtest.mbt
+++ b/src/checker/generics_wbtest.mbt
@@ -104,6 +104,7 @@ test "module_alias_resolver: combines parsed aliases with stdlib utilities" {
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
     param_optional_initializer_misuses: [],
+    class_dup_diagnostics: [],
     top_level_stmts: [],
   }
   let resolve = module_alias_resolver(m)
@@ -143,6 +144,7 @@ test "module_alias_resolver: include_standard=false omits stdlib" {
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
     param_optional_initializer_misuses: [],
+    class_dup_diagnostics: [],
     top_level_stmts: [],
   }
   let resolve = module_alias_resolver(m, include_standard=false)
@@ -184,6 +186,7 @@ test "module_alias_resolver: module aliases shadow stdlib on name clash" {
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
     param_optional_initializer_misuses: [],
+    class_dup_diagnostics: [],
     top_level_stmts: [],
   }
   let resolve = module_alias_resolver(m)

--- a/src/checker/validate_wbtest.mbt
+++ b/src/checker/validate_wbtest.mbt
@@ -16,6 +16,7 @@ fn empty_module() -> @ast.TsModule {
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
     param_optional_initializer_misuses: [],
+    class_dup_diagnostics: [],
     top_level_stmts: [],
   }
 }

--- a/src/cmd/mtsc/main.mbt
+++ b/src/cmd/mtsc/main.mbt
@@ -424,6 +424,7 @@ async fn mtsc_load_bundle_files(
           deprecated_compiler_options: [],
           parameter_property_misuses: [],
           param_optional_initializer_misuses: [],
+          class_dup_diagnostics: [],
           top_level_stmts: [],
         }
     }
@@ -634,6 +635,7 @@ async fn main {
           deprecated_compiler_options: [],
           parameter_property_misuses: [],
           param_optional_initializer_misuses: [],
+          class_dup_diagnostics: [],
           top_level_stmts: [],
         })
         let local_names : Array[String] = []
@@ -747,6 +749,7 @@ async fn main {
             deprecated_compiler_options: [],
             parameter_property_misuses: [],
             param_optional_initializer_misuses: [],
+            class_dup_diagnostics: [],
             top_level_stmts: [],
           })
           // Filter exports through the entry's `@internal` set so

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -279,6 +279,11 @@ fn build_runtime_class_decl(
   // pair.
   let counts : Map[String, Array[Int]] = {} // key -> [field, get, set, method]
   let key_name : Map[String, String] = {}
+  // Private names (`#foo`) share a *single* namespace across the static and
+  // instance halves of a class (a static `#foo` and an instance `#foo`
+  // collide, TS2804), unlike public members. Accumulate them separately keyed
+  // by the bare name with no `|s` / `|i` split.
+  let priv_counts : Map[String, Array[Int]] = {}
   for element in elements {
     let (name, is_static, slot) = match element {
       Field(s, Name(n), _, _, _, _) => (n, s, 0)
@@ -288,6 +293,19 @@ fn build_runtime_class_decl(
       _ => continue
     }
     if !is_public_runtime_class_member_name(name) {
+      // Only `#name` private identifiers participate; `<computed>` and other
+      // non-public synthetic names are skipped (we can't reason about them).
+      if name.has_prefix("#") {
+        let c = match priv_counts.get(name) {
+          Some(existing) => existing
+          None => {
+            let fresh = [0, 0, 0, 0]
+            priv_counts[name] = fresh
+            fresh
+          }
+        }
+        c[slot] += 1
+      }
       continue
     }
     let key = if is_static { name + "|s" } else { name + "|i" }
@@ -316,6 +334,27 @@ fn build_runtime_class_decl(
     if is_dup && !(dup_seen.get(key) is Some(_)) {
       dup_seen[key] = ()
       duplicate_member_names.push(key_name.get(key).unwrap())
+    }
+  }
+  // Private-name duplicates (TS2300 / TS2804). The only legal repeat of a
+  // private name is a getter + setter pair (ng=ns=1, nf=nm=0 — none of the
+  // clauses fire). Pure method multiplicity is left silent to match the public
+  // rule and avoid any overload-shape false positive.
+  for name, c in priv_counts {
+    let nf = c[0]
+    let ng = c[1]
+    let ns = c[2]
+    let nm = c[3]
+    // Two data fields of the same private name is also always a duplicate
+    // (`nf >= 2`); the only legal repeat is a getter + setter pair.
+    let is_dup = nf >= 2 ||
+      (nf >= 1 && nf + ng + ns + nm > nf) ||
+      ng >= 2 ||
+      ns >= 2 ||
+      ((ng >= 1 || ns >= 1) && nm >= 1)
+    if is_dup && !(dup_seen.get(name) is Some(_)) {
+      dup_seen[name] = ()
+      duplicate_member_names.push(name)
     }
   }
   {
@@ -2136,6 +2175,15 @@ fn Parser::parse_class_decl_with_abstract(
   // TS1245: an `abstract` method with a body. Same sentinel channel.
   if abstract_member_with_body {
     runtime_decl.duplicate_member_names.push("<abstract-impl>")
+  }
+  // Surface the class's structural diagnostics for *every* class, including
+  // ones nested in function bodies that the IIFE lowering removes from
+  // `module_.classes`. The top-level collector also records these, so the
+  // checker dedups by (class, name) to avoid a double report.
+  if runtime_decl.duplicate_member_names.length() > 0 {
+    self.collected_class_dups.push(
+      (runtime_decl.name, runtime_decl.duplicate_member_names),
+    )
   }
   self.last_runtime_class_decl = Some(runtime_decl)
   // When the class extends another class, the IIFE desugar below

--- a/src/parser/parser_core.mbt
+++ b/src/parser/parser_core.mbt
@@ -83,6 +83,14 @@ pub struct Parser {
   // list to the checker. Empty for well-formed input, so it never costs
   // precision.
   param_optional_initializer_misuses : Array[String]
+  // Class-body structural diagnostics (`duplicate_member_names`, which also
+  // carries the `<multiple-ctor-impl>` / `<index-sig-modifier>` /
+  // `<abstract-impl>` sentinels) collected for *every* class parsed, including
+  // classes nested in function bodies that are lowered away (IIFE desugar) and
+  // so never reach `module_.classes`. Each entry is `(class_name, names)`.
+  // `parse_class_decl_with_abstract` appends; the checker surfaces them. Empty
+  // for well-formed input, so it never costs precision.
+  collected_class_dups : Array[(String, Array[String])]
   // Token-position → "JSDoc `/* @__PURE__ */` annotation seen
   // just before this token". The lexer populates this when it
   // skips a block comment whose contents contain the literal
@@ -160,6 +168,7 @@ pub fn Parser::new_with_strict_and_jsx(
     param_property_scopes: [],
     param_property_misuses: [],
     param_optional_initializer_misuses: [],
+    collected_class_dups: [],
     pure_marker_positions: {},
     internal_marker_positions: {},
     collected_internal_names: {},
@@ -215,6 +224,7 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
     param_property_scopes: [],
     param_property_misuses: [],
     param_optional_initializer_misuses: [],
+    collected_class_dups: [],
     pure_marker_positions: lexer.pure_marker_positions,
     internal_marker_positions: lexer.internal_marker_positions,
     collected_internal_names: {},

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -136,6 +136,7 @@ fn empty_ts_module() -> @ast.TsModule {
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
     param_optional_initializer_misuses: [],
+    class_dup_diagnostics: [],
   }
 }
 
@@ -3274,6 +3275,7 @@ fn Parser::parse_module_with_seeded_const_values_internal(
     deprecated_compiler_options: detect_deprecated_compiler_options(self.src),
     parameter_property_misuses: self.param_property_misuses,
     param_optional_initializer_misuses: self.param_optional_initializer_misuses,
+    class_dup_diagnostics: self.collected_class_dups,
   }
 }
 


### PR DESCRIPTION
Generalizes the parse-time class-body structural checks (duplicate members and the `<multiple-ctor-impl>` / `<index-sig-modifier>` / `<abstract-impl>` sentinels) to classes **nested** in function bodies, which the IIFE lowering removes from `module_.classes`.

The parser now collects every class's `duplicate_member_names` into `collected_class_dups` → `TsModule.class_dup_diagnostics`; `check_class_duplicate_members` reads that superset, deduping by `(class, name)`. Also restored private-name duplicate detection: a `#foo` declared twice is a duplicate (only a get/set pair is legal), and private names share a single static/instance namespace (TS2300 / TS2804).

## Validation
- Whole-corpus oracle (`--max-fp 0`): TP 1693 → 1694, **0 false positives**.
- Pinned conformance recall: **657 → 658/815** (`privateNameDuplicateField`), precision 414/414 (0 FP).
- Full suite: 2371/2371 green. Whitebox-tested (private field+method dup flags; get/set pair and nested duplicates handled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_