### PR TITLE
checker: TS2423/2426 method&lt;-&gt;accessor override mismatch

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1690,6 +1690,19 @@ conformance sources (`.errors.txt` baseline = ground truth):
     static/instance namespace). Whole-corpus TP 1693 -> 1694, 0 FP; pinned
     recall 657 -> 658 (privateNameDuplicateField). Whitebox-tested.
 
+2026-06-25 (T118)  660/815 (81 %)        414/414 ( 0 FP)   TS2423/2426 method<->accessor override mismatch
+
+  T118 -- TS2423 ("base defines a method, derived defines an accessor") and
+    TS2426 (the reverse). A method and a get/set accessor are structurally
+    incompatible, so overriding one with the other is always an error
+    (unlike TS2610's property case, this is not flag-gated). Added
+    `nearest_ancestor_member_kind` (reads the `accessor` field precisely, so it
+    never conflates method/accessor/abstract the way the property predicate
+    does) and `check_method_accessor_override_mismatch`; skips when the chain
+    isn't resolvable. Whole-corpus TP 1694 -> 1696, 0 FP; pinned recall
+    658 -> 660 (accessorsOverrideMethod, derivedClassFunctionOverridesBaseClassAccessor).
+    Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -14873,6 +14873,95 @@ fn check_reserved_type_alias_names(module_ : @ast.TsModule) -> Array[ExprIssue] 
 /// nearest ancestor declaration is a *data property*, `Some(false)` when it is
 /// an *accessor*, and `None` when no ancestor declares it (or the chain leaves
 /// resolvable classes — an expression base, an external class, a cycle).
+/// Walk the heritage chain (nearest first) to the first class that declares
+/// `name` (matching `is_static`), reporting its *kind*: `1` = a regular
+/// (non-accessor) method, `2` = a get/set accessor, `3` = a data property.
+/// Returns `None` when the chain reaches an unresolvable / expression base
+/// before the member is found — there the kind is unknown and the caller must
+/// not assume a mismatch. Used for TS2423 / TS2426 (a base method overridden
+/// as an accessor, or vice-versa — always an error regardless of compiler
+/// flags). Method vs. accessor is read precisely from the `accessor` field so
+/// this never conflates the two the way the property-vs-other predicate does.
+fn nearest_ancestor_member_kind(
+  resolver : Resolver,
+  start_base : String,
+  name : String,
+  is_static : Bool,
+) -> Int? {
+  let seen : Map[String, Unit] = {}
+  let mut cur = start_base
+  while not(seen.contains(cur)) {
+    seen[cur] = ()
+    let cls = match resolver.classes.get(cur) {
+      Some(c) => c
+      None => return None
+    }
+    for m in cls.methods {
+      if m.name == name && m.is_static == is_static {
+        return if m.accessor != "" { Some(2) } else { Some(1) }
+      }
+    }
+    for p in cls.properties {
+      if p.name == name && p.is_static == is_static {
+        return Some(3)
+      }
+    }
+    if cls.base_names.length() != 1 || cls.base_names[0] == "<expr-base>" {
+      return None
+    }
+    cur = cls.base_names[0]
+  }
+  None
+}
+
+///|
+/// TS2423 / TS2426: a derived class may not override a base-class *method* with
+/// an accessor, nor a base-class *accessor* with a method — the two member
+/// shapes are structurally incompatible. Only fires when the nearest ancestor
+/// declaration's kind is known (resolvable chain), so it is false-positive-free.
+fn check_method_accessor_override_mismatch(
+  module_ : @ast.TsModule,
+  resolver : Resolver,
+) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  for cls in module_.classes {
+    if cls.base_names.length() != 1 || cls.base_names[0] == "<expr-base>" {
+      continue
+    }
+    let base = cls.base_names[0]
+    let reported : Map[String, Unit] = {}
+    for m in cls.methods {
+      if reported.contains(m.name) {
+        continue
+      }
+      let derived_is_accessor = m.accessor != ""
+      match nearest_ancestor_member_kind(resolver, base, m.name, m.is_static) {
+        // Derived accessor over a base regular method.
+        Some(1) =>
+          if derived_is_accessor {
+            reported[m.name] = ()
+            issues.push({
+              path: "class \{cls.name}.\{m.name}",
+              message: "`\{m.name}` is defined as a method in a base class but is overridden here as an accessor",
+            })
+          }
+        // Derived regular method over a base accessor.
+        Some(2) =>
+          if not(derived_is_accessor) {
+            reported[m.name] = ()
+            issues.push({
+              path: "class \{cls.name}.\{m.name}",
+              message: "`\{m.name}` is defined as an accessor in a base class but is overridden here as a method",
+            })
+          }
+        _ => ()
+      }
+    }
+  }
+  issues
+}
+
+///|
 fn nearest_ancestor_member_is_property(
   resolver : Resolver,
   start_base : String,
@@ -16125,6 +16214,9 @@ fn check_module_function_bodies_layered(
     all.push(issue)
   }
   for issue in check_field_init_references_ctor_param(module_) {
+    all.push(issue)
+  }
+  for issue in check_method_accessor_override_mismatch(module_, resolver) {
     all.push(issue)
   }
   for issue in check_rest_param_position(module_) {

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -9974,3 +9974,26 @@ test "expr_check: duplicate private name and nested-class duplicates" {
   // flagged (the IIFE lowering would otherwise drop it from `module.classes`).
   assert_true(issues("function f() { class D { #foo = 1; #foo() {} } }") > 0)
 }
+
+///|
+test "expr_check: method/accessor override mismatch (TS2423/2426)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Base method overridden by a derived accessor (TS2423).
+  assert_true(
+    issues("class A { m() {} } class B extends A { get m() { return 1 } }") > 0,
+  )
+  // Base accessor overridden by a derived method (TS2426).
+  assert_true(
+    issues("class A { get m() { return 1 } } class B extends A { m() {} }") > 0,
+  )
+  // Same-kind overrides are fine.
+  @test.assert_eq(issues("class A { m() {} } class B extends A { m() {} }"), 0)
+  @test.assert_eq(
+    issues(
+      "class A { get m() { return 1 } } class B extends A { get m() { return 2 } }",
+    ),
+    0,
+  )
+}


### PR DESCRIPTION
A base-class method overridden by a derived accessor (TS2423), or a base accessor overridden by a derived method (TS2426), is always an error — the two member shapes are structurally incompatible (and, unlike the property case TS2610, this is **not** gated on `useDefineForClassFields`).

Added `nearest_ancestor_member_kind`, which reads the `accessor` field directly so it never conflates method/accessor/abstract the way the property predicate does, and `check_method_accessor_override_mismatch`. The walk skips when the heritage chain is not fully resolvable, so it stays false-positive-free.

## Validation
- Whole-corpus oracle (`--max-fp 0`): TP 1694 → 1696, **0 false positives**.
- Pinned conformance recall: **658 → 660/815** (`accessorsOverrideMethod`, `derivedClassFunctionOverridesBaseClassAccessor`), precision 414/414 (0 FP).
- Full suite: 2371/2371 green. Whitebox-tested (mismatches flag; same-kind overrides stay silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_