### PR TITLE
checker: TS2610 base accessor overridden by derived data property

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1703,6 +1703,18 @@ conformance sources (`.errors.txt` baseline = ground truth):
     658 -> 660 (accessorsOverrideMethod, derivedClassFunctionOverridesBaseClassAccessor).
     Whitebox-tested.
 
+2026-06-25 (T119)  661/815 (81 %)        414/414 ( 0 FP)   TS2610 base accessor overridden by derived property
+
+  T119 -- TS2610 ("defined as an accessor in a base class, overridden here as a
+    property"). Re-added (a first attempt was reverted for FPs) now that
+    `nearest_ancestor_member_kind` distinguishes a *true* get/set accessor
+    (kind 2) from auto-accessors and abstract properties (kind 3) -- the
+    conflation that caused the earlier FPs (abstractProperty, autoAccessor7,
+    autoAccessorAllowedModifiers). Gated on `use_define_for_class_fields`, since
+    under legacy assignment semantics the property flows through the setter and
+    is allowed. Whole-corpus TP 1696 -> 1697, 0 FP; pinned recall 660 -> 661
+    (propertyOverridesAccessors6). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -14957,6 +14957,31 @@ fn check_method_accessor_override_mismatch(
         _ => ()
       }
     }
+    // TS2610: a base-class *accessor* overridden by a derived data property.
+    // Only an error under `useDefineForClassFields` semantics (there the field
+    // uses `[[DefineOwnProperty]]`, shadowing the accessor; under the legacy
+    // assignment semantics the property flows through the setter and is
+    // allowed). `nearest_ancestor_member_kind` returns `2` only for a *true*
+    // get/set accessor — auto-accessors and abstract properties resolve to a
+    // property kind — so this no longer conflates them.
+    if module_.use_define_for_class_fields {
+      for p in cls.properties {
+        if p.is_accessor || reported.contains(p.name) {
+          continue
+        }
+        if cls.abstract_members.contains(p.name) {
+          continue
+        }
+        if nearest_ancestor_member_kind(resolver, base, p.name, p.is_static)
+          is Some(2) {
+          reported[p.name] = ()
+          issues.push({
+            path: "class \{cls.name}.\{p.name}",
+            message: "`\{p.name}` is defined as an accessor in a base class but is overridden here as a property",
+          })
+        }
+      }
+    }
   }
   issues
 }

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -9997,3 +9997,23 @@ test "expr_check: method/accessor override mismatch (TS2423/2426)" {
     0,
   )
 }
+
+///|
+test "expr_check: base accessor overridden by derived property (TS2610)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Under useDefineForClassFields, a base accessor overridden by a data
+  // property is an error.
+  assert_true(
+    issues(
+      "// @useDefineForClassFields: true\nclass A { get x() { return 1 } } class B extends A { x = 2; }",
+    ) >
+    0,
+  )
+  // Without the flag the property flows through the setter -- allowed.
+  @test.assert_eq(
+    issues("class A { get x() { return 1 } } class B extends A { x = 2; }"),
+    0,
+  )
+}


### PR DESCRIPTION
Re-adds TS2610 ("defined as an accessor in a base class, overridden here as a property") — an earlier attempt was reverted for false positives — now that `nearest_ancestor_member_kind` distinguishes a *true* get/set accessor (kind 2) from auto-accessors and abstract properties (kind 3), which is the conflation that produced the earlier FPs on `abstractProperty` / `autoAccessor7` / `autoAccessorAllowedModifiers`.

Gated on `use_define_for_class_fields`, since under the legacy assignment semantics the property flows through the inherited setter and is allowed.

## Validation
- Whole-corpus oracle (`--max-fp 0`): TP 1696 → 1697, **0 false positives** (the three prior-FP files confirmed silent).
- Pinned conformance recall: **660 → 661/815** (`propertyOverridesAccessors6`), precision 414/414 (0 FP).
- Full suite: 2372/2372 green. Whitebox-tested (flag-on errors, flag-off stays silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_