### PR TITLE
checker: TS2369 parameter property in ambient declare class

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1728,6 +1728,18 @@ conformance sources (`.errors.txt` baseline = ground truth):
     1698, 0 FP; pinned recall 661 -> 662 (superPropertyInConstructorBeforeSuperCall).
     Whitebox-tested.
 
+2026-06-25 (T121)  663/815 (81 %)        414/414 ( 0 FP)   TS2369 parameter property in ambient declare class
+
+  T121 -- TS2369 ("A parameter property is only allowed in a constructor
+    implementation") for declare-class member signatures. These go through
+    `parse_declare_signature_params`, which bypassed the misuse recording in
+    `parse_param`, so `declare class C { constructor(public x); method(readonly
+    y); }` went unflagged. The signature parser now detects a leading
+    accessibility/`readonly` modifier (only when another identifier follows, so
+    a parameter literally named `readonly` is unaffected) and records it in the
+    existing `param_property_misuses` channel. Whole-corpus TP 1698 -> 1700,
+    0 FP; pinned recall 662 -> 663 (readonlyInAmbientClass). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10038,3 +10038,18 @@ test "expr_check: super property access before super() call (TS17011)" {
     0,
   )
 }
+
+///|
+test "expr_check: parameter property in ambient declare class (TS2369)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A parameter property in an ambient `declare class` member signature has no
+  // implementation, so it is always an error.
+  assert_true(issues("declare class C { method(readonly x: number); }") > 0)
+  assert_true(issues("declare class C { constructor(public x: number); }") > 0)
+  // A plain ambient signature is fine.
+  @test.assert_eq(issues("declare class C { method(x: number): void; }"), 0)
+  // A parameter literally named `readonly` is not a modifier.
+  @test.assert_eq(issues("declare function f(readonly: number): void;"), 0)
+}

--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -1883,7 +1883,35 @@ fn Parser::parse_declare_signature_params(
   let params : Array[(String, @ast.TsType)] = []
   while !self.check(RParen) && !self.check(Eof) {
     let _ = self.match_ellipsis()
+    // A parameter-property modifier (`public` / `private` / `protected` /
+    // `readonly`) on a declare-class member signature is always TS2369: these
+    // signatures have no implementation. A leading modifier is only a modifier
+    // when another identifier (the real parameter name, or a further modifier)
+    // follows; otherwise the keyword *is* the parameter name (`readonly: T`).
+    let mut saw_param_prop_modifier = false
+    while true {
+      let is_modifier = match self.peek().kind {
+        Ident(m) =>
+          (
+            m == "public" ||
+            m == "private" ||
+            m == "protected" ||
+            m == "readonly"
+          ) &&
+          self.peek_at(1).kind is Ident(_)
+        _ => false
+      }
+      if is_modifier {
+        let _ = self.advance()
+        saw_param_prop_modifier = true
+      } else {
+        break
+      }
+    }
     let param_name = self.parse_declare_param_name()
+    if saw_param_prop_modifier {
+      self.param_property_misuses.push(param_name)
+    }
     let is_optional = self.match_(Question)
     let base_param_type = if self.check(Colon) {
       let _ = self.advance()


### PR DESCRIPTION
A parameter property (`public` / `private` / `protected` / `readonly` on a parameter) in a `declare class` member signature has no implementation, so it is always an error (TS2369).

These signatures parse through `parse_declare_signature_params`, which bypassed the misuse recording in `parse_param`. The signature parser now detects a leading accessibility/`readonly` modifier — only when another identifier follows, so a parameter literally named `readonly` is unaffected — and records it in the existing `param_property_misuses` channel.

## Validation
- Whole-corpus oracle (`--max-fp 0`): TP 1698 → 1700, **0 false positives**.
- Pinned conformance recall: **662 → 663/815** (`readonlyInAmbientClass`), precision 414/414 (0 FP).
- Full suite: 2374/2374 green (bridge declare-class emission unaffected). Whitebox-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_