### PR TITLE
checker: TS2387/2388 overload signatures mixing static and instance

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1740,6 +1740,20 @@ conformance sources (`.errors.txt` baseline = ground truth):
     existing `param_property_misuses` channel. Whole-corpus TP 1698 -> 1700,
     0 FP; pinned recall 662 -> 663 (readonlyInAmbientClass). Whitebox-tested.
 
+2026-06-25 (T122)  664/815 (81 %)        414/414 ( 0 FP)   TS2387/2388 overload signatures mixing static/instance
+
+  T122 -- TS2387/TS2388 ("Function overload must [not] be static"). Bodyless
+    overload signatures of one name may not mix static and instance. Detected
+    at parse time via the reliable `has_body_block` signal (the AST `body`
+    field can't tell an empty `{}` from a bodyless signature). A name with both
+    a static and an instance *implementation* is two distinct, legal overload
+    sets (`memberFunctionsWithPublicOverloads`), so the mix is flagged only
+    when that full instance+static impl pair is absent. Surfaced via the
+    `<overload-static-mix>` sentinel. Whole-corpus TP 1700 -> 1701, 0 FP;
+    pinned recall 663 -> 664 (memberFunctionOverloadMixingStaticAndInstance).
+    Whitebox-tested. (A first attempt using the AST `body` field FP'd and was
+    reverted before switching to the parse-time signal.)
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -15725,6 +15725,11 @@ fn check_class_duplicate_members(module_ : @ast.TsModule) -> Array[ExprIssue] {
           path: "class \{cls_name}",
           message: "an abstract method cannot have an implementation",
         })
+      } else if name == "<overload-static-mix>" {
+        issues.push({
+          path: "class \{cls_name}",
+          message: "function overload signatures must not mix static and instance",
+        })
       } else {
         issues.push({
           path: "class \{cls_name}",

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10053,3 +10053,22 @@ test "expr_check: parameter property in ambient declare class (TS2369)" {
   // A parameter literally named `readonly` is not a modifier.
   @test.assert_eq(issues("declare function f(readonly: number): void;"), 0)
 }
+
+///|
+test "expr_check: overload signatures mixing static and instance (TS2387/2388)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Bodyless overload signatures of the same name mixing static and instance.
+  assert_true(issues("class C { foo(); static foo(); }") > 0)
+  // A legal static+instance method pair (each with a body) is not flagged,
+  // even when each side also has its own overload signatures.
+  @test.assert_eq(
+    issues(
+      "class C { foo(x: number); foo(x: any) {} static foo(x: number); static foo(x: any) {} }",
+    ),
+    0,
+  )
+  // Same-kind overloads with an implementation are fine.
+  @test.assert_eq(issues("class C { foo(x: number); foo(x: any): void {} }"), 0)
+}

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -1072,6 +1072,7 @@ fn Parser::parse_class_body(
   Int,
   Bool,
   Bool,
+  Bool,
 ) raise ParseError {
   let _ = self.expect(LBrace)
   // Class body is implicitly strict mode
@@ -1089,6 +1090,19 @@ fn Parser::parse_class_body(
   // TS1245 ("Method cannot have an implementation because it is marked
   // abstract").
   let mut abstract_member_with_body = false
+  // Bodyless overload-signature method names by static-ness. A name appearing
+  // as both a static and an instance overload signature is TS2387/2388. Uses
+  // `has_body_block` (not the AST body, which can't tell an empty `{}` from a
+  // signature) so an ordinary static+instance method *pair with bodies* is not
+  // flagged.
+  let ov_static : Map[String, Unit] = {}
+  let ov_instance : Map[String, Unit] = {}
+  // Body-bearing (implementation) methods by name, per static-ness. A name
+  // with both a static and an instance *implementation* is two distinct
+  // overload sets (e.g. `foo(){}` and `static foo(){}`), which is legal even
+  // when each side also has bodyless overload signatures.
+  let impl_static : Map[String, Unit] = {}
+  let impl_instance : Map[String, Unit] = {}
   let elements : Array[ClassElement] = []
   // Names declared `private` / `protected`, collected so the class decl
   // can expose member visibility to the checker (TS2341 / TS2445).
@@ -1398,6 +1412,23 @@ fn Parser::parse_class_body(
         if is_abstract_member && has_body_block {
           abstract_member_with_body = true
         }
+        // Track bodyless overload signatures (non-accessor, non-abstract) for
+        // the TS2387/2388 static/instance-mix check.
+        if accessor_kind is None &&
+          not(is_abstract_member) &&
+          method_name != "<computed>" {
+          if has_body_block {
+            if is_static {
+              impl_static[method_name] = ()
+            } else {
+              impl_instance[method_name] = ()
+            }
+          } else if is_static {
+            ov_static[method_name] = ()
+          } else {
+            ov_instance[method_name] = ()
+          }
+        }
         elements.push(Method(is_static, key, accessor_kind, func))
       }
     } else {
@@ -1436,9 +1467,19 @@ fn Parser::parse_class_body(
   }
   let _ = self.expect(RBrace)
   self.in_strict = prev_strict
+  let mut overload_static_mix = false
+  for name in ov_instance.keys() {
+    // Bodyless signatures on both sides, but NOT a full instance+static
+    // implementation pair (which would be two distinct, legal overload sets).
+    if ov_static.contains(name) &&
+      not(impl_static.contains(name) && impl_instance.contains(name)) {
+      overload_static_mix = true
+      break
+    }
+  }
   (
     ctor, elements, private_members, protected_members, abstract_members, ctor_impl_count,
-    index_sig_modifier_misuse, abstract_member_with_body,
+    index_sig_modifier_misuse, abstract_member_with_body, overload_static_mix,
   )
 }
 
@@ -1489,6 +1530,7 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
     private_members,
     protected_members,
     abstract_members,
+    _,
     _,
     _,
     _,
@@ -2153,6 +2195,7 @@ fn Parser::parse_class_decl_with_abstract(
     ctor_impl_count,
     index_sig_modifier_misuse,
     abstract_member_with_body,
+    overload_static_mix,
   ) = self.parse_class_body()
   self.current_class_brand = prev_brand
   self.restore_local_type_param_bounds(class_type_param_bound_len)
@@ -2175,6 +2218,10 @@ fn Parser::parse_class_decl_with_abstract(
   // TS1245: an `abstract` method with a body. Same sentinel channel.
   if abstract_member_with_body {
     runtime_decl.duplicate_member_names.push("<abstract-impl>")
+  }
+  // TS2387/2388: bodyless overload signatures mixing static and instance.
+  if overload_static_mix {
+    runtime_decl.duplicate_member_names.push("<overload-static-mix>")
   }
   // Surface the class's structural diagnostics for *every* class, including
   // ones nested in function bodies that the IIFE lowering removes from


### PR DESCRIPTION
Bodyless overload signatures of one method name may not mix static and instance (TS2387/TS2388).

Detected at parse time via the reliable `has_body_block` signal (the AST `body` field can't distinguish an empty `{}` from a bodyless signature — a first attempt using it FP'd and was reverted). A name with both a static and an instance *implementation* is two distinct, legal overload sets (`memberFunctionsWithPublicOverloads`), so the mix is flagged only when that full instance+static implementation pair is absent.

## Validation
- Whole-corpus oracle (`--max-fp 0`): TP 1700 → 1701, **0 false positives**.
- Pinned conformance recall: **663 → 664/815** (`memberFunctionOverloadMixingStaticAndInstance`), precision 414/414 (0 FP).
- Full suite: 2375/2375 green. Whitebox-tested (mix without impl-pair flags; legal static+instance impl pairs and same-kind overloads stay silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_