### PR TITLE
checker: TS2391 overload signature with no implementation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1754,6 +1754,18 @@ conformance sources (`.errors.txt` baseline = ground truth):
     Whitebox-tested. (A first attempt using the AST `body` field FP'd and was
     reverted before switching to the parse-time signal.)
 
+2026-06-25 (T123)  665/815 (82 %)        414/414 ( 0 FP)   TS2391 overload signature with no implementation
+
+  T123 -- TS2391 ("Function implementation is missing or not immediately
+    following the declaration"). A bodyless overload signature in a runtime
+    (non-declare) class with no implementation of any static-ness is an error.
+    Reuses the parse-time overload/impl tracking from T122 (`has_body_block`).
+    Excludes optional methods (`foo?()` may omit its body -- the FP that the
+    first attempt hit on optionalMethods / controlFlowSuperPropertyAccess),
+    abstract members, accessors, and declare classes. Surfaced via the
+    `<overload-no-impl>` sentinel. Whole-corpus TP 1701 -> 1711 (+10), 0 FP;
+    pinned recall 664 -> 665 (classAbstractOverloads). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -15730,6 +15730,11 @@ fn check_class_duplicate_members(module_ : @ast.TsModule) -> Array[ExprIssue] {
           path: "class \{cls_name}",
           message: "function overload signatures must not mix static and instance",
         })
+      } else if name == "<overload-no-impl>" {
+        issues.push({
+          path: "class \{cls_name}",
+          message: "function implementation is missing or not immediately following the declaration",
+        })
       } else {
         issues.push({
           path: "class \{cls_name}",

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10072,3 +10072,18 @@ test "expr_check: overload signatures mixing static and instance (TS2387/2388)" 
   // Same-kind overloads with an implementation are fine.
   @test.assert_eq(issues("class C { foo(x: number); foo(x: any): void {} }"), 0)
 }
+
+///|
+test "expr_check: overload signature with no implementation (TS2391)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A bodyless method with no implementation in a runtime class is TS2391.
+  assert_true(issues("class C { foo(); }") > 0)
+  // An overload signature followed by an implementation is fine.
+  @test.assert_eq(issues("class C { foo(x: number); foo(x: any): void {} }"), 0)
+  // An optional method may omit its body.
+  @test.assert_eq(issues("class C { foo?(): number; }"), 0)
+  // Ambient declare-class signatures need no implementation.
+  @test.assert_eq(issues("declare class C { foo(): number; }"), 0)
+}

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -1073,6 +1073,7 @@ fn Parser::parse_class_body(
   Bool,
   Bool,
   Bool,
+  Bool,
 ) raise ParseError {
   let _ = self.expect(LBrace)
   // Class body is implicitly strict mode
@@ -1414,8 +1415,11 @@ fn Parser::parse_class_body(
         }
         // Track bodyless overload signatures (non-accessor, non-abstract) for
         // the TS2387/2388 static/instance-mix check.
+        // Optional methods (`foo?()`) may omit their body, so they are neither
+        // overload signatures nor missing implementations -- skip them.
         if accessor_kind is None &&
           not(is_abstract_member) &&
+          not(is_optional) &&
           method_name != "<computed>" {
           if has_body_block {
             if is_static {
@@ -1477,9 +1481,25 @@ fn Parser::parse_class_body(
       break
     }
   }
+  // TS2391: a bodyless overload signature with no implementation *of any
+  // kind*. Conservative (a name with any-side impl is left to the more precise
+  // diagnostics), so it is false-positive-free on well-formed runtime classes.
+  let mut overload_missing_impl = false
+  fn check_missing(names : Map[String, Unit]) -> Bool {
+    for name in names.keys() {
+      if not(impl_static.contains(name)) && not(impl_instance.contains(name)) {
+        return true
+      }
+    }
+    false
+  }
+
+  if check_missing(ov_instance) || check_missing(ov_static) {
+    overload_missing_impl = true
+  }
   (
     ctor, elements, private_members, protected_members, abstract_members, ctor_impl_count,
-    index_sig_modifier_misuse, abstract_member_with_body, overload_static_mix,
+    index_sig_modifier_misuse, abstract_member_with_body, overload_static_mix, overload_missing_impl,
   )
 }
 
@@ -1530,6 +1550,7 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
     private_members,
     protected_members,
     abstract_members,
+    _,
     _,
     _,
     _,
@@ -2196,6 +2217,7 @@ fn Parser::parse_class_decl_with_abstract(
     index_sig_modifier_misuse,
     abstract_member_with_body,
     overload_static_mix,
+    overload_missing_impl,
   ) = self.parse_class_body()
   self.current_class_brand = prev_brand
   self.restore_local_type_param_bounds(class_type_param_bound_len)
@@ -2222,6 +2244,10 @@ fn Parser::parse_class_decl_with_abstract(
   // TS2387/2388: bodyless overload signatures mixing static and instance.
   if overload_static_mix {
     runtime_decl.duplicate_member_names.push("<overload-static-mix>")
+  }
+  // TS2391: a bodyless overload signature with no implementation.
+  if overload_missing_impl {
+    runtime_decl.duplicate_member_names.push("<overload-no-impl>")
   }
   // Surface the class's structural diagnostics for *every* class, including
   // ones nested in function bodies that the IIFE lowering removes from


### PR DESCRIPTION
A bodyless overload signature in a runtime (non-declare) class with no implementation of any static-ness is TS2391 ("Function implementation is missing or not immediately following the declaration").

Reuses the parse-time overload/implementation tracking (`has_body_block`). Excludes optional methods (`foo?()` may omit its body — the FP the first attempt hit on `optionalMethods` / `controlFlowSuperPropertyAccess`), abstract members, accessors, and ambient declare classes.

## Validation
- Whole-corpus oracle (`--max-fp 0`): TP 1701 → **1711 (+10)**, **0 false positives**.
- Pinned conformance recall: **664 → 665/815** (`classAbstractOverloads`), precision 414/414 (0 FP).
- Full suite: 2376/2376 green. Whitebox-tested (bodyless-no-impl flags; overload+impl, optional methods, and declare classes stay silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_