### PR TITLE
checker: TS2304 capitalized-primitive type misspelling (Null/Undefined)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1766,6 +1766,24 @@ conformance sources (`.errors.txt` baseline = ground truth):
     `<overload-no-impl>` sentinel. Whole-corpus TP 1701 -> 1711 (+10), 0 FP;
     pinned recall 664 -> 665 (classAbstractOverloads). Whitebox-tested.
 
+2026-06-26 (T124)  667/815 (82 %)        414/414 ( 0 FP)   TS2304 capitalized-primitive type misspelling
+
+  T124 -- TS2304 ("Cannot find name") for the capitalized-primitive
+    misspellings `Null` / `Undefined` used as type names (`var x: Null`).
+    These are never valid TS type names (the primitives spell as the
+    lowercase literals `null` / `undefined`) and the standard library
+    declares no global by either name (verified against the generated
+    `lib_globals` registry), so a reference to one is an unambiguous
+    "Cannot find name". The check is false-positive-free: it fires only on
+    these two exact spellings and is still guarded by `module_declared_names`
+    so a module that genuinely declares `type Null` / `interface Undefined`
+    stays silent. Scans value declarations, type aliases, interface fields,
+    function signatures, and runtime top-level `var`/`let`/`const` statements
+    (the test files use bare `var x: Null;`, which is retained as a statement
+    rather than lowered into `module_.values`). Whole-corpus TP 1711 -> 1713
+    (+2), 0 FP; pinned recall 665 -> 667 (directReferenceToNull,
+    directReferenceToUndefined). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -14967,6 +14967,122 @@ fn check_reserved_type_alias_names(module_ : @ast.TsModule) -> Array[ExprIssue] 
 }
 
 ///|
+/// Collect references to the capitalized-primitive *misspellings* `Null` and
+/// `Undefined` reachable in `type_`. These are never valid TypeScript type
+/// names — the primitives spell as the lowercase literals `null` / `undefined`
+/// — and the standard library declares no global by either name (verified
+/// against the generated `lib_globals` registry). A reference to one is
+/// therefore an unambiguous "Cannot find name" (TS2304); a user who wrote
+/// `var x: Null` meant `var x: null`. Mirrors `check_type`'s structural
+/// recursion so the misspelling is found in every nested type position.
+fn collect_invalid_primitive_type_names(
+  type_ : @ast.TsType,
+  acc : Array[String],
+) -> Unit {
+  fn note(name : String) -> Unit {
+    if (name == "Null" || name == "Undefined") && !acc.contains(name) {
+      acc.push(name)
+    }
+  }
+
+  match type_ {
+    Named(name) => note(name)
+    Applied(name, args) => {
+      note(name)
+      for a in args {
+        collect_invalid_primitive_type_names(a, acc)
+      }
+    }
+    Array(inner) => collect_invalid_primitive_type_names(inner, acc)
+    Tuple(items) =>
+      for it in items {
+        collect_invalid_primitive_type_names(it, acc)
+      }
+    Object(fields) =>
+      for f in fields {
+        collect_invalid_primitive_type_names(f.0, acc)
+        collect_invalid_primitive_type_names(f.1, acc)
+      }
+    Struct(_, fields) =>
+      for f in fields {
+        collect_invalid_primitive_type_names(f.1, acc)
+      }
+    Func(params, ret) => {
+      for p in params {
+        collect_invalid_primitive_type_names(p, acc)
+      }
+      collect_invalid_primitive_type_names(ret, acc)
+    }
+    Union(members) | Intersection(members) =>
+      for m in members {
+        collect_invalid_primitive_type_names(m, acc)
+      }
+    Conditional(check_t, extends, t_branch, f_branch) => {
+      collect_invalid_primitive_type_names(check_t, acc)
+      collect_invalid_primitive_type_names(extends, acc)
+      collect_invalid_primitive_type_names(t_branch, acc)
+      collect_invalid_primitive_type_names(f_branch, acc)
+    }
+    IndexedAccess(base, key) => {
+      collect_invalid_primitive_type_names(base, acc)
+      collect_invalid_primitive_type_names(key, acc)
+    }
+    _ => ()
+  }
+}
+
+///|
+/// TS2304 ("Cannot find name") for the capitalized-primitive misspellings
+/// `Null` / `Undefined` used as type names (`var x: Null`). The check is
+/// false-positive-free: it fires only on these two specific spellings, which
+/// are never valid TS types and never standard-library globals, and is still
+/// guarded by `module_declared_names` so a module that genuinely declares a
+/// `type Null`/`interface Undefined` of its own stays silent.
+fn check_invalid_primitive_type_names(
+  module_ : @ast.TsModule,
+) -> Array[ExprIssue] {
+  let declared = module_declared_names(module_)
+  let found : Array[String] = []
+  for v in module_.values {
+    collect_invalid_primitive_type_names(v.type_, found)
+  }
+  for ta in module_.type_aliases {
+    collect_invalid_primitive_type_names(ta.type_, found)
+  }
+  for iface in module_.interfaces {
+    for field in iface.fields {
+      collect_invalid_primitive_type_names(field.1, found)
+    }
+  }
+  for f in module_.funcs {
+    for param in f.params {
+      collect_invalid_primitive_type_names(param.type_, found)
+    }
+    collect_invalid_primitive_type_names(f.return_type, found)
+  }
+  // Runtime top-level `var x: Null` / `let x: Undefined` declarations are
+  // retained as statements (not lowered into `module_.values`), so scan their
+  // annotations directly.
+  for stmt in module_.top_level_stmts {
+    match stmt {
+      Var(_, type_, _) | Let(_, type_, _) | Const(_, type_, _) =>
+        collect_invalid_primitive_type_names(type_, found)
+      _ => ()
+    }
+  }
+  let issues : Array[ExprIssue] = []
+  for name in found {
+    if !declared.contains(name) {
+      issues.push({
+        path: "type \{name}",
+        message: "Cannot find name '\{name}'.",
+      })
+    }
+  }
+  issues
+}
+
+///|
 /// Walk a class's `extends` ancestry (nearest first) looking for how `name`
 /// (matching `is_static`) was last declared. Returns `Some(true)` when the
 /// nearest ancestor declaration is a *data property*, `Some(false)` when it is
@@ -16339,6 +16455,9 @@ fn check_module_function_bodies_layered(
     all.push(issue)
   }
   for issue in check_reserved_type_alias_names(module_) {
+    all.push(issue)
+  }
+  for issue in check_invalid_primitive_type_names(module_) {
     all.push(issue)
   }
   for issue in check_property_overridden_as_accessor(module_, resolver) {

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10087,3 +10087,24 @@ test "expr_check: overload signature with no implementation (TS2391)" {
   // Ambient declare-class signatures need no implementation.
   @test.assert_eq(issues("declare class C { foo(): number; }"), 0)
 }
+
+///|
+test "expr_check: capitalized-primitive type misspelling (TS2304)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // `Null` / `Undefined` are never valid TS type names (the primitives spell
+  // lowercase), so a reference to one as a type is "Cannot find name".
+  assert_true(issues("var x: Null;") > 0)
+  assert_true(issues("var x: Undefined;") > 0)
+  assert_true(issues("let y: Null;") > 0)
+  assert_true(issues("declare const z: Undefined;") > 0)
+  assert_true(issues("interface I { x: Null; }") > 0)
+  assert_true(issues("function f(p: Undefined): void {}") > 0)
+  // The lowercase primitives are valid and must stay silent.
+  @test.assert_eq(issues("var x: null;"), 0)
+  @test.assert_eq(issues("var x: undefined;"), 0)
+  // A module that genuinely declares the name is silent (no false positive).
+  @test.assert_eq(issues("type Null = string; var x: Null;"), 0)
+  @test.assert_eq(issues("interface Undefined {} var x: Undefined;"), 0)
+}


### PR DESCRIPTION
## Summary

Adds TS2304 ("Cannot find name") for the capitalized-primitive misspellings `Null` / `Undefined` used as type names (`var x: Null`).

These are never valid TypeScript type names — the primitives spell as the lowercase literals `null` / `undefined` — and the standard library declares no global by either name (verified against the generated `lib_globals` registry). A reference to one as a type is therefore an unambiguous "Cannot find name".

## Soundness

The check is **false-positive-free**:
- It fires only on these two exact spellings.
- It is guarded by `module_declared_names`, so a module that genuinely declares `type Null` / `interface Undefined` of its own stays silent.
- Across the entire conformance corpus, only the two target files reference `: Null` / `: Undefined` as types.

It scans value declarations, type aliases, interface fields, function signatures, and runtime top-level `var`/`let`/`const` statements (the conformance test files use a bare `var x: Null;`, which the parser retains as a statement rather than lowering into `module_.values`).

## Results

- Whole-corpus TP **1711 → 1713** (+2), **0 FP** maintained.
- Pinned recall **665 → 667** (`directReferenceToNull`, `directReferenceToUndefined`), precision 414/414.
- Whitebox-tested; full suite **2378/2378** passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_