### PR TITLE
checker: un-gate TS2729 field-initialization-order check + fix FP

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1784,6 +1784,28 @@ conformance sources (`.errors.txt` baseline = ground truth):
     (+2), 0 FP; pinned recall 665 -> 667 (directReferenceToNull,
     directReferenceToUndefined). Whitebox-tested.
 
+2026-06-26 (T125)  668/815 (82 %)        414/414 ( 0 FP)   TS2729 field-init-order check un-gated + FP fix
+
+  T125 -- TS2729 ("Property 'X' is used before its initialization"). The
+    field-initialization-order check (`check_class_property_init_order`)
+    already existed and was whitebox-tested, but it was effectively DEAD in
+    the recall path: it only ran behind `if strict_root.use_define_for_class_fields`,
+    while the wbtest exercised it by calling the function directly. TS reports
+    TS2729 regardless of `useDefineForClassFields` (field initializers run in
+    declaration order either way), so the gate was wrong -- it suppressed the
+    diagnostic on `@target: es2015` files like `privateNamesUseBeforeDef`.
+    Un-gating it surfaced one false positive (`scopeResolutionIdentifiers`:
+    `s!: Date; n = this.s;`), caused by the candidate-field set including
+    declared-but-uninitialized fields: a field with no initializer has no
+    initialization to be "used before", yet `inited` (populated only from
+    `instance_field_inits`) could never mark it seen. Fixed by restricting the
+    flaggable set to fields that actually carry an initializer, plus parameter
+    *properties* (constructor params that also materialize as a property --
+    a plain `constructor(x: T)` param creates no field, so reading `this.x`
+    there is TS2339, not TS2729). Whole-corpus TP 1713 -> 1715 (+2), 0 FP;
+    pinned recall 667 -> 668 (privateNamesUseBeforeDef). Whitebox-tested
+    through the full permissive pipeline (the prior tests bypassed the gate).
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -16499,10 +16499,8 @@ fn check_module_function_bodies_layered(
     ) {
     all.push(issue)
   }
-  if strict_root.use_define_for_class_fields {
-    for issue in check_class_property_init_order(module_) {
-      all.push(issue)
-    }
+  for issue in check_class_property_init_order(module_) {
+    all.push(issue)
   }
   // Object-shaped names visible from outer scopes (a nested namespace's
   // interface can `extends` a member typed by a top-level interface).
@@ -18456,22 +18454,40 @@ fn check_class_property_init_order(module_ : @ast.TsModule) -> Array[ExprIssue] 
     // getters/setters) are listed in `decl.methods` and we exclude
     // their names from the field set so `this.m1()` -> a method call
     // isn't flagged.
+    //
+    // Only fields that carry an *initializer* (the entries of
+    // `instance_field_inits`) are flaggable: TS2729 is about reading a field
+    // before its initializer has run, so a field declared without one
+    // (`s!: Date`, `s: Date`) has no initialization to be "used before" and
+    // reading it -- even from an earlier field's initializer -- is silent.
+    // Restricting the candidate set to init-bearing fields avoids flagging
+    // those declarations (the `scopeResolutionIdentifiers` false positive:
+    // `s!: Date; n = this.s;`, where `s` precedes `n` and has no init).
     let field_names : Map[String, Unit] = {}
-    for prop in decl.properties {
-      if !prop.is_static && !prop.is_accessor {
-        field_names[prop.name] = ()
-      }
+    for entry in decl.instance_field_inits {
+      field_names[entry.0] = ()
     }
-    // Constructor parameter properties (`constructor(public foo: T)`)
-    // declare `this.foo` slots that are written *during* the constructor
-    // body — i.e. after every instance-field initializer has already
-    // run. Treat their names as fields so a field-init that reads
-    // `this.foo` before the constructor runs is reported.
+    // Parameter properties (`constructor(public foo: T)`) declare a `this.foo`
+    // slot written *during* the constructor body -- after every instance-field
+    // initializer has run -- so a field-init that reads `this.foo` is TS2729.
+    // They materialize as no-initializer entries in `properties`, so a
+    // constructor parameter that *also* appears as a property is a parameter
+    // property (a plain `constructor(x: T)` param does not materialize a field,
+    // and reading `this.x` there is TS2339, handled elsewhere -- not TS2729).
     match decl.constructor_params {
-      Some(params) =>
-        for entry in params {
-          field_names[entry.0] = ()
+      Some(params) => {
+        let prop_names : Map[String, Unit] = {}
+        for prop in decl.properties {
+          if !prop.is_static {
+            prop_names[prop.name] = ()
+          }
         }
+        for entry in params {
+          if prop_names.contains(entry.0) {
+            field_names[entry.0] = ()
+          }
+        }
+      }
       None => ()
     }
     for m in decl.methods {

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10089,6 +10089,37 @@ test "expr_check: overload signature with no implementation (TS2391)" {
 }
 
 ///|
+test "expr_check: field-init-order (TS2729) via full permissive pipeline" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A field initializer reading a *later* field that has its own initializer
+  // is "used before initialization" -- and it now fires through the full
+  // pipeline regardless of `useDefineForClassFields` (TS reports it on
+  // `@target: es2015` too).
+  assert_true(issues("class C { x = this.y; y = 5; }") > 0)
+  // Private-field forward reference (`privateNamesUseBeforeDef`).
+  assert_true(issues("class A { foo = this.bar; bar = 3; }") > 0)
+  // Reading an *earlier* initialized field is fine.
+  @test.assert_eq(issues("class C { x = 5; y = this.x; }"), 0)
+  // A field declared *without* an initializer has no initialization to be
+  // "used before", so reading it is silent even from an earlier field's init
+  // (`scopeResolutionIdentifiers` regression: `s!: Date; n = this.s;`).
+  @test.assert_eq(issues("class C { s!: number; n = this.s; }"), 0)
+  // A parameter *property* materializes a field assigned during the
+  // constructor, so reading it from a field init is flagged...
+  assert_true(
+    issues("class C { a = this.foo; constructor(public foo: number) {} }") > 0,
+  )
+  // ...but a plain constructor parameter creates no field (reading `this.x`
+  // there is TS2339, not TS2729 -- this check stays silent).
+  @test.assert_eq(
+    issues("class E { a = this.x; constructor(x: number) {} }"),
+    0,
+  )
+}
+
+///|
 test "expr_check: capitalized-primitive type misspelling (TS2304)" {
   let issues = fn(src : String) -> Int {
     check_module_function_bodies_permissive(parse_module_or_empty(src)).length()


### PR DESCRIPTION
## Summary

The field-initialization-order check (`check_class_property_init_order`, TS2729 "Property 'X' is used before its initialization") already existed and was whitebox-tested, but it was **dead in the recall path**: it only ran behind `if strict_root.use_define_for_class_fields`, while its test exercised it by calling the function directly.

TypeScript reports TS2729 **regardless** of `useDefineForClassFields` — field initializers run in declaration order either way — so the gate was wrong. It suppressed the diagnostic on `@target: es2015` files such as `privateNamesUseBeforeDef`.

## The false positive it surfaced, and the fix

Un-gating surfaced one FP (`scopeResolutionIdentifiers`: `s!: Date; n = this.s;`): the candidate-field set included declared-but-uninitialized fields, but a field with **no initializer** has no initialization to be "used before", and `inited` (populated only from `instance_field_inits`) could never mark it seen.

Fixed by restricting the flaggable set to:
- fields that actually carry an initializer (`instance_field_inits`), plus
- parameter *properties* — constructor params that also materialize as a property. A plain `constructor(x: T)` param creates no field, so reading `this.x` there is TS2339, not TS2729.

## Results

- Whole-corpus TP **1713 → 1715** (+2), **0 FP** maintained.
- Pinned recall **667 → 668** (`privateNamesUseBeforeDef`), precision 414/414.
- Whitebox-tested through the **full permissive pipeline** (the prior tests bypassed the gate); full suite **2379/2379** passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_