### PR TITLE
checker: union all-members property rule (TS2339) + runtime constraint check (TS2344) + priority triage doc

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1824,6 +1824,30 @@ conformance sources (`.errors.txt` baseline = ground truth):
     index-signature subtyping, tuple rest), not the basic runtime-decl case.
     Whitebox-tested through the full permissive pipeline.
 
+2026-06-26 (T127)  669/815 (82 %)        414/414 ( 0 FP)   TS2339 property on some-but-not-all union members
+
+  T127 -- TS2339 ("Property does not exist"). A property access on a union `A |
+    B` is valid only when *every* member has the property (TS gives the union
+    the intersection of its members' members). Previously we flagged only when
+    the property was on *no* member (`field_on_any_union_member`), staying
+    silent on the "some but not all" case to avoid false positives on
+    discriminated-union narrowing we couldn't model. Discovery: the narrowing
+    engine already exists and handles simple-`Var` discriminant narrowing
+    precisely (`if (v.kind === "a")` rewrites `v`'s type), so a *residual* union
+    at the access site on a simple `Var` receiver means no guard applied.
+    Added `union_field_definitely_missing`: flags only when the receiver is a
+    simple `Var` AND every member is a fully-enumerable object shape
+    (`enumerable_object_shape`: interface/class/Struct, no index signature,
+    resolvable enumerable `extends`/`base` chain) AND the field is absent from
+    at least one member (per-member `lookup_field`, which folds in
+    `Object.prototype` members + each member's heritage). Non-enumerable members
+    (primitive / `any` / index-sig / generic-applied / `Object`-literal /
+    unresolved) bail to the old conservative behaviour. The `Var` gate (mirrors
+    the TS18048 branch) avoids the `controlFlowAliasing2` FP: a `this.test.name`
+    PropAccess-chain receiver is never narrowed by our engine (aliased-
+    discriminant / property narrowing we don't model). Whole-corpus TP 1715 ->
+    1716 (+1), 0 FP; pinned recall 668 -> 669 (unionTypeMembers). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/TODO.md
+++ b/TODO.md
@@ -1806,6 +1806,24 @@ conformance sources (`.errors.txt` baseline = ground truth):
     pinned recall 667 -> 668 (privateNamesUseBeforeDef). Whitebox-tested
     through the full permissive pipeline (the prior tests bypassed the gate).
 
+2026-06-26 (T126)  668/815 (82 %)        414/414 ( 0 FP)   TS2344 constraint check on runtime declarations
+
+  T126 -- TS2344 ("Type does not satisfy the constraint"). `check_module`'s
+    generic-constraint walk already covered interfaces, classes, type aliases,
+    function signatures, and ambient `declare const` values -- but runtime
+    top-level `var`/`let`/`const x: Foo<Bad>` declarations are retained as
+    statements (`top_level_stmts`), not lowered into `module_.values`, so their
+    annotations were never constraint-checked (same gap class as T124's TS2304
+    fix). Extended only the constraint walk to `top_level_stmts` (the
+    unresolved-reference walk is deliberately left on `module_.values` to avoid
+    widening its narrow well-known-type allowlist onto runtime declarations).
+    Sound real-world consistency fix (a runtime `let b: Box<number>` where
+    `interface Box<T extends string>` now flags like the ambient form); 0 FP.
+    Conformance recall unchanged (668) -- the pinned TS2344 misses need
+    higher-order machinery (`object` constraints, intrinsic string types,
+    index-signature subtyping, tuple rest), not the basic runtime-decl case.
+    Whitebox-tested through the full permissive pipeline.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/docs/checker-priority.md
+++ b/docs/checker-priority.md
@@ -105,6 +105,27 @@
    TS2339・TS18047/48・TS2367・TS2872 がまとめて動く。実世界頻度は最大だが
    エンジンなので Phase 1 で足場を固めてから。
 
+   > **実装時に判明した制約（2026-06-26 調査）**:
+   > - **narrowing エンジンは既に存在し、かなり完成している**
+   >   （`analyse_narrowing` / `narrow_by_discriminant` / `narrow_union` /
+   >   `typeof` / `instanceof` / `=== null/undefined` / 判別共用体 / `&&`）。
+   >   単純 `Var` レシーバの判別共用体プロパティアクセスは正しく flag する
+   >   （`if (v.kind==="a") v.y` → TS2339）。よって Phase 2 は「ゼロから
+   >   エンジンを作る」ではなく **既存エンジンの穴を埋める**作業。
+   > - 残る narrowing miss の正体は 2 つ:
+   >   **(a) プリミティブ prototype テーブル未モデル** — `x.toFixed()` の
+   >   `x:string` ですら 0 issue。`string`/`number`/`boolean` のメソッド表が
+   >   無いので「narrowed 後に間違ったメソッド」を検出できない。完全な表が
+   >   無いと逆に valid メソッドを誤検出するため FP リスク大。
+   >   **(b) PropAccess-chain / aliased-discriminant の narrowing 未対応** —
+   >   `this.test.name`（`this.test` がプロパティアクセス）や
+   >   `const t = x.type; if (t===…)` は engine が narrow しない
+   >   （`controlFlowAliasing2`）。union-プロパティ検査はここで FP を出すため、
+   >   T127 では「単純 `Var` レシーバ限定」ゲートで回避済み。
+   > - **T127 で union "全メンバーに無いと不正" ルールを追加済み**
+   >   （some-but-not-all、`Var` レシーバ＋全メンバー列挙可能時のみ）。
+   >   pinned recall 668→669（unionTypeMembers）。
+
 ### Phase 3 — 最後（FP リスク最大）
 5. **代入可能性の深化**（関数共用体・交差・深い構造比較）。narrowing 投入後の方が
    「本当に不一致か」を切り分けやすく FP を避けやすい。miss 数は最多だが着手は最後。

--- a/docs/checker-priority.md
+++ b/docs/checker-priority.md
@@ -73,10 +73,24 @@
 交差領域**。ここを攻めるとどちらの目的でも無駄にならない。各 Phase は
 「0-FP を守れる単位」で区切る。
 
-### Phase 0 — 足場（低リスク・即効）
+### Phase 0 — 足場（低 FP リスク・ただし要プラミング・recall ほぼ +0）
 1. **noImplicitAny（TS7006 系）**: トップレベル関数宣言の「型注釈なし param」限定で
    開始。文脈型が付く位置（コールバック引数等）は除外して FP を抑える。
-   小コスト・自己完結。最初の 1 本に最適。
+
+   > **実装時に判明した制約（2026-06-26 調査）**:
+   > - AST の `TsParam.type_` は非 optional で、**「注釈なし」と「明示 `: any`」を
+   >   区別できない**（両方 `Any` になる）。TS7006 は前者だけに出すべきなので、
+   >   パーサに「注釈なし param」を記録する新チャネル（`has_body_block` /
+   >   `param_optional_initializer_misuses` と同パターン）が必要。
+   > - `noImplicitAny` フラグも未追跡（`strict_null_checks` /
+   >   `strict_property_initialization` はあるが noImplicitAny はない）。
+   >   `TsModule` に `no_implicit_any : Bool` 追加＋ `@noImplicitAny` /
+   >   `@strict` ディレクティブ検出が要る（構築サイト約 8 箇所）。
+   > - **conformance recall は ~+0**: pinned の TS7006 miss 5 件は全て
+   >   contextual-typing ケース（comma / `&&` の左辺 arrow、class expression
+   >   method）で、単純なトップレベル param チェックでは捕捉できない。
+   >   よってこれは「実世界の品質・プロダクト価値」枠であり、recall 目標には
+   >   寄与しない。着手するなら期待値をそう設定する。
 
 ### Phase 1 — 交差領域（中コスト・両トラックに効く）
 2. **ジェネリック制約検証（TS2344）**: `type_param_bounds` が既にあるので、
@@ -124,6 +138,19 @@
   （`string|number` と `number|string` を等価判定できないと FP）。型機構が要る。
 - **TS2445 を namespace 本体に拡張**: 全コーパスで namespace 本体の式を walk する必要があり
   ブラスト半径が大きい（1 ファイルのために全 namespace を新規検査）。非推奨。
+
+## 結論（2026-06-26 時点）
+
+- **増分的な sound recall win は枯渇**。`recall=668/815` までで、構造的・パース時・
+  ヒープチェーン・オーバーロード検出系は全て収穫済み。残る miss を全クラスタ
+  （≥2 件 + 主要 single）まで個別調査した結果、例外なく
+  **(a) 型機構（代入可能性 / flow narrowing / generic instantiation）**、
+  **(b) パーサ変更が前提（TS18014）**、**(c) エッジ/抑制フィルタ** のいずれか。
+- したがって 668→700 は「小さな pass の積み上げ」では到達せず、上の Phase で挙げた
+  **本格的な機能を 1 つずつ腰を据えて作る**ことになる。Phase 0 ですら
+  パーサ・プラミングが要り、かつ recall には寄与しない（上記参照）。
+- 次に着手する機能は **ユーザーが明示的に選んでから**始める（各 Phase は
+  複数ターンの実装コミットメントで、0-FP 検証も個別に要るため）。
 
 ## 守るべき制約（数値目標より上位）
 

--- a/docs/checker-priority.md
+++ b/docs/checker-priority.md
@@ -1,0 +1,137 @@
+# Checker 未実装機能の実装優先度トリアージ
+
+> 作成: 2026-06-26 / 基準: pinned conformance gate `recall=668/815`, `precision=414/414 (0 FP)`
+>
+> このドキュメントは「未実装の TS 機能をどの順番で実装するか」を、conformance の
+> ファイル数ではなく **実世界の遭遇頻度** と **bridge プロダクトへの寄与** で
+> トリアージしたもの。`TODO.md` の T0–T125 が「実装済みチェックの履歴」なのに対し、
+> こちらは「これから何を、どの順で」の戦略メモ。
+
+## 大前提：2 つのトラックを分離する
+
+この repo の checker には 2 つの役割があり、「未実装機能」の優先度は
+**どちらを最適化するかで逆転する**。
+
+- **Track A（プロダクト = bridge）**: 実ユーザーが `ts2mbt` で npm の `.d.ts` を
+  変換するときに踏むもの。= **パーサ網羅性** と **型マッピング忠実度**
+  （generics / union / conditional / mapped / template-literal / utility types を
+  MoonBit に正確に写す）。checker recall とは別軸。
+- **Track B（checker recall = conformance）**: TS の型エラー検出（TS2322 等）。
+  これまで `recall→700` を目指してきた軸。bridge では合成出力の sanity gate
+  （`@checker.check_module`）として働く。
+
+**conformance のファイル数 ≠ 実世界の遭遇頻度** に注意。例：
+
+- `TS18014`（nested private name shadowing）は conformance に 6 ファイルあるが、
+  実コードではほぼ書かれない。さらに実装にはパーサのクラス lowering 変更が前提
+  （後述の「確定した手詰まり」参照）。
+- 逆に「`.d.ts` の conditional type を MoonBit にどうマップするか」は
+  checker recall には 1 ポイントも効かないが、bridge の実ユーザーは毎回踏む。
+
+## conformance miss 分布（pinned 142 files / 815）
+
+実頻度で重み付けする前の生データ。上位バケットのみ。
+
+| miss 数 | コード | 機能 |
+|---|---|---|
+| 36 | TS2322 | Type X not assignable to Y（代入可能性） |
+| 18 | TS2339 | Property does not exist（プロパティ解決＋絞り込み） |
+| 14 | TS2345 | Argument not assignable（呼び出しの代入可能性） |
+| 7 | TS2344 | does not satisfy constraint（ジェネリック制約） |
+| 6 | TS2415 | incorrectly extends base（クラス代入可能性） |
+| 6 | TS18014 | nested private name shadowing（エッジ・パーサ前提） |
+| 5 | TS7006 | parameter implicitly has 'any'（noImplicitAny） |
+| 4 | TS2554 | expected N arguments（アリティ・現在抑制中） |
+| 3 ×複数 | TS7053 / TS2769 / TS2741 / TS2564 / TS2551 / TS2403 / TS2349 / TS2304 / TS2300 | — |
+| 2 ×複数 | TS2872 / TS2806 / TS2739 / TS2684 / TS2502 / TS2445 / TS2420 / TS2411 / TS2367 / TS2353 / TS2352 / TS2314 / TS1268 / TS1206 / TS1005 | — |
+| 1 ×約50 | ロングテール | エッジケース群 |
+
+## 実世界の遭遇頻度でのトリアージ（Track B）
+
+| 頻度 | 機能バケット | 関連コード | コスト | FP リスク |
+|---|---|---|---|---|
+| **S（毎日）** | 制御フロー絞り込み（typeof / instanceof / truthy / 判別共用体） | TS2339, TS18047/48, TS2367, TS2872, TS2345/2322 の一部 | 大 | 中〜高 |
+| **A（頻繁）** | ジェネリック制約・インスタンス化 | TS2344, TS2314, TS2589 | 中 | 中 |
+| **A** | 引数アリティ（現在意図的に抑制中） | TS2554, TS2575 | 小〜中 | 高 |
+| **A** | noImplicitAny（文脈型推論） | TS7006/7008/7031/7053 | 中 | 中 |
+| **B（時々）** | 高度な代入可能性（関数共用体・交差・深い構造比較） | TS2322/2345 の残り, TS2741/2739/2353 の高度形 | 中 | **高** |
+| **B** | クラス継承エッジ | TS2415, TS2420, TS2445 | 中 | 低〜中 |
+| **C（稀・エッジ）** | ロングテール | TS18014 ほか 1 件ずつ約 50 | 様々 | 様々 |
+
+### 重要な非対称性（FP 方向）
+
+- **代入可能性（TS2322 系）**: miss 最多（~55）だが **FP 方向が危険**。
+  「TS は代入 OK なのに我々が NG」= FP。構造比較が過剰厳格だと valid を flag し、
+  0-FP gate を最も壊しやすい。**数は多いが着手は最後**。
+- **narrowing（絞り込み）**: 実世界頻度が最大。現状は union のプロパティアクセスを
+  保守的に黙認しているので、ここを入れると TS2339 の塊＋null 系＋等価比較が
+  一気に動く。ただしエンジンが大きい。
+
+## 推奨ロードマップ（バランス軸・既定案）
+
+`generics / union / narrowing` は **プロダクト忠実度と checker recall の両方に効く
+交差領域**。ここを攻めるとどちらの目的でも無駄にならない。各 Phase は
+「0-FP を守れる単位」で区切る。
+
+### Phase 0 — 足場（低リスク・即効）
+1. **noImplicitAny（TS7006 系）**: トップレベル関数宣言の「型注釈なし param」限定で
+   開始。文脈型が付く位置（コールバック引数等）は除外して FP を抑える。
+   小コスト・自己完結。最初の 1 本に最適。
+
+### Phase 1 — 交差領域（中コスト・両トラックに効く）
+2. **ジェネリック制約検証（TS2344）**: `type_param_bounds` が既にあるので、
+   明示型引数 `Foo<T>` の制約違反を構造的に検証。bridge では「制約付き
+   ジェネリックの正しいマッピング」にも直結。
+3. **判別共用体の絞り込み（narrowing 第一歩）**: `typeof` / リテラルタグによる
+   discriminated union の絞り込みだけ先に。TS2339 の一部と bridge の union 表現
+   精度が両方上がる。
+
+### Phase 2 — 最大価値（要エンジン）
+4. **制御フロー絞り込み本体**: `instanceof` / truthiness / null チェック。
+   TS2339・TS18047/48・TS2367・TS2872 がまとめて動く。実世界頻度は最大だが
+   エンジンなので Phase 1 で足場を固めてから。
+
+### Phase 3 — 最後（FP リスク最大）
+5. **代入可能性の深化**（関数共用体・交差・深い構造比較）。narrowing 投入後の方が
+   「本当に不一致か」を切り分けやすく FP を避けやすい。miss 数は最多だが着手は最後。
+
+## レンズを変える場合の差分
+
+- **bridge プロダクト忠実度を最優先**にするなら順序を組み替え、
+  「**パーサ網羅性**（実 npm の `.d.ts` で parse 失敗する構文）＋
+  **conditional / mapped / template-literal / utility types の MoonBit マッピング
+  忠実度**」を Phase 0–1 に引き上げる。checker recall はほぼ動かないが、
+  実ユーザーの体感は最も良くなる。**着手前に実 npm パッケージ数本を `ts2mbt` に
+  通して parse 失敗・型ロスを実測**し、そのデータでロードマップを引き直すのを推奨。
+- **純粋に recall=700 最短**なら、ファイル数の多い TS2322（~55）バケットに機械的に
+  突っ込む順序になるが、FP リスク最大で 0-FP gate と衝突しやすく **非推奨**。
+
+## 後回し / 確定した手詰まり
+
+着手前に判断済みの「やらない／今はできない」項目。再調査の無駄を防ぐため記録。
+
+- **アリティ un-suppression（TS2554）**: optional / rest / overload を先にモデル化
+  しないと FP 確定。実測で「`is not callable` 抑制を外すと +4 recall / 10 FP」を確認済み。
+- **TS18014（nested private name shadowing, 6 files）**: メソッド/コンストラクタ本体内の
+  ネストしたクラスは **IIFE 関数式に lowering** され、クリーンなクラス AST
+  （private 名集合・メソッド param 型・`a.#foo` レシーバ）が失われる。実装には
+  パーサのクラス lowering 変更が前提で、bridge/emit への回帰リスクが大きい。非増分。
+- **permissive 抑制フィルタ（`is_permissively_suppressed`）の緩和**: 微妙に均衡しており、
+  arity / `not callable` を外すと FP が出ることを確認済み。触らない。
+- **`object` キーワード（NonPrimitive）**: 実装すると recall が **下がる**（665→661）
+  ことを実測で確認済み（~149 箇所の Any wildcard match を継承しないため）。revert 済み。
+- **TS2403（subsequent declarations must have same type）**: 構造的型 **等価性** が必要
+  （`string|number` と `number|string` を等価判定できないと FP）。型機構が要る。
+- **TS2445 を namespace 本体に拡張**: 全コーパスで namespace 本体の式を walk する必要があり
+  ブラスト半径が大きい（1 ファイルのために全 namespace を新規検査）。非推奨。
+
+## 守るべき制約（数値目標より上位）
+
+実装順に関わらず、以下は **常に** 数値目標より優先する（明示指示）。
+
+1. **0 false positives** を維持（`scripts/checker_conformance_oracle.sh --max-fp 0`）。
+2. テストスイート（現在 2379）と bridge プロダクトを壊さない。
+3. recall 数値を捏造しない・unsound なチェックを出さない。
+
+各機能は個別に oracle で 0-FP を検証してから merge する（measure → implement →
+oracle-gate → commit → PR → merge → sync のループ）。

--- a/src/checker/check_module.mbt
+++ b/src/checker/check_module.mbt
@@ -423,6 +423,26 @@ pub fn check_module(module_ : @ast.TsModule) -> TypeCheckReport {
         issues,
       )
     }
+    // Runtime top-level `var`/`let`/`const x: Foo<Bad>` declarations are
+    // retained as statements rather than lowered into `module_.values`, so
+    // scan their annotations too (mirrors the ambient-value walk above). Only
+    // the constraint check runs here -- the unresolved-reference walk is left
+    // to `module_.values` to avoid widening its (intentionally narrow)
+    // well-known-type allowlist onto runtime declarations.
+    for stmt in module_.top_level_stmts {
+      match stmt {
+        Var(_, type_, _) | Let(_, type_, _) | Const(_, type_, _) =>
+          check_constraints(
+            type_,
+            [],
+            alias_params,
+            alias_bounds,
+            resolve,
+            issues,
+          )
+        _ => ()
+      }
+    }
   }
   { issues, }
 }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -1344,6 +1344,100 @@ fn Resolver::field_on_any_union_member(
 }
 
 ///|
+/// True when `ty` is an object shape whose member set we can enumerate
+/// *completely* — so "field absent" is a definite fact, not an artefact of an
+/// unmodeled construct. Restricted to interfaces / classes (with no index
+/// signature, whose entire `extends` chain is itself enumerable and
+/// resolvable) and `Struct` literals. Everything else — primitives, `any` /
+/// `unknown`, `Object` literals (whose index-signature encoding we don't
+/// inspect here), generic-applied aliases, conditional / mapped / unresolved
+/// names — returns `false` so the caller stays silent. The depth guard bails
+/// on pathological / cyclic heritage rather than risking a wrong "absent".
+fn Resolver::enumerable_object_shape(
+  self : Resolver,
+  ty : @ast.TsType,
+  depth : Int,
+) -> Bool {
+  if depth > 4 {
+    return false
+  }
+  match self.unwrap(ty) {
+    Struct(_, _) => true
+    Named(n) | Applied(n, _) =>
+      match self.interfaces.get(n) {
+        Some(iface) => {
+          if iface.index_signatures.length() > 0 {
+            return false
+          }
+          for b in iface.extends_names {
+            if !self.enumerable_object_shape(@ast.TsType::Named(b), depth + 1) {
+              return false
+            }
+          }
+          true
+        }
+        None =>
+          match self.classes.get(n) {
+            Some(cls) => {
+              if cls.index_signatures.length() > 0 {
+                return false
+              }
+              for b in cls.base_names {
+                // `<expr-base>` (an expression heritage clause) or any base we
+                // can't resolve makes the member set unknowable.
+                if !self.enumerable_object_shape(
+                    @ast.TsType::Named(b),
+                    depth + 1,
+                  ) {
+                  return false
+                }
+              }
+              true
+            }
+            // Unresolved name: could be an external type with the field.
+            None => false
+          }
+      }
+    _ => false
+  }
+}
+
+///|
+/// TS2339 for a union receiver: a property access on `A | B` is valid only when
+/// *every* member has the property (TS gives the union the intersection of its
+/// members' properties). We flag the access only when we can be certain — every
+/// member is a fully-enumerable object shape (`enumerable_object_shape`) and at
+/// least one of them lacks the field (per-member `lookup_field`, which already
+/// folds in `Object.prototype` members like `toString` and each member's
+/// `extends` chain). Any non-enumerable member (primitive, `any`, index
+/// signature, unresolved, generic-applied alias) makes the whole check bail, so
+/// discriminated-union narrowing gaps and unmodeled shapes stay silent.
+fn Resolver::union_field_definitely_missing(
+  self : Resolver,
+  recv : @ast.TsType,
+  field : String,
+) -> Bool {
+  match self.unwrap(recv) {
+    Union(items) => {
+      if items.length() == 0 {
+        return false
+      }
+      let mut any_missing = false
+      for it in items {
+        if !self.enumerable_object_shape(it, 0) {
+          return false
+        }
+        if self.lookup_field(it, field) is None {
+          any_missing = true
+        }
+      }
+      any_missing
+    }
+    _ => false
+  }
+}
+
+///|
 
 ///|
 /// When `recv` is a class instance whose field `field` has no type annotation
@@ -12320,11 +12414,31 @@ fn check_call_args_in_expr(
         // exists. The pure-null case is handled by the branch above.
         !(ctx.resolver.lookup_field(prune_nullish(ctx.resolver, recv_ty), prop)
         is Some(_)) &&
-        // Discriminated unions: when at least one member has the field the
-        // access is valid under flow-narrowing we can't model. Stay silent.
-        !ctx.resolver.field_on_any_union_member(
-          prune_nullish(ctx.resolver, recv_ty),
-          prop,
+        // Union receivers: a member access is valid only when *every* member
+        // has the field. Stay silent when at least one member has it UNLESS the
+        // receiver is a simple `Var` AND we can enumerate every member's full
+        // shape and prove the field is genuinely absent from one of them
+        // (`union_field_definitely_missing`) — that case is a real TS2339 even
+        // without narrowing. The `Var` gate matches the TS18048 branch above:
+        // those are the bindings the narrowing engine rewrites precisely, so a
+        // residual union at the access site means no guard applied. A
+        // `PropAccess`-chain receiver (`this.test.name`) is never narrowed by
+        // our engine (aliased-discriminant / property narrowing we don't model
+        // — see controlFlowAliasing2), so it stays conservative. Non-enumerable
+        // members (primitive / `any` / index-sig / generic-applied / unresolved)
+        // also keep the "at least one member has it ⇒ silent" behaviour.
+        (
+          !ctx.resolver.field_on_any_union_member(
+            prune_nullish(ctx.resolver, recv_ty),
+            prop,
+          ) ||
+          (
+            recv is Var(_) &&
+            ctx.resolver.union_field_definitely_missing(
+              prune_nullish(ctx.resolver, recv_ty),
+              prop,
+            )
+          )
         ) &&
         // Suppress when the receiver shape contains an unresolvable Named
         // ref (`this`, an in-scope generic, a qualified-namespace name

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10120,6 +10120,29 @@ test "expr_check: field-init-order (TS2729) via full permissive pipeline" {
 }
 
 ///|
+test "expr_check: generic constraint on runtime declaration (TS2344)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A runtime `let`/`const`/`var` is retained as a statement, not lowered into
+  // `module_.values`; its type annotation must still be constraint-checked the
+  // same way an ambient `declare const` already is.
+  assert_true(
+    issues("interface Box<T extends string> {} let b: Box<number>;") > 0,
+  )
+  assert_true(
+    issues("interface Box<T extends string> {} var b: Box<number>;") > 0,
+  )
+  // A satisfied bound, an unconstrained parameter, and a plain type stay silent.
+  @test.assert_eq(
+    issues("interface Box<T extends string> {} let b: Box<string>;"),
+    0,
+  )
+  @test.assert_eq(issues("interface Box<T> {} let b: Box<number>;"), 0)
+  @test.assert_eq(issues("let x: number = 1;"), 0)
+}
+
+///|
 test "expr_check: capitalized-primitive type misspelling (TS2304)" {
   let issues = fn(src : String) -> Int {
     check_module_function_bodies_permissive(parse_module_or_empty(src)).length()

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10120,6 +10120,54 @@ test "expr_check: field-init-order (TS2729) via full permissive pipeline" {
 }
 
 ///|
+test "expr_check: property on some-but-not-all union members (TS2339)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A property present on only some members of a union is a TS2339 on a simple
+  // `Var` receiver when every member is a fully-enumerable object shape.
+  assert_true(
+    issues(
+      "interface I1 { p: number } interface I2 { q: number } declare var x: I1 | I2; x.p;",
+    ) >
+    0,
+  )
+  assert_true(
+    issues(
+      "interface A { a: number } interface B { b: number } function f(v: A | B) { return v.a; }",
+    ) >
+    0,
+  )
+  // Present on *every* member -> valid, silent.
+  @test.assert_eq(
+    issues(
+      "interface A { a: number } interface B { a: string } function f(v: A | B) { return v.a; }",
+    ),
+    0,
+  )
+  // `Object.prototype` members exist on every object member -> silent.
+  @test.assert_eq(
+    issues(
+      "interface A { a: number } interface B { b: number } declare var x: A | B; x.toString;",
+    ),
+    0,
+  )
+  // A non-enumerable member (`any`) makes the whole union opaque -> silent.
+  @test.assert_eq(
+    issues("interface A { a: number } declare var x: A | any; x.a;"),
+    0,
+  )
+  // A `PropAccess`-chain receiver is never narrowed by our engine, so we stay
+  // conservative there (no false positive on aliased-discriminant narrowing).
+  @test.assert_eq(
+    issues(
+      "interface A { k: number } interface B { m: number } class C { t!: A | B; f() { return this.t.k; } }",
+    ),
+    0,
+  )
+}
+
+///|
 test "expr_check: generic constraint on runtime declaration (TS2344)" {
   let issues = fn(src : String) -> Int {
     check_module_function_bodies_permissive(parse_module_or_empty(src)).length()


### PR DESCRIPTION
Implements features from the new `docs/checker-priority.md` roadmap. Two checker improvements + the planning doc.

## TS2339 — property on some-but-not-all union members (recall mover)
A property access on `A | B` is valid only when **every** member has it. We previously flagged only when it was on *no* member, staying silent on the "some but not all" case to avoid FPs on discriminated-union narrowing.

**Discovery:** the flow-narrowing engine already exists and handles simple-`Var` discriminant narrowing precisely — so a *residual* union at the access site on a simple `Var` receiver means no guard applied, making "some but not all" a real TS2339 there.

Adds `union_field_definitely_missing`, gated to fire only when (1) receiver is a simple `Var`, (2) every member is a fully-enumerable object shape (`enumerable_object_shape`: interface/class/Struct, no index signature, resolvable enumerable heritage), and (3) the field is absent from ≥1 member. Non-enumerable members (primitive/`any`/index-sig/generic-applied/`Object`-literal/unresolved) bail to the old conservative behaviour. The `Var` gate mirrors the TS18048 branch and avoids the `controlFlowAliasing2` FP (a `this.test.name` chain receiver is never narrowed by our engine).
- Whole-corpus TP 1715→1716, **pinned recall 668→669** (unionTypeMembers), **0 FP**.

## TS2344 — generic constraint check on runtime declarations
`check_module`'s constraint walk already covered interfaces/classes/aliases/params/ambient values, but runtime `var`/`let`/`const x: Foo<Bad>` lives in `top_level_stmts`, not `module_.values`, so it was never checked (same gap class as the earlier TS2304 fix). Extended only the constraint walk; the unresolved-ref walk stays narrow. Sound consistency fix, **0 FP**; conformance recall unchanged (the pinned TS2344 misses need higher-order machinery).

## docs/checker-priority.md
Triage of unimplemented TS features by real-world frequency + bridge-product impact, with implementation-time findings (narrowing engine already exists; the real gaps are primitive prototype tables and PropAccess-chain narrowing; noImplicitAny needs a parser annotation-presence signal).

All: full suite **2381/2381**, whitebox-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_