### PR TITLE
checker: generalize discriminant narrowing to numeric/boolean/enum tags

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1848,6 +1848,31 @@ conformance sources (`.errors.txt` baseline = ground truth):
     discriminant / property narrowing we don't model). Whole-corpus TP 1715 ->
     1716 (+1), 0 FP; pinned recall 668 -> 669 (unionTypeMembers). Whitebox-tested.
 
+2026-06-26 (T128)  669/815 (82 %)        414/414 ( 0 FP)   discriminant narrowing: numeric / boolean / enum tags
+
+  T128 -- generalized `narrow_by_discriminant` from string-`Literal`-only to a
+    predicate over the discriminant field type, adding numeric (`NumberLiteral`),
+    boolean (`BooleanLiteral`), and qualified enum-member (`Named("Enum.Member")`)
+    tags across all four call sites (switch-disc, switch-disc-default, the `if`
+    `=== <lit>` path, plus the new matcher `discriminant_field_matcher`). So
+    `switch (v.kind) { case 0: ... }` / `case Choice.Yes:` / `v.ok === true`
+    now narrow a discriminated union the same way string tags already did.
+    Guarded by `is_literal_discriminant_type`: if any variant's discriminant
+    field is NOT a recognizable literal tag (e.g. a template-literal type
+    `` `${AnimalType.cat}` ``), narrowing bails rather than narrow the union to
+    `never` and emit a spurious property-on-`never` (the `discriminatedUnionTypes4`
+    FP found while building this). Conformance recall-neutral (TP 1716, 0 FP)
+    but a real correctness fix -- it hardens the T127 union-property check
+    against numeric/enum-discriminated unions (a class of latent false
+    positives) and is the foundation for extending that check to object-literal
+    unions later. Whitebox-tested (switch + if + template-bail).
+
+    Object-literal union-property extension (`{a}|{b}`) was attempted on top of
+    this and REVERTED: it still needs `=== undefined` discriminant narrowing
+    and `"k" in obj` membership narrowing to be FP-free (discriminatedUnionTypes3,
+    controlFlowWithTemplateLiterals), and its recall payoff is small relative to
+    that FP tail. See docs/checker-priority.md.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/docs/checker-priority.md
+++ b/docs/checker-priority.md
@@ -125,6 +125,20 @@
    > - **T127 で union "全メンバーに無いと不正" ルールを追加済み**
    >   （some-but-not-all、`Var` レシーバ＋全メンバー列挙可能時のみ）。
    >   pinned recall 668→669（unionTypeMembers）。
+   > - **T128 で判別 narrowing を数値/真偽/enum タグに一般化済み**
+   >   （`narrow_by_discriminant` を述語ベース化、switch/if/default の全経路）。
+   >   `switch(x.kind){case 0:}` / `case Choice.Yes:` / `v.ok === true` が
+   >   narrow するように。`is_literal_discriminant_type` ガードで、判別フィールドが
+   >   テンプレートリテラル型等の認識不能形のときは narrow を中止
+   >   （`never` 誤縮約＝`discriminatedUnionTypes4` FP を回避）。recall 中立だが
+   >   T127 の union 検査を数値/enum 判別 union の潜在 FP から守る正当性修正。
+   > - **オブジェクトリテラル union への拡張（`{a}|{b}`）は T128 上で試行 → 撤回**。
+   >   残る FP 源は **(a) `=== undefined` 判別 narrowing 未対応**
+   >   （`discriminatedUnionTypes3`）と **(b) `"k" in obj` メンバーシップ
+   >   narrowing 未対応**（`controlFlowWithTemplateLiterals`）。この 2 form を
+   >   narrowing に足せば 0-FP 化できるが、オブジェクトリテラル union の recall
+   >   利得は小さく FP テールが長いので優先度は低い。enum/数値判別の interface
+   >   union（T127 で既にカバー）が主な実利。
 
 ### Phase 3 — 最後（FP リスク最大）
 5. **代入可能性の深化**（関数共用体・交差・深い構造比較）。narrowing 投入後の方が

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -1363,6 +1363,11 @@ fn Resolver::enumerable_object_shape(
   }
   match self.unwrap(ty) {
     Struct(_, _) => true
+    // NOTE: `Object` type literals (`{ a } | { b }`) are intentionally NOT
+    // enumerated here. Enabling them flags object-literal unions discriminated
+    // by forms the narrowing engine doesn't yet cover (`=== undefined`
+    // discriminants, `"k" in obj` membership), producing false positives that
+    // outweigh the small object-literal recall gain. See docs/checker-priority.md.
     Named(n) | Applied(n, _) =>
       match self.interfaces.get(n) {
         Some(iface) => {
@@ -9919,20 +9924,24 @@ fn apply_switch_disc_default_narrowing(
   prop : String,
   cases : Array[@ast.TsSwitchCase],
 ) -> Unit {
-  let str_lits : Array[String] = []
+  let matchers : Array[(@ast.TsType) -> Bool] = []
   for c in cases {
     match c.test_expr {
-      Some(StringLit(s)) => str_lits.push(s)
-      _ => ()
+      Some(e) =>
+        match discriminant_field_matcher(e) {
+          Some(m) => matchers.push(m)
+          None => ()
+        }
+      None => ()
     }
   }
-  if str_lits.length() == 0 {
+  if matchers.length() == 0 {
     return
   }
   let cur = env_lookup_full(env, resolver, obj_name)
   let mut next : @ast.TsType = cur
-  for lit in str_lits {
-    match narrow_by_discriminant(resolver, next, prop, lit, false) {
+  for m in matchers {
+    match narrow_by_discriminant(resolver, next, prop, m, false) {
       Some(remainder) => next = remainder
       None => ()
     }
@@ -9985,15 +9994,15 @@ fn apply_switch_disc_narrowing(
   prop : String,
   case_test : @ast.TsExpr,
 ) -> Unit {
-  match case_test {
-    StringLit(lit) => {
+  match discriminant_field_matcher(case_test) {
+    Some(matcher) => {
       let cur = env_lookup_full(env, resolver, obj_name)
-      match narrow_by_discriminant(resolver, cur, prop, lit, true) {
+      match narrow_by_discriminant(resolver, cur, prop, matcher, true) {
         Some(narrowed) => env.bind(obj_name, narrowed)
         None => ()
       }
     }
-    _ => ()
+    None => ()
   }
 }
 
@@ -10099,11 +10108,70 @@ fn type_eq(a : @ast.TsType, b : @ast.TsType) -> Bool {
 /// Inspect a discriminator field on each variant and keep only those whose
 /// field is the matching literal. Returns `None` when the receiver isn't a
 /// union of structurally-known variants (so the caller can skip narrowing).
+/// Build a predicate over a *discriminant field type* from a `case` / `===`
+/// literal operand. Handles string (`Literal`), numeric (`NumberLiteral`) and
+/// boolean (`BooleanLiteral`) literal tags; returns `None` for any other
+/// operand shape (so the caller skips narrowing). Numeric literals are matched
+/// on their rendered text, mirroring `apply_switch_case_narrowing`.
+fn discriminant_field_matcher(
+  case_test : @ast.TsExpr,
+) -> ((@ast.TsType) -> Bool)? {
+  match case_test {
+    StringLit(s) =>
+      Some(fn(ft) {
+        match ft {
+          Literal(x) => x == s
+          _ => false
+        }
+      })
+    IntLit(i) => {
+      let s = "\{i}"
+      Some(fn(ft) {
+        match ft {
+          NumberLiteral(x) => x == s
+          _ => false
+        }
+      })
+    }
+    NumberLit(d) => {
+      let s = "\{d}"
+      Some(fn(ft) {
+        match ft {
+          NumberLiteral(x) => x == s
+          _ => false
+        }
+      })
+    }
+    BoolLit(b) =>
+      Some(fn(ft) {
+        match ft {
+          BooleanLiteral(x) => x == b
+          _ => false
+        }
+      })
+    // Enum-member tag (`case Choice.Yes:` / `x.kind === Choice.Yes`). The
+    // member access renders as `PropAccess(Var(enum), member)` and the field
+    // type of an enum-member literal parses as `Named("Enum.Member")`, so we
+    // match on the qualified name.
+    PropAccess(Var(enum_name), member) => {
+      let qualified = enum_name + "." + member
+      Some(fn(ft) {
+        match ft {
+          Named(x) => x == qualified
+          _ => false
+        }
+      })
+    }
+    _ => None
+  }
+}
+
+///|
 fn narrow_by_discriminant(
   resolver : Resolver,
   recv : @ast.TsType,
   field : String,
-  literal : String,
+  field_matches : (@ast.TsType) -> Bool,
   keep : Bool,
 ) -> @ast.TsType? {
   // Unwrap type aliases first so a `type Shape = A | B` receiver
@@ -10117,13 +10185,18 @@ fn narrow_by_discriminant(
   for v in variants {
     match resolver.lookup_field(v, field) {
       Some(field_ty) => {
-        any_resolved = true
-        let matches = match field_ty {
-          Literal(s) => s == literal
-          // String/Number primitives aren't a discriminator — be conservative.
-          _ => false
+        // Bail entirely if any variant's discriminant field is NOT a
+        // recognizable literal form (string / number / boolean literal, or a
+        // qualified enum-member `Named("Enum.Member")`). Otherwise a field we
+        // can't evaluate — e.g. a template-literal type `` `${AnimalType.cat}` ``
+        // — would fail every predicate and wrongly narrow the union to `never`
+        // (the `discriminatedUnionTypes4` false positive). Conservative
+        // non-narrowing matches the previous string-only behaviour there.
+        if !is_literal_discriminant_type(field_ty) {
+          return None
         }
-        if matches == keep {
+        any_resolved = true
+        if field_matches(field_ty) == keep {
           kept.push(v)
         }
       }
@@ -10134,6 +10207,20 @@ fn narrow_by_discriminant(
     return None
   }
   Some(union_of(kept))
+}
+
+///|
+/// True when `ft` is a literal type usable as a discriminant tag: a string /
+/// number / boolean literal, or a qualified enum-member name
+/// (`Named("Enum.Member")`). Bare primitives, template-literal types, plain
+/// `Named` references, and everything else are not — `narrow_by_discriminant`
+/// bails rather than risk narrowing a variant away on a tag it can't evaluate.
+fn is_literal_discriminant_type(ft : @ast.TsType) -> Bool {
+  match ft {
+    Literal(_) | NumberLiteral(_) | BooleanLiteral(_) => true
+    Named(x) => x.contains(".")
+    _ => false
+  }
 }
 
 ///|
@@ -10941,29 +11028,31 @@ fn analyze_equality(
     None => ()
   }
 
-  // `<chain>.<prop> === "literal"` — discriminated union narrowing on
+  // `<chain>.<prop> === <literal>` — discriminated union narrowing on
   // the parent chain. Accepts any `Var` / `PropAccess`-chain on the LHS
-  // so `o.shape.kind === "circle"` narrows `o.shape`.
-  let disc_match = match (left, right) {
-    (PropAccess(parent, prop), StringLit(lit)) =>
-      match narrowing_key_for_expr(parent) {
-        Some(parent_key) => Some((parent_key, prop, lit))
-        None => None
+  // so `o.shape.kind === "circle"` narrows `o.shape`. The literal may be a
+  // string, numeric, or boolean tag (`x.kind === 0`, `x.ok === true`).
+  let disc_match : (String, String, (@ast.TsType) -> Bool)? = match
+    (left, right) {
+    (PropAccess(parent, prop), rhs) =>
+      match (narrowing_key_for_expr(parent), discriminant_field_matcher(rhs)) {
+        (Some(parent_key), Some(m)) => Some((parent_key, prop, m))
+        _ => None
       }
-    (StringLit(lit), PropAccess(parent, prop)) =>
-      match narrowing_key_for_expr(parent) {
-        Some(parent_key) => Some((parent_key, prop, lit))
-        None => None
+    (lhs, PropAccess(parent, prop)) =>
+      match (narrowing_key_for_expr(parent), discriminant_field_matcher(lhs)) {
+        (Some(parent_key), Some(m)) => Some((parent_key, prop, m))
+        _ => None
       }
     _ => None
   }
   match disc_match {
-    Some((parent_key, prop, lit)) => {
+    Some((parent_key, prop, matcher)) => {
       let cur = narrowing_current_type(env, resolver, parent_key)
-      match narrow_by_discriminant(resolver, cur, prop, lit, true) {
+      match narrow_by_discriminant(resolver, cur, prop, matcher, true) {
         Some(then_ty) => {
           true_side.push((parent_key, then_ty))
-          match narrow_by_discriminant(resolver, cur, prop, lit, false) {
+          match narrow_by_discriminant(resolver, cur, prop, matcher, false) {
             Some(else_ty) => false_side.push((parent_key, else_ty))
             None => ()
           }

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10168,6 +10168,44 @@ test "expr_check: property on some-but-not-all union members (TS2339)" {
 }
 
 ///|
+test "expr_check: numeric / enum discriminant narrowing (switch + if)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A numeric-discriminated union narrowed by `switch (v.k)` must let each
+  // case body access its own variant's members (no T127 union false positive).
+  @test.assert_eq(
+    issues(
+      "interface A { k: 0; x: number } interface B { k: 1; y: number } declare var v: A | B; function f() { switch (v.k) { case 0: return v.x; case 1: return v.y; } }",
+    ),
+    0,
+  )
+  // Same via an `if` discriminant guard.
+  @test.assert_eq(
+    issues(
+      "interface A { k: 0; x: number } interface B { k: 1; y: number } function f(v: A | B) { if (v.k === 0) { return v.x; } return v.y; }",
+    ),
+    0,
+  )
+  // Control: without any narrowing, accessing a non-common member still flags.
+  assert_true(
+    issues(
+      "interface A { k: 0; x: number } interface B { k: 1; y: number } declare var v: A | B; function f() { return v.x; }",
+    ) >
+    0,
+  )
+  // A template-literal-typed discriminant is not a recognizable literal tag, so
+  // narrowing bails (no spurious narrow-to-`never`): the union access stays
+  // silent rather than producing a property-on-`never` false positive.
+  @test.assert_eq(
+    issues(
+      "declare var x: { type: `a`; meow: string } | { type: `b`; bark: string }; function f() { if ((x as any).type === \"a\") { return 1; } return 2; }",
+    ),
+    0,
+  )
+}
+
+///|
 test "expr_check: generic constraint on runtime declaration (TS2344)" {
   let issues = fn(src : String) -> Int {
     check_module_function_bodies_permissive(parse_module_or_empty(src)).length()


### PR DESCRIPTION
## Summary

Generalizes `narrow_by_discriminant` from **string-`Literal`-only** to a predicate over the discriminant field type, adding numeric (`NumberLiteral`), boolean (`BooleanLiteral`), and qualified enum-member (`Named("Enum.Member")`) tags across all call sites (switch-disc, switch-disc-default, the `if` `=== <lit>` path) plus a new matcher `discriminant_field_matcher`.

So `switch (v.kind) { case 0: … }`, `case Choice.Yes:`, and `v.ok === true` now narrow a discriminated union the same way string tags already did.

## Soundness guard

Guarded by `is_literal_discriminant_type`: when any variant's discriminant field is **not** a recognizable literal tag (e.g. a template-literal type `` `${AnimalType.cat}` ``), narrowing **bails** rather than narrow the union to `never` and emit a spurious property-on-`never`. This was the `discriminatedUnionTypes4` false positive found while building it.

## Why it matters (recall-neutral but real)

Conformance recall is unchanged (whole-corpus TP 1716, **0 FP**), but this is a genuine correctness fix:
- It hardens the T127 union-property check against numeric/enum-discriminated unions — a class of **latent false positives** (a numeric-tagged interface union + `switch` would otherwise be wrongly flagged).
- It's the foundation for extending the union-property check to object-literal unions.

The object-literal extension itself was attempted on top and **reverted**: it still needs `=== undefined` discriminant narrowing and `"k" in obj` membership narrowing to be FP-free (`discriminatedUnionTypes3`, `controlFlowWithTemplateLiterals`), with small recall payoff relative to that FP tail. Documented in `docs/checker-priority.md`.

Whitebox-tested (switch + if + template-bail); full suite **2382/2382**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_