### PR TITLE
checker: TS2322/2345 string literal vs template-literal-type pattern

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1873,6 +1873,24 @@ conformance sources (`.errors.txt` baseline = ground truth):
     controlFlowWithTemplateLiterals), and its recall payoff is small relative to
     that FP tail. See docs/checker-priority.md.
 
+2026-06-26 (T129)  671/815 (82 %)        414/414 ( 0 FP)   TS2322/2345 string literal vs template-literal-type pattern
+
+  T129 -- TS2322 / TS2345. A concrete string literal assigned to (or passed
+    where the slot expects) a template-literal type is an error when the
+    pattern can't produce that literal (`const x: `a${string}` = "hello"`,
+    `f("xyz")` where the param is `` `a${string}` ``). The pattern matcher
+    (`literal_matches_template` / `is_assignable_to`) already existed and is
+    conservative -- an unknown/opaque placeholder accepts any substring -- so a
+    `false` verdict is a *definite* mismatch and false-positive-free. The gap
+    was purely that `check_expr_against` never reached a flagging path for a
+    `(Literal, TemplateLiteralType)` pair (it bailed earlier). Added an early,
+    tightly-gated check there, emitted via `record_unfiltered` because the
+    permissive suppression filter only whitelists primitive/simple-shape
+    mismatch pairs and would otherwise drop the template-target diagnostic in
+    the recall path. Whole-corpus TP 1716 -> 1718 (+2), 0 FP; pinned recall
+    669 -> 671 (templateLiteralTypes / stringLiteralTypesWithTemplateStrings
+    family). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -6604,6 +6604,26 @@ fn check_expr_against(
   // correctly assigns to `string` without a false mismatch.
   let inferred_u = ctx.resolver.unwrap(inferred)
   let expected_u = ctx.resolver.unwrap(expected)
+  // TS2322 / TS2345: a concrete string literal assigned to a template-literal
+  // type pattern is an error when the pattern can't produce that literal
+  // (`const x: `a${string}` = "hello"`). `is_assignable_to`'s pattern matcher
+  // is conservative — an unknown / opaque placeholder accepts any substring —
+  // so a `false` verdict here is a *definite* mismatch and false-positive-free.
+  // Emitted unfiltered: the permissive suppression filter only whitelists
+  // primitive/simple-shape pairs, and a template-literal target isn't one, so
+  // it would otherwise be dropped in the recall path.
+  match (inferred_u, expected_u) {
+    (Literal(_), TemplateLiteralType(_, _)) =>
+      if !is_assignable_to(inferred_u, expected_u) {
+        record_unfiltered(
+          ctx,
+          sub_path,
+          "expected `\{type_display(expected_u)}` but got `\{type_display(inferred_u)}`",
+        )
+        return
+      }
+    _ => ()
+  }
   // Boxed wrapper objects (`String`/`Number`/`Boolean`/`BigInt`/`Symbol`)
   // are not assignable to their primitive counterparts: `var s: string =
   // new String("")` is TS2322. These wrapper names are lib globals the

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10206,6 +10206,23 @@ test "expr_check: numeric / enum discriminant narrowing (switch + if)" {
 }
 
 ///|
+test "expr_check: string literal vs template-literal-type pattern (TS2322/2345)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A string literal that the pattern cannot produce is a mismatch.
+  assert_true(issues("const x: `a${string}` = \"hello\";") > 0)
+  assert_true(issues("const x: `${number}px` = \"10em\";") > 0)
+  assert_true(issues("function f(x: `a${string}`): void {} f(\"xyz\");") > 0)
+  // A literal the pattern *can* produce is fine.
+  @test.assert_eq(issues("const x: `a${string}` = \"abc\";"), 0)
+  @test.assert_eq(issues("const x: `${number}px` = \"10px\";"), 0)
+  // A widened `string` source is not a concrete literal -> stay silent (the
+  // pattern matcher only judges concrete literals).
+  @test.assert_eq(issues("const x: `a${string}` = (\"y\" as string);"), 0)
+}
+
+///|
 test "expr_check: generic constraint on runtime declaration (TS2344)" {
   let issues = fn(src : String) -> Int {
     check_module_function_bodies_permissive(parse_module_or_empty(src)).length()


### PR DESCRIPTION
## Summary

A concrete string literal assigned to (or passed where the slot expects) a **template-literal type** is an error when the pattern can't produce that literal:
- `const x: \`a${string}\` = "hello"` (must start with `a`)
- `f("xyz")` where the param is `\`a${string}\``
- `const x: \`${number}px\` = "10em"` (must end with `px`)

## Why it's false-positive-free

The pattern matcher (`literal_matches_template` via `is_assignable_to`) already existed and is **conservative** — an unknown/opaque placeholder accepts any substring — so a `false` verdict is a *definite* mismatch. The only gap was that `check_expr_against` never reached a flagging path for a `(Literal, TemplateLiteralType)` pair (it bailed earlier among its many special cases).

Added an early, tightly-gated check there, emitted via `record_unfiltered` because the permissive suppression filter only whitelists primitive/simple-shape mismatch pairs and would otherwise drop the template-target diagnostic in the recall path. A widened `string` source (not a concrete literal) stays silent.

## Results

- Whole-corpus TP **1716 → 1718** (+2), **0 FP**.
- Pinned recall **669 → 671** (templateLiteralTypes / stringLiteralTypesWithTemplateStrings family).
- Full suite **2383/2383**; whitebox-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_