### PR TITLE
checker: TS2322 string literal vs intrinsic string-mapping type

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1891,6 +1891,25 @@ conformance sources (`.errors.txt` baseline = ground truth):
     669 -> 671 (templateLiteralTypes / stringLiteralTypesWithTemplateStrings
     family). Whitebox-tested.
 
+2026-06-26 (T130)  673/815 (83 %)        414/414 ( 0 FP)   TS2322 string literal vs intrinsic string-mapping type
+
+  T130 -- TS2322. A string literal assigned where an intrinsic string-mapping
+    type is expected (`Uppercase<…>` / `Lowercase<…>` / `Capitalize<…>` /
+    `Uncapitalize<…>`) is flagged when it violates the case constraint that
+    holds for *every* member regardless of the inner type: a member of
+    `Uppercase<X>` is always all-uppercase, so a literal with an ASCII
+    lowercase letter (`x = "a"` where `x: Uppercase<Lowercase<string>>`) can
+    never be one. `string_mapping_case_violation` implements this as a
+    *necessary*-condition check -- sound and false-positive-free (non-ASCII
+    letters stay conservative; it never flags a literal that could still be a
+    member, only definite case violations). Added in `check_expr_against`
+    beside the T129 template-literal check, emitted unfiltered for the same
+    reason. Whole-corpus TP 1718 -> 1720 (+2), 0 FP; pinned recall 671 -> 673
+    (stringLiteralsAssignedToStringMappings / stringMappingOverPatternLiterals).
+    Whitebox-tested. (The pattern-match half -- e.g. `y = "A"` against
+    `Uppercase<Lowercase<`${number}`>>`, where the number pattern can't produce
+    "A" -- is a deliberate MISS: it needs intrinsic-over-template evaluation.)
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -6323,6 +6323,37 @@ fn Resolver::object_call_signature(
 }
 
 ///|
+
+///|
+/// True when the string literal `s` *cannot* be a member of the intrinsic
+/// string-mapping type `name<…>` because it violates the case constraint that
+/// holds for every member regardless of the inner type:
+///   - `Uppercase<X>`   members are all-uppercase  -> any ASCII lowercase a-z is a violation
+///   - `Lowercase<X>`   members are all-lowercase  -> any ASCII uppercase A-Z is a violation
+///   - `Capitalize<X>`  first char is not lowercase -> a leading a-z is a violation
+///   - `Uncapitalize<X>` first char is not uppercase -> a leading A-Z is a violation
+/// Conservative: non-ASCII letters are never treated as violations, so this
+/// only ever fires on a definite mismatch. Any other `name` returns false.
+fn string_mapping_case_violation(name : String, s : String) -> Bool {
+  fn is_lower(c : Char) -> Bool {
+    c >= 'a' && c <= 'z'
+  }
+
+  fn is_upper(c : Char) -> Bool {
+    c >= 'A' && c <= 'Z'
+  }
+
+  let chars = s.to_array()
+  match name {
+    "Uppercase" => chars.iter().any(fn(c) { is_lower(c) })
+    "Lowercase" => chars.iter().any(fn(c) { is_upper(c) })
+    "Capitalize" => chars.length() > 0 && is_lower(chars[0])
+    "Uncapitalize" => chars.length() > 0 && is_upper(chars[0])
+    _ => false
+  }
+}
+
+///|
 fn check_expr_against(
   env : ExprEnv,
   expr : @ast.TsExpr,
@@ -6615,6 +6646,24 @@ fn check_expr_against(
   match (inferred_u, expected_u) {
     (Literal(_), TemplateLiteralType(_, _)) =>
       if !is_assignable_to(inferred_u, expected_u) {
+        record_unfiltered(
+          ctx,
+          sub_path,
+          "expected `\{type_display(expected_u)}` but got `\{type_display(inferred_u)}`",
+        )
+        return
+      }
+    // Intrinsic string-mapping target (`Uppercase<…>` / `Lowercase<…>` /
+    // `Capitalize<…>` / `Uncapitalize<…>`). Every member of `Uppercase<X>` is
+    // an all-uppercase string regardless of `X`, so a string literal carrying
+    // an ASCII *lowercase* letter is a definite mismatch (and symmetrically for
+    // the others). This is a *necessary*-condition check — sound and
+    // false-positive-free: it never flags a literal that could still be a
+    // member (non-ASCII letters are left conservative), it only catches the
+    // case-constraint violations (`x = "a"` where `x: Uppercase<…>`). Emitted
+    // unfiltered like the template-target check above.
+    (Literal(s), Applied(intrinsic, [_])) =>
+      if string_mapping_case_violation(intrinsic, s) {
         record_unfiltered(
           ctx,
           sub_path,

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10223,6 +10223,27 @@ test "expr_check: string literal vs template-literal-type pattern (TS2322/2345)"
 }
 
 ///|
+test "expr_check: string literal vs intrinsic string-mapping type (TS2322)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A literal that violates the case constraint of the mapping is a mismatch.
+  assert_true(
+    issues("declare var x: Uppercase<Lowercase<string>>; x = \"a\";") > 0,
+  )
+  assert_true(issues("declare var l: Lowercase<string>; l = \"ABC\";") > 0)
+  assert_true(issues("declare var c: Capitalize<string>; c = \"abc\";") > 0)
+  assert_true(issues("declare var u: Uncapitalize<string>; u = \"Abc\";") > 0)
+  // Literals that satisfy the (necessary) case constraint stay silent.
+  @test.assert_eq(
+    issues("declare var x: Uppercase<Lowercase<string>>; x = \"A\";"),
+    0,
+  )
+  @test.assert_eq(issues("declare var x: Uppercase<string>; x = \"1\";"), 0)
+  @test.assert_eq(issues("declare var c: Capitalize<string>; c = \"Abc\";"), 0)
+}
+
+///|
 test "expr_check: generic constraint on runtime declaration (TS2344)" {
   let issues = fn(src : String) -> Int {
     check_module_function_bodies_permissive(parse_module_or_empty(src)).length()


### PR DESCRIPTION
## Summary

A string literal assigned where an intrinsic string-mapping type is expected (`Uppercase<…>` / `Lowercase<…>` / `Capitalize<…>` / `Uncapitalize<…>`) is flagged when it violates the **case constraint** that holds for *every* member regardless of the inner type:
- a member of `Uppercase<X>` is always all-uppercase → `x = "a"` where `x: Uppercase<Lowercase<string>>` can never be one.

## Why it's false-positive-free

`string_mapping_case_violation` is a **necessary-condition** check: it only flags definite case violations, and is conservative on non-ASCII letters. It never flags a literal that could still be a member. (`x = "A"`, `x = "1"`, `c = "Abc"` against `Capitalize` all stay silent.)

Added in `check_expr_against` beside the T129 template-literal check, emitted via `record_unfiltered` for the same reason (the permissive filter would otherwise drop the mapping-target diagnostic).

The pattern-match half — e.g. `y = "A"` against `Uppercase<Lowercase<\`${number}\`>>`, where the number pattern can't produce "A" — is a deliberate miss requiring intrinsic-over-template evaluation.

## Results

- Whole-corpus TP **1718 → 1720** (+2), **0 FP**.
- Pinned recall **671 → 673** (stringLiteralsAssignedToStringMappings / stringMappingOverPatternLiterals).
- Full suite **2384/2384**; whitebox-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_