### PR TITLE
checker: flag string literal vs string-literal union as a call argument

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1910,6 +1910,26 @@ conformance sources (`.errors.txt` baseline = ground truth):
     `Uppercase<Lowercase<`${number}`>>`, where the number pattern can't produce
     "A" -- is a deliberate MISS: it needs intrinsic-over-template evaluation.)
 
+2026-06-26 (T131)  673/815 (83 %)        414/414 ( 0 FP)   TS2345 string literal vs string-literal union (call args)
+
+  T131 -- TS2345 / TS2322 consistency fix. A concrete string literal that
+    isn't a member of a string-literal union was flagged on the binding-init /
+    assignment path (`const x: "a" | "b" = "c"`) but NOT as a call argument
+    (`f("c")` where the param is `"a" | "b"`): the call path widens the literal
+    source to `string`, and `string`-vs-literal-union is dropped by the
+    permissive suppression filter's over-widening guard (it can't tell an
+    over-widened valid literal from an invalid one). Added an early precise
+    check in `check_expr_against` for `(Literal, Union-of-string-literals)`
+    using `is_assignable_to`, emitted unfiltered, scoped to all-string-literal
+    unions (numeric / boolean unions already emit normally). A widened `string`
+    source never reaches it (not a precise `Literal`), so the over-widening
+    guard is preserved -- no false positive. Conformance recall-neutral (TP
+    1720, 0 FP): the corpus's literal-union call-arg misses are derived from
+    generic/conditional types (`templateLiteralTypes4`'s `TypedObject<[...]>`)
+    we don't evaluate, not the basic case -- but it's a real correctness /
+    consistency fix (a common real-world error now caught uniformly).
+    Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -6671,6 +6671,24 @@ fn check_expr_against(
         )
         return
       }
+    // A concrete string literal assigned where a union of *string literals* is
+    // expected, when the literal isn't one of them (`f("c")` where the param is
+    // `"a" | "b"`). `is_assignable_to` decides this precisely. Emitted unfiltered
+    // because the call-argument path otherwise widens the literal source to
+    // `string`, and `string`-vs-literal-union is dropped by the permissive
+    // filter's over-widening guard — so the binding-init path flags this but the
+    // call-argument path silently missed it. Scoped to all-string-literal unions
+    // (numeric / boolean unions already emit through the normal path).
+    (Literal(_), Union(members)) =>
+      if members.iter().all(fn(m) { m is Literal(_) }) &&
+        !is_assignable_to(inferred_u, expected_u) {
+        record_unfiltered(
+          ctx,
+          sub_path,
+          "expected `\{type_display(expected_u)}` but got `\{type_display(inferred_u)}`",
+        )
+        return
+      }
     _ => ()
   }
   // Boxed wrapper objects (`String`/`Number`/`Boolean`/`BigInt`/`Symbol`)

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10223,6 +10223,28 @@ test "expr_check: string literal vs template-literal-type pattern (TS2322/2345)"
 }
 
 ///|
+test "expr_check: string literal vs string-literal union, call args (TS2345)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A string literal not in the union, passed as a call argument, is flagged
+  // — previously only the binding-init path caught this (the call path widened
+  // the literal source to `string`, which the permissive filter then dropped).
+  assert_true(issues("function f(x: \"a\" | \"b\"): void {} f(\"c\");") > 0)
+  assert_true(issues("const x: \"a\" | \"b\" = \"c\";") > 0)
+  // A literal that IS in the union is fine.
+  @test.assert_eq(issues("function f(x: \"a\" | \"b\"): void {} f(\"a\");"), 0)
+  // A widened `string` source stays silent (could be a valid member; matches
+  // the over-widening guard, no false positive).
+  @test.assert_eq(
+    issues(
+      "function f(x: \"a\" | \"b\"): void {} declare const s: string; f(s);",
+    ),
+    0,
+  )
+}
+
+///|
 test "expr_check: string literal vs intrinsic string-mapping type (TS2322)" {
   let issues = fn(src : String) -> Int {
     check_module_function_bodies_permissive(parse_module_or_empty(src)).length()


### PR DESCRIPTION
## Summary

A concrete string literal not in a string-literal union was flagged on the binding-init/assignment path (`const x: "a" | "b" = "c"`) but **not** as a call argument (`f("c")` where the param is `"a" | "b"`).

Root cause: the call path widens the literal source to `string`, and `string`-vs-literal-union is dropped by the permissive suppression filter's over-widening guard (which can't distinguish an over-widened *valid* literal from an *invalid* one).

## Fix

Adds an early precise check in `check_expr_against` for `(Literal, Union-of-string-literals)` using `is_assignable_to`, emitted via `record_unfiltered`, scoped to all-string-literal unions (numeric/boolean unions already emit normally). A widened `string` source never reaches it (not a precise `Literal`), so the over-widening guard is preserved — **no false positive** (`f(s)` where `s: string` stays silent).

## Results

- **0 FP**; full suite **2385/2385**; whitebox-tested.
- Conformance **recall-neutral** (TP 1720): the corpus's literal-union call-arg misses are derived from generic/conditional types we don't evaluate (`templateLiteralTypes4`'s `TypedObject<[...]>`), not the basic case. This is a real **correctness/consistency** fix — a common real-world error (passing a wrong string literal to a literal-union parameter) is now caught uniformly across binding and call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_