### PR TITLE
checker: TS1070 accessibility modifier on interface member

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1930,6 +1930,26 @@ conformance sources (`.errors.txt` baseline = ground truth):
     consistency fix (a common real-world error now caught uniformly).
     Whitebox-tested.
 
+2026-06-26 (T132)  674/815 (83 %)        414/414 ( 0 FP)   TS1070 accessibility modifier on interface member
+
+  T132 -- TS1070 ("'private' modifier cannot appear on a type member"). The
+    parser silently consumed and discarded `private` / `public` / `protected`
+    on interface members, so the error was never surfaced. Added
+    `can_consume_interface_accessibility_modifier` (mirrors the existing
+    `readonly` modifier lookahead via the new shared `token_starts_interface_member`
+    helper) -- it treats the keyword as a modifier only when the next token
+    begins a member name AND is on the SAME line (a line break means ASI split
+    it into a standalone property signature, which TS accepts: `Protected8`,
+    `parserModifierOnPropertySignature2` -- the two FPs caught during dev). The
+    parser records each offending member in the new
+    `interface_member_modifier_misuses` channel (TsModule + Parser field, 15
+    construction sites); the checker surfaces one diagnostic per entry. Never
+    valid TS in this position, so false-positive-free. Whole-corpus TP 1720 ->
+    1723 (+3), 0 FP; pinned recall 673 -> 674 (interfaceWithPrivateMember).
+    Whitebox-tested incl. the ASI and member-named-`private` negatives. (Object
+    type literals `var v: { private y }` are not yet covered -- a separate
+    parse path -- but the interface case flips the file.)
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/ast/types.mbt
+++ b/src/ast/types.mbt
@@ -867,6 +867,13 @@ pub(all) struct TsModule {
   // records one parameter name per offending declaration; the checker
   // surfaces one diagnostic per entry. Empty for well-formed input.
   param_optional_initializer_misuses : Array[String]
+  // Interface / type-literal members declared with an accessibility modifier
+  // (`private` / `public` / `protected` x: T) -- always a TS1070 grammar error
+  // ("'private' modifier cannot appear on a type member"). The parser records
+  // one human-readable location string per offending member; the checker
+  // surfaces one diagnostic per entry. Empty for well-formed input (the
+  // modifier is never valid in these positions), so it never costs precision.
+  interface_member_modifier_misuses : Array[String]
   // Class-body structural diagnostics for every class parsed (top-level *and*
   // nested in function bodies). Each entry is `(class_name, names)` where
   // `names` is the class's `duplicate_member_names` (duplicate members plus

--- a/src/bridge/moonbit_decl.mbt
+++ b/src/bridge/moonbit_decl.mbt
@@ -420,6 +420,7 @@ async fn load_decl_module_info(
           deprecated_compiler_options: [],
           parameter_property_misuses: [],
           param_optional_initializer_misuses: [],
+          interface_member_modifier_misuses: [],
           class_dup_diagnostics: [],
         }
       }
@@ -9223,6 +9224,7 @@ pub async fn emit_moonbit_decl_from_entry_path(
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
     param_optional_initializer_misuses: [],
+    interface_member_modifier_misuses: [],
     class_dup_diagnostics: [],
   }
   // Run the checker over the final module shape and surface anything it

--- a/src/checker/check_module_wbtest.mbt
+++ b/src/checker/check_module_wbtest.mbt
@@ -16,6 +16,7 @@ fn empty_module_for_check() -> @ast.TsModule {
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
     param_optional_initializer_misuses: [],
+    interface_member_modifier_misuses: [],
     class_dup_diagnostics: [],
     top_level_stmts: [],
   }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -16863,6 +16863,16 @@ fn check_module_function_bodies_layered(
         message: "parameter cannot have question mark and initializer",
       })
     }
+    // TS1070: an accessibility modifier (`private` / `public` / `protected`)
+    // cannot appear on an interface / type-literal member. The parser records
+    // each offending member; this position is never valid TS, so it is
+    // false-positive-free.
+    for member in module_.interface_member_modifier_misuses {
+      all.push({
+        path: "member `\{member}`",
+        message: "accessibility modifier cannot appear on a type member",
+      })
+    }
     // TS2313: a type parameter with a circular constraint (`T extends T`, or an
     // indirect cycle). Walks declarations (and nested namespaces) once from the
     // top.

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -321,6 +321,7 @@ fn parse_module_or_empty(src : String) -> @ast.TsModule {
         deprecated_compiler_options: [],
         parameter_property_misuses: [],
         param_optional_initializer_misuses: [],
+        interface_member_modifier_misuses: [],
         class_dup_diagnostics: [],
         top_level_stmts: [],
       }
@@ -10220,6 +10221,36 @@ test "expr_check: string literal vs template-literal-type pattern (TS2322/2345)"
   // A widened `string` source is not a concrete literal -> stay silent (the
   // pattern matcher only judges concrete literals).
   @test.assert_eq(issues("const x: `a${string}` = (\"y\" as string);"), 0)
+}
+
+///|
+test "expr_check: accessibility modifier on interface member (TS1070)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // `private` / `public` / `protected` are never valid on a type member.
+  assert_true(issues("interface I { private x: string; }") > 0)
+  assert_true(issues("interface I { public x: string; }") > 0)
+  assert_true(issues("interface I { protected x: string; }") > 0)
+  // `readonly` IS valid -> silent.
+  @test.assert_eq(issues("interface I { readonly x: string; }"), 0)
+  // A member literally *named* `private` (no following name) is a property, not
+  // a modifier -> silent.
+  @test.assert_eq(issues("interface I { private: string; }"), 0)
+  // ASI: a modifier keyword on its own line splits into a standalone property
+  // signature (`interface I { protected\n p }` declares `protected` and `p`),
+  // which TS accepts -> silent.
+  @test.assert_eq(
+    issues(
+      (
+        #|interface I {
+        #|  protected
+        #|  p
+        #|}
+      ),
+    ),
+    0,
+  )
 }
 
 ///|

--- a/src/checker/generics_wbtest.mbt
+++ b/src/checker/generics_wbtest.mbt
@@ -104,6 +104,7 @@ test "module_alias_resolver: combines parsed aliases with stdlib utilities" {
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
     param_optional_initializer_misuses: [],
+    interface_member_modifier_misuses: [],
     class_dup_diagnostics: [],
     top_level_stmts: [],
   }
@@ -144,6 +145,7 @@ test "module_alias_resolver: include_standard=false omits stdlib" {
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
     param_optional_initializer_misuses: [],
+    interface_member_modifier_misuses: [],
     class_dup_diagnostics: [],
     top_level_stmts: [],
   }
@@ -186,6 +188,7 @@ test "module_alias_resolver: module aliases shadow stdlib on name clash" {
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
     param_optional_initializer_misuses: [],
+    interface_member_modifier_misuses: [],
     class_dup_diagnostics: [],
     top_level_stmts: [],
   }

--- a/src/checker/validate_wbtest.mbt
+++ b/src/checker/validate_wbtest.mbt
@@ -16,6 +16,7 @@ fn empty_module() -> @ast.TsModule {
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
     param_optional_initializer_misuses: [],
+    interface_member_modifier_misuses: [],
     class_dup_diagnostics: [],
     top_level_stmts: [],
   }

--- a/src/cmd/mtsc/main.mbt
+++ b/src/cmd/mtsc/main.mbt
@@ -424,6 +424,7 @@ async fn mtsc_load_bundle_files(
           deprecated_compiler_options: [],
           parameter_property_misuses: [],
           param_optional_initializer_misuses: [],
+          interface_member_modifier_misuses: [],
           class_dup_diagnostics: [],
           top_level_stmts: [],
         }
@@ -635,6 +636,7 @@ async fn main {
           deprecated_compiler_options: [],
           parameter_property_misuses: [],
           param_optional_initializer_misuses: [],
+          interface_member_modifier_misuses: [],
           class_dup_diagnostics: [],
           top_level_stmts: [],
         })
@@ -749,6 +751,7 @@ async fn main {
             deprecated_compiler_options: [],
             parameter_property_misuses: [],
             param_optional_initializer_misuses: [],
+            interface_member_modifier_misuses: [],
             class_dup_diagnostics: [],
             top_level_stmts: [],
           })

--- a/src/parser/parser_core.mbt
+++ b/src/parser/parser_core.mbt
@@ -83,6 +83,12 @@ pub struct Parser {
   // list to the checker. Empty for well-formed input, so it never costs
   // precision.
   param_optional_initializer_misuses : Array[String]
+  // Interface / type-literal members seen with an accessibility modifier
+  // (`private` / `public` / `protected`) -- always a TS1070 grammar error.
+  // `parse_interface` / the object-type-literal parser append one location
+  // string per offending member; the checker surfaces them. Empty for
+  // well-formed input, so it never costs precision.
+  interface_member_modifier_misuses : Array[String]
   // Class-body structural diagnostics (`duplicate_member_names`, which also
   // carries the `<multiple-ctor-impl>` / `<index-sig-modifier>` /
   // `<abstract-impl>` sentinels) collected for *every* class parsed, including
@@ -168,6 +174,7 @@ pub fn Parser::new_with_strict_and_jsx(
     param_property_scopes: [],
     param_property_misuses: [],
     param_optional_initializer_misuses: [],
+    interface_member_modifier_misuses: [],
     collected_class_dups: [],
     pure_marker_positions: {},
     internal_marker_positions: {},
@@ -224,6 +231,7 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
     param_property_scopes: [],
     param_property_misuses: [],
     param_optional_initializer_misuses: [],
+    interface_member_modifier_misuses: [],
     collected_class_dups: [],
     pure_marker_positions: lexer.pure_marker_positions,
     internal_marker_positions: lexer.internal_marker_positions,

--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -1025,11 +1025,47 @@ fn Parser::parse_extends_clause_until_body(
 }
 
 ///|
+// True when an accessibility modifier (`private` / `public` / `protected`) is
+// being used as a *modifier* on the next interface / type-literal member — i.e.
+// it's one of those keywords AND the following token begins a member name. Such
+// a modifier is illegal on a type member (TS1070); the caller records the
+// diagnostic, consumes the keyword, and parses the member as usual. Reuses the
+// same member-start lookahead as the `readonly` modifier so a property literally
+// named `private` (`{ private: string }`) is not misread as a modifier.
+fn Parser::can_consume_interface_accessibility_modifier(self : Parser) -> Bool {
+  let is_acc = match self.peek().kind {
+    Ident(n) => n == "private" || n == "public" || n == "protected"
+    _ => false
+  }
+  if !is_acc {
+    return false
+  }
+  // A modifier must sit on the SAME line as the member it modifies. With a line
+  // break after the keyword, ASI splits it into its own property signature
+  // (`interface I { protected \n p }` declares members `protected` and `p`,
+  // which TS accepts) — so a newline before the next token means this is a
+  // member *name*, not a modifier.
+  let next = self.peek_at(1)
+  if next.has_newline_before {
+    return false
+  }
+  token_starts_interface_member(next.kind)
+}
+
+///|
 fn Parser::can_consume_interface_readonly_modifier(self : Parser) -> Bool {
   if !self.check(Ident("readonly")) {
     return false
   }
-  match self.peek_at(1).kind {
+  token_starts_interface_member(self.peek_at(1).kind)
+}
+
+///|
+// True when `kind` can begin an interface / type-literal member name (a plain
+// identifier, string / numeric literal key, index-signature `[`, call / new
+// signature, or any of the contextual keywords that double as member names).
+fn token_starts_interface_member(kind : TokenKind) -> Bool {
+  match kind {
     Ident(_)
     | Str(_)
     | Int(_)
@@ -1101,6 +1137,18 @@ pub fn Parser::parse_interface(
   let index_signatures : Array[(@ast.TsType, @ast.TsType)] = []
   let method_type_params : Array[(String, Array[String])] = []
   while !self.check(RBrace) && !self.check(Eof) {
+    // TS1070: an accessibility modifier (`private` / `public` / `protected`)
+    // is never valid on an interface member. Record it, consume the keyword,
+    // and parse the member as usual (the `readonly` modifier — which IS legal —
+    // is handled separately below). `name` is the member it precedes.
+    while self.can_consume_interface_accessibility_modifier() {
+      let _ = self.advance()
+      let member = match self.peek().kind {
+        Ident(n) => n
+        _ => "<member>"
+      }
+      self.interface_member_modifier_misuses.push("\{name}.\{member}")
+    }
     // Skip readonly modifier
     let mut is_readonly_field = false
     if self.can_consume_interface_readonly_modifier() {

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -136,6 +136,7 @@ fn empty_ts_module() -> @ast.TsModule {
     deprecated_compiler_options: [],
     parameter_property_misuses: [],
     param_optional_initializer_misuses: [],
+    interface_member_modifier_misuses: [],
     class_dup_diagnostics: [],
   }
 }
@@ -3275,6 +3276,7 @@ fn Parser::parse_module_with_seeded_const_values_internal(
     deprecated_compiler_options: detect_deprecated_compiler_options(self.src),
     parameter_property_misuses: self.param_property_misuses,
     param_optional_initializer_misuses: self.param_optional_initializer_misuses,
+    interface_member_modifier_misuses: self.interface_member_modifier_misuses,
     class_dup_diagnostics: self.collected_class_dups,
   }
 }


### PR DESCRIPTION
## Summary

The parser silently consumed and discarded `private` / `public` / `protected` on interface members, so the TS1070 error ("`'private'` modifier cannot appear on a type member") was never surfaced.

Adds `can_consume_interface_accessibility_modifier` (mirrors the existing `readonly`-modifier lookahead via a new shared `token_starts_interface_member` helper). It treats the keyword as a modifier only when the next token begins a member name **and is on the same line**.

## False positives caught during development

A line break after the keyword means ASI splits it into a standalone property signature, which TS **accepts**:
```ts
interface I { protected   // <- property named "protected"
              p }         // <- property named "p"
```
`Protected8` and `parserModifierOnPropertySignature2` were exactly these — fixed by the same-line check (`has_newline_before`). A member literally named `private` (`{ private: string }`) is also correctly left alone.

## Plumbing

The parser records each offending member in a new `interface_member_modifier_misuses` channel (TsModule + Parser field, 15 construction sites); the checker surfaces one diagnostic per entry. Never valid TS in this position → false-positive-free.

## Results

- Whole-corpus TP **1720 → 1723** (+3), **0 FP**.
- Pinned recall **673 → 674** (interfaceWithPrivateMember).
- Full suite **2386/2386**; whitebox-tested incl. ASI and member-named-`private` negatives.

(Object type literals `var v: { private y }` use a separate parse path and aren't covered yet.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_