### PR TITLE
checker: TS2371 parameter initializer in interface signature

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1950,6 +1950,22 @@ conformance sources (`.errors.txt` baseline = ground truth):
     type literals `var v: { private y }` are not yet covered -- a separate
     parse path -- but the interface case flips the file.)
 
+2026-06-26 (T133)  675/815 (83 %)        414/414 ( 0 FP)   TS2371 parameter initializer in interface signature
+
+  T133 -- TS2371 ("A parameter initializer is only allowed in a function or
+    constructor implementation"). An interface method / call signature has no
+    body, so a parameter default (`interface I { foo(y = 1); }`, `{ (x = 1); }`)
+    is always an error. Detected in `parse_interface` right after the signature
+    `parse_params()` (any param with a non-`None` `default`), recorded via the
+    shared `interface_member_modifier_misuses` channel with a `<param-init>`
+    sentinel so the checker emits TS2371 vs the TS1070 modifier message.
+    Function / class-method *implementations* (which legitimately allow
+    initializers) go through different parse paths and are unaffected. Never
+    valid TS in a signature, so false-positive-free. Whole-corpus TP 1723 ->
+    1724 (+1), 0 FP; pinned recall 674 -> 675 (callSignaturesWithParameterInitializers).
+    Whitebox-tested. (Object-type-literal signatures `{ (x = 1) }` use a
+    separate parse path and aren't covered, but the interface case flips the file.)
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -16863,15 +16863,26 @@ fn check_module_function_bodies_layered(
         message: "parameter cannot have question mark and initializer",
       })
     }
-    // TS1070: an accessibility modifier (`private` / `public` / `protected`)
-    // cannot appear on an interface / type-literal member. The parser records
-    // each offending member; this position is never valid TS, so it is
-    // false-positive-free.
+    // Interface / type-literal member misuses recorded by the parser, never
+    // valid TS so false-positive-free:
+    //   - `<param-init>…` -> TS2371: a parameter initializer is only allowed in
+    //     an implementation signature (an interface method / call signature has
+    //     no body).
+    //   - otherwise        -> TS1070: an accessibility modifier
+    //     (`private` / `public` / `protected`) cannot appear on a type member.
     for member in module_.interface_member_modifier_misuses {
-      all.push({
-        path: "member `\{member}`",
-        message: "accessibility modifier cannot appear on a type member",
-      })
+      if member.has_prefix("<param-init>") {
+        let m = member.substring(start="<param-init>".length())
+        all.push({
+          path: "member `\{m}`",
+          message: "a parameter initializer is only allowed in an implementation signature",
+        })
+      } else {
+        all.push({
+          path: "member `\{member}`",
+          message: "accessibility modifier cannot appear on a type member",
+        })
+      }
     }
     // TS2313: a type parameter with a circular constraint (`T extends T`, or an
     // indirect cycle). Walks declarations (and nested namespaces) once from the

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10224,6 +10224,22 @@ test "expr_check: string literal vs template-literal-type pattern (TS2322/2345)"
 }
 
 ///|
+test "expr_check: parameter initializer in interface signature (TS2371)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A parameter initializer in an interface method / call signature is illegal
+  // (no implementation body).
+  assert_true(issues("interface I { foo(x: number, y = 1); }") > 0)
+  assert_true(issues("interface I { (x = 1); }") > 0)
+  // Implementations (function / class method) DO allow initializers -> silent.
+  @test.assert_eq(issues("function foo(x = 1) {}"), 0)
+  @test.assert_eq(issues("class C { foo(x = 1) {} }"), 0)
+  // A signature with no initializer is fine.
+  @test.assert_eq(issues("interface I { foo(x: number): void; }"), 0)
+}
+
+///|
 test "expr_check: accessibility modifier on interface member (TS1070)" {
   let issues = fn(src : String) -> Int {
     check_module_function_bodies_permissive(parse_module_or_empty(src)).length()

--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -1435,6 +1435,17 @@ pub fn Parser::parse_interface(
       let _ = self.advance()
       let method_params = self.parse_params()
       let _ = self.expect(RParen)
+      // TS2371: a parameter initializer (`x = 1`) is only allowed in an
+      // implementation signature. An interface method / call signature never
+      // has a body, so any default here is an error. Recorded via the shared
+      // interface-member-misuse channel with a `<param-init>` sentinel.
+      for param in method_params {
+        if !(param.default is None) {
+          self.interface_member_modifier_misuses.push(
+            "<param-init>\{field_name}.\{param.name}",
+          )
+        }
+      }
       // Return type
       let return_type = if self.check(Colon) {
         let _ = self.advance()


### PR DESCRIPTION
## Summary

An interface method / call signature has no implementation body, so a parameter default (`interface I { foo(y = 1); }`, `{ (x = 1); }`) is always a TS2371 error ("A parameter initializer is only allowed in a function or constructor implementation").

Detected in `parse_interface` right after the signature `parse_params()` (any param with a non-`None` `default`), recorded via the shared `interface_member_modifier_misuses` channel with a `<param-init>` sentinel so the checker emits TS2371 instead of the TS1070 modifier message.

## Soundness

Function and class-method **implementations** (which legitimately allow initializers) use different parse paths and are unaffected — verified silent. A signature is never valid TS with an initializer, so this is false-positive-free.

## Results

- Whole-corpus TP **1723 → 1724** (+1), **0 FP**.
- Pinned recall **674 → 675** (callSignaturesWithParameterInitializers).
- Full suite **2387/2387**; whitebox-tested.

(Object-type-literal signatures `{ (x = 1) }` use a separate parse path and aren't covered, but the interface case flips the file.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_