### PR TITLE
checker: TS2385 constructor overload accessibility mismatch

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1966,6 +1966,23 @@ conformance sources (`.errors.txt` baseline = ground truth):
     Whitebox-tested. (Object-type-literal signatures `{ (x = 1) }` use a
     separate parse path and aren't covered, but the interface case flips the file.)
 
+2026-06-26 (T134)  676/815 (83 %)        414/414 ( 0 FP)   TS2385 constructor overload accessibility mismatch
+
+  T134 -- TS2385 ("Overload signatures must all be public, private or
+    protected"). A class declaring 2+ constructor signatures whose
+    accessibilities differ (`public constructor(...); protected constructor(...);
+    private constructor(...)`) is an error. The class-body parser already tracks
+    per-element `visibility` (defaults to "public", captures private/protected);
+    added a `ctor_visibilities` accumulator that records each constructor
+    signature's visibility, computes an `overload_accessibility_mix` flag (2+
+    entries not all equal), threads it through the parse_class_body return tuple
+    (now 11-tuple) and surfaces it via the existing `duplicate_member_names`
+    sentinel channel (`<overload-accessibility-mix>`) -> checker emits TS2385.
+    Scoped to constructors (the conformance file's focus); all-same and single
+    constructors stay silent. Never valid TS, so false-positive-free.
+    Whole-corpus TP 1724 -> 1725 (+1), 0 FP; pinned recall 675 -> 676
+    (classConstructorOverloadsAccessibility). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -16141,6 +16141,11 @@ fn check_class_duplicate_members(module_ : @ast.TsModule) -> Array[ExprIssue] {
           path: "class \{cls_name}",
           message: "function implementation is missing or not immediately following the declaration",
         })
+      } else if name == "<overload-accessibility-mix>" {
+        issues.push({
+          path: "class \{cls_name}",
+          message: "overload signatures must all be public, private or protected",
+        })
       } else {
         issues.push({
           path: "class \{cls_name}",

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10224,6 +10224,41 @@ test "expr_check: string literal vs template-literal-type pattern (TS2322/2345)"
 }
 
 ///|
+test "expr_check: constructor overload accessibility mismatch (TS2385)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Constructor overload signatures with inconsistent accessibility are TS2385.
+  assert_true(
+    issues(
+      "class A { public constructor(a: boolean); protected constructor(a: number); private constructor(a: string); private constructor() {} }",
+    ) >
+    0,
+  )
+  assert_true(
+    issues(
+      "class B { protected constructor(a: number); constructor(a: string); constructor() {} }",
+    ) >
+    0,
+  )
+  // All-same accessibility (incl. all-default-public) is fine.
+  @test.assert_eq(
+    issues(
+      "class C { protected constructor(a: number); protected constructor(a: string); protected constructor() {} }",
+    ),
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "class D { constructor(a: number); constructor(a: string); constructor() {} }",
+    ),
+    0,
+  )
+  // A single constructor (no overloads) is never flagged.
+  @test.assert_eq(issues("class E { private constructor() {} }"), 0)
+}
+
+///|
 test "expr_check: parameter initializer in interface signature (TS2371)" {
   let issues = fn(src : String) -> Int {
     check_module_function_bodies_permissive(parse_module_or_empty(src)).length()

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -1074,6 +1074,7 @@ fn Parser::parse_class_body(
   Bool,
   Bool,
   Bool,
+  Bool,
 ) raise ParseError {
   let _ = self.expect(LBrace)
   // Class body is implicitly strict mode
@@ -1110,6 +1111,11 @@ fn Parser::parse_class_body(
   let private_members : Array[String] = []
   let protected_members : Array[String] = []
   let abstract_members : Array[String] = []
+  // Accessibility of each constructor signature / implementation seen, in
+  // order. Used for TS2385 ("overload signatures must all be public, private
+  // or protected"): if a class declares 2+ constructor signatures whose
+  // accessibilities differ, it's an error.
+  let ctor_visibilities : Array[String] = []
   while !self.check(RBrace) && !self.check(Eof) {
     while self.check(At) {
       self.skip_decorator()
@@ -1275,6 +1281,10 @@ fn Parser::parse_class_body(
       let is_constructor_method = key is Name("constructor")
       if is_constructor_method {
         self.param_property_scopes.push([])
+        // TS2385: record this constructor signature's accessibility so we can
+        // flag an overload set whose members don't all share one (`visibility`
+        // defaults to "public" and captures private / protected modifiers).
+        ctor_visibilities.push(visibility)
       }
       let params = if self.check(LParen) {
         let _ = self.expect(LParen)
@@ -1497,9 +1507,23 @@ fn Parser::parse_class_body(
   if check_missing(ov_instance) || check_missing(ov_static) {
     overload_missing_impl = true
   }
+  // TS2385: a constructor overload set (2+ signatures) whose members don't all
+  // share one accessibility. Conservative — fires only when the visibilities
+  // genuinely differ, which is never valid TS, so it is false-positive-free.
+  let mut overload_accessibility_mix = false
+  if ctor_visibilities.length() >= 2 {
+    let first = ctor_visibilities[0]
+    for v in ctor_visibilities {
+      if v != first {
+        overload_accessibility_mix = true
+        break
+      }
+    }
+  }
   (
     ctor, elements, private_members, protected_members, abstract_members, ctor_impl_count,
     index_sig_modifier_misuse, abstract_member_with_body, overload_static_mix, overload_missing_impl,
+    overload_accessibility_mix,
   )
 }
 
@@ -1550,6 +1574,7 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
     private_members,
     protected_members,
     abstract_members,
+    _,
     _,
     _,
     _,
@@ -2218,6 +2243,7 @@ fn Parser::parse_class_decl_with_abstract(
     abstract_member_with_body,
     overload_static_mix,
     overload_missing_impl,
+    overload_accessibility_mix,
   ) = self.parse_class_body()
   self.current_class_brand = prev_brand
   self.restore_local_type_param_bounds(class_type_param_bound_len)
@@ -2248,6 +2274,10 @@ fn Parser::parse_class_decl_with_abstract(
   // TS2391: a bodyless overload signature with no implementation.
   if overload_missing_impl {
     runtime_decl.duplicate_member_names.push("<overload-no-impl>")
+  }
+  // TS2385: constructor overload signatures with inconsistent accessibility.
+  if overload_accessibility_mix {
+    runtime_decl.duplicate_member_names.push("<overload-accessibility-mix>")
   }
   // Surface the class's structural diagnostics for *every* class, including
   // ones nested in function bodies that the IIFE lowering removes from


### PR DESCRIPTION
## Summary

A class declaring 2+ constructor signatures whose accessibilities differ is a TS2385 error ("Overload signatures must all be public, private or protected"):
```ts
class A {
    public constructor(a: boolean)     // error
    protected constructor(a: number)   // error
    private constructor(a: string)
    private constructor() {}
}
```

## Implementation

The class-body parser already tracks per-element `visibility` (defaults to `"public"`, captures `private`/`protected`). Added a `ctor_visibilities` accumulator recording each constructor signature's visibility, computes an `overload_accessibility_mix` flag (2+ entries, not all equal), threads it through the `parse_class_body` return tuple, and surfaces it via the existing `duplicate_member_names` sentinel channel (`<overload-accessibility-mix>`) → checker emits TS2385.

## Soundness

Scoped to constructors (the conformance file's focus). All-same-accessibility (including all-default-public) and single-constructor classes stay silent. Never valid TS, so false-positive-free.

## Results

- Whole-corpus TP **1724 → 1725** (+1), **0 FP**.
- Pinned recall **675 → 676** (classConstructorOverloadsAccessibility).
- Full suite **2388/2388**; whitebox-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_