### PR TITLE
checker: TS1029 `static` must precede `async` modifier

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1983,6 +1983,21 @@ conformance sources (`.errors.txt` baseline = ground truth):
     Whole-corpus TP 1724 -> 1725 (+1), 0 FP; pinned recall 675 -> 676
     (classConstructorOverloadsAccessibility). Whitebox-tested.
 
+2026-06-26 (T135)  677/815 (83 %)        414/414 ( 0 FP)   TS1029 `static` must precede `async` modifier
+
+  T135 -- TS1029 ("'static' modifier must precede 'async' modifier"). A class
+    member written `async static foo()` has the modifiers in the wrong order.
+    Detected in the class-body modifier loop: when `static` is consumed while
+    `async` was already seen for the same member, set `modifier_order_misuse`,
+    thread it through the parse_class_body return tuple (now 12-tuple), and
+    surface via the `duplicate_member_names` / `collected_class_dups` sentinel
+    channel (`<modifier-order>`) -> checker emits TS1029. Wired for BOTH class
+    declarations and class *expressions* (`parse_class_stub`, which previously
+    ignored every structural flag -- a general blind spot; the conformance file
+    is a class expression). Never valid TS, so false-positive-free. Whole-corpus
+    TP 1725 -> 1727 (+2), 0 FP; pinned recall 676 -> 677
+    (privateNameStaticMethodAsync). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -16146,6 +16146,11 @@ fn check_class_duplicate_members(module_ : @ast.TsModule) -> Array[ExprIssue] {
           path: "class \{cls_name}",
           message: "overload signatures must all be public, private or protected",
         })
+      } else if name == "<modifier-order>" {
+        issues.push({
+          path: "class \{cls_name}",
+          message: "`static` modifier must precede `async` modifier",
+        })
       } else {
         issues.push({
           path: "class \{cls_name}",

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10224,6 +10224,22 @@ test "expr_check: string literal vs template-literal-type pattern (TS2322/2345)"
 }
 
 ///|
+test "expr_check: async-before-static modifier order (TS1029)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // `async static` (wrong order) is TS1029 — in a class declaration and a
+  // class expression, with or without a generator.
+  assert_true(issues("class C { async static foo() {} }") > 0)
+  assert_true(issues("class C { async static *bar() {} }") > 0)
+  assert_true(issues("const C = class { async static foo() {} };") > 0)
+  // Correct order, or only one of the modifiers -> silent.
+  @test.assert_eq(issues("class C { static async foo() {} }"), 0)
+  @test.assert_eq(issues("class C { async foo() {} }"), 0)
+  @test.assert_eq(issues("class C { static foo() {} }"), 0)
+}
+
+///|
 test "expr_check: constructor overload accessibility mismatch (TS2385)" {
   let issues = fn(src : String) -> Int {
     check_module_function_bodies_permissive(parse_module_or_empty(src)).length()

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -1075,6 +1075,7 @@ fn Parser::parse_class_body(
   Bool,
   Bool,
   Bool,
+  Bool,
 ) raise ParseError {
   let _ = self.expect(LBrace)
   // Class body is implicitly strict mode
@@ -1116,6 +1117,9 @@ fn Parser::parse_class_body(
   // or protected"): if a class declares 2+ constructor signatures whose
   // accessibilities differ, it's an error.
   let ctor_visibilities : Array[String] = []
+  // Set when a member wrote `async` before `static` (`async static foo()`) --
+  // always TS1029 ("'static' modifier must precede 'async' modifier").
+  let mut modifier_order_misuse = false
   while !self.check(RBrace) && !self.check(Eof) {
     while self.check(At) {
       self.skip_decorator()
@@ -1142,6 +1146,11 @@ fn Parser::parse_class_body(
         Ident(n) if n == "static" =>
           if self.can_consume_class_modifier() {
             let _ = self.advance()
+            // TS1029: `static` must precede `async`. If `async` was already
+            // consumed for this member, the source order was `async static`.
+            if is_async_method {
+              modifier_order_misuse = true
+            }
             is_static = true
             has_modifier = true
             // Check for static initialization block: static { ... }
@@ -1523,7 +1532,7 @@ fn Parser::parse_class_body(
   (
     ctor, elements, private_members, protected_members, abstract_members, ctor_impl_count,
     index_sig_modifier_misuse, abstract_member_with_body, overload_static_mix, overload_missing_impl,
-    overload_accessibility_mix,
+    overload_accessibility_mix, modifier_order_misuse,
   )
 }
 
@@ -1580,9 +1589,18 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
     _,
     _,
     _,
+    modifier_order_misuse,
   ) = self.parse_class_body()
   self.current_class_brand = prev_brand
   self.restore_local_type_param_bounds(class_type_param_bound_len)
+  // TS1029 (`async` before `static`) on a class *expression* member. The
+  // expression paths below build the result several different ways, so record
+  // the sentinel up front via the shared `collected_class_dups` channel the
+  // checker already reads (declarations record it through
+  // `build_runtime_class_decl`'s caller instead).
+  if modifier_order_misuse {
+    self.collected_class_dups.push((class_name, ["<modifier-order>"]))
+  }
   // Self-extending classes (`class C extends C {}`) intentionally
   // throw at evaluation time per ES spec; preserve that with a
   // tiny IIFE.
@@ -2244,6 +2262,7 @@ fn Parser::parse_class_decl_with_abstract(
     overload_static_mix,
     overload_missing_impl,
     overload_accessibility_mix,
+    modifier_order_misuse,
   ) = self.parse_class_body()
   self.current_class_brand = prev_brand
   self.restore_local_type_param_bounds(class_type_param_bound_len)
@@ -2278,6 +2297,10 @@ fn Parser::parse_class_decl_with_abstract(
   // TS2385: constructor overload signatures with inconsistent accessibility.
   if overload_accessibility_mix {
     runtime_decl.duplicate_member_names.push("<overload-accessibility-mix>")
+  }
+  // TS1029: a member wrote `async` before `static`.
+  if modifier_order_misuse {
+    runtime_decl.duplicate_member_names.push("<modifier-order>")
   }
   // Surface the class's structural diagnostics for *every* class, including
   // ones nested in function bodies that the IIFE lowering removes from


### PR DESCRIPTION
## Summary

A class member written `async static foo()` has its modifiers in the wrong order — TS1029 ("'static' modifier must precede 'async' modifier").

Detected in the class-body modifier loop: when `static` is consumed while `async` was already seen for the same member, set `modifier_order_misuse`, thread it through the `parse_class_body` return tuple, and surface via the `duplicate_member_names` / `collected_class_dups` sentinel channel (`<modifier-order>`) → checker emits TS1029.

Wired for **both class declarations and class expressions** (`parse_class_stub`, which previously ignored every structural flag — a general blind spot; the conformance file `privateNameStaticMethodAsync` is a class expression).

## Soundness

`static async` (correct order), and members with only one of the modifiers, stay silent. Never valid TS in the wrong order, so false-positive-free.

## Results

- Whole-corpus TP **1725 → 1727** (+2), **0 FP**.
- Pinned recall **676 → 677** (privateNameStaticMethodAsync).
- Full suite **2389/2389**; whitebox-tested (declaration + expression + generator + negatives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_