### PR TITLE
checker: surface class-body structural diagnostics on class expressions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1998,6 +1998,21 @@ conformance sources (`.errors.txt` baseline = ground truth):
     TP 1725 -> 1727 (+2), 0 FP; pinned recall 676 -> 677
     (privateNameStaticMethodAsync). Whitebox-tested.
 
+2026-06-26 (T136)  677/815 (83 %)        414/414 ( 0 FP)   class-expression structural-diagnostic blind spot
+
+  T136 -- `parse_class_stub` (class *expressions*, `const C = class { … }`)
+    ignored every class-body structural flag the declaration path surfaces, so
+    class expressions never reported TS2392 / TS1071 / TS1245 / TS2387-8 /
+    TS2391 / TS2385 / TS1029. Generalized the T135 modifier-order push: capture
+    all the flags from the parse_class_body tuple and push their sentinels to
+    the shared `collected_class_dups` channel up front (covers all three
+    expression return paths). All always-an-error conditions, so
+    false-positive-free. Conformance recall-neutral (TP 1727, 0 FP) -- the
+    corpus has no class-expression structural-misuse files beyond the
+    modifier-order ones T135 already caught -- but a sound consistency /
+    robustness fix that closes the blind spot (class expressions now match
+    declarations). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10224,6 +10224,27 @@ test "expr_check: string literal vs template-literal-type pattern (TS2322/2345)"
 }
 
 ///|
+test "expr_check: class-expression structural diagnostics" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Class *expressions* now surface the same class-body structural errors as
+  // declarations (previously a blind spot in `parse_class_stub`).
+  // TS2391: a bodyless overload signature with no implementation.
+  assert_true(issues("const C = class { foo(); };") > 0)
+  // TS2392: multiple constructor implementations.
+  assert_true(
+    issues(
+      "const C = class { constructor(a: number) {} constructor(b: string) {} };",
+    ) >
+    0,
+  )
+  // Valid class expressions stay silent.
+  @test.assert_eq(issues("const C = class { foo() {} };"), 0)
+  @test.assert_eq(issues("const C = class { foo(); foo() {} };"), 0)
+}
+
+///|
 test "expr_check: async-before-static modifier order (TS1029)" {
   let issues = fn(src : String) -> Int {
     check_module_function_bodies_permissive(parse_module_or_empty(src)).length()

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -1583,23 +1583,47 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
     private_members,
     protected_members,
     abstract_members,
-    _,
-    _,
-    _,
-    _,
-    _,
-    _,
+    ctor_impl_count,
+    index_sig_modifier_misuse,
+    abstract_member_with_body,
+    overload_static_mix,
+    overload_missing_impl,
+    overload_accessibility_mix,
     modifier_order_misuse,
   ) = self.parse_class_body()
   self.current_class_brand = prev_brand
   self.restore_local_type_param_bounds(class_type_param_bound_len)
-  // TS1029 (`async` before `static`) on a class *expression* member. The
-  // expression paths below build the result several different ways, so record
-  // the sentinel up front via the shared `collected_class_dups` channel the
-  // checker already reads (declarations record it through
-  // `build_runtime_class_decl`'s caller instead).
+  // Class *expressions* (`const C = class { … }`) build their result through
+  // several branches below, none of which record the class-body structural
+  // diagnostics that the declaration path surfaces via
+  // `build_runtime_class_decl`'s caller. Record the flag-derived sentinels up
+  // front through the shared `collected_class_dups` channel the checker reads,
+  // so these always-an-error conditions (TS2392 / TS1071 / TS1245 / TS2387-8 /
+  // TS2391 / TS2385 / TS1029) are flagged on class expressions too.
+  let expr_class_sentinels : Array[String] = []
+  if ctor_impl_count >= 2 {
+    expr_class_sentinels.push("<multiple-ctor-impl>")
+  }
+  if index_sig_modifier_misuse {
+    expr_class_sentinels.push("<index-sig-modifier>")
+  }
+  if abstract_member_with_body {
+    expr_class_sentinels.push("<abstract-impl>")
+  }
+  if overload_static_mix {
+    expr_class_sentinels.push("<overload-static-mix>")
+  }
+  if overload_missing_impl {
+    expr_class_sentinels.push("<overload-no-impl>")
+  }
+  if overload_accessibility_mix {
+    expr_class_sentinels.push("<overload-accessibility-mix>")
+  }
   if modifier_order_misuse {
-    self.collected_class_dups.push((class_name, ["<modifier-order>"]))
+    expr_class_sentinels.push("<modifier-order>")
+  }
+  if expr_class_sentinels.length() > 0 {
+    self.collected_class_dups.push((class_name, expr_class_sentinels))
   }
   // Self-extending classes (`class C extends C {}`) intentionally
   // throw at evaluation time per ES spec; preserve that with a


### PR DESCRIPTION
## Summary

`parse_class_stub` (class *expressions*, `const C = class { … }`) ignored every class-body structural flag the declaration path surfaces, so class expressions never reported TS2392 / TS1071 / TS1245 / TS2387-8 / TS2391 / TS2385 / TS1029.

Generalizes the T135 modifier-order push: capture all the flags from the `parse_class_body` tuple and push their sentinels to the shared `collected_class_dups` channel up front (covering all three expression return paths). All are always-an-error conditions, so false-positive-free.

## Results

- **Conformance recall-neutral** (TP 1727, **0 FP**): the corpus has no class-expression structural-misuse files beyond the modifier-order ones T135 already caught. This is a sound **consistency/robustness** fix that closes a blind spot — class expressions now match declarations (e.g. `const C = class { foo(); }` now flags TS2391, `class { constructor(a){} constructor(b){} }` flags TS2392).
- Full suite **2390/2390**; whitebox-tested (targets + valid-class-expression negatives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_