### PR TITLE
checker: TS1128 statement in class body

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2013,6 +2013,21 @@ conformance sources (`.errors.txt` baseline = ground truth):
     robustness fix that closes the blind spot (class expressions now match
     declarations). Whitebox-tested.
 
+2026-06-26 (T137)  678/815 (83 %)        414/414 ( 0 FP)   TS1128 statement in class body
+
+  T137 -- TS1128 ("Declaration or statement expected"). A `var x = 1` /
+    `function foo() {}` statement at class-member position is not a member
+    declaration. Detected in the class-body loop: a `Var`/`Let`/`Const`/`Function`
+    keyword followed by an identifier ON THE SAME LINE (the statement form).
+    The same-line guard (`has_newline_before`) avoids the parserClassDeclaration26
+    FP -- a keyword on its own line is ASI-split into a standalone member named
+    `var`/`public` (TS accepts that); a member named `var` via `var: T` / `var() {}`
+    is also untouched (identifier doesn't follow). Threaded through the
+    parse_class_body return tuple (now 13-tuple) and surfaced via the
+    `<class-body-statement>` sentinel for both declarations and class
+    expressions. Whole-corpus TP 1727 -> 1729 (+2), 0 FP; pinned recall 677 ->
+    678 (classBodyWithStatements). Whitebox-tested incl. the ASI negative.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -16151,6 +16151,11 @@ fn check_class_duplicate_members(module_ : @ast.TsModule) -> Array[ExprIssue] {
           path: "class \{cls_name}",
           message: "`static` modifier must precede `async` modifier",
         })
+      } else if name == "<class-body-statement>" {
+        issues.push({
+          path: "class \{cls_name}",
+          message: "declaration or statement expected",
+        })
       } else {
         issues.push({
           path: "class \{cls_name}",

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10224,6 +10224,34 @@ test "expr_check: string literal vs template-literal-type pattern (TS2322/2345)"
 }
 
 ///|
+test "expr_check: statement in class body (TS1128)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A `var`/`function` statement in a class body (declaration and expression).
+  assert_true(issues("class C { var x = 1; }") > 0)
+  assert_true(issues("class C { function foo() {} }") > 0)
+  assert_true(issues("const C = class { var x = 1; };") > 0)
+  // Valid members stay silent.
+  @test.assert_eq(issues("class C { x: number = 1; }"), 0)
+  @test.assert_eq(issues("class C { foo() {} }"), 0)
+  // ASI: a keyword on its own line is a standalone member (`var` then `public`
+  // are two fields), which TS accepts -> silent (the parserClassDeclaration26
+  // regression).
+  @test.assert_eq(
+    issues(
+      (
+        #|class C {
+        #|  var
+        #|  public
+        #|}
+      ),
+    ),
+    0,
+  )
+}
+
+///|
 test "expr_check: class-expression structural diagnostics" {
   let issues = fn(src : String) -> Int {
     check_module_function_bodies_permissive(parse_module_or_empty(src)).length()

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -1076,6 +1076,7 @@ fn Parser::parse_class_body(
   Bool,
   Bool,
   Bool,
+  Bool,
 ) raise ParseError {
   let _ = self.expect(LBrace)
   // Class body is implicitly strict mode
@@ -1120,7 +1121,26 @@ fn Parser::parse_class_body(
   // Set when a member wrote `async` before `static` (`async static foo()`) --
   // always TS1029 ("'static' modifier must precede 'async' modifier").
   let mut modifier_order_misuse = false
+  // Set when a class body contains a *statement* rather than a member
+  // declaration -- `var x = 1` / `function foo() {}` at member position
+  // (TS1128 "Declaration or statement expected"). Distinguished from a member
+  // literally named `var` / `function` by requiring an identifier to follow
+  // (the statement form), so `{ var: T }` / `{ var() {} }` stay valid members.
+  let mut class_body_statement_misuse = false
   while !self.check(RBrace) && !self.check(Eof) {
+    // `var x` / `function foo` etc. at member position is a statement, not a
+    // member (TS1128) -- but only when the identifier is on the SAME line. A
+    // line break makes ASI split the keyword into a standalone member named
+    // `var` / `function` (`class C { var \n public }`), which TS accepts.
+    if !self.peek_at(1).has_newline_before {
+      match (self.peek().kind, self.peek_at(1).kind) {
+        (Var, Ident(_))
+        | (Let, Ident(_))
+        | (Const, Ident(_))
+        | (Function, Ident(_)) => class_body_statement_misuse = true
+        _ => ()
+      }
+    }
     while self.check(At) {
       self.skip_decorator()
     }
@@ -1532,7 +1552,7 @@ fn Parser::parse_class_body(
   (
     ctor, elements, private_members, protected_members, abstract_members, ctor_impl_count,
     index_sig_modifier_misuse, abstract_member_with_body, overload_static_mix, overload_missing_impl,
-    overload_accessibility_mix, modifier_order_misuse,
+    overload_accessibility_mix, modifier_order_misuse, class_body_statement_misuse,
   )
 }
 
@@ -1590,6 +1610,7 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
     overload_missing_impl,
     overload_accessibility_mix,
     modifier_order_misuse,
+    class_body_statement_misuse,
   ) = self.parse_class_body()
   self.current_class_brand = prev_brand
   self.restore_local_type_param_bounds(class_type_param_bound_len)
@@ -1621,6 +1642,9 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
   }
   if modifier_order_misuse {
     expr_class_sentinels.push("<modifier-order>")
+  }
+  if class_body_statement_misuse {
+    expr_class_sentinels.push("<class-body-statement>")
   }
   if expr_class_sentinels.length() > 0 {
     self.collected_class_dups.push((class_name, expr_class_sentinels))
@@ -2287,6 +2311,7 @@ fn Parser::parse_class_decl_with_abstract(
     overload_missing_impl,
     overload_accessibility_mix,
     modifier_order_misuse,
+    class_body_statement_misuse,
   ) = self.parse_class_body()
   self.current_class_brand = prev_brand
   self.restore_local_type_param_bounds(class_type_param_bound_len)
@@ -2325,6 +2350,10 @@ fn Parser::parse_class_decl_with_abstract(
   // TS1029: a member wrote `async` before `static`.
   if modifier_order_misuse {
     runtime_decl.duplicate_member_names.push("<modifier-order>")
+  }
+  // TS1128: a statement (`var x = 1` / `function foo() {}`) in a class body.
+  if class_body_statement_misuse {
+    runtime_decl.duplicate_member_names.push("<class-body-statement>")
   }
   // Surface the class's structural diagnostics for *every* class, including
   // ones nested in function bodies that the IIFE lowering removes from


### PR DESCRIPTION
## Summary

A `var x = 1` / `function foo() {}` statement at class-member position is not a member declaration — TS1128 ("Declaration or statement expected").

Detected in the class-body loop: a `Var`/`Let`/`Const`/`Function` keyword followed by an identifier **on the same line** (the statement form), threaded through the `parse_class_body` return tuple and surfaced via the `<class-body-statement>` sentinel for both class declarations and class expressions.

## False positive caught during development (ASI)

A keyword on its own line is ASI-split into a standalone member, which TS accepts:
```ts
class C {
  var      // <- field named "var"
  public   // <- field named "public"
}
```
`parserClassDeclaration26` was exactly this — fixed by the same-line guard (`has_newline_before`). A member named `var` via `var: T` / `var() {}` is also untouched (no identifier follows).

## Results

- Whole-corpus TP **1727 → 1729** (+2), **0 FP**.
- Pinned recall **677 → 678** (classBodyWithStatements).
- Full suite **2391/2391**; whitebox-tested incl. the ASI negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_