### PR TITLE
checker: TS2339 static private member not on class

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2028,6 +2028,21 @@ conformance sources (`.errors.txt` baseline = ground truth):
     expressions. Whole-corpus TP 1727 -> 1729 (+2), 0 FP; pinned recall 677 ->
     678 (classBodyWithStatements). Whitebox-tested incl. the ASI negative.
 
+2026-06-26 (T138)  681/815 (84 %)        414/414 ( 0 FP)   TS2339 static private member not on class
+
+  T138 -- TS2339 / TS18013. A private name accessed on the *static* side of a
+    class (`C.#x` / `B.#foo`) is valid only when `C` itself declares that static
+    private -- private names are never inherited and never global. The existing
+    static-member existence check (`Var(class).prop`) already computed
+    `has_static`, but only flagged when the unmodeled `typeof C` receiver type
+    was "checkable", so it silently fell through. For a private-brand name a
+    `has_static == false` is a *definite* error (no inheritance/global escape
+    hatch), so flag it directly (unfiltered). The mangled name carries the
+    *accessing* class's brand, so same-class access matches `has_static` and is
+    not flagged. Whole-corpus TP 1729 -> 1732 (+3), 0 FP; pinned recall 678 ->
+    681 (privateNamesConstructorChain-1/2, privateNamesAndStaticFields).
+    Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -12536,6 +12536,24 @@ fn check_call_args_in_expr(
                   if has_static {
                     return
                   }
+                  // TS2339 / TS18013: a private name accessed on the *static*
+                  // side of a class (`C.#x`) is only valid when `C` itself
+                  // declares that static private — private names are never
+                  // inherited and never global, so a miss here is a definite
+                  // error (e.g. `Child.#bar` where `#bar` is the *base*'s static
+                  // private, or `B.#foo` where `B` declares its own different
+                  // `#foo`). The brand in the mangled name is the *accessing*
+                  // class's, so same-class access matches `has_static` above and
+                  // is not flagged. Emitted unfiltered (the general lookup below
+                  // can't see the unmodeled `typeof C` static side).
+                  if prop.has_prefix("__private_brand__") {
+                    record_unfiltered(
+                      ctx,
+                      "PropAccess `.#…`",
+                      "private static member does not exist on class `\{class_name}`",
+                    )
+                    return
+                  }
                   // Fall through to the general lookup below.
                   let recv_ty = infer_expr(env, ctx.resolver, recv)
                   if is_checkable(recv_ty) &&

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10224,6 +10224,27 @@ test "expr_check: string literal vs template-literal-type pattern (TS2322/2345)"
 }
 
 ///|
+test "expr_check: static private member not on class (TS2339)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A private name accessed on the static side of a class that doesn't declare
+  // it (private statics aren't inherited) is an error.
+  assert_true(
+    issues(
+      "class Parent { static #bar = 5; m() { Child.#bar; } } class Child extends Parent { #bar = 1; }",
+    ) >
+    0,
+  )
+  // Same-class static private access is valid -> silent.
+  @test.assert_eq(issues("class P { static #b = 5; m() { return P.#b; } }"), 0)
+  @test.assert_eq(
+    issues("class P { static get #g() { return 1; } m() { return P.#g; } }"),
+    0,
+  )
+}
+
+///|
 test "expr_check: statement in class body (TS1128)" {
   let issues = fn(src : String) -> Int {
     check_module_function_bodies_permissive(parse_module_or_empty(src)).length()


### PR DESCRIPTION
## Summary

A private name accessed on the **static** side of a class (`C.#x` / `B.#foo`) is valid only when `C` itself declares that static private — private names are never inherited and never global.

The existing static-member existence check (`Var(class).prop`) already computed `has_static`, but only flagged when the unmodeled `typeof C` receiver type was "checkable", so it silently fell through. For a private-brand name, `has_static == false` is a **definite** error (no inheritance/global escape hatch), so we flag it directly (unfiltered). The mangled name carries the *accessing* class's brand, so same-class static private access matches `has_static` and is not flagged.

## Results

- Whole-corpus TP **1729 → 1732** (+3), **0 FP**.
- Pinned recall **678 → 681** (privateNamesConstructorChain-1/2, privateNamesAndStaticFields).
- Full suite **2392/2392**; whitebox-tested (cross-class targets + same-class / accessor negatives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_