### PR TITLE
checker: TS2339 static private on `typeof C` receiver

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2043,6 +2043,17 @@ conformance sources (`.errors.txt` baseline = ground truth):
     681 (privateNamesConstructorChain-1/2, privateNamesAndStaticFields).
     Whitebox-tested.
 
+2026-06-26 (T139)  682/815 (84 %)        414/414 ( 0 FP)   TS2339 static private on `typeof C` receiver
+
+  T139 -- extends T138 to the static-side analogue where the receiver is a
+    `typeof C` value (`x: typeof Derived; x.#prop`), not a bare class name.
+    When the inferred receiver type unwraps to `TypeOf(cname)` and the accessed
+    private-brand name isn't a static member of class `cname`, flag TS2339
+    (private statics are never inherited). Same-class `typeof C` access of C's
+    own static private stays silent. Whole-corpus TP 1732 -> 1733 (+1), 0 FP;
+    pinned recall 681 -> 682 (privateNameStaticAccessorssDerivedClasses).
+    Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -12574,6 +12574,35 @@ fn check_call_args_in_expr(
         _ => ()
       }
       let recv_ty = infer_expr(env, ctx.resolver, recv)
+      // TS2339: a private name accessed on a `typeof C` value (`x: typeof
+      // Derived; x.#prop`) — the static-side analogue of the `C.#x` check
+      // above. Private statics are never inherited, so a private-brand name
+      // that `C` doesn't declare statically is a definite error.
+      match ctx.resolver.unwrap(recv_ty) {
+        TypeOf(cname) =>
+          if prop.has_prefix("__private_brand__") {
+            match ctx.resolver.classes.get(cname) {
+              Some(cls) => {
+                let has_static = cls.properties
+                  .iter()
+                  .any(fn(p) { p.is_static && p.name == prop }) ||
+                  cls.methods
+                  .iter()
+                  .any(fn(m) { m.is_static && m.name == prop })
+                if !has_static {
+                  record_unfiltered(
+                    ctx,
+                    "PropAccess `.#…`",
+                    "private static member does not exist on class `\{cname}`",
+                  )
+                  return
+                }
+              }
+              None => ()
+            }
+          }
+        _ => ()
+      }
       // Null/undefined receiver: `.foo` on `null | undefined` is a runtime error.
       if is_nullable_type(recv_ty) {
         record(

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10242,6 +10242,19 @@ test "expr_check: static private member not on class (TS2339)" {
     issues("class P { static get #g() { return 1; } m() { return P.#g; } }"),
     0,
   )
+  // Same via a `typeof C` receiver: a static private not on the resolved class.
+  assert_true(
+    issues(
+      "class Base { static get #prop() { return 1; } static m(x: typeof Derived) { return x.#prop; } } class Derived extends Base {}",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "class C { static get #p() { return 1; } static m(x: typeof C) { return x.#p; } }",
+    ),
+    0,
+  )
 }
 
 ///|


### PR DESCRIPTION
## Summary

Extends the static-private check (PR #170) to the case where the receiver is a `typeof C` *value* (`x: typeof Derived; x.#prop`) rather than a bare class name. When the inferred receiver type unwraps to `TypeOf(cname)` and the accessed private-brand name isn't a static member of class `cname`, flag TS2339 (private statics are never inherited). Same-class `typeof C` access of C's own static private stays silent.

## Results

- Whole-corpus TP **1732 → 1733** (+1), **0 FP**.
- Pinned recall **681 → 682** (privateNameStaticAccessorssDerivedClasses).
- Full suite **2393/2393**; whitebox-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_