### PR TITLE
checker: TS2806 read of setter-only private accessor

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2054,6 +2054,19 @@ conformance sources (`.errors.txt` baseline = ground truth):
     pinned recall 681 -> 682 (privateNameStaticAccessorssDerivedClasses).
     Whitebox-tested.
 
+2026-06-26 (T140)  683/815 (84 %)        414/414 ( 0 FP)   TS2806 read of setter-only private accessor
+
+  T140 -- TS2806 ("Private accessor was defined without a getter"). Reading a
+    private accessor declared with a setter but no getter is an error. A write
+    (`this.#x = v`) parses as `PropAssignExpr`, so any `PropAccess` of a
+    set-only private name is a read. `is_set_only_private_accessor` scans the
+    resolver's classes for a mangled accessor name with a `set` but no `get`
+    (a get/set pair shares the mangled name with distinct accessor markers);
+    the PropAccess arm flags such reads. Whole-corpus TP 1733 -> 1734 (+1),
+    0 FP; pinned recall 682 -> 683 (privateWriteOnlyAccessorRead). (The
+    class-expression variant privateNameSetterNoGetter stays uncaught -- IIFE
+    lowering buries the read.) Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -1331,6 +1331,37 @@ fn Resolver::lookup_field(
 // discriminant) would make the access valid.  The PropAccess existence check
 // uses this to stay silent in that situation — we can't model the narrowing,
 // so we trust the partial match.
+///|
+/// True when `name` is the mangled name of a private *accessor* that some
+/// class declares with a setter but NO getter. Reading such a member
+/// (`this.#x` in a value position) is TS2806 ("Private accessor was defined
+/// without a getter"). The mangled name embeds the declaring class's brand, so
+/// a global scan is unambiguous. A get/set pair shares the same mangled name
+/// with distinct `accessor` markers, so any matching `get` makes it readable.
+fn Resolver::is_set_only_private_accessor(
+  self : Resolver,
+  name : String,
+) -> Bool {
+  if !name.has_prefix("__private_brand__") {
+    return false
+  }
+  let mut has_set = false
+  let mut has_get = false
+  for _, cls in self.classes {
+    for m in cls.methods {
+      if m.name == name {
+        if m.accessor == "set" {
+          has_set = true
+        } else if m.accessor == "get" {
+          has_get = true
+        }
+      }
+    }
+  }
+  has_set && !has_get
+}
+
+///|
 fn Resolver::field_on_any_union_member(
   self : Resolver,
   recv : @ast.TsType,
@@ -12508,6 +12539,15 @@ fn check_call_args_in_expr(
       check_call_args_in_expr(env, recv, ctx)
       check_private_name_access(ctx, prop)
       check_member_accessibility(env, ctx, recv, prop)
+      // TS2806: reading a private accessor that was defined with a setter but
+      // no getter. A write (`this.#x = v`) parses as `PropAssignExpr`, so a
+      // `PropAccess` of a set-only private name is always a read.
+      if ctx.resolver.is_set_only_private_accessor(prop) {
+        record_unfiltered(
+          ctx, "PropAccess `.#…`", "private accessor was defined without a getter",
+        )
+        return
+      }
       // Property-existence check: when the receiver has a concrete
       // structural shape and the resolver can't find `prop` on it,
       // surface a diagnostic. The class static-side fallback used

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10224,6 +10224,30 @@ test "expr_check: string literal vs template-literal-type pattern (TS2322/2345)"
 }
 
 ///|
+test "expr_check: read of setter-only private accessor (TS2806)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Reading a private accessor defined with a setter but no getter is TS2806.
+  assert_true(
+    issues("class T { set #v(x: number) {} m() { return this.#v; } }") > 0,
+  )
+  // A write (`this.#v = x`) is fine -- it parses as PropAssignExpr, not a read.
+  @test.assert_eq(
+    issues("class T { set #v(x: number) {} m() { this.#v = 1; } }"),
+    0,
+  )
+  // A get/set pair (readable) and a plain private field are fine.
+  @test.assert_eq(
+    issues(
+      "class T { get #v() { return 1; } set #v(x: number) {} m() { return this.#v; } }",
+    ),
+    0,
+  )
+  @test.assert_eq(issues("class T { #v = 1; m() { return this.#v; } }"), 0)
+}
+
+///|
 test "expr_check: static private member not on class (TS2339)" {
   let issues = fn(src : String) -> Int {
     check_module_function_bodies_permissive(parse_module_or_empty(src)).length()


### PR DESCRIPTION
## Summary

Reading a private accessor declared with a setter but no getter is an error — TS2806 ("Private accessor was defined without a getter").

A write (`this.#x = v`) parses as `PropAssignExpr`, so any `PropAccess` of a set-only private name is a *read*. `is_set_only_private_accessor` scans the resolver's classes for a mangled accessor name with a `set` but no `get` (a get/set pair shares the mangled name with distinct accessor markers); the PropAccess arm flags such reads.

## Results

- Whole-corpus TP **1733 → 1734** (+1), **0 FP**.
- Pinned recall **682 → 683** (privateWriteOnlyAccessorRead).
- Full suite **2393/2393**; whitebox-tested (read flagged; write / get-set-pair / plain-field negatives silent).

(The class-expression variant `privateNameSetterNoGetter` stays uncaught — IIFE lowering buries the read.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_