### PR TITLE
checker: TS2304 type parameter used as base class/interface

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2067,6 +2067,16 @@ conformance sources (`.errors.txt` baseline = ground truth):
     class-expression variant privateNameSetterNoGetter stays uncaught -- IIFE
     lowering buries the read.) Whitebox-tested.
 
+2026-06-26 (T141)  684/815 (84 %)        414/414 ( 0 FP)   TS2304 type parameter used as base
+
+  T141 -- TS2304 ("Cannot find name"). A class / interface whose `extends`
+    clause names one of its OWN type parameters (`class C<T> extends T {}`,
+    `interface I<T> extends T {}`) -- a type parameter is not a value / nominal
+    base, so the name is unresolvable as a base. `check_type_param_as_base`
+    flags base names that appear in the declaration's own `type_params`.
+    Always an error, false-positive-free. Whole-corpus TP 1734 -> 1736 (+2),
+    0 FP; pinned recall 683 -> 684 (typeParameterAsBaseType). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -1331,6 +1331,7 @@ fn Resolver::lookup_field(
 // discriminant) would make the access valid.  The PropAccess existence check
 // uses this to stay silent in that situation — we can't model the narrowing,
 // so we trust the partial match.
+
 ///|
 /// True when `name` is the mangled name of a private *accessor* that some
 /// class declares with a setter but NO getter. Reading such a member
@@ -15319,6 +15320,37 @@ fn check_reserved_class_names(module_ : @ast.TsModule) -> Array[ExprIssue] {
 /// `type string = …`) is always a TS error (TS2457, "Type alias name cannot
 /// be 'X'"). The parser already lowers these keyword tokens to their spelling
 /// (`parse_binding_ident`), so the alias name is visible here directly.
+/// TS2304 ("Cannot find name"): a class / interface whose `extends` clause
+/// names one of its OWN type parameters (`class C<T> extends T {}`,
+/// `interface I<T> extends T {}`). A type parameter is not a value / nominal
+/// base, so this is always an error -- false-positive-free (the name is
+/// genuinely unresolvable as a base, shadowed by the type parameter).
+fn check_type_param_as_base(module_ : @ast.TsModule) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  for cls in module_.classes {
+    for base in cls.base_names {
+      if cls.type_params.contains(base) {
+        issues.push({
+          path: "class \{cls.name}",
+          message: "cannot find name `\{base}` (a type parameter cannot be used as a base class)",
+        })
+      }
+    }
+  }
+  for iface in module_.interfaces {
+    for base in iface.extends_names {
+      if iface.type_params.contains(base) {
+        issues.push({
+          path: "interface \{iface.name}",
+          message: "cannot find name `\{base}` (a type parameter cannot be extended)",
+        })
+      }
+    }
+  }
+  issues
+}
+
+///|
 fn check_reserved_type_alias_names(module_ : @ast.TsModule) -> Array[ExprIssue] {
   let issues : Array[ExprIssue] = []
   for ta in module_.type_aliases {
@@ -16844,6 +16876,9 @@ fn check_module_function_bodies_layered(
     all.push(issue)
   }
   for issue in check_reserved_class_names(module_) {
+    all.push(issue)
+  }
+  for issue in check_type_param_as_base(module_) {
     all.push(issue)
   }
   for issue in check_reserved_type_alias_names(module_) {

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10224,6 +10224,19 @@ test "expr_check: string literal vs template-literal-type pattern (TS2322/2345)"
 }
 
 ///|
+test "expr_check: type parameter used as base (TS2304)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // A class / interface extending one of its own type parameters is TS2304.
+  assert_true(issues("class C<T> extends T {}") > 0)
+  assert_true(issues("interface I<T> extends T {}") > 0)
+  // Extending a real base is fine.
+  @test.assert_eq(issues("class B {} class C<T> extends B {}"), 0)
+  @test.assert_eq(issues("interface J {} interface I<T> extends J {}"), 0)
+}
+
+///|
 test "expr_check: read of setter-only private accessor (TS2806)" {
   let issues = fn(src : String) -> Int {
     check_module_function_bodies_permissive(parse_module_or_empty(src)).length()


### PR DESCRIPTION
## Summary

A class / interface whose `extends` clause names one of its **own type parameters** (`class C<T> extends T {}`, `interface I<T> extends T {}`) is TS2304 ("Cannot find name") — a type parameter is not a value / nominal base, so the name is unresolvable as a base.

`check_type_param_as_base` flags base names that appear in the declaration's own `type_params`. Always an error, so false-positive-free (extending a real base stays silent).

## Results

- Whole-corpus TP **1734 → 1736** (+2), **0 FP**.
- Pinned recall **683 → 684** (typeParameterAsBaseType).
- Full suite **2394/2394**; whitebox-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_