### PR TITLE
checker: TS2302 static index signature referencing class type parameter

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2077,6 +2077,21 @@ conformance sources (`.errors.txt` baseline = ground truth):
     Always an error, false-positive-free. Whole-corpus TP 1734 -> 1736 (+2),
     0 FP; pinned recall 683 -> 684 (typeParameterAsBaseType). Whitebox-tested.
 
+2026-06-29 (T142)  685/815 (84 %)        414/414 ( 0 FP)   TS2302 static index sig refs class type param
+
+  T142 -- TS2302 ("Static members cannot reference class type parameters").
+    A *static* index signature whose value type names one of the enclosing
+    class's type parameters (`class E<T> { static [x: string]: T }`). Detected
+    in the parser inside `parse_class_body` (which now receives the class's
+    `type_params`): when a static index signature is parsed and its value type
+    mentions a class type-param name, a `<static-type-param-ref>` sentinel is
+    pushed through the existing `collected_class_dups` channel and mapped to
+    the TS2302 message in `check_class_duplicate_members`. Gated on `is_static`
+    so instance index signatures (which may reference `T` freely) are never
+    flagged -- false-positive-free. `type_references_type_param_name` walks the
+    common compound type shapes conservatively. Pinned recall 684 -> 685
+    (staticIndexers). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -16275,6 +16275,11 @@ fn check_class_duplicate_members(module_ : @ast.TsModule) -> Array[ExprIssue] {
           path: "class \{cls_name}",
           message: "declaration or statement expected",
         })
+      } else if name == "<static-type-param-ref>" {
+        issues.push({
+          path: "class \{cls_name}",
+          message: "static members cannot reference class type parameters",
+        })
       } else {
         issues.push({
           path: "class \{cls_name}",

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10526,3 +10526,28 @@ test "expr_check: capitalized-primitive type misspelling (TS2304)" {
   @test.assert_eq(issues("type Null = string; var x: Null;"), 0)
   @test.assert_eq(issues("interface Undefined {} var x: Undefined;"), 0)
 }
+
+///|
+test "expr_check: static index signature referencing class type parameter (TS2302)" {
+  let issues = fn(src : String) -> Int {
+    let mut n = 0
+    for i in check_module_function_bodies_permissive(parse_module_or_empty(src)) {
+      if i.message.contains(
+          "static members cannot reference class type parameters",
+        ) {
+        n += 1
+      }
+    }
+    n
+  }
+  // A static index signature whose value type names a class type parameter.
+  assert_true(issues("class E<T> { static [x: string]: T; }") > 0)
+  assert_true(issues("class F<U> { static [x: number]: U[]; }") > 0)
+  // Instance index signatures may reference `T` freely -- never flagged.
+  @test.assert_eq(issues("class G<T> { [x: string]: T; }"), 0)
+  // Static index signature with a concrete value type -- no type-param ref.
+  @test.assert_eq(issues("class C { static [x: string]: string; }"), 0)
+  @test.assert_eq(issues("class D { static [x: number]: string; }"), 0)
+  // Non-generic class: no type parameters in scope, so nothing to reference.
+  @test.assert_eq(issues("class H { static [x: string]: number; }"), 0)
+}

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -397,6 +397,72 @@ fn Parser::take_last_runtime_class_decl(self : Parser) -> @ast.TsClassDecl? {
 }
 
 ///|
+/// True when `t` mentions any of the type-parameter names held in `bounds`
+/// (the `(name, bound)` pairs pushed for the enclosing scope). Used to detect a
+/// static index signature whose value type references a class type parameter
+/// (TS2302). Conservative: variants it does not descend simply return `false`,
+/// so a missed reference never produces a false positive.
+fn type_references_type_param_name(
+  t : @ast.TsType,
+  names : Array[String],
+) -> Bool {
+  fn mentions(name : String) -> Bool {
+    for n in names {
+      if n == name {
+        return true
+      }
+    }
+    false
+  }
+
+  fn walk(ty : @ast.TsType) -> Bool {
+    match ty {
+      Named(n) => mentions(n)
+      Applied(n, args) => {
+        if mentions(n) {
+          return true
+        }
+        for a in args {
+          if walk(a) {
+            return true
+          }
+        }
+        false
+      }
+      Array(inner) | Rest(inner) | Keyof(inner) => walk(inner)
+      Union(members) | Intersection(members) | Tuple(members) => {
+        for m in members {
+          if walk(m) {
+            return true
+          }
+        }
+        false
+      }
+      Func(params, ret) => {
+        for p in params {
+          if walk(p) {
+            return true
+          }
+        }
+        walk(ret)
+      }
+      IndexedAccess(base, idx) => walk(base) || walk(idx)
+      Object(fields) => {
+        for f in fields {
+          if walk(f.1) {
+            return true
+          }
+        }
+        false
+      }
+      _ => false
+    }
+  }
+
+  walk(t)
+}
+
+///|
 fn has_static_private_elements(elements : Array[ClassElement]) -> Bool {
   for element in elements {
     match element {
@@ -1063,6 +1129,7 @@ fn Parser::inject_instance_field_assigns(
 ///|
 fn Parser::parse_class_body(
   self : Parser,
+  class_type_params : Array[String],
 ) -> (
   @ast.TsFunc?,
   Array[ClassElement],
@@ -1070,6 +1137,7 @@ fn Parser::parse_class_body(
   Array[String],
   Array[String],
   Int,
+  Bool,
   Bool,
   Bool,
   Bool,
@@ -1127,6 +1195,14 @@ fn Parser::parse_class_body(
   // literally named `var` / `function` by requiring an identifier to follow
   // (the statement form), so `{ var: T }` / `{ var() {} }` stay valid members.
   let mut class_body_statement_misuse = false
+  // Set when a *static* index signature's value type references one of the
+  // enclosing class's type parameters (`class C<T> { static [k: string]: T }`)
+  // -- always TS2302 ("Static members cannot reference class type
+  // parameters"). The class type parameters are in scope via
+  // `self.local_type_param_bounds` at the point the body is parsed. Only static
+  // index signatures qualify; instance ones may reference `T` freely, so the
+  // check is gated on `is_static` and never produces a false positive.
+  let mut static_index_type_param_ref = false
   while !self.check(RBrace) && !self.check(Eof) {
     // `var x` / `function foo` etc. at member position is a statement, not a
     // member (TS1128) -- but only when the identifier is on the SAME line. A
@@ -1236,6 +1312,11 @@ fn Parser::parse_class_body(
         Some((key, value)) => {
           if saw_visibility_modifier {
             index_sig_modifier_misuse = true
+          }
+          if is_static &&
+            class_type_params.length() > 0 &&
+            type_references_type_param_name(value, class_type_params) {
+            static_index_type_param_ref = true
           }
           elements.push(IndexSig(key, value))
           continue
@@ -1553,6 +1634,7 @@ fn Parser::parse_class_body(
     ctor, elements, private_members, protected_members, abstract_members, ctor_impl_count,
     index_sig_modifier_misuse, abstract_member_with_body, overload_static_mix, overload_missing_impl,
     overload_accessibility_mix, modifier_order_misuse, class_body_statement_misuse,
+    static_index_type_param_ref,
   )
 }
 
@@ -1611,7 +1693,8 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
     overload_accessibility_mix,
     modifier_order_misuse,
     class_body_statement_misuse,
-  ) = self.parse_class_body()
+    static_index_type_param_ref,
+  ) = self.parse_class_body(class_type_params)
   self.current_class_brand = prev_brand
   self.restore_local_type_param_bounds(class_type_param_bound_len)
   // Class *expressions* (`const C = class { … }`) build their result through
@@ -1645,6 +1728,9 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
   }
   if class_body_statement_misuse {
     expr_class_sentinels.push("<class-body-statement>")
+  }
+  if static_index_type_param_ref {
+    expr_class_sentinels.push("<static-type-param-ref>")
   }
   if expr_class_sentinels.length() > 0 {
     self.collected_class_dups.push((class_name, expr_class_sentinels))
@@ -2312,7 +2398,8 @@ fn Parser::parse_class_decl_with_abstract(
     overload_accessibility_mix,
     modifier_order_misuse,
     class_body_statement_misuse,
-  ) = self.parse_class_body()
+    static_index_type_param_ref,
+  ) = self.parse_class_body(class_type_params)
   self.current_class_brand = prev_brand
   self.restore_local_type_param_bounds(class_type_param_bound_len)
   let runtime_decl = build_runtime_class_decl(
@@ -2354,6 +2441,10 @@ fn Parser::parse_class_decl_with_abstract(
   // TS1128: a statement (`var x = 1` / `function foo() {}`) in a class body.
   if class_body_statement_misuse {
     runtime_decl.duplicate_member_names.push("<class-body-statement>")
+  }
+  // TS2302: a static index signature references a class type parameter.
+  if static_index_type_param_ref {
+    runtime_decl.duplicate_member_names.push("<static-type-param-ref>")
   }
   // Surface the class's structural diagnostics for *every* class, including
   // ones nested in function bodies that the IIFE lowering removes from


### PR DESCRIPTION
A static index signature whose value type names one of the enclosing class's type parameters (`class E<T> { static [x: string]: T }`) is always TS2302 ("Static members cannot reference class type parameters").

`parse_class_body` now receives the class type-parameter names and flags a static index signature whose value type mentions one, pushing a `<static-type-param-ref>` sentinel through the existing `collected_class_dups` channel; the checker maps it to the TS2302 message in `check_class_duplicate_members`. Gated on `is_static` so instance index signatures referencing `T` stay valid — false-positive-free.

- Pinned recall 684 → 685 (staticIndexers).
- Whole-corpus oracle TP 1736 → 1737, **FP 0** (`--max-fp 0`).
- Whitebox regression test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_