### PR TITLE
checker: TS1277 / TS1257 / TS1005 grammar diagnostics

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2092,6 +2092,45 @@ conformance sources (`.errors.txt` baseline = ground truth):
     common compound type shapes conservatively. Pinned recall 684 -> 685
     (staticIndexers). Whitebox-tested.
 
+2026-06-29 (T143)  686/815 (84 %)        414/414 ( 0 FP)   TS1277 const modifier on interface/alias type param
+
+  T143 -- TS1277 ("`const` modifier can only appear on a type parameter of a
+    function, method or class"). The TS5.0 `const` type-parameter modifier is
+    legal on function / method / class type-parameter lists but NOT on an
+    interface's own list (`interface I<const T>`) or a type alias's
+    (`type T<const U> = …`). `parse_interface` and
+    `parse_type_alias_after_type_keyword` now read the per-parameter const
+    flags (already captured by `parse_type_param_names_bounds_and_const_flags`)
+    and push a `<const-typeparam>NAME` sentinel through the
+    `interface_member_modifier_misuses` channel, mapped to the TS1277 message.
+    Always an error, false-positive-free. Pinned recall 685 -> 686
+    (typeParameterConstModifiers). Whitebox-tested.
+
+2026-06-29 (T144)  687/815 (84 %)        414/414 ( 0 FP)   TS1257 required tuple element after optional
+
+  T144 -- TS1257 ("A required element cannot follow an optional element").
+    In a tuple type, once an optional element appears (`[string?, ...]`) a
+    later required (non-optional, non-rest) element is illegal -- a rest
+    element is exempt, so `[string?, ...number[]]` stays valid. `parse_tuple_type`
+    tracks `seen_optional` / `required_after_optional` across the element loop
+    and pushes a `<tuple-required-after-optional>` sentinel mapped to the
+    TS1257 message. Always an error, false-positive-free. Whole-corpus TP
+    1738 -> 1739. Pinned recall 686 -> 687 (restTupleElements1). Whitebox-tested.
+
+2026-06-29 (T145)  688/815 (84 %)        414/414 ( 0 FP)   TS1005 object-type members on same line w/o separator
+
+  T145 -- TS1005 ("';' expected"). Two object-type-literal members on the SAME
+    line with no `,` / `;` separator (`{ foo: string bar: string }`) -- a line
+    break between members is valid (ASI), so the check requires the next member
+    token to sit on the same line (`!has_line_terminator_before()`).
+    `try_parse_object_type_with_members` (the parser that previously accepted
+    this silently) sets a `missing_separator` flag and, only on the success
+    path, pushes an `<object-member-no-separator>` sentinel mapped to the
+    TS1005 message. Recording on success only keeps speculative parses that
+    later fall back from leaving a spurious diagnostic. Always an error,
+    false-positive-free. Pinned recall 687 -> 688 (objectTypeLiteralSyntax2).
+    Whitebox-tested. **Reaches the recall-688 goal.**
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -17019,6 +17019,19 @@ fn check_module_function_bodies_layered(
           path: "member `\{m}`",
           message: "a parameter initializer is only allowed in an implementation signature",
         })
+      } else if member.has_prefix("<const-typeparam>") {
+        let m = member.substring(start="<const-typeparam>".length())
+        all.push({
+          path: "type parameter `\{m}`",
+          message: "`const` modifier can only appear on a type parameter of a function, method or class",
+        })
+      } else if member == "<tuple-required-after-optional>" {
+        all.push({
+          path: "tuple type",
+          message: "a required element cannot follow an optional element",
+        })
+      } else if member == "<object-member-no-separator>" {
+        all.push({ path: "object type", message: "`;` expected" })
       } else {
         all.push({
           path: "member `\{member}`",

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10551,3 +10551,76 @@ test "expr_check: static index signature referencing class type parameter (TS230
   // Non-generic class: no type parameters in scope, so nothing to reference.
   @test.assert_eq(issues("class H { static [x: string]: number; }"), 0)
 }
+
+///|
+test "expr_check: const modifier on interface/type-alias type parameter (TS1277)" {
+  let issues = fn(src : String) -> Int {
+    let mut n = 0
+    for i in check_module_function_bodies_permissive(parse_module_or_empty(src)) {
+      if i.message.contains(
+          "`const` modifier can only appear on a type parameter",
+        ) {
+        n += 1
+      }
+    }
+    n
+  }
+  // `const` on an interface's own type parameter -- TS1277.
+  assert_true(issues("interface I1<const T> { x: T }") > 0)
+  // `const` on a type-alias type parameter -- TS1277.
+  assert_true(issues("type T1<const T> = T;") > 0)
+  // `const` IS valid on function / method / class type parameters: silent.
+  @test.assert_eq(issues("function f<const T>(x: T): T { return x }"), 0)
+  @test.assert_eq(issues("class C<const T> { x: T }"), 0)
+  @test.assert_eq(issues("interface I2 { f<const T>(x: T): T }"), 0)
+  // No `const` modifier at all: silent.
+  @test.assert_eq(issues("interface J<T> { x: T }"), 0)
+  @test.assert_eq(issues("type T2<U> = U;"), 0)
+}
+
+///|
+test "expr_check: required tuple element after optional (TS1257)" {
+  let issues = fn(src : String) -> Int {
+    let mut n = 0
+    for i in check_module_function_bodies_permissive(parse_module_or_empty(src)) {
+      if i.message.contains(
+          "a required element cannot follow an optional element",
+        ) {
+        n += 1
+      }
+    }
+    n
+  }
+  // Required element following an optional one.
+  assert_true(issues("type T = [string, string?, number];") > 0)
+  assert_true(issues("type T = [a?: string, b: number];") > 0)
+  // Valid tuples: trailing optionals, rest after optional, all-required.
+  @test.assert_eq(issues("type T = [string, string?];"), 0)
+  @test.assert_eq(issues("type T = [string?];"), 0)
+  @test.assert_eq(issues("type T = [string?, ...number[]];"), 0)
+  @test.assert_eq(issues("type T = [string, number];"), 0)
+  @test.assert_eq(issues("type T = [a: string, b?: number];"), 0)
+}
+
+///|
+test "expr_check: object-type members on same line without separator (TS1005)" {
+  let issues = fn(src : String) -> Int {
+    let mut n = 0
+    for i in check_module_function_bodies_permissive(parse_module_or_empty(src)) {
+      if i.message.contains("`;` expected") {
+        n += 1
+      }
+    }
+    n
+  }
+  // Two members on the same line with no separator.
+  assert_true(issues("var z: { foo: string bar: string };") > 0)
+  assert_true(issues("type T = { a: number b: number };") > 0)
+  // Separators present: valid.
+  @test.assert_eq(issues("var z: { foo: string, bar: string };"), 0)
+  @test.assert_eq(issues("var z: { foo: string; bar: string };"), 0)
+  // ASI via line break between members: valid.
+  @test.assert_eq(issues("var y: {\n foo: string\n bar: string\n};"), 0)
+  // Single member: valid.
+  @test.assert_eq(issues("var x: { foo: string };"), 0)
+}

--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -1126,7 +1126,16 @@ pub fn Parser::parse_interface(
     Ident(n) => n
     k => raise ParseError("Expected interface name, got \{k}")
   }
-  let (type_params, type_param_bounds) = self.parse_type_param_names_and_bounds()
+  let (type_params, const_flags, type_param_bounds) = self.parse_type_param_names_bounds_and_const_flags()
+  // TS1277: a `const` modifier on a type parameter is only valid on a
+  // function, method, or class. An interface's own type-parameter list is
+  // none of those, so `interface I<const T>` is always an error. Record it
+  // through the shared interface-misuse channel with a distinct sentinel.
+  for i, name_i in type_params {
+    if i < const_flags.length() && const_flags[i] {
+      self.interface_member_modifier_misuses.push("<const-typeparam>\{name_i}")
+    }
+  }
   let local_type_param_bound_len = self.push_local_type_param_bounds(
     type_param_bounds,
   )
@@ -1721,7 +1730,14 @@ fn Parser::parse_type_alias_after_type_keyword(
   // `parse_type` substitute `Named(T) → bound` inside the alias body, eagerly
   // erasing the generic shape (e.g. `DateArg<DateType>` would become
   // `Date | ...` and lose precision).
-  let (type_params, type_param_bounds) = self.parse_type_param_names_and_bounds()
+  let (type_params, const_flags, type_param_bounds) = self.parse_type_param_names_bounds_and_const_flags()
+  // TS1277: a `const` modifier on a type-alias type parameter is invalid
+  // (only functions, methods, and classes allow it). `type T<const U> = …`.
+  for i, name_i in type_params {
+    if i < const_flags.length() && const_flags[i] {
+      self.interface_member_modifier_misuses.push("<const-typeparam>\{name_i}")
+    }
+  }
   let _ = self.expect(Eq)
   let alias_type = self.parse_type()
   self.consume_semicolon()

--- a/src/parser/parser_type.mbt
+++ b/src/parser/parser_type.mbt
@@ -147,6 +147,12 @@ fn Parser::parse_tuple_type(self : Parser) -> @ast.TsType raise ParseError {
   if self.match_(RBracket) {
     return Tuple(items)
   }
+  // TS1257: a required element cannot follow an optional one
+  // (`[string?, number]`). A rest element is neither required nor optional
+  // for this rule, so `[string?, ...number[]]` stays valid. Tracked across
+  // the element loop and surfaced once per offending tuple.
+  let mut seen_optional = false
+  let mut required_after_optional = false
   while !self.check(Eof) {
     let is_rest = self.match_ellipsis()
     // Labels like `[name: T]` strip the label tokens; `[name?: T]` is
@@ -172,7 +178,13 @@ fn Parser::parse_tuple_type(self : Parser) -> @ast.TsType raise ParseError {
     }
     let item_type = self.parse_type()
     let trailing_optional = self.match_(Question)
-    let with_optional : @ast.TsType = if label_optional || trailing_optional {
+    let is_optional = label_optional || trailing_optional
+    if is_optional {
+      seen_optional = true
+    } else if !is_rest && seen_optional {
+      required_after_optional = true
+    }
+    let with_optional : @ast.TsType = if is_optional {
       wrap_optional_ts_type(item_type)
     } else {
       item_type
@@ -186,6 +198,11 @@ fn Parser::parse_tuple_type(self : Parser) -> @ast.TsType raise ParseError {
     }
     let _ = self.expect(RBracket)
     break
+  }
+  if required_after_optional {
+    self.interface_member_modifier_misuses.push(
+      "<tuple-required-after-optional>",
+    )
   }
   Tuple(items)
 }
@@ -484,6 +501,12 @@ fn Parser::try_parse_object_type_with_members(self : Parser) -> @ast.TsType? {
   }
   let saved_pos = self.pos
   let fields : Array[(@ast.TsType, @ast.TsType)] = []
+  // TS1005 (';' expected): two object-type members on the SAME line with no
+  // `,` / `;` separator (`{ foo: string bar: string }`). A line break between
+  // members is fine (ASI), so the check requires the next member token to sit
+  // on the same line. Recorded only on the success path so a speculative parse
+  // that later falls back leaves no spurious diagnostic.
+  let mut missing_separator = false
   try {
     let _ = self.expect(LBrace)
     while !self.check(Eof) && !self.check(RBrace) {
@@ -611,9 +634,20 @@ fn Parser::try_parse_object_type_with_members(self : Parser) -> @ast.TsType? {
         self.pos = saved_pos
         return None
       }
-      let _ = self.match_(Semicolon) || self.match_(Comma)
+      let had_sep = self.match_(Semicolon) || self.match_(Comma)
+      if !had_sep &&
+        !self.check(RBrace) &&
+        !self.check(Eof) &&
+        !self.has_line_terminator_before() {
+        missing_separator = true
+      }
     }
     let _ = self.expect(RBrace)
+    if missing_separator {
+      self.interface_member_modifier_misuses.push(
+        "<object-member-no-separator>",
+      )
+    }
     Some(Object(fields))
   } catch {
     _ => {


### PR DESCRIPTION
Three sound, parse-time grammar checks:

- **TS1277** (`const` modifier can only appear on a type parameter of a function, method or class) — the TS5.0 `const` type-parameter modifier is valid on function / method / class type-parameter lists but not on an interface's own list (`interface I<const T>`) or a type alias's (`type T<const U> = …`).
- **TS1257** (a required element cannot follow an optional element) — in a tuple type, a required (non-optional, non-rest) element after an optional one is illegal; a rest element is exempt, so `[string?, ...number[]]` stays valid.
- **TS1005** (`;` expected) — two object-type-literal members on the same line with no `,`/`;` separator (`{ foo: string bar: string }`); a line break between members is valid via ASI.

Each is detected in the parser and surfaced through the shared interface-misuse channel with a distinct sentinel mapped to its message. All three are always-errors, so false-positive-free.

- Pinned recall 685 → **688**.
- Whole-corpus oracle TP 1737 → 1740, **FP 0** (`--max-fp 0`).
- Whitebox regression tests added for each check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_