### PR TITLE
checker: TS2872 always-truthy left operand of &&

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2131,6 +2131,19 @@ conformance sources (`.errors.txt` baseline = ground truth):
     false-positive-free. Pinned recall 687 -> 688 (objectTypeLiteralSyntax2).
     Whitebox-tested. **Reaches the recall-688 goal.**
 
+2026-06-29 (T146)  689/815 (85 %)        414/414 ( 0 FP)   TS2872 always-truthy left operand of &&
+
+  T146 -- TS2872 ("This kind of expression is always truthy"). A `&&` whose
+    left operand is a literal always-truthy value -- a function / arrow / class
+    expression, an object literal, or an array literal (`(a => a) && f`,
+    `{} && x`, `[] && x`) -- is redundant; the guard never short-circuits.
+    `is_syntactically_always_truthy` matches only syntactic literal forms (a
+    bare identifier or call result is never matched), so the check needs no
+    inference and is false-positive-free. Added in the `BinOp(And, …)` arm of
+    the expression walker via `record_unfiltered`. Whole-corpus TP 1740 ->
+    1741, 0 FP. Pinned recall 688 -> 689 (contextuallyTypeLogicalAnd03).
+    Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -3529,6 +3529,24 @@ fn record(ctx : CheckCtx, sub_path : String, message : String) -> Unit {
 /// Like `record`, but bypasses the permissive-mode suppression filter. Used
 /// for diagnostics the caller has already established are reliable in
 /// permissive mode (e.g. constructor / direct-function-call arity).
+/// True when `expr` is a literal form that always evaluates to a truthy
+/// value: a function / arrow / class expression, an object literal, or an
+/// array literal. Used to flag `<always-truthy> && rhs` (TS2872, "This kind
+/// of expression is always truthy"). Only syntactic literal forms qualify --
+/// a bare identifier or call result is never matched, so no inference is
+/// needed and the check is false-positive-free.
+fn is_syntactically_always_truthy(expr : @ast.TsExpr) -> Bool {
+  match expr {
+    ArrowFunc(_, _, _, _)
+    | FuncExpr(_)
+    | NativeClassExpr(_, _)
+    | ObjectLit(_)
+    | ArrayLit(_) => true
+    _ => false
+  }
+}
+
+///|
 fn record_unfiltered(
   ctx : CheckCtx,
   sub_path : String,
@@ -12405,6 +12423,15 @@ fn check_call_args_in_expr(
     }
     BinOp(op, l, r) => {
       check_call_args_in_expr(env, l, ctx)
+      // TS2872: a `&&` whose left operand is a literal always-truthy value
+      // (`(a => a) && f`, `{} && x`, `[] && x`) is redundant -- the guard
+      // never short-circuits. Only syntactic literal forms are matched, so
+      // this needs no inference and never false-positives.
+      if op is And && is_syntactically_always_truthy(l) {
+        record_unfiltered(
+          ctx, "logical `&&`", "this kind of expression is always truthy",
+        )
+      }
       // Short-circuit narrowing: the RHS of `&&` runs only when the LHS is
       // truthy, and the RHS of `||` only when the LHS is falsy. Apply the
       // corresponding flow narrowing to a scratch env before walking the

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10624,3 +10624,29 @@ test "expr_check: object-type members on same line without separator (TS1005)" {
   // Single member: valid.
   @test.assert_eq(issues("var x: { foo: string };"), 0)
 }
+
+///|
+test "expr_check: always-truthy left operand of && (TS2872)" {
+  let issues = fn(src : String) -> Int {
+    let mut n = 0
+    for i in check_module_function_bodies_permissive(parse_module_or_empty(src)) {
+      if i.message.contains("this kind of expression is always truthy") {
+        n += 1
+      }
+    }
+    n
+  }
+  // Literal always-truthy left operands of `&&`.
+  assert_true(issues("let f: any; f = (a => a) && (b => b);") > 0)
+  assert_true(issues("function g() { return (function(){}) && 1; }") > 0)
+  assert_true(issues("let z = {} && 1;") > 0)
+  assert_true(issues("let z = [] && 1;") > 0)
+  // A bare identifier / call result is NOT a literal truthy form: silent.
+  @test.assert_eq(issues("let a: any; let z = a && a.b;"), 0)
+  @test.assert_eq(
+    issues("function h(): any { return 0; } let z = h() && 1;"),
+    0,
+  )
+  // `||` is not flagged by this check.
+  @test.assert_eq(issues("let z = {} || 1;"), 0)
+}


### PR DESCRIPTION
A `&&` whose left operand is a literal always-truthy value — a function / arrow / class expression, an object literal, or an array literal (`(a => a) && f`, `{} && x`, `[] && x`) — is redundant; the guard never short-circuits (TS2872, "This kind of expression is always truthy").

`is_syntactically_always_truthy` matches only syntactic literal forms — a bare identifier or call result is never matched — so the check needs no type inference and is false-positive-free. Added in the `BinOp(And, …)` arm of the expression walker.

- Pinned recall 688 → **689**.
- Whole-corpus oracle TP 1740 → 1741, **FP 0** (`--max-fp 0`).
- Whitebox regression test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_