### PR TITLE
checker: TS2873 always-falsy left operand of ||

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2144,6 +2144,19 @@ conformance sources (`.errors.txt` baseline = ground truth):
     1741, 0 FP. Pinned recall 688 -> 689 (contextuallyTypeLogicalAnd03).
     Whitebox-tested.
 
+2026-06-29 (T147)  690/815 (85 %)        414/414 ( 0 FP)   TS2873 always-falsy left operand of ||
+
+  T147 -- TS2873 ("This kind of expression is always falsy"). The companion to
+    T146: a `||` whose left operand is a literal always-falsy value -- `null`,
+    `false`, `0`, `0n`, `""`, or `void <expr>` (always `undefined`) -- is
+    redundant; the guard always falls through to the right operand
+    (`null || x`, `void 0 || y`, `0 || z`). `is_syntactically_always_falsy`
+    matches only those literal forms; `undefined` is deliberately excluded
+    because it parses as a shadowable identifier. Added in the `BinOp(Or, …)`
+    arm via `record_unfiltered`. Whole-corpus TP 1741 -> 1745 (+4, caught
+    several files beyond the pinned set), 0 FP. Pinned recall 689 -> 690
+    (initializersWidened). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -3547,6 +3547,22 @@ fn is_syntactically_always_truthy(expr : @ast.TsExpr) -> Bool {
 }
 
 ///|
+/// True when `expr` is a literal form that always evaluates to a falsy value:
+/// `null`, `false`, `0`, `0n`, `""`, or `void <expr>` (always `undefined`).
+/// Used to flag `<always-falsy> || rhs` (TS2873, "This kind of expression is
+/// always falsy"). `undefined` is intentionally excluded -- it parses as a
+/// bare identifier that can be shadowed -- so the check stays sound.
+fn is_syntactically_always_falsy(expr : @ast.TsExpr) -> Bool {
+  match expr {
+    NullLit | BoolLit(false) | StringLit("") | IntLit(0) => true
+    NumberLit(n) => n == 0.0
+    BigIntLit(s) => s == "0" || s == "0n"
+    UnaryOp(Void, _) => true
+    _ => false
+  }
+}
+
+///|
 fn record_unfiltered(
   ctx : CheckCtx,
   sub_path : String,
@@ -12430,6 +12446,15 @@ fn check_call_args_in_expr(
       if op is And && is_syntactically_always_truthy(l) {
         record_unfiltered(
           ctx, "logical `&&`", "this kind of expression is always truthy",
+        )
+      }
+      // TS2873: a `||` whose left operand is a literal always-falsy value
+      // (`null || x`, `void 0 || y`, `0 || z`) is redundant -- the guard
+      // always falls through to the right operand. Same literal-only matching,
+      // so no inference and no false positives.
+      if op is Or && is_syntactically_always_falsy(l) {
+        record_unfiltered(
+          ctx, "logical `||`", "this kind of expression is always falsy",
         )
       }
       // Short-circuit narrowing: the RHS of `&&` runs only when the LHS is

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10650,3 +10650,28 @@ test "expr_check: always-truthy left operand of && (TS2872)" {
   // `||` is not flagged by this check.
   @test.assert_eq(issues("let z = {} || 1;"), 0)
 }
+
+///|
+test "expr_check: always-falsy left operand of || (TS2873)" {
+  let issues = fn(src : String) -> Int {
+    let mut n = 0
+    for i in check_module_function_bodies_permissive(parse_module_or_empty(src)) {
+      if i.message.contains("this kind of expression is always falsy") {
+        n += 1
+      }
+    }
+    n
+  }
+  // Literal always-falsy left operands of `||`.
+  assert_true(issues("let z = null || 1;") > 0)
+  assert_true(issues("let z = void 0 || 1;") > 0)
+  assert_true(issues("let z = 0 || 1;") > 0)
+  assert_true(issues("let z = \"\" || 1;") > 0)
+  assert_true(issues("let z = false || 1;") > 0)
+  // A bare identifier (incl. `undefined`, which is shadowable) is NOT matched.
+  @test.assert_eq(issues("let a: any; let z = a || 1;"), 0)
+  @test.assert_eq(issues("let z = undefined || 1;"), 0)
+  // Non-falsy literals and `&&` are not flagged by this check.
+  @test.assert_eq(issues("let z = 1 || 2;"), 0)
+  @test.assert_eq(issues("let z = null && 1;"), 0)
+}


### PR DESCRIPTION
Companion to TS2872 (#176): a `||` whose left operand is a literal always-falsy value — `null`, `false`, `0`, `0n`, `""`, or `void <expr>` (always `undefined`) — is redundant; the guard always falls through to the right operand (`null || x`, `void 0 || y`, `0 || z`) (TS2873, "This kind of expression is always falsy").

`is_syntactically_always_falsy` matches only those literal forms. `undefined` is deliberately excluded because it parses as a shadowable identifier, keeping the check false-positive-free. Added in the `BinOp(Or, …)` arm of the expression walker.

- Pinned recall 689 → **690**.
- Whole-corpus oracle TP 1741 → **1745** (+4, caught several files beyond the pinned set), **FP 0** (`--max-fp 0`).
- Whitebox regression test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_