### PR TITLE
checker: extend TS2872 to always-truthy literal scalars

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2157,6 +2157,15 @@ conformance sources (`.errors.txt` baseline = ground truth):
     several files beyond the pinned set), 0 FP. Pinned recall 689 -> 690
     (initializersWidened). Whitebox-tested.
 
+2026-06-29 (T148)  691/815 (85 %)        414/414 ( 0 FP)   TS2872 extended to always-truthy literal scalars
+
+  T148 -- extends T146's always-truthy set (TS2872) to literal scalars: a
+    non-empty string, a non-zero number / bigint, or `true` (`10 && x`,
+    `"s" && x`, `true && x`). Symmetric with the always-falsy set (T147), which
+    proved 0-FP across the corpus, so the same literal-only matching applies.
+    Whole-corpus TP 1745 -> 1746, 0 FP. Pinned recall 690 -> 691
+    (typeGuardsInIfStatement, via `10 && x.toString()`). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -3542,6 +3542,14 @@ fn is_syntactically_always_truthy(expr : @ast.TsExpr) -> Bool {
     | NativeClassExpr(_, _)
     | ObjectLit(_)
     | ArrayLit(_) => true
+    // Literal scalars whose value is statically truthy: a non-empty string, a
+    // non-zero number / bigint, or `true`. Mirrors the always-falsy set, so a
+    // bare identifier or call result is still never matched.
+    BoolLit(b) => b
+    StringLit(s) => s != ""
+    IntLit(n) => n != 0
+    NumberLit(n) => n != 0.0
+    BigIntLit(s) => s != "0" && s != "0n"
     _ => false
   }
 }

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10641,6 +10641,13 @@ test "expr_check: always-truthy left operand of && (TS2872)" {
   assert_true(issues("function g() { return (function(){}) && 1; }") > 0)
   assert_true(issues("let z = {} && 1;") > 0)
   assert_true(issues("let z = [] && 1;") > 0)
+  // Literal scalars that are statically truthy.
+  assert_true(issues("let z = 10 && 1;") > 0)
+  assert_true(issues("let z = \"x\" && 1;") > 0)
+  assert_true(issues("let z = true && 1;") > 0)
+  // Falsy scalars are NOT always-truthy: silent under this check.
+  @test.assert_eq(issues("let z = 0 && 1;"), 0)
+  @test.assert_eq(issues("let z = \"\" && 1;"), 0)
   // A bare identifier / call result is NOT a literal truthy form: silent.
   @test.assert_eq(issues("let a: any; let z = a && a.b;"), 0)
   @test.assert_eq(


### PR DESCRIPTION
Extends the always-truthy set (TS2872, #176) to literal scalars whose value is statically truthy — a non-empty string, a non-zero number / bigint, or `true` (`10 && x`, `"s" && x`, `true && x`).

Symmetric with the always-falsy set (TS2873, #177), which proved 0-FP across the whole corpus, so the same literal-only matching keeps it false-positive-free (a bare identifier or call result is never matched).

- Pinned recall 690 → **691** (typeGuardsInIfStatement, via `10 && x.toString()`).
- Whole-corpus oracle TP 1745 → 1746, **FP 0** (`--max-fp 0`).
- Whitebox test strengthened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_