### PR TITLE
checker: generalize TS2872/2873 to both && and ||

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2166,6 +2166,17 @@ conformance sources (`.errors.txt` baseline = ground truth):
     Whole-corpus TP 1745 -> 1746, 0 FP. Pinned recall 690 -> 691
     (typeGuardsInIfStatement, via `10 && x.toString()`). Whitebox-tested.
 
+2026-06-29 (T149)  691/815 (85 %)        414/414 ( 0 FP)   TS2872/2873 generalized to both && and ||
+
+  T149 -- generalizes T146-T148: TS reports on the LEFT operand's truthiness
+    regardless of which logical operator gates it. A truthy literal left
+    operand is TS2872 in both `x && y` and `x || y` (in `||` the right operand
+    is then unreachable); a falsy literal left operand is TS2873 in both (in
+    `&&` the operator always yields the falsy left value). The check now fires
+    for `op is (And | Or)` on either truthiness. Whole-corpus TP 1746 -> 1749
+    (+3 beyond the pinned set: `{} || x`, `0 && x`, `null && x` forms), 0 FP.
+    Pinned recall unchanged at 691. Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -12447,23 +12447,22 @@ fn check_call_args_in_expr(
     }
     BinOp(op, l, r) => {
       check_call_args_in_expr(env, l, ctx)
-      // TS2872: a `&&` whose left operand is a literal always-truthy value
-      // (`(a => a) && f`, `{} && x`, `[] && x`) is redundant -- the guard
-      // never short-circuits. Only syntactic literal forms are matched, so
-      // this needs no inference and never false-positives.
-      if op is And && is_syntactically_always_truthy(l) {
-        record_unfiltered(
-          ctx, "logical `&&`", "this kind of expression is always truthy",
-        )
-      }
-      // TS2873: a `||` whose left operand is a literal always-falsy value
-      // (`null || x`, `void 0 || y`, `0 || z`) is redundant -- the guard
-      // always falls through to the right operand. Same literal-only matching,
-      // so no inference and no false positives.
-      if op is Or && is_syntactically_always_falsy(l) {
-        record_unfiltered(
-          ctx, "logical `||`", "this kind of expression is always falsy",
-        )
+      // TS2872 / TS2873: the left operand of a `&&` / `||` whose value is a
+      // statically truthy / falsy literal makes the short-circuit redundant.
+      // TS reports on the operand's truthiness regardless of which logical
+      // operator it gates (`{} && x`, `{} || x` -> always truthy; `0 && x`,
+      // `null || x` -> always falsy). Only syntactic literal forms are matched,
+      // so the check needs no inference and never false-positives.
+      if op is (And | Or) {
+        if is_syntactically_always_truthy(l) {
+          record_unfiltered(
+            ctx, "logical operand", "this kind of expression is always truthy",
+          )
+        } else if is_syntactically_always_falsy(l) {
+          record_unfiltered(
+            ctx, "logical operand", "this kind of expression is always falsy",
+          )
+        }
       }
       // Short-circuit narrowing: the RHS of `&&` runs only when the LHS is
       // truthy, and the RHS of `||` only when the LHS is falsy. Apply the

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10654,8 +10654,9 @@ test "expr_check: always-truthy left operand of && (TS2872)" {
     issues("function h(): any { return 0; } let z = h() && 1;"),
     0,
   )
-  // `||` is not flagged by this check.
-  @test.assert_eq(issues("let z = {} || 1;"), 0)
+  // A truthy literal also flags as the left operand of `||` (the right
+  // operand is then unreachable).
+  assert_true(issues("let z = {} || 1;") > 0)
 }
 
 ///|
@@ -10678,7 +10679,9 @@ test "expr_check: always-falsy left operand of || (TS2873)" {
   // A bare identifier (incl. `undefined`, which is shadowable) is NOT matched.
   @test.assert_eq(issues("let a: any; let z = a || 1;"), 0)
   @test.assert_eq(issues("let z = undefined || 1;"), 0)
-  // Non-falsy literals and `&&` are not flagged by this check.
+  // A falsy literal also flags as the left operand of `&&` (the operator
+  // then always yields the falsy left value).
+  assert_true(issues("let z = null && 1;") > 0)
+  // A truthy literal is not "always falsy".
   @test.assert_eq(issues("let z = 1 || 2;"), 0)
-  @test.assert_eq(issues("let z = null && 1;"), 0)
 }


### PR DESCRIPTION
TypeScript reports always-truthy / always-falsy on the **left operand's** truthiness regardless of which logical operator gates it. This generalizes #176–#178:

- A truthy literal left operand is TS2872 in both `x && y` and `x || y` (in `||` the right operand is then unreachable).
- A falsy literal left operand is TS2873 in both (in `&&` the operator always yields the falsy left value).

The check now fires for `op is (And | Or)` on either truthiness, still matching only syntactic literal forms.

- Whole-corpus oracle TP 1746 → **1749** (+3 beyond the pinned set: `{} || x`, `0 && x`, `null && x` forms), **FP 0** (`--max-fp 0`).
- Pinned recall unchanged at 691.
- Whitebox tests updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_