### PR TITLE
checker: TS2344 intrinsic string-mapping type with non-string argument

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2177,6 +2177,21 @@ conformance sources (`.errors.txt` baseline = ground truth):
     (+3 beyond the pinned set: `{} || x`, `0 && x`, `null && x` forms), 0 FP.
     Pinned recall unchanged at 691. Whitebox-tested.
 
+2026-07-01 (T150)  692/815 (85 %)        414/414 ( 0 FP)   TS2344 intrinsic string-mapping type w/ non-string arg
+
+  T150 -- TS2344 ("Type ... does not satisfy the constraint ..."). The
+    intrinsic string-mapping utility types (`Uppercase` / `Lowercase` /
+    `Capitalize` / `Uncapitalize`) carry an implicit `S extends string` bound.
+    Rather than hand-roll a predicate, they are registered as synthetic bounded
+    aliases in `check_constraints`' `alias_params` / `alias_bounds` maps -- so
+    the existing, tested constraint machinery flags a non-string argument
+    (`Uppercase<42>`, `Lowercase<number>`) exactly like a user alias would.
+    Guarded against files that declare their own type of the same name (an
+    unbounded `type Uppercase<T>` must not be flagged). Registering them also
+    makes `alias_bounds` non-empty, so the constraint walk runs even in files
+    with no user generics. Whole-corpus TP 1749 -> 1750, 0 FP. Pinned recall
+    691 -> 692 (intrinsicTypes). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/check_module.mbt
+++ b/src/checker/check_module.mbt
@@ -322,6 +322,30 @@ pub fn check_module(module_ : @ast.TsModule) -> TypeCheckReport {
       alias_bounds[iface.name] = iface.type_param_bounds
     }
   }
+  // The intrinsic string-mapping utility types carry an implicit `extends
+  // string` bound on their single parameter (`Uppercase<S extends string>`,
+  // etc.). Register them as synthetic bounded aliases -- unless the file
+  // declares its own type of the same name (an unbounded `type Uppercase<T>`
+  // would otherwise be flagged spuriously) -- so the existing constraint
+  // machinery flags a non-string argument (`Uppercase<42>`) as TS2344. This
+  // also makes `alias_bounds` non-empty, so the constraint walk below always
+  // runs even in files that declare no generics of their own.
+  let user_declared_type_names : Map[String, Unit] = {}
+  for ta in module_.type_aliases {
+    user_declared_type_names[ta.name] = ()
+  }
+  for iface in module_.interfaces {
+    user_declared_type_names[iface.name] = ()
+  }
+  for cls in module_.classes {
+    user_declared_type_names[cls.name] = ()
+  }
+  for intrinsic in ["Uppercase", "Lowercase", "Capitalize", "Uncapitalize"] {
+    if user_declared_type_names.get(intrinsic) is None {
+      alias_params[intrinsic] = ["S"]
+      alias_bounds[intrinsic] = [("S", @ast.TsType::String_)]
+    }
+  }
   let resolve = fn(name : String) -> @ast.TsType? {
     non_generic_alias_bodies.get(name)
   }

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10685,3 +10685,28 @@ test "expr_check: always-falsy left operand of || (TS2873)" {
   // A truthy literal is not "always falsy".
   @test.assert_eq(issues("let z = 1 || 2;"), 0)
 }
+
+///|
+test "expr_check: intrinsic string-mapping type with non-string arg (TS2344)" {
+  let issues = fn(src : String) -> Int {
+    let mut n = 0
+    for i in check_module_function_bodies_permissive(parse_module_or_empty(src)) {
+      if i.message.contains("does not satisfy the `S` constraint") {
+        n += 1
+      }
+    }
+    n
+  }
+  // Non-string concrete arguments to the intrinsic string-mapping types.
+  assert_true(issues("type T = Uppercase<42>;") > 0)
+  assert_true(issues("type T = Lowercase<number>;") > 0)
+  assert_true(issues("type T = Capitalize<0>;") > 0)
+  assert_true(issues("type T = Uncapitalize<123>;") > 0)
+  // Valid string arguments: silent.
+  @test.assert_eq(issues("type T = Uppercase<\"hello\">;"), 0)
+  @test.assert_eq(issues("type T = Uppercase<string>;"), 0)
+  @test.assert_eq(issues("type T = Uppercase<'a' | 'b'>;"), 0)
+  @test.assert_eq(issues("type T = Uppercase<any>;"), 0)
+  // A user-declared `Uppercase` alias is not the intrinsic: no forced flag.
+  @test.assert_eq(issues("type Uppercase<T> = T; type X = Uppercase<42>;"), 0)
+}


### PR DESCRIPTION
The intrinsic string-mapping utility types (`Uppercase` / `Lowercase` / `Capitalize` / `Uncapitalize`) carry an implicit `S extends string` bound, so a non-string type argument (`Uppercase<42>`, `Lowercase<number>`) is TS2344 ("Type ... does not satisfy the constraint ...").

Rather than hand-roll a predicate, the four intrinsics are registered as synthetic bounded aliases in `check_constraints`' `alias_params` / `alias_bounds` maps, so the existing (tested, `infer`/forwarding-gated) constraint machinery handles them exactly like a user-declared bounded alias. Guarded against files that declare their own type of the same name, so an unbounded `type Uppercase<T>` is never spuriously flagged. Registering them also makes `alias_bounds` non-empty, so the constraint walk runs even in files with no user generics.

- Pinned recall 691 → **692** (intrinsicTypes).
- Whole-corpus oracle TP 1749 → 1750, **FP 0** (`--max-fp 0`).
- Whitebox regression test added (incl. the user-shadowing guard case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_