### PR TITLE
checker: walk exported var initializers; abstain on opaque targets

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2192,6 +2192,24 @@ conformance sources (`.errors.txt` baseline = ground truth):
     with no user generics. Whole-corpus TP 1749 -> 1750, 0 FP. Pinned recall
     691 -> 692 (intrinsicTypes). Whitebox-tested.
 
+2026-07-01 (T151)  693/815 (85 %)        414/414 ( 0 FP)   exported var initializers are walked (+ opaque-target abstain)
+
+  T151 -- coverage gap: `export var/let/const b = <expr>` dropped its
+    initializer -- the parser collected the value decl but never pushed the
+    statement into `top_level_stmts`, so NO expression-level check ever ran on
+    an exported initializer, including every binding inside a namespace (where
+    all members are exported). `parse_export_stmt` now pushes the statement
+    like the non-export path does. This surfaced a latent structural-
+    assignability false positive (`const arr: Obj[] = xs.map(...)` where `Obj =
+    { code: LangCode }` and `LangCode = keyof typeof s` -- an unmodeled
+    type-level construct nested behind an alias), so a companion guard,
+    `type_deeply_contains_unmodeled`, makes the general `expected X but got Y`
+    fallback abstain when either shape contains a nested `keyof` / `typeof` /
+    conditional / mapped / indexed-access after alias resolution. Whole-corpus
+    TP 1750 -> 1753 (+3, incl. protectedStaticNotAccessibleInClodule), 0 FP.
+    Pinned recall 692 -> 693. Whitebox-tested (both the new coverage and the
+    abstain).
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -7326,6 +7326,17 @@ fn check_expr_against(
     if type_contains_typeof(inferred_u) || type_contains_typeof(expected_u) {
       return
     }
+    // A `keyof` / `typeof` / conditional / mapped / indexed-access nested
+    // anywhere inside either shape (e.g. `Obj[]` where `Obj = { code:
+    // LangCode }` and `LangCode = keyof typeof set`) is resolved fully by
+    // TypeScript but only approximated here, so a structural mismatch against
+    // it is a false positive. The shallow `type_contains_typeof` guard above
+    // misses the case where the construct sits behind a named alias / array
+    // element; this deep walk (which resolves aliases) covers it.
+    if type_deeply_contains_unmodeled(expected_u, ctx.resolver) ||
+      type_deeply_contains_unmodeled(inferred_u, ctx.resolver) {
+      return
+    }
     if type_has_call_signature(inferred_u, ctx.resolver) ||
       type_has_call_signature(expected_u, ctx.resolver) {
       return
@@ -7700,6 +7711,91 @@ fn type_is_unmodeled_shape(ty : @ast.TsType, resolver : Resolver) -> Bool {
     | TemplateLiteralType(_, _) => true
     Applied(n, _) =>
       resolver.classes.get(n) is None && resolver.interfaces.get(n) is None
+    _ => false
+  }
+}
+
+///|
+/// Deep variant of `type_is_unmodeled_shape`: true when the type contains an
+/// unmodeled type-level construct (`keyof` / `typeof` / conditional / mapped /
+/// indexed-access / template-literal, or an `Applied` to a non-class/interface)
+/// ANYWHERE inside it -- nested in an array element, object field, tuple slot,
+/// union / intersection member, or a resolved alias / interface body. Used to
+/// abstain from structural assignability diagnostics against a target whose
+/// members TypeScript resolves but we approximate (`Obj[]` where `Obj = { code:
+/// LangCode }` and `LangCode = keyof typeof set`); flagging such a target
+/// produces false positives, so the check stays silent.
+fn type_deeply_contains_unmodeled(
+  ty : @ast.TsType,
+  resolver : Resolver,
+  depth? : Int = 0,
+  visited? : Array[String] = [],
+) -> Bool {
+  if depth > 8 {
+    return false
+  }
+  if type_is_unmodeled_shape(ty, resolver) {
+    return true
+  }
+  fn recur(t : @ast.TsType) -> Bool {
+    type_deeply_contains_unmodeled(t, resolver, depth=depth + 1, visited~)
+  }
+
+  match resolver.unwrap(ty) {
+    Array(inner) | Rest(inner) => recur(inner)
+    Union(parts) | Intersection(parts) | Tuple(parts) => {
+      for p in parts {
+        if recur(p) {
+          return true
+        }
+      }
+      false
+    }
+    Object(fields) => {
+      for f in fields {
+        if recur(f.1) {
+          return true
+        }
+      }
+      false
+    }
+    Func(params, ret) => {
+      for p in params {
+        if recur(p) {
+          return true
+        }
+      }
+      recur(ret)
+    }
+    Named(n) => {
+      if visited.contains(n) {
+        return false
+      }
+      visited.push(n)
+      let result = match resolver.interfaces.get(n) {
+        Some(iface) => {
+          let mut hit = false
+          for field in iface.fields {
+            if recur(field.1) {
+              hit = true
+              break
+            }
+          }
+          hit
+        }
+        None => false
+      }
+      let _ = visited.pop()
+      result
+    }
+    Applied(_, args) => {
+      for a in args {
+        if recur(a) {
+          return true
+        }
+      }
+      false
+    }
     _ => false
   }
 }

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10710,3 +10710,40 @@ test "expr_check: intrinsic string-mapping type with non-string arg (TS2344)" {
   // A user-declared `Uppercase` alias is not the intrinsic: no forced flag.
   @test.assert_eq(issues("type Uppercase<T> = T; type X = Uppercase<42>;"), 0)
 }
+
+///|
+test "expr_check: exported var initializer is walked; opaque target abstains" {
+  let count = fn(src : String, needle : String) -> Int {
+    let mut n = 0
+    for i in check_module_function_bodies_permissive(parse_module_or_empty(src)) {
+      if i.message.contains(needle) {
+        n += 1
+      }
+    }
+    n
+  }
+  // An `export var` initializer is now checked the same as a plain `var`:
+  // reading a protected static from outside the class is flagged.
+  assert_true(
+    count(
+      "class C { protected static bar: string; }\nexport var b = C.bar;", "protected",
+    ) >
+    0,
+  )
+  // Structural assignability abstains when the target's element/field type
+  // is an unmodeled type-level construct behind an alias (`keyof typeof`),
+  // which TypeScript resolves but we approximate -- no false positive.
+  @test.assert_eq(
+    count(
+      (
+        #|const s = { a: 1, b: 2 };
+        #|type K = keyof typeof s;
+        #|type Obj = { code: K };
+        #|declare function mk(): { code: string }[];
+        #|const arr: Obj[] = mk();
+      ),
+      "expected",
+    ),
+    0,
+  )
+}

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -2717,6 +2717,7 @@ fn Parser::parse_export_stmt(
   namespaces : Array[@ast.TsNamespaceDecl],
   enums : Array[@ast.TsEnumDecl],
   const_values : Map[String, @ast.TsExpr],
+  top_level_stmts : Array[@ast.TsStmt],
 ) -> Unit raise ParseError {
   let _ = self.expect(Export)
   if self.match_(As) || self.match_ident("as") {
@@ -2990,6 +2991,13 @@ fn Parser::parse_export_stmt(
     let stmt = self.parse_stmt()
     collect_static_const_exprs_from_stmt(stmt, const_values)
     collect_value_decls_from_stmt(stmt, values, const_values)
+    // Retain the statement so the checker walks the initializer expression
+    // (`export var b = C.bar`) the same way it does a non-exported
+    // `var b = C.bar`. Without this the initializer was dropped, so no
+    // expression-level check (accessibility, call arity, always-truthy, …)
+    // ever fired on exported variable initializers -- including every
+    // binding inside a namespace, where all members are exported.
+    top_level_stmts.push(stmt)
     return
   }
   // ES2023 `using` / `await using` declarations at the module export
@@ -3173,7 +3181,7 @@ fn Parser::parse_module_with_seeded_const_values_internal(
     } else if self.check(Export) {
       self.parse_export_stmt(
         funcs, interfaces, type_aliases, imports, values, classes, namespaces, enums,
-        const_values,
+        const_values, top_level_stmts,
       )
     } else if self.check(Type) {
       let type_alias = self.parse_type_alias()


### PR DESCRIPTION
**Coverage gap:** `export var/let/const b = <expr>` dropped its initializer — the parser collected the value declaration but never pushed the statement into `top_level_stmts`, so *no* expression-level check (accessibility, call arity, always-truthy, …) ever ran on an exported initializer. This includes every binding inside a namespace, where all members are exported. `parse_export_stmt` now pushes the statement like the non-export path already does.

Enabling this surfaced a **latent** structural-assignability false positive: `const arr: Obj[] = xs.map(...)` where `Obj = { code: LangCode }` and `LangCode = keyof typeof s` — an unmodeled type-level construct nested behind an alias, which TypeScript resolves but we only approximate. A companion guard, `type_deeply_contains_unmodeled`, makes the general `expected X but got Y` fallback abstain when either shape contains a nested `keyof` / `typeof` / conditional / mapped / indexed-access after alias resolution (the pre-existing shallow `type_contains_typeof` guard missed the aliased/nested case).

- Pinned recall 692 → **693** (protectedStaticNotAccessibleInClodule), precision 414/414.
- Whole-corpus oracle TP 1750 → **1753** (+3), **FP 0** (`--max-fp 0`).
- Whitebox regression tests for both the new coverage and the abstain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_