### PR TITLE
checker: TS2687 class/interface merge with conflicting modifiers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2210,6 +2210,19 @@ conformance sources (`.errors.txt` baseline = ground truth):
     Pinned recall 692 -> 693. Whitebox-tested (both the new coverage and the
     abstain).
 
+2026-07-01 (T152)  694/815 (85 %)        414/414 ( 0 FP)   TS2687 class/interface merge conflicting modifiers
+
+  T152 -- TS2687 ("All declarations of 'X' must have identical modifiers.").
+    When a class and a same-named interface merge and the class declares a
+    member with a `private` / `protected` accessibility modifier that the
+    interface also declares, the modifiers differ (interface members are always
+    public), so it is always an error. `check_class_interface_merge_modifiers`
+    flags only private/protected class members that also appear as interface
+    fields; a `public` class member matches the interface's implicit public and
+    is left alone -- false-positive-free. Whole-corpus TP 1753 -> 1754, 0 FP.
+    Pinned recall 693 -> 694 (classAndInterfaceMergeConflictingMembers).
+    Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -15506,6 +15506,60 @@ fn check_type_param_as_base(module_ : @ast.TsModule) -> Array[ExprIssue] {
 }
 
 ///|
+/// TS2687: "All declarations of 'X' must have identical modifiers." When a
+/// class and a same-named interface merge (declaration merging) and the class
+/// declares a member with a `private` / `protected` accessibility modifier that
+/// the interface also declares, the modifiers differ -- interface members are
+/// always public -- so it is always an error. Only private/protected class
+/// members that also appear as interface fields are flagged; a `public` class
+/// member matches the interface's implicit public and is left alone, keeping
+/// this false-positive-free.
+fn check_class_interface_merge_modifiers(
+  module_ : @ast.TsModule,
+) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  for cls in module_.classes {
+    // Find a same-named interface (the merge partner).
+    let mut merged : @ast.TsInterface? = None
+    for iface in module_.interfaces {
+      if iface.name == cls.name {
+        merged = Some(iface)
+        break
+      }
+    }
+    match merged {
+      Some(iface) => {
+        let iface_field_names : Map[String, Unit] = {}
+        for field in iface.fields {
+          iface_field_names[field.0] = ()
+        }
+        let seen : Map[String, Unit] = {}
+        for name in cls.private_members {
+          if iface_field_names.get(name) is Some(_) && seen.get(name) is None {
+            seen[name] = ()
+            issues.push({
+              path: "class \{cls.name}",
+              message: "all declarations of `\{name}` must have identical modifiers",
+            })
+          }
+        }
+        for name in cls.protected_members {
+          if iface_field_names.get(name) is Some(_) && seen.get(name) is None {
+            seen[name] = ()
+            issues.push({
+              path: "class \{cls.name}",
+              message: "all declarations of `\{name}` must have identical modifiers",
+            })
+          }
+        }
+      }
+      None => ()
+    }
+  }
+  issues
+}
+
+///|
 fn check_reserved_type_alias_names(module_ : @ast.TsModule) -> Array[ExprIssue] {
   let issues : Array[ExprIssue] = []
   for ta in module_.type_aliases {
@@ -17039,6 +17093,9 @@ fn check_module_function_bodies_layered(
     all.push(issue)
   }
   for issue in check_type_param_as_base(module_) {
+    all.push(issue)
+  }
+  for issue in check_class_interface_merge_modifiers(module_) {
     all.push(issue)
   }
   for issue in check_reserved_type_alias_names(module_) {

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10747,3 +10747,40 @@ test "expr_check: exported var initializer is walked; opaque target abstains" {
     0,
   )
 }
+
+///|
+test "expr_check: class/interface merge with conflicting modifiers (TS2687)" {
+  let issues = fn(src : String) -> Int {
+    let mut n = 0
+    for i in check_module_function_bodies_permissive(parse_module_or_empty(src)) {
+      if i.message.contains("must have identical modifiers") {
+        n += 1
+      }
+    }
+    n
+  }
+  // A protected / private class member re-declared by a merged interface.
+  assert_true(
+    issues(
+      "declare class C { protected x: number; }\ninterface C { x: number; }",
+    ) >
+    0,
+  )
+  assert_true(
+    issues("declare class C { private x: number; }\ninterface C { x: number; }") >
+    0,
+  )
+  // A public class member matches the interface's implicit public: silent.
+  @test.assert_eq(
+    issues("declare class C { public x: number; }\ninterface C { x: number; }"),
+    0,
+  )
+  // No merged interface, or member not shared: silent.
+  @test.assert_eq(issues("declare class C { protected x: number; }"), 0)
+  @test.assert_eq(
+    issues(
+      "declare class C { protected x: number; }\ninterface C { y: number; }",
+    ),
+    0,
+  )
+}


### PR DESCRIPTION
TS2687 ("All declarations of 'X' must have identical modifiers."). When a class and a same-named interface merge (declaration merging) and the class declares a member with a `private` / `protected` accessibility modifier that the interface also declares, the modifiers differ — interface members are always public — so it is always an error.

`check_class_interface_merge_modifiers` flags only private/protected class members that also appear as interface fields; a `public` class member matches the interface's implicit public and is left alone, keeping the check false-positive-free.

- Pinned recall 693 → **694** (classAndInterfaceMergeConflictingMembers).
- Whole-corpus oracle TP 1753 → 1754, **FP 0** (`--max-fp 0`).
- Whitebox regression test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_