### PR TITLE
checker: TS2314 generic type used without type arguments

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2223,6 +2223,27 @@ conformance sources (`.errors.txt` baseline = ground truth):
     Pinned recall 693 -> 694 (classAndInterfaceMergeConflictingMembers).
     Whitebox-tested.
 
+2026-07-01 (T153)  695/815 (85 %)        414/414 ( 0 FP)   TS2314 generic type used without type arguments
+
+  T153 -- TS2314 ("Generic type 'C<T>' requires N type argument(s)."). A bare
+    reference to a locally-declared generic (class / interface / alias /
+    declare class) with no defaulted type parameter (`var c: C` where
+    `class C<T>`) supplies zero type arguments and is an error. The parser
+    records the had-a-default flag per declaration (via a new
+    `last_type_params_had_default` field set in
+    `parse_type_param_names_bounds_and_const_flags`) and pushes a
+    `<generic-noarg-required>NAME` sentinel for each no-default generic. It
+    also records every type-parameter name (`<type-param-name>NAME`); the
+    checker EXCLUDES any such name from the flag set, because
+    `check_arity`'s `scope` does not track nested call / construct-signature
+    generics -- a bare `Named(B)` might be an in-scope type parameter (e.g.
+    `new <A, B>(...)`) rather than a same-named generic class, so skipping it
+    keeps the check false-positive-free. `check_arity` gained a `Named` case
+    that flags names in the (arity-conflict-free) required set. Whole-corpus TP
+    1754 -> 1756 (+2: genericTypeReferenceWithoutTypeArgument{,3}), 0 FP. Pinned
+    recall 694 -> 695. Whitebox-tested (incl. default-param and type-param-name
+    exclusion cases).
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/check_module.mbt
+++ b/src/checker/check_module.mbt
@@ -245,33 +245,61 @@ pub fn check_module(module_ : @ast.TsModule) -> TypeCheckReport {
   for name, _ in arity_conflict {
     arities.remove(name) |> ignore
   }
+  // TS2314: names of locally-declared generics with NO defaulted type
+  // parameter -- a bare reference to one (`C` without `<...>`) supplies zero
+  // arguments and is an error. The parser records each via the
+  // `<generic-noarg-required>NAME` sentinel. A name dropped from `arities`
+  // for an arity conflict is excluded (ambiguous merge), keeping this sound.
+  // Every type-parameter name seen anywhere in the module (including nested
+  // call / construct signature and method generics). A name in this set is
+  // excluded from `noarg_required` because a bare `Named(X)` reference might
+  // resolve to an in-scope type parameter rather than a same-named generic
+  // declaration -- `check_arity`'s `scope` does not track nested signature
+  // scopes, so this exclusion keeps the bare-reference check sound.
+  let all_type_param_names : Map[String, Unit] = {}
+  for entry in module_.interface_member_modifier_misuses {
+    if entry.has_prefix("<type-param-name>") {
+      all_type_param_names[entry.substring(start="<type-param-name>".length())] = ()
+    }
+  }
+  let noarg_required : Map[String, Unit] = {}
+  for entry in module_.interface_member_modifier_misuses {
+    if entry.has_prefix("<generic-noarg-required>") {
+      let nm = entry.substring(start="<generic-noarg-required>".length())
+      if arities.get(nm) is Some(_) &&
+        arity_conflict.get(nm) is None &&
+        all_type_param_names.get(nm) is None {
+        noarg_required[nm] = ()
+      }
+    }
+  }
   for iface in module_.interfaces {
     let scope = scope_with_iface_params(iface)
     for field in iface.fields {
-      check_arity(field.1, scope, arities, issues)
+      check_arity(field.1, scope, arities, noarg_required, issues)
     }
   }
   for ta in module_.type_aliases {
     let scope = ta.type_params
-    check_arity(ta.type_, scope, arities, issues)
+    check_arity(ta.type_, scope, arities, noarg_required, issues)
   }
   for f in module_.funcs {
     let scope : Array[String] = []
     for p in f.params {
-      check_arity(p.type_, scope, arities, issues)
+      check_arity(p.type_, scope, arities, noarg_required, issues)
     }
-    check_arity(f.return_type, scope, arities, issues)
+    check_arity(f.return_type, scope, arities, noarg_required, issues)
   }
   for i in module_.imports {
     let scope : Array[String] = []
     for p in i.params {
-      check_arity(p.1, scope, arities, issues)
+      check_arity(p.1, scope, arities, noarg_required, issues)
     }
-    check_arity(i.return_type, scope, arities, issues)
+    check_arity(i.return_type, scope, arities, noarg_required, issues)
   }
   for v in module_.values {
     let scope : Array[String] = []
-    check_arity(v.type_, scope, arities, issues)
+    check_arity(v.type_, scope, arities, noarg_required, issues)
   }
   // Top-level `var`/`let`/`const` declarations whose annotation references a
   // declared type (`var v: C<string>`) -- these live in `top_level_stmts`,
@@ -279,7 +307,7 @@ pub fn check_module(module_ : @ast.TsModule) -> TypeCheckReport {
   for stmt in module_.top_level_stmts {
     match stmt {
       Var(_, t, _) | Let(_, t, _) | Const(_, t, _) =>
-        check_arity(t, [], arities, issues)
+        check_arity(t, [], arities, noarg_required, issues)
       _ => ()
     }
   }
@@ -755,9 +783,31 @@ fn check_arity(
   type_ : @ast.TsType,
   scope : Array[String],
   arities : Map[String, Int],
+  noarg_required : Map[String, Unit],
   issues : Array[TypeIssue],
 ) -> Unit {
   match type_ {
+    // TS2314: a bare reference to a generic that has no defaulted type
+    // parameter (`C` where `class C<T> {}`) supplies zero type arguments and
+    // is an error. `noarg_required` holds exactly those names (recorded by the
+    // parser, arity-conflict names excluded), so this is false-positive-free.
+    Named(name) =>
+      if not(scope.contains(name)) && noarg_required.get(name) is Some(_) {
+        let already = issues
+          .iter()
+          .any(fn(i) { i.kind == TypeAliasArityMismatch && i.name == name })
+        if not(already) {
+          match arities.get(name) {
+            Some(expected) =>
+              issues.push({
+                kind: TypeAliasArityMismatch,
+                name,
+                detail: "generic type requires \{expected} type argument(s)",
+              })
+            None => ()
+          }
+        }
+      }
     Applied(name, args) => {
       if !scope.contains(name) {
         match arities.get(name) {
@@ -780,38 +830,38 @@ fn check_arity(
         }
       }
       for a in args {
-        check_arity(a, scope, arities, issues)
+        check_arity(a, scope, arities, noarg_required, issues)
       }
     }
-    Array(inner) => check_arity(inner, scope, arities, issues)
+    Array(inner) => check_arity(inner, scope, arities, noarg_required, issues)
     Tuple(items) =>
       for it in items {
-        check_arity(it, scope, arities, issues)
+        check_arity(it, scope, arities, noarg_required, issues)
       }
     Object(fields) =>
       for f in fields {
-        check_arity(f.0, scope, arities, issues)
-        check_arity(f.1, scope, arities, issues)
+        check_arity(f.0, scope, arities, noarg_required, issues)
+        check_arity(f.1, scope, arities, noarg_required, issues)
       }
     Func(params, ret) => {
       for p in params {
-        check_arity(p, scope, arities, issues)
+        check_arity(p, scope, arities, noarg_required, issues)
       }
-      check_arity(ret, scope, arities, issues)
+      check_arity(ret, scope, arities, noarg_required, issues)
     }
     Union(items) | Intersection(items) =>
       for m in items {
-        check_arity(m, scope, arities, issues)
+        check_arity(m, scope, arities, noarg_required, issues)
       }
     Conditional(c, e, t, f) => {
-      check_arity(c, scope, arities, issues)
-      check_arity(e, scope, arities, issues)
-      check_arity(t, scope, arities, issues)
-      check_arity(f, scope, arities, issues)
+      check_arity(c, scope, arities, noarg_required, issues)
+      check_arity(e, scope, arities, noarg_required, issues)
+      check_arity(t, scope, arities, noarg_required, issues)
+      check_arity(f, scope, arities, noarg_required, issues)
     }
     IndexedAccess(b, k) => {
-      check_arity(b, scope, arities, issues)
-      check_arity(k, scope, arities, issues)
+      check_arity(b, scope, arities, noarg_required, issues)
+      check_arity(k, scope, arities, noarg_required, issues)
     }
     _ => ()
   }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -17244,6 +17244,11 @@ fn check_module_function_bodies_layered(
         })
       } else if member == "<object-member-no-separator>" {
         all.push({ path: "object type", message: "`;` expected" })
+      } else if member.has_prefix("<generic-noarg-required>") ||
+        member.has_prefix("<type-param-name>") {
+        // Consumed by the TS2314 arity check in `check_module`, not a
+        // diagnostic of its own -- skip it here.
+        ()
       } else {
         all.push({
           path: "member `\{member}`",

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10784,3 +10784,38 @@ test "expr_check: class/interface merge with conflicting modifiers (TS2687)" {
     0,
   )
 }
+
+///|
+test "expr_check: bare reference to generic without type arguments (TS2314)" {
+  let issues = fn(src : String) -> Int {
+    let mut n = 0
+    for i in check_module_function_bodies_permissive(parse_module_or_empty(src)) {
+      if i.message.contains("generic type requires") {
+        n += 1
+      }
+    }
+    n
+  }
+  // Bare reference to a generic class / interface / alias / declare class.
+  assert_true(issues("class C<T> { x: T = 0 as any; }\nvar c: C;") > 0)
+  assert_true(issues("interface I<T> { x: T; }\nvar i: I;") > 0)
+  assert_true(issues("declare class D<T> { x: T; }\ndeclare var d: D;") > 0)
+  // A defaulted type parameter makes the bare reference valid: silent.
+  @test.assert_eq(issues("interface I<T = string> { x: T; }\nvar i: I;"), 0)
+  @test.assert_eq(
+    issues("declare class D<T = string> { x: T; }\ndeclare var d: D;"),
+    0,
+  )
+  // A supplied type argument is fine.
+  @test.assert_eq(issues("interface I<T> { x: T; }\nvar i: I<number>;"), 0)
+  // A non-generic type referenced bare is fine.
+  @test.assert_eq(issues("interface I { x: number; }\nvar i: I;"), 0)
+  // A name that is also used as a type parameter anywhere is not flagged
+  // (it may be an in-scope type parameter, not the generic declaration).
+  @test.assert_eq(
+    issues(
+      "class B<U, V> { x: U = 0 as any; }\ndeclare var f: { new <A, B>(x: A): B };",
+    ),
+    0,
+  )
+}

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -1657,6 +1657,15 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
     let (names, type_param_bounds) = self.parse_type_param_names_and_bounds()
     class_type_params = names
     class_type_param_bounds = type_param_bounds
+    // TS2314: a named generic class expression with no defaulted type
+    // parameter requires all of its type arguments on a bare reference.
+    if class_name != "" &&
+      names.length() > 0 &&
+      not(self.last_type_params_had_default) {
+      self.interface_member_modifier_misuses.push(
+        "<generic-noarg-required>\{class_name}",
+      )
+    }
     class_type_param_bound_len = self.push_local_type_param_bounds(
       type_param_bounds,
     )
@@ -2362,6 +2371,17 @@ fn Parser::parse_class_decl_with_abstract(
     let (names, type_param_bounds) = self.parse_type_param_names_and_bounds()
     class_type_params = names
     class_type_param_bounds = type_param_bounds
+    // TS2314: a generic class with no defaulted type parameter requires all of
+    // its type arguments; a bare `C` reference is an error. Read the flag now,
+    // before the base / body parse clobbers it via a nested generic.
+    if name != "" &&
+      name != "<class>" &&
+      names.length() > 0 &&
+      not(self.last_type_params_had_default) {
+      self.interface_member_modifier_misuses.push(
+        "<generic-noarg-required>\{name}",
+      )
+    }
     class_type_param_bound_len = self.push_local_type_param_bounds(
       type_param_bounds,
     )

--- a/src/parser/parser_core.mbt
+++ b/src/parser/parser_core.mbt
@@ -51,6 +51,13 @@ pub struct Parser {
   // when it builds the `Call` / `New` / `MethodCall` so the result can be
   // wrapped in `TypeArgs`. Empty when the following call had none.
   mut pending_call_type_args : Array[@ast.TsType]
+  // Set by `parse_type_param_names_bounds_and_const_flags` to record whether
+  // the type-parameter list it just parsed contained ANY defaulted parameter
+  // (`<T = string>`). A generic declaration with no defaulted parameter
+  // requires all of its type arguments, so a bare reference to it (`C` with no
+  // `<...>`) is TS2314. Read immediately after the call by the class /
+  // interface / type-alias parsers.
+  mut last_type_params_had_default : Bool
   local_type_param_bounds : Array[(String, @ast.TsType)]
   // Decorator expressions parsed at the statement level that should be
   // attached to the next class declaration. The class parsers drain
@@ -169,6 +176,7 @@ pub fn Parser::new_with_strict_and_jsx(
     current_class_brand: None,
     last_runtime_class_decl: None,
     pending_class_base_expr: None,
+    last_type_params_had_default: false,
     local_type_param_bounds: [],
     pending_decorators: [],
     param_property_scopes: [],
@@ -226,6 +234,7 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
     current_class_brand: None,
     last_runtime_class_decl: None,
     pending_class_base_expr: None,
+    last_type_params_had_default: false,
     local_type_param_bounds: [],
     pending_decorators: [],
     param_property_scopes: [],

--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -775,6 +775,12 @@ fn Parser::parse_type_param_names_bounds_and_const_flags(
   let names : Array[String] = []
   let const_flags : Array[Bool] = []
   let bounds : Array[(String, @ast.TsType)] = []
+  self.last_type_params_had_default = false
+  // Tracked in a local (not the parser field) because parsing a parameter's
+  // bound can recursively invoke this function for a nested generic function
+  // type and clobber the field; the field is assigned once at the end from
+  // this local so the outermost call's value wins.
+  let mut had_default = false
   if !self.check(Lt) {
     return (names, const_flags, bounds)
   }
@@ -839,6 +845,14 @@ fn Parser::parse_type_param_names_bounds_and_const_flags(
     }
     names.push(name)
     const_flags.push(is_const)
+    // Record every type-parameter name seen anywhere (class / interface /
+    // alias / function / method / call+construct-signature generics). The
+    // TS2314 bare-reference check excludes these names: a bare `Named(X)` that
+    // is also a type-parameter name might be an in-scope type parameter rather
+    // than a reference to a same-named generic declaration (e.g. `new <Y, Z,
+    // A, B>(...)` uses `B` as a type parameter while a class `B<U, V>` also
+    // exists), so skipping it keeps the check false-positive-free.
+    self.interface_member_modifier_misuses.push("<type-param-name>\{name}")
     if self.match_(Extends) {
       let saved_pos = self.pos
       let saved_pending_gt = self.pending_gt
@@ -856,6 +870,7 @@ fn Parser::parse_type_param_names_bounds_and_const_flags(
       }
     }
     if self.match_(Eq) {
+      had_default = true
       self.skip_type_param_tail_until_delim()
     }
     if self.check(Comma) {
@@ -867,6 +882,7 @@ fn Parser::parse_type_param_names_bounds_and_const_flags(
       break
     }
   }
+  self.last_type_params_had_default = had_default
   (names, const_flags, bounds)
 }
 
@@ -1127,6 +1143,14 @@ pub fn Parser::parse_interface(
     k => raise ParseError("Expected interface name, got \{k}")
   }
   let (type_params, const_flags, type_param_bounds) = self.parse_type_param_names_bounds_and_const_flags()
+  // TS2314: a generic interface with no defaulted type parameter requires all
+  // of its type arguments, so a bare reference (`I` without `<...>`) is an
+  // error. Recorded via the shared channel; the checker consults it.
+  if type_params.length() > 0 && not(self.last_type_params_had_default) {
+    self.interface_member_modifier_misuses.push(
+      "<generic-noarg-required>\{name}",
+    )
+  }
   // TS1277: a `const` modifier on a type parameter is only valid on a
   // function, method, or class. An interface's own type-parameter list is
   // none of those, so `interface I<const T>` is always an error. Record it
@@ -1731,6 +1755,15 @@ fn Parser::parse_type_alias_after_type_keyword(
   // erasing the generic shape (e.g. `DateArg<DateType>` would become
   // `Date | ...` and lose precision).
   let (type_params, const_flags, type_param_bounds) = self.parse_type_param_names_bounds_and_const_flags()
+  // TS2314: a generic type alias with no defaulted type parameter requires all
+  // of its type arguments; a bare reference (`A` without `<...>`) is an error.
+  // Read before the alias body is parsed (which could clobber the flag via a
+  // nested generic).
+  if type_params.length() > 0 && not(self.last_type_params_had_default) {
+    self.interface_member_modifier_misuses.push(
+      "<generic-noarg-required>\{name}",
+    )
+  }
   // TS1277: a `const` modifier on a type-alias type parameter is invalid
   // (only functions, methods, and classes allow it). `type T<const U> = …`.
   for i, name_i in type_params {
@@ -2309,6 +2342,16 @@ fn Parser::parse_declare_class(
     let (names, type_param_bounds) = self.parse_type_param_names_and_bounds()
     class_type_params = names
     class_type_param_bounds = type_param_bounds
+    // TS2314: a generic `declare class` with no defaulted type parameter
+    // requires all of its type arguments on a bare reference. Read the flag
+    // before the base / body parse clobbers it via a nested generic.
+    if name != "" &&
+      names.length() > 0 &&
+      not(self.last_type_params_had_default) {
+      self.interface_member_modifier_misuses.push(
+        "<generic-noarg-required>\{name}",
+      )
+    }
     class_type_param_bound_len = self.push_local_type_param_bounds(
       type_param_bounds,
     )


### PR DESCRIPTION
TS2314 ("Generic type 'C<T>' requires N type argument(s)."). A bare reference to a locally-declared generic (class / interface / type alias / `declare class`) with no defaulted type parameter — `var c: C` where `class C<T>` — supplies zero type arguments and is an error.

**Soundness handling:**
- The parser records a per-declaration "had a default parameter" flag (new `last_type_params_had_default`, set in `parse_type_param_names_bounds_and_const_flags`) and pushes a `<generic-noarg-required>NAME` sentinel only for no-default generics, so `class C<T = string>` referenced bare is *not* flagged.
- It also records every type-parameter name (`<type-param-name>NAME`). The checker **excludes** any such name from the flag set, because `check_arity`'s `scope` does not track nested call / construct-signature generics — a bare `Named(B)` might be an in-scope type parameter (e.g. `new <A, B>(...)`) rather than a same-named generic class. Skipping those keeps the check false-positive-free.
- Arity-conflict (merged-at-different-arity) names are excluded too.

- Pinned recall 694 → **695**.
- Whole-corpus oracle TP 1754 → **1756** (+2: genericTypeReferenceWithoutTypeArgument{,3}), **FP 0** (`--max-fp 0`).
- Whitebox regression tests incl. default-param and type-param-name exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_