### PR TITLE
checker: TS2456 circular type alias through typeof value query

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2244,6 +2244,19 @@ conformance sources (`.errors.txt` baseline = ground truth):
     recall 694 -> 695. Whitebox-tested (incl. default-param and type-param-name
     exclusion cases).
 
+2026-07-01 (T154)  696/815 (85 %)        414/414 ( 0 FP)   TS2456 circular type alias through typeof value query
+
+  T154 -- TS2456 ("Type alias 'A' circularly references itself."). The pattern
+    `type A = typeof v; var v: A;` is circular through the value query but the
+    existing `reaches_alias` walker only followed `Named` alias references. A
+    `TypeOf(v)` case now looks up the queried value's explicitly-annotated
+    declared type (from `top_level_stmts` / `values`) and recurses; if it
+    reaches the target alias, the cycle is reported. The value name is tracked
+    in `visited` (NUL-prefixed to avoid colliding with alias names). Only
+    explicitly-annotated values participate -- an inferred value type is opaque
+    and safely reports no cycle. Whole-corpus TP 1756 -> 1757, 0 FP. Pinned
+    recall 695 -> 696 (circularTypeofWithVarOrFunc). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/check_module.mbt
+++ b/src/checker/check_module.mbt
@@ -919,6 +919,46 @@ fn reaches_alias(
       }
       false
     }
+    // `type A = typeof v; var v: A;` is circular through the value query.
+    // Follow the queried value's declared type: if it reaches `target`, the
+    // alias references itself (TS2456). The value name is tracked in `visited`
+    // (prefixed with a NUL so it can't collide with an alias name) to break
+    // cycles. Only a value with an explicit type annotation participates -- an
+    // inferred value type is opaque here and safely reports no cycle.
+    TypeOf(vname) => {
+      let key = "\u{0}" + vname
+      if visited.contains(key) {
+        return false
+      }
+      let mut vty : @ast.TsType? = None
+      for stmt in module_.top_level_stmts {
+        match stmt {
+          Var(Ident(n), t, _) | Let(Ident(n), t, _) | Const(Ident(n), t, _) =>
+            if n == vname {
+              vty = Some(t)
+              break
+            }
+          _ => ()
+        }
+      }
+      if vty is None {
+        for val in module_.values {
+          if val.name == vname {
+            vty = Some(val.type_)
+            break
+          }
+        }
+      }
+      match vty {
+        Some(t) => {
+          visited.push(key)
+          let result = reaches_alias(module_, target, t, visited)
+          let _ = visited.pop()
+          result
+        }
+        None => false
+      }
+    }
     _ => false
   }
 }

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10819,3 +10819,22 @@ test "expr_check: bare reference to generic without type arguments (TS2314)" {
     0,
   )
 }
+
+///|
+test "expr_check: circular type alias through typeof value query (TS2456)" {
+  let issues = fn(src : String) -> Int {
+    let mut n = 0
+    for i in check_module_function_bodies_permissive(parse_module_or_empty(src)) {
+      if i.message.contains("resolves to itself") {
+        n += 1
+      }
+    }
+    n
+  }
+  // `type A = typeof v; var v: A;` is circular through the value query.
+  assert_true(issues("type A = typeof v;\nvar v: A;") > 0)
+  assert_true(issues("var w: B;\ntype B = typeof w;") > 0)
+  // A non-circular typeof alias is fine.
+  @test.assert_eq(issues("var n: number;\ntype A = typeof n;"), 0)
+  @test.assert_eq(issues("type A = typeof v;\nvar v: number;"), 0)
+}


### PR DESCRIPTION
TS2456 ("Type alias 'A' circularly references itself."). The pattern `type A = typeof v; var v: A;` is circular through the value query, but the existing `reaches_alias` walker only followed `Named` alias references.

A `TypeOf(v)` case now looks up the queried value's explicitly-annotated declared type (from `top_level_stmts` / `values`) and recurses; if it reaches the target alias, the cycle is reported. The value name is tracked in `visited` (NUL-prefixed so it can't collide with an alias name). Only explicitly-annotated values participate — an inferred value type is opaque here and safely reports no cycle.

- Pinned recall 695 → **696** (circularTypeofWithVarOrFunc).
- Whole-corpus oracle TP 1756 → 1757, **FP 0** (`--max-fp 0`).
- Whitebox regression test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_