### PR TITLE
checker: TS2352 assertion between primitive and object type

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2257,6 +2257,20 @@ conformance sources (`.errors.txt` baseline = ground truth):
     and safely reports no cycle. Whole-corpus TP 1756 -> 1757, 0 FP. Pinned
     recall 695 -> 696 (circularTypeofWithVarOrFunc). Whitebox-tested.
 
+2026-07-01 (T155)  697/815 (86 %)        414/414 ( 0 FP)   TS2352 assertion between primitive and object type
+
+  T155 -- TS2352 ("Conversion of type X to Y may be a mistake because neither
+    type sufficiently overlaps..."). Extends the existing primitive↔primitive
+    assertion check to primitive↔object: a bare primitive (`number` / `string`
+    / `boolean` / `bigint`) and a concrete object type (an interface or object
+    literal) never overlap, so `z as number` (z: SomeInterface) / `<I>n`
+    (n: number) is always a mistake. Enums (number-ish) and CLASSES are
+    excluded -- a class name is also a value, so an ASI-split `as`-function
+    call (`var y = 20\nas(Foo)`) mis-parses as `20 as Foo` and would otherwise
+    false-positive (caught by the oracle on asOperatorASI). Aliases are
+    resolved via `unwrap` first. Whole-corpus TP 1757 -> 1758, 0 FP. Pinned
+    recall 696 -> 697 (typeAssertionsWithUnionTypes01). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -13204,6 +13204,44 @@ fn check_call_args_in_expr(
           "as",
           "Type '\{type_display(inferred)}' cannot be asserted to type '\{type_display(asserted)}' (no overlap)",
         )
+      } else {
+        // TS2352: a bare primitive and a concrete object type (a user
+        // interface / class / object literal) never overlap, so asserting one
+        // to the other (`z as number` where `z: SomeInterface`, `<I>n` where
+        // `n: number`) is always a mistake. Enums are number-ish and boxed
+        // wrapper objects are excluded so the check stays false-positive-free;
+        // aliases are resolved via `unwrap` first.
+        let inferred_u = ctx.resolver.unwrap(inferred)
+        let asserted_u = ctx.resolver.unwrap(asserted)
+        let is_bare_primitive = fn(t : @ast.TsType) -> Bool {
+          match t {
+            Number | Int | String_ | Boolean | BigInt => true
+            _ => false
+          }
+        }
+        // Classes are deliberately excluded: a class name is also a value, so
+        // an ASI-split `as` call (`var y = 20\nas(Foo)`, where `as` is a
+        // function and `Foo` a class) mis-parses as `20 as Foo` and would
+        // false-positive. Interfaces / object-literal types are not values, so
+        // they don't hit that ambiguity.
+        let is_concrete_object = fn(t : @ast.TsType) -> Bool {
+          match t {
+            Object(_) | Struct(_, _) => true
+            Named(n) => ctx.resolver.interfaces.get(n) is Some(_)
+            _ => false
+          }
+        }
+        let no_overlap = (
+            is_bare_primitive(inferred_u) && is_concrete_object(asserted_u)
+          ) ||
+          (is_concrete_object(inferred_u) && is_bare_primitive(asserted_u))
+        if no_overlap {
+          record(
+            ctx,
+            "as",
+            "conversion of type '\{type_display(inferred_u)}' to type '\{type_display(asserted_u)}' may be a mistake because neither type sufficiently overlaps with the other",
+          )
+        }
       }
     }
     NonNull(inner) => check_call_args_in_expr(env, inner, ctx)

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10838,3 +10838,46 @@ test "expr_check: circular type alias through typeof value query (TS2456)" {
   @test.assert_eq(issues("var n: number;\ntype A = typeof n;"), 0)
   @test.assert_eq(issues("type A = typeof v;\nvar v: number;"), 0)
 }
+
+///|
+test "expr_check: type assertion between primitive and object (TS2352)" {
+  let issues = fn(src : String) -> Int {
+    let mut n = 0
+    for i in check_module_function_bodies_permissive(parse_module_or_empty(src)) {
+      if i.message.contains("neither type sufficiently overlaps") {
+        n += 1
+      }
+    }
+    n
+  }
+  // Asserting an interface value to a primitive (and vice versa) never overlaps.
+  assert_true(
+    issues(
+      "interface I { a: number; }\ndeclare var z: I;\nlet n = z as number;",
+    ) >
+    0,
+  )
+  assert_true(
+    issues(
+      "interface I { a: number; }\ndeclare var n: number;\nlet z = n as I;",
+    ) >
+    0,
+  )
+  // `any` / `unknown` sources overlap with everything: silent.
+  @test.assert_eq(
+    issues("interface I { a: number; }\ndeclare var a: any;\nlet z = a as I;"),
+    0,
+  )
+  // Enums are number-ish: no TS2352 against number.
+  @test.assert_eq(
+    issues("enum E { A }\ndeclare var e: E;\nlet n = e as number;"),
+    0,
+  )
+  // Classes are excluded (ASI `as`-call ambiguity): silent.
+  @test.assert_eq(
+    issues(
+      "class C { a: number = 0; }\ndeclare var n: number;\nlet c = n as C;",
+    ),
+    0,
+  )
+}


### PR DESCRIPTION
TS2352 ("Conversion of type X to Y may be a mistake because neither type sufficiently overlaps with the other."). Extends the existing primitive↔primitive assertion check to primitive↔object: a bare primitive (`number` / `string` / `boolean` / `bigint`) and a concrete object type (an interface or object-literal type) never overlap, so `z as number` (z: SomeInterface) / `<I>n` (n: number) is always a mistake.

**Soundness:** enums (number-ish) are excluded, and so are **classes** — a class name is also a value, so an ASI-split `as`-function call (`var y = 20`⏎`as(Foo)`) mis-parses as `20 as Foo`; excluding classes avoids that false positive (which the oracle caught on `asOperatorASI`). Aliases are resolved via `unwrap` first.

- Pinned recall 696 → **697** (typeAssertionsWithUnionTypes01).
- Whole-corpus oracle TP 1757 → 1758, **FP 0** (`--max-fp 0`).
- Whitebox regression tests incl. the enum/class/any exclusions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_