### PR TITLE
checker: TS2411 enum property under string index signature

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2271,6 +2271,18 @@ conformance sources (`.errors.txt` baseline = ground truth):
     resolved via `unwrap` first. Whole-corpus TP 1757 -> 1758, 0 FP. Pinned
     recall 696 -> 697 (typeAssertionsWithUnionTypes01). Whitebox-tested.
 
+2026-07-01 (T156)  698/815 (86 %)        414/414 ( 0 FP)   TS2411 enum property under string index signature
+
+  T156 -- TS2411 ("Property 'X' of type 'E' is not assignable to '<idx>' index
+    type"). An enum-typed field is not assignable to a `string` (or other
+    non-`number` bare primitive) index signature on the same interface -- an
+    enum is only assignable to `number` / `any`. `interface I { [x: string]:
+    string; foo: E }`. Restricted to an enum-typed field under a string index
+    whose value type unwraps to `string` / `boolean` / `bigint`, so a `number`
+    index (accepts numeric enums) and an `any` index (accepts everything) never
+    fire -- false-positive-free. Whole-corpus TP 1758 -> 1759, 0 FP. Pinned
+    recall 697 -> 698 (enumIsNotASubtypeOfAnythingButNumber). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -15598,6 +15598,51 @@ fn check_class_interface_merge_modifiers(
 }
 
 ///|
+/// TS2411: a named property whose type is an enum is not assignable to a
+/// `string` (or other non-`number` primitive) index signature on the same
+/// interface -- an enum type is only assignable to `number` / `any`, never to
+/// `string` / `boolean` / `bigint`. `interface I { [x: string]: string; foo:
+/// E }` is the canonical case. Restricted to an enum-typed field under a
+/// string index of a non-`number` bare primitive so it never false-positives
+/// (a `number` index accepts a numeric enum, and `any` accepts everything).
+fn check_index_signature_enum_violation(
+  module_ : @ast.TsModule,
+  resolver : Resolver,
+) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  for iface in module_.interfaces {
+    // The value type of a `string` index signature, when it is a non-`number`
+    // bare primitive (an enum is not assignable to it).
+    let mut string_index_value : @ast.TsType? = None
+    for sig in iface.index_signatures {
+      if sig.0 is String_ {
+        match resolver.unwrap(sig.1) {
+          String_ | Boolean | BigInt as v => string_index_value = Some(v)
+          _ => ()
+        }
+      }
+    }
+    match string_index_value {
+      Some(idx_ty) =>
+        for field in iface.fields {
+          match resolver.unwrap(field.1) {
+            Named(n) =>
+              if resolver.enums.get(n) is Some(_) {
+                issues.push({
+                  path: "interface \{iface.name}",
+                  message: "property `\{field.0}` of type `\{n}` is not assignable to `\{type_display(idx_ty)}` index type",
+                })
+              }
+            _ => ()
+          }
+        }
+      None => ()
+    }
+  }
+  issues
+}
+
+///|
 fn check_reserved_type_alias_names(module_ : @ast.TsModule) -> Array[ExprIssue] {
   let issues : Array[ExprIssue] = []
   for ta in module_.type_aliases {
@@ -17134,6 +17179,9 @@ fn check_module_function_bodies_layered(
     all.push(issue)
   }
   for issue in check_class_interface_merge_modifiers(module_) {
+    all.push(issue)
+  }
+  for issue in check_index_signature_enum_violation(module_, resolver) {
     all.push(issue)
   }
   for issue in check_reserved_type_alias_names(module_) {

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10881,3 +10881,39 @@ test "expr_check: type assertion between primitive and object (TS2352)" {
     0,
   )
 }
+
+///|
+test "expr_check: enum property under string index signature (TS2411)" {
+  let issues = fn(src : String) -> Int {
+    let mut n = 0
+    for i in check_module_function_bodies_permissive(parse_module_or_empty(src)) {
+      if i.message.contains("is not assignable to") &&
+        i.message.contains("index type") {
+        n += 1
+      }
+    }
+    n
+  }
+  // An enum-typed property under a string index of `string` is TS2411.
+  assert_true(
+    issues("enum E { A }\ninterface I { [x: string]: string; foo: E; }") > 0,
+  )
+  assert_true(
+    issues("enum E { A }\ninterface I { [x: string]: boolean; foo: E; }") > 0,
+  )
+  // A `number` index accepts a numeric enum: silent.
+  @test.assert_eq(
+    issues("enum E { A }\ninterface I { [x: string]: number; foo: E; }"),
+    0,
+  )
+  // An `any` index accepts everything: silent.
+  @test.assert_eq(
+    issues("enum E { A }\ninterface I { [x: string]: any; foo: E; }"),
+    0,
+  )
+  // A non-enum property is not flagged by this check.
+  @test.assert_eq(
+    issues("interface I { [x: string]: string; foo: string; }"),
+    0,
+  )
+}


### PR DESCRIPTION
TS2411 ("Property 'X' of type 'E' is not assignable to '<idx>' index type"). An enum-typed field is not assignable to a `string` (or other non-`number` bare primitive) index signature on the same interface — an enum is only assignable to `number` / `any`. Canonical case: `interface I { [x: string]: string; foo: E }`.

Restricted to an enum-typed field under a string index whose value type unwraps to `string` / `boolean` / `bigint`, so a `number` index (accepts numeric enums) and an `any` index (accepts everything) never fire — false-positive-free.

- Pinned recall 697 → **698** (enumIsNotASubtypeOfAnythingButNumber).
- Whole-corpus oracle TP 1758 → 1759, **FP 0** (`--max-fp 0`).
- Whitebox regression tests incl. number/any-index exclusions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_