### PR TITLE
checker: TS2513 abstract method accessed via super

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2283,6 +2283,18 @@ conformance sources (`.errors.txt` baseline = ground truth):
     fire -- false-positive-free. Whole-corpus TP 1758 -> 1759, 0 FP. Pinned
     recall 697 -> 698 (enumIsNotASubtypeOfAnythingButNumber). Whitebox-tested.
 
+2026-07-01 (T157)  699/815 (86 %)        414/414 ( 0 FP)   TS2513 abstract method accessed via super
+
+  T157 -- TS2513 ("Abstract method 'X' in class 'Y' cannot be accessed via
+    super expression."). In `class C extends B`, `super.foo` / `super.foo()`
+    where `foo` is declared `abstract` on a base in C's inheritance chain has
+    no implementation to dispatch to. `check_super_abstract_access` fires only
+    for a `super` receiver whose enclosing class has a base listing `prop` in
+    its `abstract_members` (walking the base chain), so it is
+    false-positive-free. Wired into the `PropAccess` and `MethodCall` arms of
+    the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
+    698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
+
   --- Recall-to-700 target: status & remaining-cluster map (2026-06-25) ---
   Pinned recall is 630/815 @ 0 FP. The readily-sound, structural checks have
   now been harvested (T95-T97). The remaining ~185 misses cluster by primary

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -3508,6 +3508,59 @@ fn check_member_accessibility(
 }
 
 ///|
+/// TS2513: an abstract member cannot be reached through `super`. In a class
+/// `C extends B`, `super.foo` / `super.foo()` where `foo` is declared
+/// `abstract` on a base in `C`'s inheritance chain has no implementation to
+/// dispatch to. Only fires for a `super` receiver whose enclosing class has a
+/// base that lists `prop` in its `abstract_members`, so it is
+/// false-positive-free.
+fn check_super_abstract_access(
+  ctx : CheckCtx,
+  recv : @ast.TsExpr,
+  prop : String,
+) -> Unit {
+  guard recv is Var("super") else { return }
+  let enclosing = match current_enclosing_class(ctx.path_prefix) {
+    Some(c) => c
+    None => return
+  }
+  let cls = match ctx.resolver.classes.get(enclosing) {
+    Some(c) => c
+    None => return
+  }
+  // Walk the base chain; the first base that declares `prop` abstract makes a
+  // `super` access illegal.
+  let mut current = cls.base_names
+  let mut depth = 0
+  while depth < 32 {
+    depth = depth + 1
+    let next : Array[String] = []
+    for base in current {
+      match ctx.resolver.classes.get(base) {
+        Some(bdecl) => {
+          if bdecl.abstract_members.contains(prop) {
+            record(
+              ctx,
+              "super `.\{prop}`",
+              "abstract method `\{prop}` in class `\{base}` cannot be accessed via super expression",
+            )
+            return
+          }
+          for b in bdecl.base_names {
+            next.push(b)
+          }
+        }
+        None => ()
+      }
+    }
+    if next.length() == 0 {
+      break
+    }
+    current = next
+  }
+}
+
+///|
 fn record(ctx : CheckCtx, sub_path : String, message : String) -> Unit {
   // T9: in permissive mode, drop the diagnostic families whose
   // residual FPs are dominated by features we don't model. Strict
@@ -12406,6 +12459,7 @@ fn check_call_args_in_expr(
     MethodCall(receiver, meth, args) => {
       check_private_name_access(ctx, meth)
       check_member_accessibility(env, ctx, receiver, meth)
+      check_super_abstract_access(ctx, receiver, meth)
       // Static-namespace dispatch: `Math.max(...)`, `JSON.stringify(...)`.
       // Recognised by the bare-identifier shape of the receiver. Also handle
       // a static method called through the class name (`A.s(args)`), whose
@@ -12695,6 +12749,7 @@ fn check_call_args_in_expr(
       check_call_args_in_expr(env, recv, ctx)
       check_private_name_access(ctx, prop)
       check_member_accessibility(env, ctx, recv, prop)
+      check_super_abstract_access(ctx, recv, prop)
       // TS2806: reading a private accessor that was defined with a setter but
       // no getter. A write (`this.#x = v`) parses as `PropAssignExpr`, so a
       // `PropAccess` of a set-only private name is always a read.

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -10917,3 +10917,46 @@ test "expr_check: enum property under string index signature (TS2411)" {
     0,
   )
 }
+
+///|
+test "expr_check: abstract method accessed via super (TS2513)" {
+  let issues = fn(src : String) -> Int {
+    let mut n = 0
+    for i in check_module_function_bodies_permissive(parse_module_or_empty(src)) {
+      if i.message.contains("cannot be accessed via super expression") {
+        n += 1
+      }
+    }
+    n
+  }
+  // `super.foo()` where foo is abstract in the base.
+  assert_true(
+    issues(
+      (
+        #|abstract class B { abstract foo(): number; }
+        #|class C extends B { foo() { return 2; } m() { return super.foo(); } }
+      ),
+    ) >
+    0,
+  )
+  // A concrete base method reached via super is fine.
+  @test.assert_eq(
+    issues(
+      (
+        #|class B { foo() { return 1; } }
+        #|class C extends B { foo() { return 2; } m() { return super.foo(); } }
+      ),
+    ),
+    0,
+  )
+  // `this.foo()` (not super) is never flagged by this check.
+  @test.assert_eq(
+    issues(
+      (
+        #|abstract class B { abstract foo(): number; }
+        #|class C extends B { foo() { return this.foo(); } }
+      ),
+    ),
+    0,
+  )
+}


### PR DESCRIPTION
TS2513 ("Abstract method 'X' in class 'Y' cannot be accessed via super expression."). In `class C extends B`, `super.foo` / `super.foo()` where `foo` is declared `abstract` on a base in C's inheritance chain has no implementation to dispatch to.

`check_super_abstract_access` fires only for a `super` receiver whose enclosing class has a base that lists `prop` in its `abstract_members` (walking the base chain), so it is false-positive-free. Wired into the `PropAccess` and `MethodCall` arms of the expression walker.

- Pinned recall 698 → **699** (classAbstractSuperCalls).
- Whole-corpus oracle TP 1759 → 1760, **FP 0** (`--max-fp 0`).
- Whitebox regression tests incl. concrete-base and `this`-receiver exclusions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_