### PR TITLE
perf(checker): O(classes×interfaces) merge scan + product-path benches

### DIFF
--- a/src/checker/checker_bench_wbtest.mbt
+++ b/src/checker/checker_bench_wbtest.mbt
@@ -338,6 +338,40 @@ test "bench checker: JSX-heavy (20 components, 100 call sites)" (it : @bench.T) 
 }
 
 ///|
+/// Permissive full pipeline — the path the recall gate and the bridge's
+/// sanity check actually run (`check_module_function_bodies_permissive`,
+/// which additionally runs `check_module` and every module-level structural
+/// pass, then applies the T9 suppressions). Scales the interface count so a
+/// super-linear module-level pass shows up here the same way the strict
+/// benchmarks surfaced the earlier O(n^2) scans.
+test "bench checker: permissive pipeline (500 interfaces)" (it : @bench.T) {
+  let module_ = @parser.parse_module_from_source_with_const_values(
+    bench_wide_500,
+    {},
+  ) catch {
+    _ => return
+  }
+  it.bench(fn() {
+    let issues = check_module_function_bodies_permissive(module_)
+    it.keep(issues.length())
+  })
+}
+
+///|
+test "bench checker: permissive pipeline (2000 interfaces)" (it : @bench.T) {
+  let module_ = @parser.parse_module_from_source_with_const_values(
+    bench_wide_2000,
+    {},
+  ) catch {
+    _ => return
+  }
+  it.bench(fn() {
+    let issues = check_module_function_bodies_permissive(module_)
+    it.keep(issues.length())
+  })
+}
+
+///|
 /// Resolver build alone — separates `Resolver::from_module` (which
 /// scans the whole module surface and builds 6 lookup tables) from
 /// the function-body walk. Use the same input as the wide-500 bench
@@ -376,6 +410,58 @@ test "bench checker: function-body walk only (500 interfaces)" (it : @bench.T) {
     let issues = check_module_function_bodies(module_)
     it.keep(issues.length())
   })
+}
+
+///|
+/// File-backed benchmark over the vendored conformance corpus (always
+/// present, unlike the `typescript/src` submodule). Measures the *product*
+/// path — parse + `check_module_function_bodies_permissive` — over a few of
+/// the largest real-world `.ts` files, reporting throughput in MB/s. Run:
+///   moon test --target native -p mizchi/ts/checker --filter "corpus files"
+async test "bench checker: corpus files (permissive, file IO)" {
+  let candidates = [
+    "typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts",
+    "typescript/tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts",
+    "typescript/tests/cases/conformance/fixSignatureCaching.ts",
+  ]
+  let prepared : Array[(String, Int, @ast.TsModule)] = []
+  for path in candidates {
+    try @fs.read_file(path) catch {
+      _ => ()
+    } noraise {
+      data => {
+        let text = data.text()
+        try @parser.Parser::from_source(text).parse_module() catch {
+          _ => ()
+        } noraise {
+          module_ => prepared.push((path, text.length(), module_))
+        }
+      }
+    }
+  }
+  if prepared.length() == 0 {
+    println("skip: conformance corpus files not found")
+    return
+  }
+  println("checker bench (corpus, permissive) — throughput (50 iters):")
+  for entry in prepared {
+    let (path, chars, module_) = entry
+    let iters = 50
+    let start = @bench.monotonic_clock_start()
+    for _ in 0..<iters {
+      let _ = check_module_function_bodies_permissive(module_)
+    }
+    let total_us = @bench.monotonic_clock_end(start)
+    if total_us > 0.0 {
+      let per_call_us = total_us / iters.to_double()
+      let mbps = chars.to_double() / per_call_us
+      println(
+        "  \{path}: \{mbps.to_int()} MB/s (\{chars} chars / \{per_call_us.to_int()} µs per check)",
+      )
+    } else {
+      println("  \{path}: too fast to measure (\{chars} chars)")
+    }
+  }
 }
 
 ///|

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -15611,16 +15611,22 @@ fn check_class_interface_merge_modifiers(
   module_ : @ast.TsModule,
 ) -> Array[ExprIssue] {
   let issues : Array[ExprIssue] = []
-  for cls in module_.classes {
-    // Find a same-named interface (the merge partner).
-    let mut merged : @ast.TsInterface? = None
-    for iface in module_.interfaces {
-      if iface.name == cls.name {
-        merged = Some(iface)
-        break
-      }
+  // Index interfaces by name once so the per-class lookup is O(1) rather than
+  // an inner scan over every interface (which made this O(classes ×
+  // interfaces) on files that declare many of both).
+  let iface_by_name : Map[String, @ast.TsInterface] = {}
+  for iface in module_.interfaces {
+    if iface_by_name.get(iface.name) is None {
+      iface_by_name[iface.name] = iface
     }
-    match merged {
+  }
+  for cls in module_.classes {
+    // Only classes with a private/protected member can conflict with an
+    // interface's (always-public) member.
+    if cls.private_members.length() == 0 && cls.protected_members.length() == 0 {
+      continue
+    }
+    match iface_by_name.get(cls.name) {
       Some(iface) => {
         let iface_field_names : Map[String, Unit] = {}
         for field in iface.fields {


### PR DESCRIPTION
Follow-up to #189.

- **`check_class_interface_merge_modifiers`** looked up each class's merge partner with an inner scan over every interface — O(classes × interfaces) on files that declare many of both (invisible in the wide-interface bench, which has 0 classes). Now indexes interfaces by name once (O(1) lookup) and skips classes with no `private`/`protected` members. Behaviour unchanged (same first-match semantics, verified by the T152 regression test).
- **New benchmarks for the actual product path:** the *permissive* pipeline (`check_module_function_bodies_permissive`, used by the recall gate and the bridge's sanity check) at 500/2000 interfaces, plus a file-backed corpus benchmark over the vendored conformance `.ts` files reporting MB/s (the existing file-IO bench pointed at the un-vendored `typescript/src` and always skipped).

**Verification:** recall **700/815**, precision **414/414**, **0 FP**; 749 checker + 471 parser tests green. Corpus permissive throughput measured at 100–660 MB/s on 68–83 KB real-world files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSfsEMAZNcV8u9Sa2zbD11)_