### PR TITLE
checker: raise conformance-corpus true positives 2081 → 2136 at 0 false positives

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2295,6 +2295,37 @@ conformance sources (`.errors.txt` baseline = ground truth):
     the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
     698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
 
+2026-07-07 (T184)  714/815 (88 %)        414/414 ( 0 FP)   Practical round 4: TS2403 identity keys + union-callee arity: TP 2134 -> 2136
+
+  T184 -- practical (non-edge) misses, round 4.
+    - TS2403 rewrite: the redeclaration check moves from
+      atoms-only set comparison to a canonical `identity_key` covering
+      functions, constructors, tuples, arrays, object literals, and
+      unions -- with the normalizations tsc's identity relation implies:
+      aliases unwrap, union members sort, literal members subsumed by
+      their base primitive drop (`string | "a"` == `string`),
+      `never` drops, `any`/`unknown` absorb, `Array<T>` == `T[]`,
+      `{ (x): R }` == `(x) => R`, `{ new (x): R }` == `new (x) => R`.
+      Named references: enums stay nominal; classes / interfaces expand
+      to their structural shape when simple (no generics / heritage /
+      index sigs / readonly / private / abstract) because tsc's identity
+      is structural there -- a class instance type IS identical to its
+      spelled-out object literal (nestedModules, exportImportAlias, and
+      the DeclarationMerging pair were gate FPs of the name-keyed
+      draft). Union dedup is atomic-only so `C | D` with two
+      structurally-equal classes stays a 2-member union (pinned test).
+      unionTypeLiterals.
+    - TS2554 for union-typed callees whose members have different
+      arities: a call through a union must satisfy every member, so
+      `n < max(member minimums)` always errors and -- when every member
+      is rest-free -- `n > max(member maximums)` errors too. Gated to
+      names with no function-declaration signature: overload sets ingest
+      as the same `Union`-of-`Func` shape but need only ONE overload to
+      match (typeParameterConstModifiersReturnsAndYields was a gate FP
+      until the signatures-map guard). unionTypeCallSignatures4.
+    Whole-corpus TP 2134 -> 2136 @ 0 FP (session total 1761 -> +375);
+    pinned recall 714, precision 414/414. 2446 tests.
+
 2026-07-07 (T183)  714/815 (88 %)        414/414 ( 0 FP)   Practical round 3: TS2556/TS2362/TS2365 + lexer template-division: TP 2119 -> 2134
 
   T183 -- practical (non-edge) misses, round 3.

--- a/TODO.md
+++ b/TODO.md
@@ -2295,6 +2295,32 @@ conformance sources (`.errors.txt` baseline = ground truth):
     the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
     698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
 
+2026-07-06 (T181)  714/815 (88 %)        414/414 ( 0 FP)   Practical errors first: TS2528/TS2488/TS4112-4114: TP 2081 -> 2095
+
+  T181 -- user-directed pivot: of the 605 remaining misses, ~446 are
+    practical semantic errors and ~159 parser/error-recovery edge
+    fixtures; this batch works the practical side.
+    - TS2528: a module cannot have multiple default exports. Each
+      `export default` records a kind+name marker; function markers group
+      by name (overload sets are one default), anonymous/class/expression
+      defaults count individually. multipleExportDefault1-6.
+    - TS2488: for-of over a base-less class instance lacking the iterator
+      protocol -- either no `[Symbol.iterator]` member at all, or one
+      returning `this` while the class has no `next`. A computed FIELD
+      iterator (`[Symbol.iterator]: any`) or a `next` FIELD satisfies the
+      protocol (for-of27/28 caught as FPs by the gate). for-of14/16.
+    - TS4112/4113/4114 (`override` family): per-member `override` and
+      `declare` modifiers now survive parsing (both class parsers) via
+      `<override-member:...>` / `<declare-member:...>` markers, and
+      `@noImplicitOverride: true` arms a module marker. TS4112 (override
+      without heritage) and TS4113 (override with no matching base-chain
+      member) are unconditional; TS4114 (genuine override missing the
+      modifier) fires only under the flag, with abstract implementations
+      and `declare` members exempt (override10/14 caught as FPs).
+      override1/2/3/6/13/15, overrideParameterProperty.
+    Whole-corpus TP 2081 -> 2095 @ 0 FP (session total 1761 -> +334);
+    pinned recall 714, precision 414/414. 2443 tests.
+
 2026-07-06 (T180)  714/815 (88 %)        414/414 ( 0 FP)   Partial/Required/Readonly wrapper lattice: TP 2078 -> 2081
 
   T180 -- mapped-type utility assignability (user-requested cluster): an

--- a/TODO.md
+++ b/TODO.md
@@ -2295,6 +2295,49 @@ conformance sources (`.errors.txt` baseline = ground truth):
     the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
     698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
 
+2026-07-07 (T182)  714/815 (88 %)        414/414 ( 0 FP)   Practical round 2: TS2872/TS1345/TS2695/TS1262/TS2729: TP 2095 -> 2119
+
+  T182 -- practical (non-edge) misses, round 2.
+    - TS2872/TS2873 in *condition* positions: a ternary condition or `!`
+      operand that is a non-exempt literal (object / array / function
+      literal, non-empty or empty string, numeric other than 0 / 1) is
+      always-truthy / always-falsy. Same classification as the existing
+      `&&`/`||` operand check but with tsc's `0` / `1` / boolean
+      exemptions (`1 ? a : b` and `while (1)` idioms stay legal).
+      conditionalOperatorConditionIs{Object,Number,String,Any}Type,
+      logicalNotOperatorWith{Number,String,Boolean}Type, for-inStatements.
+    - TS1345: a `void`-typed condition (annotated var or call whose
+      signature returns `void`) cannot be tested for truthiness; fires on
+      ternary conditions and `&&` left operands only for Var / call
+      shapes whose `void` verdict is trustworthy.
+      logicalAndOperatorStrictMode.
+    - TS2695: statement-level comma whose left side is side-effect-free
+      (tsc's `isSideEffectFree` subset; `!`/`-`/`+`/`~`/`typeof` don't
+      recurse). Statement position only -- nested commas include the
+      `(0, fn)()` indirect-call idiom our paren-erasing parser can't
+      distinguish. Suppressed under `@allowUnreachableCode: true` via the
+      parser's `<allowunreachable-on>` marker (two gate FPs:
+      commaOperatorWithSecondOperandAnyType, bitwiseNotOperatorWithEnumType).
+      logicalNot/negate/plus/typeofOperatorWithEnumType et al.
+    - TS1262: `await` as a top-level declaration name in a module. The
+      parser records `<top-await-name>` (var / destructuring /
+      import-equals / exported class + function via `<export-value>await`)
+      and module-syntax evidence separately (`export {}` now records
+      `<module-syntax>`); only the pair errors -- `var await` in a script
+      and a bare `import await = ns.path` stay legal (topLevelAwait.2 was
+      a gate FP until import-equals stopped counting as module syntax).
+      topLevelAwaitErrors.2/3/4/5/6/12.
+    - TS2729 in `static { }` blocks: reading or writing `this.<f>` /
+      `<Class>.<f>` where the static *field* `f` is first declared after
+      the block. Computed in the parser (`static_block_use_before_def`)
+      where element order is still known, routed through the per-class
+      `<static-use-before-def:f>` marker. Methods / accessors exempt
+      (installed before blocks run); nested function bodies not entered;
+      blocks that rebind the class name skipped.
+      classStaticBlock3/4, classStaticBlockUseBeforeDef2/5.
+    Whole-corpus TP 2095 -> 2119 @ 0 FP (session total 1761 -> +358);
+    pinned recall 714, precision 414/414. 2444 tests.
+
 2026-07-06 (T181)  714/815 (88 %)        414/414 ( 0 FP)   Practical errors first: TS2528/TS2488/TS4112-4114: TP 2081 -> 2095
 
   T181 -- user-directed pivot: of the 605 remaining misses, ~446 are

--- a/TODO.md
+++ b/TODO.md
@@ -2295,6 +2295,45 @@ conformance sources (`.errors.txt` baseline = ground truth):
     the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
     698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
 
+2026-07-07 (T183)  714/815 (88 %)        414/414 ( 0 FP)   Practical round 3: TS2556/TS2362/TS2365 + lexer template-division: TP 2119 -> 2134
+
+  T183 -- practical (non-edge) misses, round 3.
+    - TS2556: a spread argument must have a tuple type or hit a rest
+      parameter. tsc's arity rule for the first non-tuple spread at
+      effective index i: error unless i >= minArgCount && (hasRest ||
+      i < paramCount); tuple-typed and exact array-literal spreads expand
+      first. Runs only on the direct function-declaration call path
+      (`check_spread` flag) — overloaded callees become `Union` types and
+      never reach it. Spread operands classified confidently: plain
+      arrays, ReadonlyArray, and class instances; `any` / generics /
+      open tuples abstain. iteratorSpreadInCall/2/4/10, callWithSpread2/4,
+      readonlyRestParameters. (Updated one stale pin: `g2(...xs)` against
+      two required params DOES error in tsc.)
+    - Lexer: a template literal now ends an expression for the
+      regex-vs-division split, so `` `a${1}b` / 1 `` parses as division
+      instead of swallowing the rest of the line as a regex
+      (templateStringInDivision, previously mis-lexed under ES6 targets).
+    - TS2362/TS2363 in computed enum-member initializers: the enum AST
+      only keeps folded literal values, so the parser speculatively
+      parses the about-to-be-skipped initializer (position and misuse
+      side channels restored) and records string-operand arithmetic
+      (`d = "a" - "a"`, `` b = `1` - `1` ``).
+      enumConstantMemberWithString/TemplateLiterals, templateStringInDivision.
+    - TS2365 for relational `<` `<=` `>` `>=`: pairwise never-comparable
+      classification — an unconstrained type parameter against anything
+      but itself, or an object-side shape (boolean / void / symbol /
+      func / object / array / tuple / resolvable class-interface /
+      Promise-like / union containing one) against a number / string /
+      bigint / enum primitive. Identical named types and object-vs-object
+      stay silent (comparisonOperatorWithIdenticalTypeParameter and the
+      subtype-object fixtures were gate FPs of the first per-operand
+      draft). Merged into the existing TS18050 nullish-keyword arm
+      (the new arm had shadowed it — caught by the pinned suite).
+      comparisonOperatorWith{NumberOperand,IntersectionType,
+      NoRelationshipTypeParameter,TypeParameter}.
+    Whole-corpus TP 2119 -> 2134 @ 0 FP (session total 1761 -> +373);
+    pinned recall 714, precision 414/414. 2445 tests.
+
 2026-07-07 (T182)  714/815 (88 %)        414/414 ( 0 FP)   Practical round 2: TS2872/TS1345/TS2695/TS1262/TS2729: TP 2095 -> 2119
 
   T182 -- practical (non-edge) misses, round 2.

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -9234,6 +9234,67 @@ fn single_call_signature_params(
 }
 
 ///|
+/// TS2554 for a union-of-functions callee whose members have *different*
+/// signatures: a call through a union must be valid for every constituent,
+/// so fewer arguments than the largest member minimum always fails, and --
+/// when every member has a bounded parameter list -- more arguments than
+/// the largest member maximum also fails. Members with rest parameters
+/// lift the upper bound; any non-`Func` member or spread argument
+/// abstains.
+fn check_union_callee_arity(
+  ctx : CheckCtx,
+  callee_ty : @ast.TsType,
+  args : Array[@ast.TsExpr],
+  call_path : String,
+) -> Unit {
+  guard ctx.resolver.unwrap(callee_ty) is Union(members) else { return }
+  for a in args {
+    if a is Spread(_) {
+      return
+    }
+  }
+  let mut max_min = 0
+  let mut all_bounded = true
+  let mut max_max = 0
+  for m in members {
+    match ctx.resolver.unwrap(m) {
+      Func(ps, _) => {
+        let mut has_rest = false
+        for p in ps {
+          if p is Rest(_) {
+            has_rest = true
+          }
+        }
+        let min_ = required_arity_from_types(ps)
+        if min_ > max_min {
+          max_min = min_
+        }
+        if has_rest {
+          all_bounded = false
+        } else if ps.length() > max_max {
+          max_max = ps.length()
+        }
+      }
+      _ => return
+    }
+  }
+  let n = args.length()
+  if n < max_min {
+    record_unfiltered(
+      ctx,
+      call_path,
+      "expected at least \{max_min} argument(s), got \{n}",
+    )
+  } else if all_bounded && n > max_max {
+    record_unfiltered(
+      ctx,
+      call_path,
+      "expected at most \{max_max} argument(s), got \{n}",
+    )
+  }
+}
+
+///|
 /// Common call-signature parameters of a union callee: when every member of
 /// the union exposes exactly one call signature and all of them have
 /// *identical* parameter types, the union is callable with those parameters
@@ -13946,7 +14007,14 @@ fn check_call_args_in_expr(
           match union_common_call_params(other, ctx.resolver) {
             Some(params) =>
               check_arguments(env, params, args, ctx, "call `\{name}`")
-            None =>
+            None => {
+              // Overload sets also ingest as a `Union` of `Func`s; a call
+              // needs only ONE overload to match, so the every-member arity
+              // rule applies solely to union-typed *values* (names with no
+              // function-declaration signature).
+              if ctx.resolver.signatures.get(name) is None {
+                check_union_callee_arity(ctx, other, args, "call `\{name}`")
+              }
               if is_definitely_not_callable(other) {
                 record(
                   ctx,
@@ -13954,6 +14022,7 @@ fn check_call_args_in_expr(
                   "`\{type_display(other)}` is not callable",
                 )
               }
+            }
           }
       }
       for a in args {
@@ -20277,27 +20346,302 @@ fn check_class_duplicate_members(module_ : @ast.TsModule) -> Array[ExprIssue] {
 ///|
 
 ///|
-/// A type whose identity we can compare safely by structural / set equality:
-/// a primitive, a literal, or a named reference. Compound shapes (objects,
-/// functions, generics, `typeof`, conditionals, …) are excluded so the
-/// redeclaration check never mis-judges identity on a form it can't normalize.
-fn is_identity_comparable_atom(t : @ast.TsType) -> Bool {
-  match t {
-    Number
-    | Int
-    | Boolean
-    | String_
-    | BigInt
-    | Symbol
-    | Void
-    | Null
-    | Undefined
-    | Literal(_)
-    | NumberLiteral(_)
-    | BigIntLiteral(_)
-    | BooleanLiteral(_)
-    | Named(_) => true
-    _ => false
+/// Structural identity key for a named class / interface reference used by
+/// the TS2403 check, or `None` when the declaration's shape can't be
+/// expanded faithfully: generics, heritage, index / call signatures,
+/// readonly or private / protected / abstract members, computed keys.
+fn structural_named_key(
+  n : String,
+  resolver : Resolver,
+  depth : Int,
+) -> String? {
+  match resolver.interfaces.get(n) {
+    Some(iface) => {
+      if iface.type_params.length() > 0 ||
+        iface.extends_names.length() > 0 ||
+        iface.index_signatures.length() > 0 ||
+        iface.readonly_fields.length() > 0 {
+        return None
+      }
+      let pairs : Array[String] = []
+      for f in iface.fields {
+        if f.0.has_prefix("<") {
+          return None
+        }
+        match identity_key(f.1, resolver, depth + 1) {
+          Some(v) => pairs.push(f.0 + ":" + v)
+          None => return None
+        }
+      }
+      pairs.sort()
+      return Some("obj{" + pairs.join(",") + "}")
+    }
+    None => ()
+  }
+  match resolver.classes.get(n) {
+    Some(cls) => {
+      if cls.type_params.length() > 0 ||
+        cls.base_names.length() > 0 ||
+        cls.computed_field_keys.length() > 0 ||
+        cls.index_signatures.length() > 0 ||
+        cls.is_abstract ||
+        cls.private_members.length() > 0 ||
+        cls.protected_members.length() > 0 ||
+        cls.abstract_members.length() > 0 {
+        return None
+      }
+      let pairs : Array[String] = []
+      for p in cls.properties {
+        if p.is_static {
+          continue
+        }
+        if p.is_readonly || p.name.has_prefix("<") || p.name.has_prefix("#") {
+          return None
+        }
+        match identity_key(p.type_, resolver, depth + 1) {
+          Some(v) => pairs.push(p.name + ":" + v)
+          None => return None
+        }
+      }
+      for m in cls.methods {
+        if m.is_static {
+          continue
+        }
+        if m.type_params.length() > 0 ||
+          m.name.has_prefix("<") ||
+          m.name.has_prefix("#") {
+          return None
+        }
+        let pkeys : Array[String] = []
+        for prm in m.params {
+          match identity_key(prm.1, resolver, depth + 1) {
+            Some(v) => pkeys.push(v)
+            None => return None
+          }
+        }
+        match identity_key(m.return_type, resolver, depth + 1) {
+          Some(rk) => pairs.push(m.name + ":fn(" + pkeys.join(",") + ")=>" + rk)
+          None => return None
+        }
+      }
+      pairs.sort()
+      return Some("obj{" + pairs.join(",") + "}")
+    }
+    None => ()
+  }
+  None
+}
+
+///|
+/// Canonical identity key for the TS2403 redeclaration check, or `None`
+/// when the type has a form whose identity we can't decide safely
+/// (generics, intersections, `typeof`, conditionals, index signatures,
+/// unresolved applied references, …). Two `var` declarations whose keys
+/// both resolve and differ are *definitely* non-identical. Normalizations
+/// applied so spelling differences never flag: aliases unwrap, union
+/// members sort / dedupe, literal members subsumed by their base primitive
+/// drop (`string | "a"` ≡ `string`), `never` members drop, `any` /
+/// `unknown` absorb the union, and `Array<T>` ≡ `T[]`.
+fn identity_key(t : @ast.TsType, resolver : Resolver, depth : Int) -> String? {
+  if depth > 16 {
+    return None
+  }
+  match resolver.unwrap(t) {
+    Number | Int => Some("number")
+    Boolean => Some("boolean")
+    String_ => Some("string")
+    BigInt => Some("bigint")
+    Symbol => Some("symbol")
+    Void => Some("void")
+    Null => Some("null")
+    Undefined => Some("undefined")
+    Unknown => Some("unknown")
+    Never => Some("never")
+    NonPrimitiveObject => Some("object")
+    Literal(s) => Some("slit:" + s)
+    NumberLiteral(s) => Some("nlit:" + s)
+    BigIntLiteral(s) => Some("blit:" + s)
+    BooleanLiteral(b) => Some(if b { "true" } else { "false" })
+    Named(n) =>
+      // tsc's identity relation is structural for interfaces and classes
+      // (a class instance type IS identical to a spelled-out object
+      // literal of the same shape — nestedModules), so expand simple
+      // shapes to their structural key. Enums stay nominal.
+      if resolver.enums.get(n) is Some(_) {
+        Some("n:" + n)
+      } else {
+        structural_named_key(n, resolver, depth)
+      }
+    Array(e) | Applied("Array", [e]) =>
+      match identity_key(e, resolver, depth + 1) {
+        Some(k) => Some("arr(" + k + ")")
+        None => None
+      }
+    Tuple(items) => {
+      let keys : Array[String] = []
+      for it in items {
+        match it {
+          Rest(_) => return None
+          other =>
+            match identity_key(other, resolver, depth + 1) {
+              Some(k) => keys.push(k)
+              None => return None
+            }
+        }
+      }
+      Some("tup[" + keys.join(",") + "]")
+    }
+    Func(ps, r) => {
+      let keys : Array[String] = []
+      for p in ps {
+        match identity_key(p, resolver, depth + 1) {
+          Some(k) => keys.push(k)
+          None => return None
+        }
+      }
+      match identity_key(r, resolver, depth + 1) {
+        Some(rk) => Some("fn(" + keys.join(",") + ")=>" + rk)
+        None => None
+      }
+    }
+    Constructor(ps, r, is_abstract) => {
+      let keys : Array[String] = []
+      for p in ps {
+        match identity_key(p, resolver, depth + 1) {
+          Some(k) => keys.push(k)
+          None => return None
+        }
+      }
+      match identity_key(r, resolver, depth + 1) {
+        Some(rk) =>
+          Some(
+            (if is_abstract { "actor(" } else { "ctor(" }) +
+            keys.join(",") +
+            ")=>" +
+            rk,
+          )
+        None => None
+      }
+    }
+    Object(fields) => {
+      // A single call / construct signature written as a type literal is
+      // identical to the arrow form: `{ (x): R }` === `(x) => R` and
+      // `{ new (x): R }` === `new (x) => R`.
+      match fields {
+        [(Literal("<call>"), inner)] =>
+          return identity_key(inner, resolver, depth + 1)
+        [(Literal("<new>"), inner)] =>
+          return match identity_key(inner, resolver, depth + 1) {
+            Some(k) =>
+              // Reuse the Constructor spelling: `fn(...)=>r` -> `ctor(...)=>r`.
+              if k.has_prefix("fn(") {
+                Some("ctor" + k.substring(start=2))
+              } else {
+                None
+              }
+            None => None
+          }
+        _ => ()
+      }
+      let pairs : Array[String] = []
+      for f in fields {
+        match f.0 {
+          Literal(k) =>
+            // Any synthetic member (call/construct/index signatures inside a
+            // larger literal) makes identity undecidable.
+            if k.has_prefix("<") {
+              return None
+            } else {
+              match identity_key(f.1, resolver, depth + 1) {
+                Some(v) => pairs.push(k + ":" + v)
+                None => return None
+              }
+            }
+          // Index signatures / computed keys: identity undecidable.
+          _ => return None
+        }
+      }
+      pairs.sort()
+      Some("obj{" + pairs.join(",") + "}")
+    }
+    Union(_) as u => {
+      let members = normalized_union_members(u, resolver)
+      let keys : Array[String] = []
+      let mut has_string = false
+      let mut has_number = false
+      let mut has_boolean = false
+      let mut has_bigint = false
+      for m in members {
+        match resolver.unwrap(m) {
+          String_ => has_string = true
+          Number | Int => has_number = true
+          Boolean => has_boolean = true
+          BigInt => has_bigint = true
+          _ => ()
+        }
+      }
+      let mut true_lit = false
+      let mut false_lit = false
+      for m in members {
+        match resolver.unwrap(m) {
+          // `any` / `unknown` absorb the whole union.
+          Any => return None
+          Unknown => return Some("unknown")
+          // `never` members vanish; literal members subsumed by their
+          // base primitive vanish (tsc reduces before comparing identity).
+          Never => ()
+          Literal(_) if has_string => ()
+          NumberLiteral(_) if has_number => ()
+          BooleanLiteral(_) if has_boolean => ()
+          BigIntLiteral(_) if has_bigint => ()
+          BooleanLiteral(b) => {
+            if b {
+              true_lit = true
+            } else {
+              false_lit = true
+            }
+            match identity_key(m, resolver, depth + 1) {
+              Some(k) => keys.push(k)
+              None => return None
+            }
+          }
+          other =>
+            match identity_key(other, resolver, depth + 1) {
+              Some(k) => keys.push(k)
+              None => return None
+            }
+        }
+      }
+      // `true | false` reduces to `boolean`.
+      if true_lit && false_lit && !has_boolean {
+        let filtered = keys.filter(fn(k) { k != "true" && k != "false" })
+        filtered.push("boolean")
+        keys.clear()
+        for k in filtered {
+          keys.push(k)
+        }
+      }
+      keys.sort()
+      // Dedupe repeated *atomic* members (`string | string` ≡ `string`).
+      // Structural keys stay: two distinct-but-structurally-equal classes
+      // in a union (`C | D` with both empty) are separate members to tsc,
+      // so `C` vs `C | D` must remain non-identical.
+      let deduped : Array[String] = []
+      for k in keys {
+        let atomic = !k.contains("{") && !k.contains("(")
+        if deduped.length() == 0 ||
+          deduped[deduped.length() - 1] != k ||
+          !atomic {
+          deduped.push(k)
+        }
+      }
+      match deduped.length() {
+        0 => Some("never")
+        1 => Some(deduped[0])
+        _ => Some("u(" + deduped.join("|") + ")")
+      }
+    }
+    _ => None
   }
 }
 
@@ -20347,44 +20691,25 @@ fn check_var_redeclaration_types(
   resolver : Resolver,
 ) -> Array[ExprIssue] {
   let issues : Array[ExprIssue] = []
-  let first_members : Map[String, Array[@ast.TsType]] = {}
+  let first_key : Map[String, String] = {}
   let reported : Map[String, Unit] = {}
-  fn members_set_equal(a : Array[@ast.TsType], b : Array[@ast.TsType]) -> Bool {
-    for x in a {
-      if !b.iter().any(fn(y) { x == y }) {
-        return false
-      }
-    }
-    for x in b {
-      if !a.iter().any(fn(y) { x == y }) {
-        return false
-      }
-    }
-    true
-  }
-
   fn consider(name : String, ty : @ast.TsType) -> Unit {
     if !is_checkable(ty) {
       return
     }
-    let members = normalized_union_members(ty, resolver)
-    if members.length() == 0 {
-      return
-    }
-    for m in members {
-      if !is_identity_comparable_atom(m) {
-        return
-      }
-    }
-    match first_members.get(name) {
-      None => first_members[name] = members
-      Some(prev) =>
-        if !(reported.get(name) is Some(_)) && !members_set_equal(prev, members) {
-          reported[name] = ()
-          issues.push({
-            path: "var \{name}",
-            message: "subsequent variable declaration must have the same type",
-          })
+    match identity_key(ty, resolver, 0) {
+      None => ()
+      Some(key) =>
+        match first_key.get(name) {
+          None => first_key[name] = key
+          Some(prev) =>
+            if !(reported.get(name) is Some(_)) && prev != key {
+              reported[name] = ()
+              issues.push({
+                path: "var \{name}",
+                message: "subsequent variable declaration must have the same type",
+              })
+            }
         }
     }
   }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -3979,6 +3979,84 @@ fn is_syntactically_always_falsy(expr : @ast.TsExpr) -> Bool {
 }
 
 ///|
+/// TS2872 / TS2873 for *condition* positions (`cond ? a : b`, `!cond`).
+/// Same literal classification as the `&&` / `||` operand check, except
+/// that tsc exempts `0`, `1`, `true`, and `false` here -- `while (1)`,
+/// `if (0)`, and `1 ? a : b` are idiomatic debug / generated-code shapes
+/// (conditionalOperatorConditionIsNumberType flags `10000 ?` but not
+/// `1 ?` / `0 ?`). Returns `Some(truthy)` when the condition is a
+/// non-exempt literal, `None` otherwise.
+fn condition_literal_truthiness(expr : @ast.TsExpr) -> Bool? {
+  match expr {
+    IntLit(0) | IntLit(1) | BoolLit(_) => None
+    NumberLit(n) if n == 0.0 || n == 1.0 => None
+    _ =>
+      if is_syntactically_always_truthy(expr) {
+        Some(true)
+      } else if is_syntactically_always_falsy(expr) {
+        Some(false)
+      } else {
+        None
+      }
+  }
+}
+
+///|
+/// TS1345: an expression of type `void` cannot be tested for truthiness.
+/// Restricted to shapes whose `void` verdict is trustworthy -- a variable
+/// with a `void` annotation or a call whose signature returns `void`
+/// (`function foo() { }` infers `void` too). Other expression shapes
+/// abstain even if inference says `void`.
+fn tested_condition_is_void(
+  env : ExprEnv,
+  ctx : CheckCtx,
+  expr : @ast.TsExpr,
+) -> Bool {
+  match expr {
+    Var(_) | Call(_, _) | MethodCall(_, _, _) | CallExpr(_, _) =>
+      ctx.resolver.unwrap(infer_expr(env, ctx.resolver, expr)) is Void
+    _ => false
+  }
+}
+
+///|
+/// tsc's `isSideEffectFree` subset, used by the TS2695 comma-operator
+/// check. Mirrors the compiler's classification: identifiers, literals,
+/// function / class / array / object literals, templates (tagged included),
+/// the pure unary operators (`!`, `-`, `+`, `~`, `typeof` -- which don't
+/// recurse into their operand, matching tsc), and recursive conditional /
+/// binary / comma forms. Property access is *not* side-effect-free
+/// (getters), and neither are calls, `new`, assignments, or `++`/`--`.
+fn comma_left_side_effect_free(expr : @ast.TsExpr) -> Bool {
+  match expr {
+    Var(_)
+    | NumberLit(_)
+    | IntLit(_)
+    | BigIntLit(_)
+    | BoolLit(_)
+    | StringLit(_)
+    | NullLit
+    | ArrowFunc(_, _, _, _)
+    | FuncExpr(_)
+    | NativeClassExpr(_, _)
+    | ArrayLit(_)
+    | ObjectLit(_)
+    | TemplateLiteral(_, _)
+    | TaggedTemplate(_, _, _, _) => true
+    UnaryOp(op, _) =>
+      match op {
+        Not | Neg | Plus | BitwiseNot | Typeof => true
+        _ => false
+      }
+    Cond(_, t, e) =>
+      comma_left_side_effect_free(t) && comma_left_side_effect_free(e)
+    Seq(a, b) | BinOp(_, a, b) =>
+      comma_left_side_effect_free(a) && comma_left_side_effect_free(b)
+    _ => false
+  }
+}
+
+///|
 fn record_unfiltered(
   ctx : CheckCtx,
   sub_path : String,
@@ -12619,6 +12697,20 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
       let _ = infer_expr(env, ctx.resolver, init)
     }
     Expr(e) => {
+      // TS2695: a statement-level comma expression whose left side is
+      // side-effect-free discards a useless value (`!obj.a, M.n;`). Only the
+      // statement position is checked -- nested commas include the
+      // `(0, fn)(…)` indirect-call idiom, which tsc exempts and which our
+      // paren-erasing parser can't distinguish.
+      match e {
+        Seq(l, _) =>
+          if comma_left_side_effect_free(l) {
+            record_unfiltered(
+              ctx, "comma operator", "left side of comma operator is unused and has no side effects",
+            )
+          }
+        _ => ()
+      }
       check_call_args_in_expr(env, e, ctx)
       // `f(v)` where `f`'s declared return is `asserts v [is T]` narrows
       // `v` for every statement that follows.
@@ -13870,6 +13962,12 @@ fn check_call_args_in_expr(
           record_unfiltered(
             ctx, "logical operand", "this kind of expression is always falsy",
           )
+        } else if tested_condition_is_void(env, ctx, l) {
+          // TS1345: `voidValue && x` tests a `void` expression for
+          // truthiness (logicalAndOperatorStrictMode).
+          record_unfiltered(
+            ctx, "logical operand", "an expression of type `void` cannot be tested for truthiness",
+          )
         }
       }
       // TS2322 (via the `in` operator's operand constraints): the left
@@ -14027,6 +14125,20 @@ fn check_call_args_in_expr(
     UnaryOp(op, inner) => {
       check_call_args_in_expr(env, inner, ctx)
       match op {
+        // TS2872 / TS2873: `!` tests its operand for truthiness, so a
+        // non-exempt literal operand (`!{ x: 1 }`, `!""`) is always-taken.
+        Not =>
+          match condition_literal_truthiness(inner) {
+            Some(true) =>
+              record_unfiltered(
+                ctx, "unary op", "this kind of expression is always truthy",
+              )
+            Some(false) =>
+              record_unfiltered(
+                ctx, "unary op", "this kind of expression is always falsy",
+              )
+            None => ()
+          }
         Neg | BitwiseNot => {
           let inner_ty = ctx.resolver.unwrap(
             infer_expr(env, ctx.resolver, inner),
@@ -14165,6 +14277,26 @@ fn check_call_args_in_expr(
     }
     Cond(c, t, e) => {
       check_call_args_in_expr(env, c, ctx)
+      // TS2872 / TS2873: a ternary whose condition is a non-exempt literal
+      // (object / array / function literal, non-empty string, numeric other
+      // than 0 / 1) always takes the same branch. TS1345: a `void`-typed
+      // condition cannot be tested for truthiness at all.
+      match condition_literal_truthiness(c) {
+        Some(true) =>
+          record_unfiltered(
+            ctx, "cond", "this kind of expression is always truthy",
+          )
+        Some(false) =>
+          record_unfiltered(
+            ctx, "cond", "this kind of expression is always falsy",
+          )
+        None =>
+          if tested_condition_is_void(env, ctx, c) {
+            record_unfiltered(
+              ctx, "cond", "an expression of type `void` cannot be tested for truthiness",
+            )
+          }
+      }
       // Walk each branch under the condition's flow narrowing (the consequent
       // sees the truthy effect, the alternative the falsy one), so
       // `x !== undefined ? x.foo : 0` doesn't re-flag `x` as possibly-undefined.
@@ -19898,6 +20030,14 @@ fn check_class_duplicate_members(module_ : @ast.TsModule) -> Array[ExprIssue] {
         // the strict-property-initialization check (literal-named fields
         // are exempt from TS2564).
         ()
+      } else if name.has_prefix("<static-use-before-def:") {
+        // TS2729: a static block read / wrote a static field that is only
+        // declared after the block.
+        let f = name["<static-use-before-def:".length():name.length() - 1].to_string()
+        issues.push({
+          path: "class \{cls_name}",
+          message: "property `\{f}` is used before its initialization",
+        })
       } else {
         issues.push({
           path: "class \{cls_name}",
@@ -20784,6 +20924,30 @@ fn check_module_function_bodies_layered(
         message: "a module cannot have multiple default exports",
       })
     }
+    // TS1262: `await` is a reserved word at the top level of a *module*.
+    // The parser records `<top-await-name>` for a top-level binding named
+    // `await` (var / destructuring / import-equals) and module-syntax
+    // evidence separately; only the combination is an error — `var await`
+    // in a plain script stays legal.
+    let mut has_module_syntax = module_.imports.length() > 0
+    let mut top_await_name = false
+    for gm in module_.grammar_misuses {
+      if gm == "<module-syntax>" ||
+        gm.has_prefix("<export-value>") ||
+        gm.has_prefix("<export-default>") ||
+        gm.has_prefix("<export-eq>") {
+        has_module_syntax = true
+      }
+      if gm == "<top-await-name>" || gm == "<export-value>await" {
+        top_await_name = true
+      }
+    }
+    if has_module_syntax && top_await_name {
+      all.push({
+        path: "top-level `await`",
+        message: "`await` is a reserved word at the top-level of a module",
+      })
+    }
     // TS2304 for a single-bare-identifier computed key in a type position
     // (`var v: { [e]: number }`, `interface I { [e](): T }`, `declare class
     // C { [e]: T }`). The key references the *value* namespace; resolve it
@@ -20825,6 +20989,16 @@ fn check_module_function_bodies_layered(
       // Marker, not an error: the @noImplicitOverride directive flag,
       // consumed by the override-modifier checks.
       if gm == "<noimplicitoverride-on>" {
+        continue
+      }
+      // Marker, not an error: the @allowUnreachableCode directive flag,
+      // consumed by the TS2695 comma-operator suppression below.
+      if gm == "<allowunreachable-on>" {
+        continue
+      }
+      // Markers, not errors: module-syntax evidence and a top-level
+      // binding named `await`, combined into TS1262 above.
+      if gm == "<module-syntax>" || gm == "<top-await-name>" {
         continue
       }
       // TS2304: `export = name` over a provably undeclared value. Same
@@ -20990,6 +21164,17 @@ fn check_module_function_bodies_layered(
     }
     for issue in issues {
       all.push({ path: "\{prefix} > \{issue.path}", message: issue.message })
+    }
+  }
+  // tsc gates the TS2695 comma-operator check on `allowUnreachableCode`
+  // being off; under the directive (parser `<allowunreachable-on>` marker)
+  // drop any comma diagnostics the statement walkers recorded.
+  for gm in module_.grammar_misuses {
+    if gm == "<allowunreachable-on>" {
+      return all.filter(fn(i) {
+        i.message !=
+        "left side of comma operator is unused and has no side effects"
+      })
     }
   }
   all

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -12923,6 +12923,77 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
     ForOf(kind, binding, declared, iter, body) => {
       check_call_args_in_expr(env, iter, ctx)
       let iter_ty = infer_expr(env, ctx.resolver, iter)
+      // TS2488: the iterated value must have a `[Symbol.iterator]()`
+      // method returning an iterator. Decided only for base-less,
+      // index-signature-free class instances (an `extends` chain or an
+      // interface merge could add the protocol): either the class lacks
+      // the `[Symbol.iterator]` member entirely, or it returns `this`
+      // while the class has no `next` method (for-of14 / for-of16).
+      match ctx.resolver.unwrap(iter_ty) {
+        Named(icn) =>
+          match ctx.resolver.classes.get(icn) {
+            Some(icls) if icls.base_names.length() == 0 &&
+              icls.base_expr is None &&
+              icls.index_signatures.length() == 0 &&
+              icls.type_params.length() == 0 &&
+              ctx.resolver.interfaces.get(icn) is None => {
+              let mut has_sym_iter = false
+              let mut sym_iter_returns_this_only = false
+              let mut has_next = false
+              // A computed FIELD can also provide the protocol
+              // (`[Symbol.iterator]: any;` -- for-of27): its shape is
+              // unverifiable, so its presence silences the check.
+              for kexpr in icls.computed_field_keys {
+                if kexpr is PropAccess(Var("Symbol"), "iterator") {
+                  has_sym_iter = true
+                  has_next = true
+                }
+              }
+              // A FIELD named `next` (callable-typed or `any`) satisfies
+              // the iterator side too (for-of28).
+              for pr in icls.properties {
+                if !pr.is_static && pr.name == "next" {
+                  has_next = true
+                }
+              }
+              for m in icls.methods {
+                if !m.is_static {
+                  if m.name == "next" {
+                    has_next = true
+                  }
+                  if m.name == "<computed>" &&
+                    m.key_expr is Some(PropAccess(Var("Symbol"), "iterator")) {
+                    has_sym_iter = true
+                    match m.body {
+                      Some(b) => {
+                        let mut all_this = true
+                        let mut saw_return = false
+                        for st in b.stmts {
+                          match st {
+                            Return(Some(Var("this"))) => saw_return = true
+                            Return(_) => all_this = false
+                            _ => ()
+                          }
+                        }
+                        sym_iter_returns_this_only = saw_return && all_this
+                      }
+                      None => ()
+                    }
+                  }
+                }
+              }
+              if !has_sym_iter || (sym_iter_returns_this_only && !has_next) {
+                record(
+                  ctx,
+                  "for-of iterable",
+                  "type `\{icn}` must have a `[Symbol.iterator]()` method that returns an iterator",
+                )
+              }
+            }
+            _ => ()
+          }
+        _ => ()
+      }
       let inferred_elem = for_of_element_type(ctx.resolver, iter_ty)
       let elem_ty = if is_checkable(declared) {
         // Validate the declared annotation against the actual element type.
@@ -18447,6 +18518,195 @@ fn check_namespace_or_enum_member_access(
 }
 
 ///|
+/// TS4112 / TS4113 / TS4114 -- the `override` modifier family:
+///   - TS4112: an `override` member in a class with NO heritage clause.
+///   - TS4113: an `override` member that no (fully resolvable, in-module,
+///     non-generic) base-chain class or merged interface declares.
+///   - TS4114 (only under `@noImplicitOverride: true`, via the parser's
+///     `<noimplicitoverride-on>` marker): an instance member that DOES
+///     override a base member but lacks the modifier. `constructor` and
+///     computed/private names are exempt.
+fn check_override_modifiers(module_ : @ast.TsModule) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  let mut no_implicit_override = false
+  for gm in module_.grammar_misuses {
+    if gm == "<noimplicitoverride-on>" {
+      no_implicit_override = true
+    }
+  }
+  let class_by_name : Map[String, @ast.TsClassDecl] = {}
+  for c in module_.classes {
+    class_by_name[c.name] = c
+  }
+  let iface_by_name : Map[String, @ast.TsInterface] = {}
+  for i in module_.interfaces {
+    if i.type_params.length() == 0 {
+      iface_by_name[i.name] = i
+    }
+  }
+  for cls in module_.classes {
+    let overrides : Map[String, Unit] = {}
+    let declare_members : Map[String, Unit] = {}
+    for d in cls.duplicate_member_names {
+      if d.has_prefix("<override-member:") {
+        overrides[d["<override-member:".length():d.length() - 1].to_string()] = ()
+      }
+      if d.has_prefix("<declare-member:") {
+        declare_members[d["<declare-member:".length():d.length() - 1].to_string()] = ()
+      }
+    }
+    let has_heritage = cls.base_names.length() > 0 || cls.base_expr is Some(_)
+    if !has_heritage {
+      if overrides.size() > 0 {
+        issues.push({
+          path: "class \{cls.name}",
+          message: "this member cannot have an `override` modifier because its containing class does not extend another class",
+        })
+      }
+      continue
+    }
+    // Resolve the transitive base member set. Bail (conservatively) when
+    // any base is generic, expression-shaped, or not declared in-module.
+    guard cls.base_names.length() == 1 && cls.base_expr is None else {
+      continue
+    }
+    let base_instance : Map[String, Unit] = {}
+    let base_static : Map[String, Unit] = {}
+    let base_abstract : Map[String, Unit] = {}
+    let mut resolvable = true
+    let mut cursor : String? = Some(cls.base_names[0])
+    let visited : Map[String, Unit] = {}
+    while cursor is Some(bn) {
+      if visited.contains(bn) {
+        break
+      }
+      visited[bn] = ()
+      let mut next : String? = None
+      match class_by_name.get(bn) {
+        Some(b) => {
+          if b.type_params.length() > 0 {
+            resolvable = false
+            break
+          }
+          for an in b.abstract_members {
+            base_abstract[an] = ()
+          }
+          for m in b.methods {
+            if m.name != "<computed>" {
+              if m.is_static {
+                base_static[m.name] = ()
+              } else {
+                base_instance[m.name] = ()
+              }
+            }
+          }
+          for pr in b.properties {
+            if pr.name != "<computed>" {
+              if pr.is_static {
+                base_static[pr.name] = ()
+              } else {
+                base_instance[pr.name] = ()
+              }
+            }
+          }
+          if b.base_expr is Some(_) || b.base_names.length() > 1 {
+            resolvable = false
+            break
+          }
+          if b.base_names.length() == 1 {
+            next = Some(b.base_names[0])
+          }
+        }
+        None =>
+          match iface_by_name.get(bn) {
+            // The parser lowers member-only classes to interfaces.
+            Some(bi) => {
+              for f in bi.fields {
+                base_instance[f.0] = ()
+              }
+              if bi.extends_names.length() > 0 {
+                resolvable = false
+              }
+            }
+            None => resolvable = false
+          }
+      }
+      cursor = next
+    }
+    if !resolvable {
+      continue
+    }
+    // TS4113: overrides that no base declares.
+    for kv in overrides {
+      let name = kv.0
+      let is_static_m = name.has_prefix("s:")
+      let bare = name[2:].to_string()
+      let known = if is_static_m {
+        base_static.contains(bare)
+      } else {
+        base_instance.contains(bare)
+      }
+      if !known {
+        issues.push({
+          path: "class \{cls.name}",
+          message: "this member cannot have an `override` modifier because it is not declared in the base class",
+        })
+      }
+    }
+    // TS4114: genuine overrides missing the modifier.
+    if no_implicit_override {
+      let flag_missing = fn(name : String, is_static_m : Bool) -> Unit {
+        if name == "constructor" ||
+          name == "<computed>" ||
+          name.has_prefix("__private_brand__") ||
+          name.has_prefix("#") {
+          return
+        }
+        // Implementing an ABSTRACT base member does not require the
+        // modifier (override10), and `declare`-modified members are
+        // ambient re-declarations, also exempt (override14).
+        if !is_static_m && base_abstract.contains(name) {
+          return
+        }
+        if declare_members.contains(
+            (if is_static_m { "s:" } else { "i:" }) + name,
+          ) {
+          return
+        }
+        let in_base = if is_static_m {
+          base_static.contains(name)
+        } else {
+          base_instance.contains(name)
+        }
+        let key = (if is_static_m { "s:" } else { "i:" }) + name
+        if in_base && !overrides.contains(key) {
+          issues.push({
+            path: "class \{cls.name}",
+            message: "this member must have an `override` modifier because it overrides a member in the base class",
+          })
+        }
+      }
+      let seen_members : Map[String, Unit] = {}
+      for m in cls.methods {
+        let key = (if m.is_static { "s:" } else { "i:" }) + m.name
+        if !seen_members.contains(key) {
+          seen_members[key] = ()
+          flag_missing(m.name, m.is_static)
+        }
+      }
+      for pr in cls.properties {
+        let key = (if pr.is_static { "s:" } else { "i:" }) + pr.name
+        if !seen_members.contains(key) {
+          seen_members[key] = ()
+          flag_missing(pr.name, pr.is_static)
+        }
+      }
+    }
+  }
+  issues
+}
+
+///|
 /// TS2394 ("This overload signature is not compatible with its
 /// implementation signature") -- the definite subcase: an overload with a
 /// concrete scalar return type over an implementation *annotated* `void`
@@ -19628,6 +19888,11 @@ fn check_class_duplicate_members(module_ : @ast.TsModule) -> Array[ExprIssue] {
         // type was a naked bounded type parameter. Consumed by
         // `check_derived_indexer_compat`.
         ()
+      } else if name.has_prefix("<override-member:") ||
+        name.has_prefix("<declare-member:") {
+        // Markers, not errors: `override`- / `declare`-modified member
+        // names, consumed by check_override_modifiers.
+        ()
       } else if name.has_prefix("<quoted-member:") {
         // Marker, not an error: a string-literal member name. Consumed by
         // the strict-property-initialization check (literal-named fields
@@ -20297,6 +20562,9 @@ fn check_module_function_bodies_layered(
   for issue in check_overload_void_return(module_) {
     all.push(issue)
   }
+  for issue in check_override_modifiers(module_) {
+    all.push(issue)
+  }
   for issue in check_class_namespace_static_merge(module_) {
     all.push(issue)
   }
@@ -20488,6 +20756,34 @@ fn check_module_function_bodies_layered(
         }
       }
     }
+    // TS2528: a module cannot have multiple default exports. Function
+    // markers group by name (overload signatures + the implementation are
+    // ONE default); anonymous functions and class/expression defaults each
+    // count individually.
+    let mut default_count = 0
+    let seen_default_fns : Map[String, Unit] = {}
+    for gm in module_.grammar_misuses {
+      if gm.has_prefix("<export-default>") {
+        let payload = gm["<export-default>".length():].to_string()
+        if payload.has_prefix("fn:") {
+          let fname = payload["fn:".length():].to_string()
+          if fname == "<anon>" {
+            default_count += 1
+          } else if !seen_default_fns.contains(fname) {
+            seen_default_fns[fname] = ()
+            default_count += 1
+          }
+        } else {
+          default_count += 1
+        }
+      }
+    }
+    if default_count >= 2 {
+      all.push({
+        path: "export default",
+        message: "a module cannot have multiple default exports",
+      })
+    }
     // TS2304 for a single-bare-identifier computed key in a type position
     // (`var v: { [e]: number }`, `interface I { [e](): T }`, `declare class
     // C { [e]: T }`). The key references the *value* namespace; resolve it
@@ -20519,6 +20815,16 @@ fn check_module_function_bodies_layered(
       // Marker, not an error: an exported value declaration's name,
       // consumed by the class/namespace static-merge check.
       if gm.has_prefix("<export-value>") {
+        continue
+      }
+      // Marker, not an error: a default-export occurrence, consumed by the
+      // TS2528 multiple-defaults count.
+      if gm.has_prefix("<export-default>") {
+        continue
+      }
+      // Marker, not an error: the @noImplicitOverride directive flag,
+      // consumed by the override-modifier checks.
+      if gm == "<noimplicitoverride-on>" {
         continue
       }
       // TS2304: `export = name` over a provably undeclared value. Same

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -4897,6 +4897,102 @@ fn union_possibly_nullish(ty : @ast.TsType) -> @ast.TsType? {
 }
 
 ///|
+
+///|
+/// True when `ty` is an unconstrained in-scope type parameter — never
+/// comparable to anything but itself in a relational comparison.
+fn relational_unconstrained_param(ctx : CheckCtx, ty : @ast.TsType) -> Bool {
+  match ty {
+    Named(n) =>
+      ctx.in_scope_type_params.contains(n) &&
+      not(ctx.type_param_bounds.iter().any(fn(b) { b.0 == n }))
+    _ => false
+  }
+}
+
+///|
+/// Object-side classification for the relational-comparison check: shapes
+/// that are never assignable to `number | bigint | string`. Booleans join
+/// this side (comparable only to themselves), and a union counts when any
+/// non-nullish member does.
+fn relational_object_like(ctx : CheckCtx, ty : @ast.TsType) -> Bool {
+  match ty {
+    Boolean
+    | BooleanLiteral(_)
+    | Void
+    | Symbol
+    | Func(_, _)
+    | Object(_)
+    | Struct(_, _)
+    | Array(_)
+    | Tuple(_) => true
+    Named(n) => {
+      if ctx.in_scope_type_params.contains(n) ||
+        ctx.resolver.enums.get(n) is Some(_) {
+        return false
+      }
+      ctx.resolver.classes.get(n) is Some(_) ||
+      ctx.resolver.interfaces.get(n) is Some(_)
+    }
+    Applied(n, _) =>
+      n == "Promise" ||
+      n == "Map" ||
+      n == "Set" ||
+      n == "WeakMap" ||
+      n == "WeakSet"
+    Union(members) => {
+      for m in members {
+        match m {
+          Null | Undefined => ()
+          other => if relational_object_like(ctx, other) { return true }
+        }
+      }
+      false
+    }
+    _ => false
+  }
+}
+
+///|
+/// Primitive-side classification: a type that is confidently
+/// `number` / `bigint` / `string`-like (or an enum), i.e. definitely NOT
+/// comparable to the object side.
+fn relational_primitive_comparable(ctx : CheckCtx, ty : @ast.TsType) -> Bool {
+  match ty {
+    Number | Int | String_ | Literal(_) | BigInt | TemplateLiteralType(_, _) =>
+      true
+    Named(n) => ctx.resolver.enums.get(n) is Some(_)
+    _ => false
+  }
+}
+
+///|
+/// TS2365 for `<` `<=` `>` `>=`: true when the operand pair is *definitely*
+/// unrelated. tsc allows the comparison when either side is comparable to
+/// the other (so identical type parameters and subtype-related object
+/// shapes are legal) or when both sides are number/bigint-like. Definite
+/// errors: an unconstrained type parameter against anything else, and an
+/// object-side shape against a number/string/bigint primitive. Nullish
+/// operands abstain.
+fn relational_pair_never_comparable(
+  ctx : CheckCtx,
+  lt : @ast.TsType,
+  rt : @ast.TsType,
+) -> Bool {
+  match (lt, rt) {
+    // Identical named types (same type parameter, same class) compare fine.
+    (Named(a), Named(b)) if a == b => return false
+    (Null | Undefined, _) | (_, Null | Undefined) => return false
+    _ => ()
+  }
+  if relational_unconstrained_param(ctx, lt) ||
+    relational_unconstrained_param(ctx, rt) {
+    return true
+  }
+  (relational_object_like(ctx, lt) && relational_primitive_comparable(ctx, rt)) ||
+  (relational_object_like(ctx, rt) && relational_primitive_comparable(ctx, lt))
+}
+
 // Returns true only for types that can NEVER participate in numeric
 // arithmetic (`-`, `*`, `/`, bit ops, …), so the "not a valid number type"
 // diagnostic stays free of false positives.  Mirrors `is_definitely_not_callable`:
@@ -4904,6 +5000,8 @@ fn union_possibly_nullish(ty : @ast.TsType) -> @ast.TsType? {
 // Union / Intersection (could be a numeric-literal union like `0 | 1 | 2`),
 // and unresolved type-level forms.  Only concrete non-numeric primitives and
 // object-like shapes are flagged.
+
+///|
 fn is_definitely_not_arithmetic(ty : @ast.TsType) -> Bool {
   match ty {
     String_
@@ -5384,6 +5482,54 @@ fn check_binop_operands(
         )
       }
     }
+    // TS2365 for relational comparison (`<` `<=` `>` `>=`): both operands
+    // must be of type `any` / `number` / `bigint` / `string` / enum. An
+    // operand that is *definitely* never comparable -- a boolean, void,
+    // symbol, function, object / array / tuple shape, a resolvable
+    // class / interface instance, an unconstrained in-scope type
+    // parameter, or a union containing one of those -- always errors.
+    // Nullish members, unresolved names, and constrained type parameters
+    // abstain.
+    BinLt | BinLe | BinGt | BinGe => {
+      // TS18050: the literal `null` / `undefined` keyword is never a valid
+      // relational operand. (Restricted to the keyword forms; variables of
+      // nullish type are left to the assignability machinery.)
+      let nullish_kw = fn(e : @ast.TsExpr) -> String? {
+        match e {
+          NullLit => Some("null")
+          Var("undefined") => Some("undefined")
+          _ => None
+        }
+      }
+      let mut saw_nullish_kw = false
+      match nullish_kw(l) {
+        Some(kw) => {
+          saw_nullish_kw = true
+          record(ctx, "binary op", "the value `\{kw}` cannot be used here")
+        }
+        None => ()
+      }
+      match nullish_kw(r) {
+        Some(kw) => {
+          saw_nullish_kw = true
+          record(ctx, "binary op", "the value `\{kw}` cannot be used here")
+        }
+        None => ()
+      }
+      if !saw_nullish_kw {
+        let lt = ctx.resolver.unwrap(infer_expr(env, ctx.resolver, l))
+        let rt = ctx.resolver.unwrap(infer_expr(env, ctx.resolver, r))
+        if is_checkable(lt) &&
+          is_checkable(rt) &&
+          relational_pair_never_comparable(ctx, lt, rt) {
+          record_unfiltered(
+            ctx,
+            "binary op",
+            "operator cannot be applied to types `\{type_display(lt)}` and `\{type_display(rt)}`",
+          )
+        }
+      }
+    }
     // Strict equality: comparing two types with no overlap is always false.
     // e.g., `someNumber === "hello"` or `true === 42`.
     BinEq | BinNe => {
@@ -5477,30 +5623,9 @@ fn check_binop_operands(
       }
     }
     // Relational comparison (`<`, `<=`, `>`, `>=`): the `null` / `undefined`
-    // keyword is never a valid operand — TypeScript reports TS18050 ("The
-    // value 'null' / 'undefined' cannot be used here"). Restricted to the
-    // literal keyword operands so a variable of an inferred nullish type is
-    // left to the (separate) assignability machinery; the literal form is
-    // unconditionally an error, so the check is false-positive-free.
-    BinLt | BinLe | BinGt | BinGe => {
-      let nullish_kw = fn(e : @ast.TsExpr) -> String? {
-        match e {
-          NullLit => Some("null")
-          Var("undefined") => Some("undefined")
-          _ => None
-        }
-      }
-      match nullish_kw(l) {
-        Some(kw) =>
-          record(ctx, "binary op", "the value `\{kw}` cannot be used here")
-        None => ()
-      }
-      match nullish_kw(r) {
-        Some(kw) =>
-          record(ctx, "binary op", "the value `\{kw}` cannot be used here")
-        None => ()
-      }
-    }
+    // keyword operand handling (TS18050) lives in the merged
+    // `BinLt | BinLe | BinGt | BinGe` arm above, together with the TS2365
+    // never-comparable pair check.
     _ => ()
   }
 }
@@ -10541,7 +10666,103 @@ fn check_arguments_with_sig(
   ctx : CheckCtx,
   call_path : String,
   arity_reliable? : Bool = false,
+  check_spread? : Bool = false,
 ) -> Unit {
+  // TS2556 ("A spread argument must either have a tuple type or be passed
+  // to a rest parameter"): tsc's arity rule for the first non-tuple spread
+  // argument at effective index `i` -- error unless
+  // `i >= minArgCount && (hasRest || i < paramCount)`. Tuple-typed spreads
+  // (and exact array-literal spreads) expand into individual arguments and
+  // don't count. Only runs when the caller vouches the signature is exact
+  // and non-overloaded (`check_spread`, set by the direct
+  // function-declaration call path), and only for spread operands whose
+  // type is confidently a plain array or a class instance -- `any`,
+  // generics, unions, and open tuples abstain.
+  if check_spread && sig is Some(ps) {
+    let mut has_rest = false
+    let mut param_count = 0
+    for p in ps {
+      if p.is_rest {
+        has_rest = true
+      } else {
+        param_count += 1
+      }
+    }
+    let min_args = required_arity(ps)
+    let mut i = 0
+    let mut stop = false
+    for a in args {
+      if stop {
+        break
+      }
+      match a {
+        Spread(inner) => {
+          // An exact array-literal spread contributes a known count.
+          let literal_len : Int? = match inner {
+            ArrayLit(items) => {
+              let mut ok = true
+              for it in items {
+                match it {
+                  Spread(_) | ArrayHole => ok = false
+                  _ => ()
+                }
+              }
+              if ok {
+                Some(items.length())
+              } else {
+                None
+              }
+            }
+            _ => None
+          }
+          match literal_len {
+            Some(n) => i += n
+            None => {
+              let t = ctx.resolver.unwrap(infer_expr(env, ctx.resolver, inner))
+              match t {
+                Tuple(items) => {
+                  let mut fixed = true
+                  for it in items {
+                    if it is Rest(_) {
+                      fixed = false
+                    }
+                  }
+                  if fixed {
+                    i += items.length()
+                  } else {
+                    stop = true
+                  }
+                }
+                Array(_) | Applied("Array", _) | Applied("ReadonlyArray", _) => {
+                  if i < min_args || (!has_rest && i >= param_count) {
+                    record_unfiltered(
+                      ctx, call_path, "a spread argument must either have a tuple type or be passed to a rest parameter",
+                    )
+                  }
+                  stop = true
+                }
+                Named(n) =>
+                  // A class instance (e.g. a hand-rolled iterator) is never
+                  // a tuple, so the same arity formula decides.
+                  if ctx.resolver.classes.get(n) is Some(_) {
+                    if i < min_args || (!has_rest && i >= param_count) {
+                      record_unfiltered(
+                        ctx, call_path, "a spread argument must either have a tuple type or be passed to a rest parameter",
+                      )
+                    }
+                    stop = true
+                  } else {
+                    stop = true
+                  }
+                _ => stop = true
+              }
+            }
+          }
+        }
+        _ => i += 1
+      }
+    }
+  }
   // Spread arguments make positional matching unreliable — just type-check
   // each argument and skip count enforcement. Exception: when *every*
   // spread wraps a syntactic array literal (`f(1, ...[2, 3])`), the
@@ -13712,6 +13933,10 @@ fn check_call_args_in_expr(
             ctx,
             "call `\{name}`",
             arity_reliable~,
+            // Overloaded declarations never reach this branch (their callee
+            // type is a `Union`), so the signature is exact and the TS2556
+            // spread-argument arity rule can run.
+            check_spread=true,
           )
         }
         other =>

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -12293,3 +12293,86 @@ test "expr_check: TS2528/TS2488/override family (batch AE)" {
     0,
   )
 }
+
+///|
+test "expr_check: truthiness/comma/await/static-block (batch AF)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // TS2872 / TS2873: literal ternary conditions (0 / 1 / booleans exempt).
+  assert_true(issues("declare var a: any;\nvar r = ({}) ? a : a;") > 0)
+  assert_true(issues("declare var a: any;\nvar r = \"s\" ? a : a;") > 0)
+  assert_true(issues("declare var a: any;\nvar r = \"\" ? a : a;") > 0)
+  assert_true(issues("declare var a: any;\nvar r = 42 ? a : a;") > 0)
+  assert_true(issues("declare var a: any;\nnull ? a : a;") > 0)
+  @test.assert_eq(issues("declare var a: any;\nvar r = 1 ? a : a;"), 0)
+  @test.assert_eq(issues("declare var a: any;\nvar r = 0 ? a : a;"), 0)
+  @test.assert_eq(issues("declare var a: any;\nvar r = true ? a : a;"), 0)
+  @test.assert_eq(
+    issues(
+      "declare var flag: boolean;\ndeclare var a: any;\nvar r = flag ? a : a;",
+    ),
+    0,
+  )
+  // TS2872 / TS2873 on the `!` operand.
+  assert_true(issues("var b = !{ x: 1 };") > 0)
+  assert_true(issues("var b = !\"\";") > 0)
+  @test.assert_eq(issues("var b = !1;"), 0)
+  @test.assert_eq(issues("declare var n: number;\nvar b = !n;"), 0)
+  // TS1345: a void condition cannot be tested for truthiness. (An
+  // unannotated `function foo() { }` infers `Any`, not `Void`, so only
+  // annotated shapes fire -- conservative by design.)
+  assert_true(
+    issues("declare function foo(): void;\ndeclare var a: any;\nfoo() ? a : a;") >
+    0,
+  )
+  assert_true(
+    issues("const v: void = undefined;\ndeclare var a: any;\nvar r = v && a;") >
+    0,
+  )
+  @test.assert_eq(
+    issues("function foo() { return 1; }\ndeclare var a: any;\nfoo() ? a : a;"),
+    0,
+  )
+  // TS2695: statement-level comma with a side-effect-free left side;
+  // suppressed under @allowUnreachableCode.
+  assert_true(
+    issues("declare var o: { a: number, n: number };\n!o.a, o.n;") > 0,
+  )
+  assert_true(issues("enum E { A }\ntypeof E, E.A;") > 0)
+  @test.assert_eq(
+    issues("declare var o: { a: number, n: number };\no.a = 1, o.n;"),
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "// @allowUnreachableCode: true\ndeclare var o: { a: number, n: number };\n!o.a, o.n;",
+    ),
+    0,
+  )
+  // TS1262: `await` as a top-level name, only in modules.
+  assert_true(issues("export {};\nvar await = 1;") > 0)
+  assert_true(issues("export {};\nvar [await] = [1];") > 0)
+  assert_true(issues("export class await {}") > 0)
+  @test.assert_eq(issues("var await = 1;"), 0)
+  @test.assert_eq(
+    issues("export {};\nfunction g() { var await = 2; return 1; }"),
+    0,
+  )
+  // TS2729: static-block use of a static field declared after the block.
+  assert_true(
+    issues("class C { static f1 = 1; static { C.f1; C.f2; } static f2 = 2; }") >
+    0,
+  )
+  assert_true(issues("class C { static { this.x = 1; } static x; }") > 0)
+  @test.assert_eq(
+    issues(
+      "class C { static f1 = 1; static { C.f1; this.f1; } static m() { return C.f1; } }",
+    ),
+    0,
+  )
+  @test.assert_eq(
+    issues("class C { static { const g = () => C.f2; } static f2 = 2; }"),
+    0,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -11291,11 +11291,13 @@ test "expr_check: exact spread arity (TS2554) and es6 yield function names (TS12
     ),
     0,
   )
-  // Open-ended spreads still abstain.
-  @test.assert_eq(
+  // An open-ended array spread against required params abstains from the
+  // TS2554 arity check but now reports TS2556 (a spread argument must have
+  // a tuple type or hit a rest parameter) — matching tsc.
+  assert_true(
     issues(
       "declare const xs: string[];\ndeclare function g2(a: string, b: string): void;\ng2(...xs);",
-    ),
+    ) >
     0,
   )
   // `function yield` under an es6+ target directive (or as a generator).
@@ -12373,6 +12375,66 @@ test "expr_check: truthiness/comma/await/static-block (batch AF)" {
   )
   @test.assert_eq(
     issues("class C { static { const g = () => C.f2; } static f2 = 2; }"),
+    0,
+  )
+}
+
+///|
+test "expr_check: spread arity, enum string arith, relational pairs (batch AG)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // TS2556: array spread past a rest-less parameter list, or an iterator
+  // class spread short of the required count.
+  assert_true(
+    issues(
+      "declare function normal(s: string): void;\ndeclare var ns: number[];\nnormal(\"g\", ...ns);",
+    ) >
+    0,
+  )
+  assert_true(
+    issues(
+      "declare function foo(s: symbol, ...rest: symbol[]): void;\nclass It { next() { return { value: 1, done: false }; } [Symbol.iterator]() { return this; } }\nfoo(...new It);",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "declare function all(a?: number, b?: number): void;\ndeclare var ns: number[];\nall(...ns);",
+    ),
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "declare function rest(s: string, ...r: number[]): void;\ndeclare var ns: number[];\nrest(\"d\", ...ns);",
+    ),
+    0,
+  )
+  // TS2362/TS2363: string arithmetic inside enum member initializers, and
+  // a template literal in a division (regex/division lexer split).
+  assert_true(issues("enum T { d = \"a\" - \"a\" }") > 0)
+  @test.assert_eq(
+    issues("enum T { a = \"1\", b = \"1\" + \"2\", c = 1 + 2 }"),
+    0,
+  )
+  assert_true(issues("var x = `abc${ 1 }def` / 1;") > 0)
+  // TS2365: relational comparison of definitely-unrelated operands.
+  assert_true(issues("function foo<T, U>(t: T, u: U) { var r = t < u; }") > 0)
+  assert_true(issues("declare let a: { a: 1 };\na > 1;") > 0)
+  assert_true(
+    issues("declare const t1: number | Promise<number>;\nt1 >= 0;") > 0,
+  )
+  @test.assert_eq(issues("function foo<T>(t: T) { var r = t < t; }"), 0)
+  @test.assert_eq(
+    issues(
+      // (@strict: false so the uninitialized `a` doesn't trip TS2564 —
+      // this pin is about the comparison staying legal.)
+      "// @strict: false\nclass A1 { public a: string; }\ndeclare var x: A1, y: A1;\nx < y;",
+    ),
+    0,
+  )
+  @test.assert_eq(
+    issues("declare var n: number;\nenum E { a }\nn < 1;\nE.a >= 1;"),
     0,
   )
 }

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -12212,3 +12212,84 @@ test "expr_check: Partial/Required/Readonly lattice (batch AD)" {
     0,
   )
 }
+
+///|
+test "expr_check: TS2528/TS2488/override family (batch AE)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // TS2528: multiple default exports.
+  assert_true(
+    issues("export default function Foo() {}\nexport default class Bar {}") > 0,
+  )
+  @test.assert_eq(issues("export default function Foo() {}"), 0)
+  // TS2488: for-of over a class lacking the iterator protocol.
+  assert_true(
+    issues(
+      "class It { next() { return \"\"; } }\nvar v: string;\nfor (v of new It) { }",
+    ) >
+    0,
+  )
+  assert_true(
+    issues(
+      "class It { [Symbol.iterator]() { return this; } }\nvar v: string;\nfor (v of new It) { }",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "class It { next() { return { value: 1, done: false }; } [Symbol.iterator]() { return this; } }\nvar n: number;\nfor (n of new It) { }",
+    ),
+    0,
+  )
+  // A computed FIELD iterator or a `next` field satisfies the protocol.
+  @test.assert_eq(
+    issues("class It { [Symbol.iterator]: any; }\nfor (var v of new It) { }"),
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "class It { next: any;\n  [Symbol.iterator]() { return this; } }\nfor (var v of new It) { }",
+    ),
+    0,
+  )
+  // TS4112: override without heritage.
+  assert_true(issues("class C { override foo(v: string) {} }") > 0)
+  // TS4113: override with no matching base member.
+  assert_true(
+    issues(
+      "class B { foo(v: string) {} }\nclass D extends B { override bar(v: string) {} }",
+    ) >
+    0,
+  )
+  // TS4114 under noImplicitOverride: a genuine override missing the
+  // modifier; abstract implementations and declare members are exempt.
+  assert_true(
+    issues(
+      "// @noImplicitOverride: true\nclass B { foo() {} }\nclass D extends B { foo() {} }",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "// @noImplicitOverride: true\nclass B { foo() {} }\nclass D extends B { override foo() {} }",
+    ),
+    0,
+  )
+  @test.assert_eq(
+    issues("class B { foo() {} }\nclass D extends B { foo() {} }"),
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "// @noImplicitOverride: true\nabstract class B { abstract foo(): void; }\nclass D extends B { foo() {} }",
+    ),
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "// @noImplicitOverride: true\nclass B { p = 1 }\nclass D extends B { declare p: number }",
+    ),
+    0,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -12438,3 +12438,52 @@ test "expr_check: spread arity, enum string arith, relational pairs (batch AG)" 
     0,
   )
 }
+
+///|
+test "expr_check: identity keys and union callee arity (batch AH)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // TS2403 via structural identity keys: function-type unions vs a
+  // union-returning function differ; spelling variants stay silent.
+  assert_true(
+    issues(
+      "var u: (() => string) | (() => number);\nvar u: () => string | number;",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "var a: (string | number)[];\nvar a: Array<string | number>;\nvar b: { (x: string): string };\nvar b: (x: string) => string;\nvar l: string | \"a\";\nvar l: string;",
+    ),
+    0,
+  )
+  // A class instance type is structurally identical to its spelled-out
+  // object literal (nestedModules), while `C` vs `C | D` is not.
+  @test.assert_eq(
+    issues(
+      "// @strict: false\nnamespace M { export class P { x: number; y: number; } }\nvar p: { x: number; y: number; };\nvar p: M.P;",
+    ),
+    0,
+  )
+  // TS2554 for union-typed callees with differing member arities.
+  assert_true(
+    issues(
+      "type F1 = (a: string, b?: string) => void;\ntype F5 = (a: string, b: string) => void;\ndeclare var f: F1 | F5;\nf(\"a\");",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "type F1 = (a: string, b?: string) => void;\ntype F2 = (a: string, b?: string, c?: string) => void;\ndeclare var f: F1 | F2;\nf(\"a\");\nf(\"a\", \"b\", \"c\");",
+    ),
+    0,
+  )
+  // Overloaded declarations are also `Union`s of `Func`s — exempt.
+  @test.assert_eq(
+    issues(
+      "declare function g(a: string, b: string): void;\ndeclare function g(a: number): void;\ng(1);",
+    ),
+    0,
+  )
+}

--- a/src/parser/lexer.mbt
+++ b/src/parser/lexer.mbt
@@ -2063,6 +2063,9 @@ fn token_can_end_expr(kind : TokenKind) -> Bool {
     | Bool(_)
     | Str(_)
     | Regex(_, _)
+    // A template literal is a complete expression, so a following `/` is
+    // division, not a regex start (`` `a${1}b` / 1 ``).
+    | Template(_, _, _)
     | Ident(_)
     | PrivateIdent(_)
     | NumberType

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -52,6 +52,306 @@ fn runtime_class_param_name(param : @ast.TsParam, index : Int) -> String {
 }
 
 ///|
+
+///|
+/// True when `binding` declares an identifier equal to `name`.
+fn sb_binding_binds(binding : @ast.TsBinding, name : String) -> Bool {
+  match binding {
+    Ident(n) => n == name
+    Array(ab) => {
+      for item in ab.items {
+        match item {
+          Some(elem) => if sb_binding_binds(elem.binding, name) { return true }
+          None => ()
+        }
+      }
+      match ab.rest {
+        Some(rest) => sb_binding_binds(rest, name)
+        None => false
+      }
+    }
+    Object(ob) => {
+      for prop in ob.props {
+        if sb_binding_binds(prop.binding, name) {
+          return true
+        }
+      }
+      ob.rest is Some(r) && r == name
+    }
+    Target(_) => false
+  }
+}
+
+///|
+/// Expression walk for the TS2729 static-block check: record a hit when the
+/// expression reads or writes `this.<f>` / `<ClassName>.<f>` for a field
+/// name in `later`. Function-valued expressions (arrow / function / class
+/// expressions) are NOT entered -- their bodies run later, after every
+/// static field has initialized.
+fn sb_walk_expr(
+  expr : @ast.TsExpr,
+  cname : String,
+  later : Map[String, Bool],
+  hits : Array[String],
+) -> Unit {
+  let check_recv = fn(recv : @ast.TsExpr, f : String) -> Unit {
+    match recv {
+      Var(n) =>
+        if (n == "this" || n == cname) && later.get(f) is Some(_) {
+          hits.push(f)
+        }
+      _ => ()
+    }
+  }
+  match expr {
+    PropAccess(recv, f) => {
+      check_recv(recv, f)
+      sb_walk_expr(recv, cname, later, hits)
+    }
+    PropAssignExpr(recv, f, v) => {
+      check_recv(recv, f)
+      sb_walk_expr(recv, cname, later, hits)
+      sb_walk_expr(v, cname, later, hits)
+    }
+    MethodCall(recv, m, args) => {
+      check_recv(recv, m)
+      sb_walk_expr(recv, cname, later, hits)
+      for a in args {
+        sb_walk_expr(a, cname, later, hits)
+      }
+    }
+    BinOp(_, a, b) | Seq(a, b) | IndexAccess(a, b) | ComputedProp(a, b) => {
+      sb_walk_expr(a, cname, later, hits)
+      sb_walk_expr(b, cname, later, hits)
+    }
+    IndexAssignExpr(a, b, c) | Cond(a, b, c) => {
+      sb_walk_expr(a, cname, later, hits)
+      sb_walk_expr(b, cname, later, hits)
+      sb_walk_expr(c, cname, later, hits)
+    }
+    UnaryOp(_, x)
+    | Spread(x)
+    | Await(x)
+    | YieldStar(x)
+    | PureCall(x)
+    | TypeArgs(_, x)
+    | AssignExpr(_, x)
+    | AssignPattern(_, x) => sb_walk_expr(x, cname, later, hits)
+    CompoundAssignExpr(a, _, b) => {
+      sb_walk_expr(a, cname, later, hits)
+      sb_walk_expr(b, cname, later, hits)
+    }
+    Yield(opt) =>
+      match opt {
+        Some(x) => sb_walk_expr(x, cname, later, hits)
+        None => ()
+      }
+    Call(_, args) | New(_, args) =>
+      for a in args {
+        sb_walk_expr(a, cname, later, hits)
+      }
+    CallExpr(callee, args) | NewExpr(callee, args) => {
+      sb_walk_expr(callee, cname, later, hits)
+      for a in args {
+        sb_walk_expr(a, cname, later, hits)
+      }
+    }
+    ArrayLit(items) =>
+      for it in items {
+        sb_walk_expr(it, cname, later, hits)
+      }
+    ObjectLit(entries) =>
+      for ent in entries {
+        sb_walk_expr(ent.1, cname, later, hits)
+      }
+    TaggedTemplate(tag, _, _, exprs) => {
+      sb_walk_expr(tag, cname, later, hits)
+      for e in exprs {
+        sb_walk_expr(e, cname, later, hits)
+      }
+    }
+    TemplateLiteral(_, exprs) =>
+      for e in exprs {
+        sb_walk_expr(e, cname, later, hits)
+      }
+    DynamicImport(a, b) => {
+      sb_walk_expr(a, cname, later, hits)
+      match b {
+        Some(x) => sb_walk_expr(x, cname, later, hits)
+        None => ()
+      }
+    }
+    _ => ()
+  }
+}
+
+///|
+fn sb_walk_block(
+  block : @ast.TsBlock,
+  cname : String,
+  later : Map[String, Bool],
+  hits : Array[String],
+) -> Unit {
+  for s in block.stmts {
+    sb_walk_stmt(s, cname, later, hits)
+  }
+}
+
+///|
+fn sb_walk_stmt(
+  stmt : @ast.TsStmt,
+  cname : String,
+  later : Map[String, Bool],
+  hits : Array[String],
+) -> Unit {
+  match stmt {
+    Var(_, _, e)
+    | Let(_, _, e)
+    | Const(_, _, e)
+    | Assign(_, e)
+    | CompoundAssign(_, _, e)
+    | Expr(e)
+    | Throw(e)
+    | Return(Some(e)) => sb_walk_expr(e, cname, later, hits)
+    PropAssign(recv, prop, value) => {
+      match recv {
+        Var(n) =>
+          if (n == "this" || n == cname) && later.get(prop) is Some(_) {
+            hits.push(prop)
+          }
+        _ => ()
+      }
+      sb_walk_expr(recv, cname, later, hits)
+      sb_walk_expr(value, cname, later, hits)
+    }
+    IndexAssign(a, b, c) => {
+      sb_walk_expr(a, cname, later, hits)
+      sb_walk_expr(b, cname, later, hits)
+      sb_walk_expr(c, cname, later, hits)
+    }
+    Try(b, _, cb, fb) => {
+      sb_walk_block(b, cname, later, hits)
+      match cb {
+        Some(x) => sb_walk_block(x, cname, later, hits)
+        None => ()
+      }
+      match fb {
+        Some(x) => sb_walk_block(x, cname, later, hits)
+        None => ()
+      }
+    }
+    If(c, t, e) => {
+      sb_walk_expr(c, cname, later, hits)
+      sb_walk_block(t, cname, later, hits)
+      match e {
+        Some(x) => sb_walk_block(x, cname, later, hits)
+        None => ()
+      }
+    }
+    While(c, b) | DoWhile(c, b) | With(c, b) => {
+      sb_walk_expr(c, cname, later, hits)
+      sb_walk_block(b, cname, later, hits)
+    }
+    For(init, cond, upd, body) => {
+      match init {
+        Some(s) => sb_walk_stmt(s, cname, later, hits)
+        None => ()
+      }
+      match cond {
+        Some(e) => sb_walk_expr(e, cname, later, hits)
+        None => ()
+      }
+      match upd {
+        Some(s) => sb_walk_stmt(s, cname, later, hits)
+        None => ()
+      }
+      sb_walk_block(body, cname, later, hits)
+    }
+    ForOf(_, _, _, e, b) | ForAwaitOf(_, _, _, e, b) | ForIn(_, _, _, e, b) => {
+      sb_walk_expr(e, cname, later, hits)
+      sb_walk_block(b, cname, later, hits)
+    }
+    Switch(e, cases) => {
+      sb_walk_expr(e, cname, later, hits)
+      for case in cases {
+        match case.test_expr {
+          Some(t) => sb_walk_expr(t, cname, later, hits)
+          None => ()
+        }
+        sb_walk_block(case.body, cname, later, hits)
+      }
+    }
+    Label(_, s) => sb_walk_stmt(s, cname, later, hits)
+    Block(b) => sb_walk_block(b, cname, later, hits)
+    _ => ()
+  }
+}
+
+///|
+/// TS2729 for `static { … }` blocks: a read or write of `this.<f>` /
+/// `<ClassName>.<f>` inside a static block, where the static *field* `f`
+/// is first declared after that block, runs before the field initializes.
+/// Static methods and accessors are installed before blocks execute, so
+/// only data fields participate. A block whose top level rebinds the class
+/// name is skipped, and nested function bodies are never entered.
+fn static_block_use_before_def(
+  class_name : String,
+  elements : Array[ClassElement],
+) -> Array[String] {
+  let hits : Array[String] = []
+  if class_name == "" || class_name.has_prefix("<") {
+    return hits
+  }
+  // First declaration index of every public static field.
+  let first_decl : Map[String, Int] = {}
+  for i, element in elements {
+    match element {
+      Field(true, Name(n), _, _, _, _) =>
+        if is_public_runtime_class_member_name(n) && !first_decl.contains(n) {
+          first_decl[n] = i
+        }
+      _ => ()
+    }
+  }
+  if first_decl.length() == 0 {
+    return hits
+  }
+  for i, element in elements {
+    match element {
+      StaticBlock(block) => {
+        let later : Map[String, Bool] = {}
+        for n, di in first_decl {
+          if di > i {
+            later[n] = true
+          }
+        }
+        if later.length() == 0 {
+          continue
+        }
+        let mut rebinds = false
+        for s in block.stmts {
+          match s {
+            @ast.TsStmt::Var(b, _, _)
+            | @ast.TsStmt::Let(b, _, _)
+            | @ast.TsStmt::Const(b, _, _) =>
+              if sb_binding_binds(b, class_name) {
+                rebinds = true
+              }
+            _ => ()
+          }
+        }
+        if rebinds {
+          continue
+        }
+        sb_walk_block(block, class_name, later, hits)
+      }
+      _ => ()
+    }
+  }
+  hits
+}
+
+///|
 fn build_runtime_class_decl(
   name : String,
   type_params : Array[String],
@@ -391,6 +691,12 @@ fn build_runtime_class_decl(
       dup_seen[name] = ()
       duplicate_member_names.push(name)
     }
+  }
+  // TS2729: `this.<f>` / `<Name>.<f>` inside a static block before the
+  // static field `f` is declared. Routed through the per-class channel as
+  // a marker; the checker turns it into the diagnostic.
+  for f in static_block_use_before_def(name, elements) {
+    duplicate_member_names.push("<static-use-before-def:" + f + ">")
   }
   {
     name,

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -1445,6 +1445,21 @@ fn Parser::parse_class_body(
       if is_abstract_member {
         abstract_members.push(method_name)
       }
+      // TS4112/4113/4114 support: which members carried an `override`
+      // modifier (checked against the base chain, and -- under
+      // noImplicitOverride -- required on genuine overrides). Marker
+      // format matches other per-class sentinels; instance and static
+      // sides are distinguished.
+      if saw_override_modifier {
+        self.override_member_names.push(
+          (if is_static { "s:" } else { "i:" }) + method_name,
+        )
+      }
+      if has_declare {
+        self.override_member_names.push(
+          "<decl>" + (if is_static { "s:" } else { "i:" }) + method_name,
+        )
+      }
     }
     let is_optional = self.match_(Question)
     let has_definite_assertion = self.match_(Bang)
@@ -1806,6 +1821,7 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
   let prev_brand = self.current_class_brand
   self.current_class_brand = Some(brand)
   let quoted_names_start = self.quoted_member_names.length()
+  let override_names_start = self.override_member_names.length()
   let (
     ctor_opt,
     elements,
@@ -1844,6 +1860,19 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
   }
   for qn in quoted_names {
     expr_class_sentinels.push("<quoted-member:" + qn + ">")
+  }
+  while self.override_member_names.length() > override_names_start {
+    match self.override_member_names.pop() {
+      Some(n) =>
+        if n.has_prefix("<decl>") {
+          expr_class_sentinels.push(
+            "<declare-member:" + n["<decl>".length():].to_string() + ">",
+          )
+        } else {
+          expr_class_sentinels.push("<override-member:" + n + ">")
+        }
+      None => ()
+    }
   }
   if ctor_impl_count >= 2 {
     expr_class_sentinels.push("<multiple-ctor-impl>")
@@ -2578,6 +2607,7 @@ fn Parser::parse_class_decl_with_abstract(
   let prev_brand = self.current_class_brand
   self.current_class_brand = Some(brand)
   let quoted_names_start = self.quoted_member_names.length()
+  let override_names_start = self.override_member_names.length()
   let (
     ctor_opt,
     elements,
@@ -2610,6 +2640,21 @@ fn Parser::parse_class_decl_with_abstract(
     match self.quoted_member_names.pop() {
       Some(n) =>
         runtime_decl.duplicate_member_names.push("<quoted-member:" + n + ">")
+      None => ()
+    }
+  }
+  while self.override_member_names.length() > override_names_start {
+    match self.override_member_names.pop() {
+      Some(n) =>
+        if n.has_prefix("<decl>") {
+          runtime_decl.duplicate_member_names.push(
+            "<declare-member:" + n["<decl>".length():].to_string() + ">",
+          )
+        } else {
+          runtime_decl.duplicate_member_names.push(
+            "<override-member:" + n + ">",
+          )
+        }
       None => ()
     }
   }

--- a/src/parser/parser_core.mbt
+++ b/src/parser/parser_core.mbt
@@ -168,6 +168,10 @@ pub struct Parser {
   // strict-property-initialization must exempt literal-named fields --
   // drained per class into `<quoted-member:...>` sentinels.
   quoted_member_names : Array[String]
+  // Member names that carried an `override` modifier while parsing class
+  // bodies ("i:"/"s:" prefixed for instance/static). Drained per class
+  // into `<override-member:...>` sentinels for TS4112/4113/4114.
+  override_member_names : Array[String]
   // Token-position → "JSDoc `/* @__PURE__ */` annotation seen
   // just before this token". The lexer populates this when it
   // skips a block comment whose contents contain the literal
@@ -262,6 +266,7 @@ pub fn Parser::new_with_strict_and_jsx(
     interface_member_modifier_misuses: [],
     collected_class_dups: [],
     quoted_member_names: [],
+    override_member_names: [],
     pure_marker_positions: {},
     internal_marker_positions: {},
     collected_internal_names: {},
@@ -293,6 +298,11 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
   }
   if lexer.unterminated_template {
     grammar_misuses.push("unterminated template literal")
+  }
+  // Module-scoped flag marker for the override checks (TS4114 fires only
+  // under `@noImplicitOverride: true`); TS4112/TS4113 are unconditional.
+  if detect_no_implicit_override(src) {
+    grammar_misuses.push("<noimplicitoverride-on>")
   }
   {
     tokens,
@@ -339,6 +349,7 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
     interface_member_modifier_misuses: [],
     collected_class_dups: [],
     quoted_member_names: [],
+    override_member_names: [],
     pure_marker_positions: lexer.pure_marker_positions,
     internal_marker_positions: lexer.internal_marker_positions,
     collected_internal_names: {},
@@ -688,6 +699,17 @@ fn detect_no_implicit_any(src : String) -> Bool {
     return false
   }
   true
+}
+
+///|
+/// True when the conformance header enables `@noImplicitOverride`.
+/// Default OFF (unlike noImplicitAny): tsc only checks missing `override`
+/// modifiers under the explicit flag.
+fn detect_no_implicit_override(src : String) -> Bool {
+  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
+  let head = src[:head_len].to_owned()
+  head.contains("@noImplicitOverride: true") ||
+  head.contains("@noImplicitOverride:true")
 }
 
 ///|

--- a/src/parser/parser_core.mbt
+++ b/src/parser/parser_core.mbt
@@ -304,6 +304,11 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
   if detect_no_implicit_override(src) {
     grammar_misuses.push("<noimplicitoverride-on>")
   }
+  // Marker for the TS2695 comma-operator check, which tsc disables under
+  // `@allowUnreachableCode: true`.
+  if detect_allow_unreachable_code(src) {
+    grammar_misuses.push("<allowunreachable-on>")
+  }
   {
     tokens,
     pos: 0,
@@ -710,6 +715,16 @@ fn detect_no_implicit_override(src : String) -> Bool {
   let head = src[:head_len].to_owned()
   head.contains("@noImplicitOverride: true") ||
   head.contains("@noImplicitOverride:true")
+}
+
+///|
+/// True when the conformance header enables `@allowUnreachableCode`.
+/// tsc gates the TS2695 comma-operator check on this flag being off.
+fn detect_allow_unreachable_code(src : String) -> Bool {
+  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
+  let head = src[:head_len].to_owned()
+  head.contains("@allowUnreachableCode: true") ||
+  head.contains("@allowUnreachableCode:true")
 }
 
 ///|

--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -2564,6 +2564,7 @@ fn Parser::parse_declare_class(
   let index_signatures : Array[(@ast.TsType, @ast.TsType)] = []
   let static_index_signatures : Array[(@ast.TsType, @ast.TsType)] = []
   let static_blocks : Array[@ast.TsBlock] = []
+  let declare_override_names : Array[String] = []
   let mut constructor_params : Array[(String, @ast.TsType)]? = None
   let mut saw_public_constructor = false
   let mut saw_nonpublic_constructor = false
@@ -2590,6 +2591,7 @@ fn Parser::parse_declare_class(
     let mut visibility = "public"
     let mut is_accessor = false
     let mut is_abstract_member = false
+    let mut saw_override = false
     let mut has_modifier = true
     while has_modifier {
       has_modifier = false
@@ -2633,6 +2635,9 @@ fn Parser::parse_declare_class(
           }
           if mod == "abstract" {
             is_abstract_member = true
+          }
+          if mod == "override" {
+            saw_override = true
           }
           has_modifier = true
         }
@@ -2682,6 +2687,9 @@ fn Parser::parse_declare_class(
         }
         if is_abstract_member {
           abstract_members.push(n)
+        }
+        if saw_override {
+          declare_override_names.push((if is_static { "s:" } else { "i:" }) + n)
         }
       }
       None => ()
@@ -2841,6 +2849,12 @@ fn Parser::parse_declare_class(
     private_members,
     protected_members,
     abstract_members,
-    duplicate_member_names: [],
+    duplicate_member_names: {
+      let d : Array[String] = []
+      for n in declare_override_names {
+        d.push("<override-member:" + n + ">")
+      }
+      d
+    },
   }
 }

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -224,9 +224,96 @@ fn Parser::skip_enum_member_initializer_tail(self : Parser) -> Unit {
 }
 
 ///|
+
+///|
+/// True when the expression is syntactically string-valued: a string
+/// literal, a template literal, or a `+` chain containing one.
+fn enum_init_stringish(e : @ast.TsExpr) -> Bool {
+  match e {
+    StringLit(_) | TemplateLiteral(_, _) => true
+    BinOp(Add, l, r) => enum_init_stringish(l) || enum_init_stringish(r)
+    _ => false
+  }
+}
+
+///|
+/// TS2362 / TS2363 inside a computed enum-member initializer: a non-`+`
+/// arithmetic operation with a syntactically string-valued operand
+/// (`d = "a" - "a"`, `` b = `1` - `1` ``). The enum AST only keeps folded
+/// literal values, so the check runs here on the speculatively parsed
+/// initializer expression.
+fn Parser::record_enum_string_arith(self : Parser, e : @ast.TsExpr) -> Unit {
+  match e {
+    BinOp(op, l, r) => {
+      match op {
+        Sub
+        | Mul
+        | Div
+        | Mod
+        | Pow
+        | Shl
+        | Shr
+        | UShr
+        | BitAnd
+        | BitOr
+        | BitXor => {
+          if enum_init_stringish(l) {
+            self.grammar_misuses.push(
+              "the left-hand side of an arithmetic operation must be of type `any`, `number`, `bigint` or an enum type",
+            )
+          }
+          if enum_init_stringish(r) {
+            self.grammar_misuses.push(
+              "the right-hand side of an arithmetic operation must be of type `any`, `number`, `bigint` or an enum type",
+            )
+          }
+        }
+        _ => ()
+      }
+      self.record_enum_string_arith(l)
+      self.record_enum_string_arith(r)
+    }
+    UnaryOp(_, x) => self.record_enum_string_arith(x)
+    _ => ()
+  }
+}
+
+///|
+/// Speculatively parse the (non-literal) enum member initializer that is
+/// about to be skipped, and record string-arithmetic misuses found in it.
+/// Every parser side channel that expression parsing can grow is truncated
+/// back before our own recordings, and the token position is restored, so
+/// this is observation-only.
+fn Parser::scan_skipped_enum_initializer(
+  self : Parser,
+  start_pos : Int,
+) -> Unit {
+  self.pos = start_pos
+  let gm_len = self.grammar_misuses.length()
+  let sm_len = self.strict_mode_misuses.length()
+  let parsed : @ast.TsExpr? = try self.parse_ternary() catch {
+    _ => None
+  } noraise {
+    e => Some(e)
+  }
+  while self.grammar_misuses.length() > gm_len {
+    let _ = self.grammar_misuses.pop()
+  }
+  while self.strict_mode_misuses.length() > sm_len {
+    let _ = self.strict_mode_misuses.pop()
+  }
+  self.pos = start_pos
+  match parsed {
+    Some(e) => self.record_enum_string_arith(e)
+    None => ()
+  }
+}
+
+///|
 fn Parser::parse_enum_member_initializer(
   self : Parser,
 ) -> (@ast.TsEnumMemberValue?, Bool) {
+  let start_pos = self.pos
   let sign = if self.match_(Minus) {
     "-"
   } else if self.match_(Plus) {
@@ -256,6 +343,7 @@ fn Parser::parse_enum_member_initializer(
       Some(@ast.TsEnumMemberValue::Bool(value))
     }
     _ => {
+      self.scan_skipped_enum_initializer(start_pos)
       self.skip_enum_member_initializer_tail()
       return (None, true)
     }
@@ -263,6 +351,7 @@ fn Parser::parse_enum_member_initializer(
   if self.is_enum_member_initializer_delim() {
     (value, false)
   } else {
+    self.scan_skipped_enum_initializer(start_pos)
     self.skip_enum_member_initializer_tail()
     (None, true)
   }

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -759,6 +759,14 @@ fn Parser::parse_import_equals_decl(
   self : Parser,
   local_name : String,
 ) -> @ast.TsImportDecl raise ParseError {
+  // TS1262: `import await = …` binds the name `await`; an error only when
+  // the file is otherwise a module (topLevelAwaitErrors.12). An
+  // import-equals alias does NOT itself make the file a module — a bare
+  // `import await = foo.await` in a script is legal (topLevelAwait.2), so
+  // no `<module-syntax>` marker here.
+  if local_name == "await" && !self.in_function {
+    self.grammar_misuses.push("<top-await-name>")
+  }
   let _ = self.expect(Eq)
   let module_spec = if self.match_ident("require") {
     let _ = self.expect(LParen)
@@ -3027,6 +3035,9 @@ fn Parser::parse_export_stmt(
     return
   }
   if self.match_(LBrace) {
+    // Marker, not an error: even an empty `export {}` makes the file a
+    // module. Consumed by the TS1262 top-level `await`-name check.
+    self.grammar_misuses.push("<module-syntax>")
     self.parse_import_specifiers()
     let _ = self.expect(RBrace)
     if self.match_(From) || self.match_ident("from") {

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -2844,10 +2844,16 @@ fn Parser::parse_export_stmt(
     return
   }
   if self.match_(Default) || self.match_ident("default") {
+    // TS2528: a module cannot have multiple default exports. Each default
+    // is recorded with a kind+name marker; the checker groups
+    // function-declaration overload sets (bodiless signatures + one
+    // implementation of the SAME name are a single default) and reports
+    // when more than one distinct default remains.
     if self.match_ident("async") && self.check(Function) {
       self.in_async = true
       let func = self.parse_function_expr()
       self.in_async = false
+      self.grammar_misuses.push("<export-default>fn:" + func.name)
       if func.name != "<anon>" {
         funcs.push(func)
       }
@@ -2855,6 +2861,7 @@ fn Parser::parse_export_stmt(
     }
     if self.check(Function) {
       let func = self.parse_function_expr()
+      self.grammar_misuses.push("<export-default>fn:" + func.name)
       if func.name != "<anon>" {
         funcs.push(func)
       }
@@ -2882,9 +2889,11 @@ fn Parser::parse_export_stmt(
           }
         }
       }
+      self.grammar_misuses.push("<export-default>class:")
       return
     }
     let _ = self.parse_expr()
+    self.grammar_misuses.push("<export-default>expr:")
     self.consume_semicolon()
     return
   }

--- a/src/parser/parser_stmt.mbt
+++ b/src/parser/parser_stmt.mbt
@@ -285,6 +285,20 @@ fn Parser::parse_var_like(
   }
   let type_ = self.parse_var_decl_type()
   let stmts = self.parse_var_decl_list_from(binding, type_, kind)
+  // TS1262: `await` used as a top-level declaration name. Only an error
+  // when the file is a module; the checker pairs this marker with the
+  // module-syntax evidence (`<module-syntax>` / export markers / imports).
+  if !self.in_function {
+    for stmt in stmts {
+      match stmt {
+        Var(b, _, _) | Let(b, _, _) | Const(b, _, _) =>
+          if binding_contains_await_name(b) {
+            self.grammar_misuses.push("<top-await-name>")
+          }
+        _ => ()
+      }
+    }
+  }
   // TS7006 (noImplicitAny): an unannotated binding initialized by a
   // callable literal gives the callable's unannotated parameters no
   // contextual type -- they are implicitly `any` (`var x = x => x`).
@@ -304,6 +318,40 @@ fn Parser::parse_var_like(
   // arrow-function or function-expression, apply JSDoc param/return overlays
   // using the var/let/const keyword position (where the JSDoc block sits).
   apply_jsdoc_var_func_overlay(self.jsdoc_at_pos, merged, kw_pos)
+}
+
+///|
+/// True when a binding pattern declares an identifier named `await`
+/// anywhere in its structure (`var await`, `var {await} = …`,
+/// `var [await] = …`). Used by the TS1262 top-level-await-name marker.
+fn binding_contains_await_name(binding : @ast.TsBinding) -> Bool {
+  match binding {
+    Ident(name) => name == "await"
+    Array(ab) => {
+      for item in ab.items {
+        match item {
+          Some(elem) =>
+            if binding_contains_await_name(elem.binding) {
+              return true
+            }
+          None => ()
+        }
+      }
+      match ab.rest {
+        Some(rest) => binding_contains_await_name(rest)
+        None => false
+      }
+    }
+    Object(ob) => {
+      for prop in ob.props {
+        if binding_contains_await_name(prop.binding) {
+          return true
+        }
+      }
+      ob.rest is Some("await")
+    }
+    Target(_) => false
+  }
 }
 
 ///|

--- a/src/parser/pkg.generated.mbti
+++ b/src/parser/pkg.generated.mbti
@@ -143,6 +143,7 @@ pub struct Parser {
   interface_member_modifier_misuses : Array[String]
   collected_class_dups : Array[(String, Array[String])]
   quoted_member_names : Array[String]
+  override_member_names : Array[String]
   pure_marker_positions : Map[Int, Bool]
   internal_marker_positions : Map[Int, Bool]
   collected_internal_names : Map[String, Bool]


### PR DESCRIPTION
## Summary

Four batches of practical (non-parser-edge) conformance work, continuing from #191. Whole-corpus true positives rise **2081 → 2136** while the CI soundness invariant stays at **0 false positives** (`scripts/checker_conformance_oracle.sh --max-fp 0`).

### Batch AE — practical errors first (TP 2081 → 2095)
- **TS2528**: multiple `export default`s per module (function overload sets group as one default).
- **TS2488**: `for…of` over a base-less class instance lacking the iterator protocol; computed-field iterators and `next` fields satisfy it.
- **TS4112/4113/4114** (`override` family): member `override`/`declare` modifiers now survive parsing via per-class markers; TS4114 fires only under `@noImplicitOverride: true`, with abstract implementations and `declare` members exempt.

### Batch AF — truthiness, comma, top-level await, static blocks (TP 2095 → 2119)
- **TS2872/TS2873**: ternary conditions and `!` operands that are non-exempt literals are always-truthy/falsy (tsc's `0`/`1`/boolean exemptions preserved).
- **TS1345**: `void`-typed conditions (annotated vars, `void`-returning calls) can't be tested for truthiness.
- **TS2695**: statement-level comma with a side-effect-free left side, suppressed under `@allowUnreachableCode: true`; nested commas exempt so the paren-erased `(0, fn)()` idiom never flags.
- **TS1262**: `await` as a top-level declaration name in a module — name evidence and module-syntax evidence recorded separately (`export {}` now counts; a bare `import x = ns.path` does not).
- **TS2729**: static blocks reading/writing static fields declared after the block, computed in the parser while class element order is known.

### Batch AG — spread arity, enum arithmetic, relational operands (TP 2119 → 2134)
- **TS2556**: spread arguments must be tuples or hit a rest parameter — tsc's arity rule for the first non-tuple spread; gated to non-overloaded direct calls.
- **Lexer fix**: a template literal now ends an expression for the regex-vs-division split (`` `a${1}b` / 1 `` previously swallowed the rest of the line as a regex).
- **TS2362/TS2363**: string arithmetic inside computed enum-member initializers via speculative parse of the skipped initializer.
- **TS2365**: pairwise never-comparable relational operands (unconstrained type param vs anything else; object-side shape vs primitive). Identical named types and subtype-related objects stay legal.

### Batch AH — TS2403 identity keys, union-callee arity (TP 2134 → 2136)
- **TS2403 rewrite**: var-redeclaration identity moves to canonical keys covering functions, constructors, tuples, object literals, and unions, with tsc's normalizations (`Array<T>` ≡ `T[]`, `{ (x): R }` ≡ `(x) => R`, literal subsumption, alias unwrap). Enums stay nominal; simple classes/interfaces expand structurally (a class instance type is identical to its spelled-out object literal), while `C | D` with two structurally-equal classes remains a 2-member union.
- **TS2554**: union-typed callees whose members disagree on arity; overload sets (same `Union`-of-`Func` ingestion shape) are exempt.

## Testing

- `moon test --target native` — 2446 tests, all passing (one whitebox test per batch; two stale pins updated to match verified tsc behavior).
- `scripts/checker_conformance_oracle.sh --max-fp 0` — TP 2136 / FP 0 / TN 1406 over 4092 classified conformance cases.
- Every new check was counter-probed with legal-pattern files before the corpus gate; all gate-caught FPs (allowUnreachableCode comma, import-equals module-syntax, identical type parameters, subtype object comparisons, overload arity, namespace-merged interfaces) are fixed and documented in TODO.md (T181–T184).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr)_