### PR TITLE
checker: raise conformance-corpus true positives 2136 → 2155 at 0 false positives

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2295,6 +2295,34 @@ conformance sources (`.errors.txt` baseline = ground truth):
     the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
     698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
 
+2026-07-07 (T186)  714/815 (88 %)        414/414 ( 0 FP)   Practical round 6: destructuring literal misses + globalThis: TP 2140 -> 2144
+
+  T186 -- practical (non-edge) misses, round 6 (TS2339 subclusters).
+    - Destructuring from a syntactic object literal: a non-defaulted
+      pattern property the literal provably lacks (`var { x, y } = {}`,
+      `({ x } = {})`). The assignment form checks in the `AssignPattern`
+      arm; the declaration form is recorded by the PARSER, because
+      `var { a2 }: any = {}` is legal — the annotation retypes the
+      source — but annotation and absence both reach the checker as
+      `Any` (the ES5/ES6 destructuring fixtures caught that as gate
+      FPs). Spread / computed / synthetic source entries abstain;
+      defaults are legal. missingAndExcessProperties.
+    - `globalThis.<name>` where `<name>` is a top-level `let` / `const`
+      of this file: block-scoped declarations never become `globalThis`
+      properties. Standalone syntactic pass, dotted value form only.
+      globalThisBlockscopedProperties.
+    - TS2339 on a `Window & typeof globalThis` receiver (`win.hi`):
+      property must be a declared module value (env / globals / classes
+      / enums) or a known lib global; fires regardless of noImplicitAny,
+      unlike the element-access form. globalThisUnknown,
+      globalThisUnknownNoImplicitAny.
+    - Investigated and dropped: computedPropertyNames TS2411 (computed
+      getter return types are `Any` at parse time — the accessor body
+      isn't retained on the class decl), symbol-keyed TS2411
+      (symbolProperty17: both sides erase to `<computed>`).
+    Whole-corpus TP 2140 -> 2144 @ 0 FP (session total 1761 -> +383);
+    pinned recall 714, precision 414/414. 2448 tests.
+
 2026-07-07 (T185)  714/815 (88 %)        414/414 ( 0 FP)   Practical round 5: TS2352 cast overlap: TP 2136 -> 2140
 
   T185 -- practical (non-edge) misses, round 5. (PR #192 merged the

--- a/TODO.md
+++ b/TODO.md
@@ -2295,6 +2295,42 @@ conformance sources (`.errors.txt` baseline = ground truth):
     the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
     698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
 
+2026-07-07 (T187)  714/815 (88 %)        414/414 ( 0 FP)   Practical round 7: TDZ, spread overwrite, enum readonly, await type: TP 2144 -> 2155
+
+  T187 -- practical (non-edge) misses, round 7. Cluster selection came
+    from three parallel corpus-analysis passes over the remaining TS2322
+    (53), TS2345 (25), and small-code misses; their reports also
+    identified the follow-up queue (object-literal-vs-index-signature
+    values, literal-param contravariance, Symbol wrapper vs primitive,
+    call-vs-construct signatures, TS2741 missing property) and marked
+    ~34 TS2322 / ~22 TS2345 files as needing unmodelable machinery
+    (generic inference chains, lib member signatures, flow narrowing).
+    - TS2448: a top-level class's static block reading / writing a
+      block-scoped variable declared LATER at top level (TDZ at class
+      definition time). Statement order between classes and consts is
+      erased by module lowering, so the parser records `<sb-read:X>`
+      (immediate reads / writes of each top-level static block,
+      function bodies skipped) and `<letconst-decl:X>` markers whose
+      relative order in the append-only `grammar_misuses` channel IS
+      parse order; the checker pairs them. classStaticBlock16,
+      classStaticBlockUseBeforeDef3.
+    - TS2783: an explicitly-written object-literal property that a later
+      spread always overwrites (`{ b: 1, ...ab }` with `b` required in
+      `ab`'s type). Reuses `cast_shape_fields`; optional members,
+      unions, generics, spread-vs-spread abstain.
+      spreadDuplicate(Exact), spreadOverwritesProperty(Strict).
+    - TS2540: enum members are read-only — `E.B++` / `--E["B"]` with an
+      unshadowed enum receiver. incrementOperatorWithEnumType.
+    - TS2552: `await` as a type reference inside an async context can
+      never resolve (tsc suggests `Awaited`). Recorded in the type
+      parser under `in_async` — which exposed a parser bug: function
+      declarations reset `in_async = false` before parsing their body
+      (`async function` bodies parsed as non-async); both
+      `parse_function` sites now propagate `is_async`.
+      asyncArrowFunction10_*, asyncFunctionDeclaration13_*.
+    Whole-corpus TP 2144 -> 2155 @ 0 FP (session total 1761 -> +394);
+    pinned recall 714, precision 414/414. 2449 tests.
+
 2026-07-07 (T186)  714/815 (88 %)        414/414 ( 0 FP)   Practical round 6: destructuring literal misses + globalThis: TP 2140 -> 2144
 
   T186 -- practical (non-edge) misses, round 6 (TS2339 subclusters).

--- a/TODO.md
+++ b/TODO.md
@@ -2295,6 +2295,38 @@ conformance sources (`.errors.txt` baseline = ground truth):
     the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
     698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
 
+2026-07-07 (T185)  714/815 (88 %)        414/414 ( 0 FP)   Practical round 5: TS2352 cast overlap: TP 2136 -> 2140
+
+  T185 -- practical (non-edge) misses, round 5. (PR #192 merged the
+    T181-T184 batches to main as 1602d28; branch restarted from it.)
+    - TS2352 revival: the As-arm's "cannot be asserted" diagnostic was
+      blanket-suppressed in permissive mode. Carved out the reliable
+      subset as unfiltered emissions: (a) cross-family primitive casts
+      (`a as string` where `a: number`) -- requires a *keyword*
+      primitive asserted type (string/number/boolean/bigint), because
+      the ASI `var x = 10\n as `Hello world`` mis-parse reaches the arm
+      as a cast to a string-literal type (asOperatorASI was the gate
+      FP); (b) nullish sources under strictNullChecks against primitive
+      targets (`undefined as number`, `null as string`) -- non-strict
+      assignability would let them flow, so this is an explicit strict
+      branch. Also added `Int` to the concrete-operand set.
+    - TS2352 between object shapes: both directions missing a required
+      property (full extends-chain field maps via `cast_shape_fields`;
+      intersections merge; generics / index signatures / computed
+      members abstain) -- `<I3>z` where `z: I2`
+      (typeAssertionsWithIntersectionTypes01).
+    - Parser: a non-interpolating template literal in TYPE position is
+      now the string *literal* type of its text (tsc semantics), not
+      `String_` -- needed so the ASI mis-parse lands on the filtered
+      path, and more correct generally.
+    - TS2420 missing-member extension was investigated and dropped:
+      symbol-keyed members erase to `<computed>` on both the interface
+      and class sides, so the missing-member verdict isn't decidable
+      for the remaining fixtures.
+    asOperator1/2, asOperatorNames, typeAssertionsWithIntersectionTypes01.
+    Whole-corpus TP 2136 -> 2140 @ 0 FP (session total 1761 -> +379);
+    pinned recall 714, precision 414/414. 2447 tests.
+
 2026-07-07 (T184)  714/815 (88 %)        414/414 ( 0 FP)   Practical round 4: TS2403 identity keys + union-callee arity: TP 2134 -> 2136
 
   T184 -- practical (non-edge) misses, round 4.

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -15273,6 +15273,7 @@ fn check_call_args_in_expr(
       let concrete = fn(t : @ast.TsType) -> Bool {
         match t {
           Number
+          | Int
           | String_
           | Boolean
           | BigInt
@@ -15287,15 +15288,56 @@ fn check_call_args_in_expr(
           _ => false
         }
       }
-      if concrete(inferred) &&
+      // TS2352 between disjoint primitive families (`a as string` where
+      // `a: number`) is reliable: emit unfiltered. Under strictNullChecks
+      // a nullish source never overlaps a concrete primitive target
+      // (`undefined as number`, `null as string`) even though non-strict
+      // assignability would let it flow.
+      // Reliability requires a *keyword* primitive asserted type: an ASI
+      // call of a function named `as` with a tagged template (`var x = 10\n
+      // as `Hello world`;`, asOperatorASI) reaches here as a cast to a
+      // string-literal type, so literal / template asserted types stay on
+      // the filtered path.
+      let asserted_reliable = match asserted {
+        String_ | Number | Int | Boolean | BigInt => true
+        _ => false
+      }
+      let strict_nullish_cast = ctx.strict_null_checks &&
+        asserted_reliable &&
+        inferred is (Null | Undefined) &&
+        equality_primitive_family(asserted) is Some(_)
+      if strict_nullish_cast {
+        record_unfiltered(
+          ctx,
+          "as",
+          "conversion of type '\{type_display(inferred)}' to type '\{type_display(asserted)}' may be a mistake because neither type sufficiently overlaps with the other",
+        )
+      } else if concrete(inferred) &&
         concrete(asserted) &&
         !is_assignable_to(inferred, asserted) &&
         !is_assignable_to(asserted, inferred) {
-        record(
-          ctx,
-          "as",
-          "Type '\{type_display(inferred)}' cannot be asserted to type '\{type_display(asserted)}' (no overlap)",
-        )
+        let families_differ = match
+          (
+            equality_primitive_family(inferred),
+            equality_primitive_family(asserted),
+          ) {
+          (Some(a), Some(b)) => a != b
+          _ => false
+        }
+        let cross_family = asserted_reliable && families_differ
+        if cross_family {
+          record_unfiltered(
+            ctx,
+            "as",
+            "conversion of type '\{type_display(inferred)}' to type '\{type_display(asserted)}' may be a mistake because neither type sufficiently overlaps with the other",
+          )
+        } else {
+          record(
+            ctx,
+            "as",
+            "Type '\{type_display(inferred)}' cannot be asserted to type '\{type_display(asserted)}' (no overlap)",
+          )
+        }
       } else {
         // TS2352: a bare primitive and a concrete object type (a user
         // interface / class / object literal) never overlap, so asserting one
@@ -15333,6 +15375,41 @@ fn check_call_args_in_expr(
             "as",
             "conversion of type '\{type_display(inferred_u)}' to type '\{type_display(asserted_u)}' may be a mistake because neither type sufficiently overlaps with the other",
           )
+        } else {
+          // TS2352 between object shapes (interfaces, intersections of
+          // interfaces, literal shapes): the conversion is a definite
+          // mistake when EACH side declares a required property the other
+          // side lacks entirely -- then neither direction is comparable
+          // (`<I3>z` where `z: I2`; typeAssertionsWithIntersectionTypes01).
+          // Any unresolvable / generic / indexed / computed shape abstains.
+          match
+            (
+              cast_shape_fields(ctx.resolver, inferred_u, 0),
+              cast_shape_fields(ctx.resolver, asserted_u, 0),
+            ) {
+            (Some(src), Some(tgt)) => {
+              let mut tgt_requires_missing = false
+              for name, required in tgt {
+                if required && !src.contains(name) {
+                  tgt_requires_missing = true
+                }
+              }
+              let mut src_requires_missing = false
+              for name, required in src {
+                if required && !tgt.contains(name) {
+                  src_requires_missing = true
+                }
+              }
+              if tgt_requires_missing && src_requires_missing {
+                record(
+                  ctx,
+                  "as",
+                  "conversion of type '\{type_display(inferred_u)}' to type '\{type_display(asserted_u)}' may be a mistake because neither type sufficiently overlaps with the other",
+                )
+              }
+            }
+            _ => ()
+          }
         }
       }
     }
@@ -23040,6 +23117,93 @@ fn check_abstract_implementation(
     }
   }
   issues
+}
+
+///|
+/// Full field map (`name -> required`) of an object-shaped cast operand for
+/// the TS2352 comparability check, or `None` when the shape can't be
+/// collected faithfully: generic interfaces, index signatures, computed /
+/// synthetic members, generic heritage, unresolvable names. Interfaces walk
+/// their `extends` chain; intersections merge every part.
+fn cast_shape_fields(
+  resolver : Resolver,
+  t : @ast.TsType,
+  depth : Int,
+) -> Map[String, Bool]? {
+  if depth > 8 {
+    return None
+  }
+  match resolver.unwrap(t) {
+    Named(n) => {
+      guard resolver.interfaces.get(n) is Some(iface) else { return None }
+      if iface.type_params.length() > 0 || iface.index_signatures.length() > 0 {
+        return None
+      }
+      let out : Map[String, Bool] = {}
+      for f in iface.fields {
+        if f.0.has_prefix("<") {
+          return None
+        }
+        out[f.0] = !type_has_undefined(f.1)
+      }
+      for i, base in iface.extends_names {
+        if i < iface.extends_args.length() && iface.extends_args[i].length() > 0 {
+          return None
+        }
+        match cast_shape_fields(resolver, Named(base), depth + 1) {
+          Some(bf) =>
+            for k, v in bf {
+              if !out.contains(k) {
+                out[k] = v
+              }
+            }
+          None => return None
+        }
+      }
+      Some(out)
+    }
+    Intersection(parts) => {
+      let out : Map[String, Bool] = {}
+      for p in parts {
+        match cast_shape_fields(resolver, p, depth + 1) {
+          Some(pf) =>
+            for k, v in pf {
+              if !out.contains(k) {
+                out[k] = v
+              }
+            }
+          None => return None
+        }
+      }
+      Some(out)
+    }
+    Object(fields) => {
+      let out : Map[String, Bool] = {}
+      for f in fields {
+        match f.0 {
+          Literal(k) =>
+            if k.has_prefix("<") {
+              return None
+            } else {
+              out[k] = !type_has_undefined(f.1)
+            }
+          _ => return None
+        }
+      }
+      Some(out)
+    }
+    Struct(_, fields) => {
+      let out : Map[String, Bool] = {}
+      for f in fields {
+        if f.0.has_prefix("<") {
+          return None
+        }
+        out[f.0] = !type_has_undefined(f.1)
+      }
+      Some(out)
+    }
+    _ => None
+  }
 }
 
 ///|

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -14584,6 +14584,22 @@ fn check_call_args_in_expr(
         // are not trustworthy here. Unions, generics, `any`, and unresolved
         // names all abstain.
         PreInc | PreDec | PostInc | PostDec => {
+          // TS2540: enum members are read-only, so `E.B++` / `--E["B"]`
+          // (receiver resolving to an enum object, not shadowed locally)
+          // can never be an assignment target.
+          match inner {
+            PropAccess(Var(recv_name), member)
+            | IndexAccess(Var(recv_name), StringLit(member)) =>
+              if env.lookup(recv_name) is None &&
+                ctx.resolver.enums.get(recv_name) is Some(_) {
+                record_unfiltered(
+                  ctx,
+                  "unary op",
+                  "cannot assign to `\{member}` because it is a read-only property",
+                )
+              }
+            _ => ()
+          }
           let inner_ty = ctx.resolver.unwrap(
             infer_expr(env, ctx.resolver, inner),
           )
@@ -14652,10 +14668,47 @@ fn check_call_args_in_expr(
       for it in items {
         check_call_args_in_expr(env, it, ctx)
       }
-    ObjectLit(entries) =>
+    ObjectLit(entries) => {
       for ent in entries {
         check_call_args_in_expr(env, ent.1, ctx)
       }
+      // TS2783: an explicitly-written property that a LATER spread in the
+      // same literal always overwrites (`{ b: 1, ...ab }` where `ab`'s type
+      // declares `b` as required). Optional members, unions, generics, and
+      // unresolvable spread shapes abstain (`cast_shape_fields` returns
+      // `None` for those); spread-vs-spread never errors.
+      for i, ent in entries {
+        if ent.0.has_prefix("@@spread") || ent.0.has_prefix("<") {
+          continue
+        }
+        let mut reported = false
+        for j in (i + 1)..<entries.length() {
+          if reported {
+            break
+          }
+          if entries[j].0.has_prefix("@@spread") {
+            let spread_ty = ctx.resolver.unwrap(
+              infer_expr(env, ctx.resolver, entries[j].1),
+            )
+            match cast_shape_fields(ctx.resolver, spread_ty, 0) {
+              Some(fields) =>
+                match fields.get(ent.0) {
+                  Some(true) => {
+                    record_unfiltered(
+                      ctx,
+                      "object literal `\{ent.0}`",
+                      "`\{ent.0}` is specified more than once, so this usage will be overwritten by the spread",
+                    )
+                    reported = true
+                  }
+                  _ => ()
+                }
+              None => ()
+            }
+          }
+        }
+      }
+    }
     // A computed property key (`{ [e]: 1 }`, `class C { [e]() {} }`) is an
     // ordinary value expression: walk both the key and the value so an
     // undefined name in the key surfaces (TS2304) like any other reference.
@@ -21834,6 +21887,34 @@ fn check_module_function_bodies_layered(
         message: "`await` is a reserved word at the top-level of a module",
       })
     }
+    // TS2448: a top-level class's static block reading / writing a
+    // block-scoped variable declared LATER at top level (TDZ at class
+    // definition time). `grammar_misuses` is append-only in parse order,
+    // so an `<sb-read:X>` seen before X's `<letconst-decl:X>` — with the
+    // declaration present at all — is a definite use-before-declaration.
+    let tdz_declared : Map[String, Bool] = {}
+    let tdz_pending : Map[String, Bool] = {}
+    let tdz_reported : Map[String, Bool] = {}
+    for gm in module_.grammar_misuses {
+      if gm.has_prefix("<letconst-decl:") {
+        let n = gm["<letconst-decl:".length():gm.length() - 1].to_string()
+        tdz_declared[n] = true
+        if tdz_pending.get(n) is Some(_) && tdz_reported.get(n) is None {
+          tdz_reported[n] = true
+          all.push({
+            path: "static block",
+            message: "block-scoped variable `\{n}` used before its declaration",
+          })
+        }
+        continue
+      }
+      if gm.has_prefix("<sb-read:") {
+        let n = gm["<sb-read:".length():gm.length() - 1].to_string()
+        if tdz_declared.get(n) is None {
+          tdz_pending[n] = true
+        }
+      }
+    }
     // TS2304 for a single-bare-identifier computed key in a type position
     // (`var v: { [e]: number }`, `interface I { [e](): T }`, `declare class
     // C { [e]: T }`). The key references the *value* namespace; resolve it
@@ -21885,6 +21966,11 @@ fn check_module_function_bodies_layered(
       // Markers, not errors: module-syntax evidence and a top-level
       // binding named `await`, combined into TS1262 above.
       if gm == "<module-syntax>" || gm == "<top-await-name>" {
+        continue
+      }
+      // Markers, not errors: static-block reads and top-level let/const
+      // declarations, paired into TS2448 above.
+      if gm.has_prefix("<sb-read:") || gm.has_prefix("<letconst-decl:") {
         continue
       }
       // TS2304: `export = name` over a provably undeclared value. Same

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -12924,6 +12924,43 @@ fn check_ident_binding_decl(
 }
 
 ///|
+/// TS2339 for object destructuring from a syntactic object literal: a
+/// pattern property with no default whose key is provably absent from the
+/// literal (`var { x } = {}`, `({ x } = {})`). A defaulted property is
+/// legal (the default fills in), and any spread / computed / synthetic
+/// entry in the source makes the key set unknowable, so the whole pattern
+/// abstains.
+fn check_object_pattern_from_literal(
+  ctx : CheckCtx,
+  ob : @ast.TsObjectBinding,
+  entries : Array[(String, @ast.TsExpr)],
+) -> Unit {
+  let keys : Map[String, Bool] = {}
+  for e in entries {
+    if e.0.has_prefix("@@spread") || e.0.has_prefix("<") {
+      return
+    }
+    match e.1 {
+      ComputedProp(_, _) => return
+      _ => ()
+    }
+    keys[e.0] = true
+  }
+  for prop in ob.props {
+    if prop.default is None &&
+      prop.key_expr is None &&
+      !prop.key.has_prefix("<") &&
+      !keys.contains(prop.key) {
+      record_unfiltered(
+        ctx,
+        "destructuring `\{prop.key}`",
+        "property `\{prop.key}` does not exist on the object-literal source",
+      )
+    }
+  }
+}
+
+///|
 fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
   match stmt {
     Var(@ast.TsBinding::Ident(name), declared, init) =>
@@ -12963,6 +13000,10 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
     | Let(@ast.TsBinding::Object(ob), declared, init)
     | Const(@ast.TsBinding::Object(ob), declared, init) => {
       check_call_args_in_expr(env, init, ctx)
+      // (TS2339 for `var { x } = {}` is recorded by the PARSER, which can
+      // see whether a type annotation was written — `var { x }: any = {}`
+      // retypes the source and is legal, but reaches here with the same
+      // `Any` declared type as the unannotated form.)
       if is_checkable(declared) {
         check_expr_against(env, init, declared, ctx, "destructuring init")
       }
@@ -14640,6 +14681,38 @@ fn check_call_args_in_expr(
       check_member_accessibility(env, ctx, recv, prop)
       check_super_abstract_access(ctx, recv, prop)
       check_namespace_or_enum_member_access(env, ctx, recv, prop)
+      // TS2339 on a `Window & typeof globalThis` receiver (`declare let
+      // win: Window & typeof globalThis; win.hi`): the property must be a
+      // declared module value or a known lib / window global. Errors
+      // regardless of noImplicitAny (globalThisUnknown), unlike the
+      // element-access form.
+      match ctx.resolver.unwrap(infer_expr(env, ctx.resolver, recv)) {
+        Intersection(parts) => {
+          let mut has_globalthis = false
+          let mut only_window_parts = true
+          for p in parts {
+            match p {
+              TypeOf("globalThis") => has_globalthis = true
+              Named("Window") => ()
+              _ => only_window_parts = false
+            }
+          }
+          if has_globalthis &&
+            only_window_parts &&
+            env.lookup(prop) is None &&
+            ctx.resolver.globals.get(prop) is None &&
+            ctx.resolver.classes.get(prop) is None &&
+            ctx.resolver.enums.get(prop) is None &&
+            !is_lib_global_value(prop) {
+            record_unfiltered(
+              ctx,
+              "PropAccess `.\{prop}`",
+              "property `\{prop}` does not exist on `Window & typeof globalThis`",
+            )
+          }
+        }
+        _ => ()
+      }
       // TS2806: reading a private accessor that was defined with a setter but
       // no getter. A write (`this.#x = v`) parses as `PropAssignExpr`, so a
       // `PropAccess` of a set-only private name is always a read.
@@ -15017,6 +15090,17 @@ fn check_call_args_in_expr(
       // `{x, y} = …`) writes every named binding inside. Clear them
       // from the unassigned set so subsequent reads don't trip.
       clear_unassigned_in_binding(ctx, binding)
+      // TS2339: `({ x, y } = {})` — a non-defaulted pattern property the
+      // syntactic object-literal source provably lacks.
+      match binding {
+        @ast.TsBinding::Object(ob2) =>
+          match v {
+            ObjectLit(src_entries) =>
+              check_object_pattern_from_literal(ctx, ob2, src_entries)
+            _ => ()
+          }
+        _ => ()
+      }
       // TS2322: assignment-form array destructuring writes the source's
       // element type into each *existing* target's declared slot
       // (`var a: Bar, b: string; [a, b] = new FooIterator` --
@@ -20754,6 +20838,178 @@ fn normalized_union_members(
 }
 
 ///|
+/// TS2339 for `globalThis.<name>` where `<name>` is a top-level `let` /
+/// `const` in this file: block-scoped declarations never become
+/// `globalThis` properties (globalThisBlockscopedProperties). Only the
+/// dotted value form is judged — element access and type positions report
+/// different codes. Walks top-level statements and their direct
+/// initializer / operand expressions; nested function bodies are covered
+/// too via the recursive statement walk.
+fn check_globalthis_blockscoped(module_ : @ast.TsModule) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  let block_scoped : Map[String, Bool] = {}
+  for stmt in module_.top_level_stmts {
+    match stmt {
+      Let(@ast.TsBinding::Ident(n), _, _)
+      | Const(@ast.TsBinding::Ident(n), _, _) => block_scoped[n] = true
+      _ => ()
+    }
+  }
+  if block_scoped.length() == 0 {
+    return issues
+  }
+  fn walk_expr(e : @ast.TsExpr) -> Unit {
+    match e {
+      PropAccess(Var("globalThis"), p) =>
+        if block_scoped.get(p) is Some(_) {
+          issues.push({
+            path: "globalThis.\{p}",
+            message: "property `\{p}` does not exist on `typeof globalThis`",
+          })
+        }
+      PropAccess(r, _) => walk_expr(r)
+      PropAssignExpr(r, _, v) => {
+        walk_expr(r)
+        walk_expr(v)
+      }
+      BinOp(_, a, b) | Seq(a, b) | IndexAccess(a, b) | ComputedProp(a, b) => {
+        walk_expr(a)
+        walk_expr(b)
+      }
+      Cond(a, b, c) | IndexAssignExpr(a, b, c) => {
+        walk_expr(a)
+        walk_expr(b)
+        walk_expr(c)
+      }
+      UnaryOp(_, x)
+      | Spread(x)
+      | Await(x)
+      | AssignExpr(_, x)
+      | As(x, _)
+      | NonNull(x)
+      | OptionalChain(x) => walk_expr(x)
+      Call(_, args) | New(_, args) =>
+        for a in args {
+          walk_expr(a)
+        }
+      CallExpr(callee, args) | NewExpr(callee, args) => {
+        walk_expr(callee)
+        for a in args {
+          walk_expr(a)
+        }
+      }
+      MethodCall(r, _, args) => {
+        walk_expr(r)
+        for a in args {
+          walk_expr(a)
+        }
+      }
+      ArrayLit(items) =>
+        for it in items {
+          walk_expr(it)
+        }
+      ObjectLit(entries) =>
+        for ent in entries {
+          walk_expr(ent.1)
+        }
+      TemplateLiteral(_, exprs) =>
+        for x in exprs {
+          walk_expr(x)
+        }
+      _ => ()
+    }
+  }
+
+  fn walk_stmt(stmt : @ast.TsStmt) -> Unit {
+    fn walk_block(b : @ast.TsBlock) -> Unit {
+      for s in b.stmts {
+        walk_stmt(s)
+      }
+    }
+
+    match stmt {
+      Var(_, _, e)
+      | Let(_, _, e)
+      | Const(_, _, e)
+      | Assign(_, e)
+      | CompoundAssign(_, _, e)
+      | Expr(e)
+      | Throw(e)
+      | Return(Some(e)) => walk_expr(e)
+      PropAssign(r, _, v) => {
+        walk_expr(r)
+        walk_expr(v)
+      }
+      IndexAssign(a, b, c) => {
+        walk_expr(a)
+        walk_expr(b)
+        walk_expr(c)
+      }
+      If(c, t, e) => {
+        walk_expr(c)
+        walk_block(t)
+        match e {
+          Some(x) => walk_block(x)
+          None => ()
+        }
+      }
+      While(c, b) | DoWhile(c, b) | With(c, b) => {
+        walk_expr(c)
+        walk_block(b)
+      }
+      For(init, cond, upd, body) => {
+        match init {
+          Some(s) => walk_stmt(s)
+          None => ()
+        }
+        match cond {
+          Some(e) => walk_expr(e)
+          None => ()
+        }
+        match upd {
+          Some(s) => walk_stmt(s)
+          None => ()
+        }
+        walk_block(body)
+      }
+      ForOf(_, _, _, e, b) | ForAwaitOf(_, _, _, e, b) | ForIn(_, _, _, e, b) => {
+        walk_expr(e)
+        walk_block(b)
+      }
+      Switch(e, cases) => {
+        walk_expr(e)
+        for case in cases {
+          match case.test_expr {
+            Some(t) => walk_expr(t)
+            None => ()
+          }
+          walk_block(case.body)
+        }
+      }
+      Try(b, _, cb, fb) => {
+        walk_block(b)
+        match cb {
+          Some(x) => walk_block(x)
+          None => ()
+        }
+        match fb {
+          Some(x) => walk_block(x)
+          None => ()
+        }
+      }
+      Label(_, s) => walk_stmt(s)
+      Block(b) => walk_block(b)
+      _ => ()
+    }
+  }
+
+  for stmt in module_.top_level_stmts {
+    walk_stmt(stmt)
+  }
+  issues
+}
+
+///|
 /// TS2403 ("Subsequent variable declarations must have the same type"): two
 /// `var` declarations of the same name must declare the *identical* type.
 /// Identity (not assignability) -- `C` and `C | D` are mutually assignable
@@ -21300,6 +21556,9 @@ fn check_module_function_bodies_layered(
     }
   }
   for issue in check_var_redeclaration_types(module_, resolver) {
+    all.push(issue)
+  }
+  for issue in check_globalthis_blockscoped(module_) {
     all.push(issue)
   }
   for issue in check_misplaced_type_predicates(module_) {

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -12567,3 +12567,54 @@ test "expr_check: destructuring literal misses and globalThis (batch AJ)" {
     0,
   )
 }
+
+///|
+test "expr_check: static-block TDZ, spread overwrite, enum readonly, await type (batch AK)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // TS2448: a static block using a block-scoped variable declared later.
+  assert_true(
+    issues("class Baz { static { console.log(FOO); } }\nconst FOO = \"FOO\";") >
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "const FOO = \"FOO\";\nclass Bar { static { console.log(FOO); } }\nclass C2 { static { const cb = () => LATER; } }\nconst LATER = 3;",
+    ),
+    0,
+  )
+  @test.assert_eq(
+    issues("class D { static { console.log(gv); } }\nvar gv = 1;"),
+    0,
+  )
+  // TS2783: an explicit property overwritten by a later spread.
+  assert_true(
+    issues(
+      "declare var ab: { a: number, b: number };\nvar x = { b: 1, ...ab };",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "declare var ab: { a: number, b: number };\ndeclare var opt: { a: number, b?: number };\nvar ok1 = { ...ab, b: 1 };\nvar ok2 = { b: 1, ...opt };",
+    ),
+    0,
+  )
+  // TS2540: enum members are read-only.
+  assert_true(issues("enum E { A, B }\nE.B++;") > 0)
+  @test.assert_eq(issues("enum E { A, B }\nvar n = E.B;\nn++;"), 0)
+  // TS2552: `await` as a type reference inside an async context.
+  assert_true(
+    issues("var bar = async (): Promise<void> => {\n  var v: await;\n}") > 0,
+  )
+  assert_true(
+    issues("async function foo(): Promise<void> {\n  var v: await;\n}") > 0,
+  )
+  @test.assert_eq(
+    issues(
+      "type awaitAlias = number;\nfunction g() { var v: awaitAlias = 1; return v; }",
+    ),
+    0,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -12530,3 +12530,40 @@ test "expr_check: TS2352 cast overlap (batch AI)" {
     0,
   )
 }
+
+///|
+test "expr_check: destructuring literal misses and globalThis (batch AJ)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // TS2339: non-defaulted pattern properties missing from a syntactic
+  // object-literal source; defaults and annotations stay legal.
+  assert_true(issues("var { x, y } = {};") > 0)
+  assert_true(
+    issues("function f2() { var x: number; ({ x } = {}); return x; }") > 0,
+  )
+  @test.assert_eq(issues("var { x = 1, y = 2 } = {};"), 0)
+  @test.assert_eq(issues("var { a2 }: any = {};"), 0)
+  @test.assert_eq(
+    issues("declare var src: { x: number };\nvar { x } = { ...src };"),
+    0,
+  )
+  @test.assert_eq(issues("var { m } = { m: 1, extra: 2 };"), 0)
+  // TS2339: block-scoped top-level declarations are not globalThis
+  // properties; var declarations and lib globals are.
+  assert_true(issues("var x = 1\nconst y = 2\nglobalThis.y") > 0)
+  @test.assert_eq(issues("var x = 1\nglobalThis.x\nglobalThis.Infinity"), 0)
+  // TS2339 on a `Window & typeof globalThis` receiver.
+  assert_true(
+    issues(
+      "// @strict: false\ndeclare let win: Window & typeof globalThis;\nwin.hi",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "// @strict: false\nvar gx = 1\ndeclare let win: Window & typeof globalThis;\nwin.gx\nwin.document",
+    ),
+    0,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -12487,3 +12487,46 @@ test "expr_check: identity keys and union callee arity (batch AH)" {
     0,
   )
 }
+
+///|
+test "expr_check: TS2352 cast overlap (batch AI)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Cross-family primitive casts are definite mistakes.
+  assert_true(issues("var a = 20;\nvar b = a as string;") > 0)
+  assert_true(issues("declare var n: number;\nvar c = n as string;") > 0)
+  // Nullish sources under strictNullChecks never overlap a primitive.
+  assert_true(issues("var x = undefined as number;") > 0)
+  assert_true(issues("var y = (null as string).length;") > 0)
+  @test.assert_eq(issues("// @strict: false\nvar x = undefined as number;"), 0)
+  // Widening / any / union targets stay legal.
+  @test.assert_eq(
+    issues(
+      "declare var e: any;\nvar f = e as string;\nvar g = \"s\" as string;\nvar h = 20 as number | string;\nvar i = undefined as void;",
+    ),
+    0,
+  )
+  // Interface shapes: both directions missing a required property flag;
+  // sub/super shapes stay legal.
+  assert_true(
+    issues(
+      "// @strict: false\ninterface I1 { p1: number }\ninterface I2 extends I1 { p2: number }\ninterface I3 { p3: number }\ndeclare var z: I2;\nvar b = z as I3;",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "// @strict: false\ninterface I1 { p1: number }\ninterface I2 extends I1 { p2: number }\ndeclare var a: I1;\nvar b = a as I2;\nvar c = a as I1;",
+    ),
+    0,
+  )
+  // A non-interpolating template in type position is that string literal
+  // type (also keeps the ASI `as `Hello world`` mis-parse silent).
+  @test.assert_eq(
+    issues(
+      "// @strict: false\ndeclare function as(...args: any[]);\nvar x = 10\nas `Hello world`;",
+    ),
+    0,
+  )
+}

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -54,6 +54,222 @@ fn runtime_class_param_name(param : @ast.TsParam, index : Int) -> String {
 ///|
 
 ///|
+/// Every identifier a binding pattern declares (helper for the static-block
+/// TDZ scan).
+fn sb_binding_names(binding : @ast.TsBinding, out : Array[String]) -> Unit {
+  match binding {
+    Ident(n) => out.push(n)
+    Array(ab) => {
+      for item in ab.items {
+        match item {
+          Some(e) => sb_binding_names(e.binding, out)
+          None => ()
+        }
+      }
+      match ab.rest {
+        Some(r) => sb_binding_names(r, out)
+        None => ()
+      }
+    }
+    Object(ob) => {
+      for p in ob.props {
+        sb_binding_names(p.binding, out)
+      }
+      match ob.rest {
+        Some(r) => out.push(r)
+        None => ()
+      }
+    }
+    Target(_) => ()
+  }
+}
+
+///|
+/// Free identifier reads / writes of a static block's *immediate* execution
+/// (function bodies are deferred and skipped): `Var` reads in any operand
+/// position and assignment-statement target names. Block-local declarations
+/// are collected into `locals` and excluded by the caller.
+fn sb_reads_expr(e : @ast.TsExpr, out : Array[String]) -> Unit {
+  match e {
+    Var(n) => out.push(n)
+    PropAccess(recv, _) => sb_reads_expr(recv, out)
+    PropAssignExpr(recv, _, v) => {
+      sb_reads_expr(recv, out)
+      sb_reads_expr(v, out)
+    }
+    MethodCall(recv, _, args) => {
+      sb_reads_expr(recv, out)
+      for a in args {
+        sb_reads_expr(a, out)
+      }
+    }
+    BinOp(_, a, b) | Seq(a, b) | IndexAccess(a, b) | ComputedProp(a, b) => {
+      sb_reads_expr(a, out)
+      sb_reads_expr(b, out)
+    }
+    IndexAssignExpr(a, b, c) | Cond(a, b, c) => {
+      sb_reads_expr(a, out)
+      sb_reads_expr(b, out)
+      sb_reads_expr(c, out)
+    }
+    UnaryOp(_, x)
+    | Spread(x)
+    | Await(x)
+    | YieldStar(x)
+    | PureCall(x)
+    | TypeArgs(_, x) => sb_reads_expr(x, out)
+    AssignExpr(n, v) => {
+      out.push(n)
+      sb_reads_expr(v, out)
+    }
+    CompoundAssignExpr(a, _, b) => {
+      sb_reads_expr(a, out)
+      sb_reads_expr(b, out)
+    }
+    Yield(opt) =>
+      match opt {
+        Some(x) => sb_reads_expr(x, out)
+        None => ()
+      }
+    Call(n, args) => {
+      out.push(n)
+      for a in args {
+        sb_reads_expr(a, out)
+      }
+    }
+    New(_, args) =>
+      for a in args {
+        sb_reads_expr(a, out)
+      }
+    CallExpr(callee, args) | NewExpr(callee, args) => {
+      sb_reads_expr(callee, out)
+      for a in args {
+        sb_reads_expr(a, out)
+      }
+    }
+    ArrayLit(items) =>
+      for it in items {
+        sb_reads_expr(it, out)
+      }
+    ObjectLit(entries) =>
+      for ent in entries {
+        sb_reads_expr(ent.1, out)
+      }
+    TemplateLiteral(_, exprs) =>
+      for x in exprs {
+        sb_reads_expr(x, out)
+      }
+    TaggedTemplate(tag, _, _, exprs) => {
+      sb_reads_expr(tag, out)
+      for x in exprs {
+        sb_reads_expr(x, out)
+      }
+    }
+    _ => ()
+  }
+}
+
+///|
+fn sb_reads_stmt(
+  stmt : @ast.TsStmt,
+  locals : Array[String],
+  out : Array[String],
+) -> Unit {
+  fn walk_block(b : @ast.TsBlock) -> Unit {
+    for s in b.stmts {
+      sb_reads_stmt(s, locals, out)
+    }
+  }
+
+  match stmt {
+    Var(b, _, e) | Let(b, _, e) | Const(b, _, e) => {
+      sb_binding_names(b, locals)
+      sb_reads_expr(e, out)
+    }
+    Assign(n, e) => {
+      out.push(n)
+      sb_reads_expr(e, out)
+    }
+    CompoundAssign(n, _, e) => {
+      out.push(n)
+      sb_reads_expr(e, out)
+    }
+    Expr(e) | Throw(e) | Return(Some(e)) => sb_reads_expr(e, out)
+    PropAssign(recv, _, v) => {
+      sb_reads_expr(recv, out)
+      sb_reads_expr(v, out)
+    }
+    IndexAssign(a, b, c) => {
+      sb_reads_expr(a, out)
+      sb_reads_expr(b, out)
+      sb_reads_expr(c, out)
+    }
+    If(c, t, e) => {
+      sb_reads_expr(c, out)
+      walk_block(t)
+      match e {
+        Some(x) => walk_block(x)
+        None => ()
+      }
+    }
+    While(c, b) | DoWhile(c, b) | With(c, b) => {
+      sb_reads_expr(c, out)
+      walk_block(b)
+    }
+    For(init, cond, upd, body) => {
+      match init {
+        Some(s) => sb_reads_stmt(s, locals, out)
+        None => ()
+      }
+      match cond {
+        Some(e) => sb_reads_expr(e, out)
+        None => ()
+      }
+      match upd {
+        Some(s) => sb_reads_stmt(s, locals, out)
+        None => ()
+      }
+      walk_block(body)
+    }
+    ForOf(_, b, _, e, body)
+    | ForAwaitOf(_, b, _, e, body)
+    | ForIn(_, b, _, e, body) => {
+      sb_binding_names(b, locals)
+      sb_reads_expr(e, out)
+      walk_block(body)
+    }
+    Switch(e, cases) => {
+      sb_reads_expr(e, out)
+      for case in cases {
+        match case.test_expr {
+          Some(t) => sb_reads_expr(t, out)
+          None => ()
+        }
+        walk_block(case.body)
+      }
+    }
+    Try(b, cb_binding, cb, fb) => {
+      walk_block(b)
+      match cb_binding {
+        Some(bind) => sb_binding_names(bind, locals)
+        None => ()
+      }
+      match cb {
+        Some(x) => walk_block(x)
+        None => ()
+      }
+      match fb {
+        Some(x) => walk_block(x)
+        None => ()
+      }
+    }
+    Label(_, s) => sb_reads_stmt(s, locals, out)
+    Block(b) => walk_block(b)
+    _ => ()
+  }
+}
+
+///|
 /// True when `binding` declares an identifier equal to `name`.
 fn sb_binding_binds(binding : @ast.TsBinding, name : String) -> Bool {
   match binding {
@@ -1608,6 +1824,23 @@ fn Parser::parse_class_body(
             if self.check(LBrace) {
               let block = self.parse_block()
               elements.push(StaticBlock(block))
+              // TS2448: a top-level class's static block executes at class
+              // definition time, so its immediate reads / writes of a
+              // block-scoped variable declared LATER at top level hit the
+              // TDZ. Record the free identifiers in parse order; the
+              // checker pairs them with `<letconst-decl:…>` markers.
+              if !self.in_function {
+                let locals : Array[String] = []
+                let reads : Array[String] = []
+                for s in block.stmts {
+                  sb_reads_stmt(s, locals, reads)
+                }
+                for r in reads {
+                  if !locals.contains(r) {
+                    self.grammar_misuses.push("<sb-read:" + r + ">")
+                  }
+                }
+              }
               parsed_static_block = true
               break // Exit inner loop, then continue outer loop
             }

--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -404,7 +404,10 @@ pub fn Parser::parse_function(self : Parser) -> @ast.TsFunc raise ParseError {
   if is_generator {
     self.in_generator = true
   }
-  self.in_async = false // Reset for nested functions
+  // The body's async-ness follows THIS function (a non-async nested
+  // function leaves the async context; an `async` one enters it -- `await`
+  // is reserved in its type positions).
+  self.in_async = is_async
   self.in_function = true
   self.in_iteration = false
   self.in_switch = false
@@ -710,7 +713,10 @@ fn Parser::parse_function_expr(self : Parser) -> @ast.TsFunc raise ParseError {
   if is_generator {
     self.in_generator = true
   }
-  self.in_async = false // Reset for nested functions
+  // The body's async-ness follows THIS function (a non-async nested
+  // function leaves the async context; an `async` one enters it -- `await`
+  // is reserved in its type positions).
+  self.in_async = is_async
   self.in_function = true
   self.in_iteration = false
   self.in_switch = false

--- a/src/parser/parser_stmt.mbt
+++ b/src/parser/parser_stmt.mbt
@@ -343,6 +343,21 @@ fn Parser::parse_var_like(
         _ => ()
       }
     }
+    // TS2448 pairing data: top-level `let` / `const` declarations, in
+    // parse order relative to the `<sb-read:…>` markers static blocks
+    // record. `var` is hoisted and never in the TDZ, so it is excluded.
+    for stmt in stmts {
+      match stmt {
+        Let(b, _, _) | Const(b, _, _) => {
+          let names : Array[String] = []
+          sb_binding_names(b, names)
+          for n in names {
+            self.grammar_misuses.push("<letconst-decl:" + n + ">")
+          }
+        }
+        _ => ()
+      }
+    }
   }
   // TS7006 (noImplicitAny): an unannotated binding initialized by a
   // callable literal gives the callable's unannotated parameters no

--- a/src/parser/parser_stmt.mbt
+++ b/src/parser/parser_stmt.mbt
@@ -283,8 +283,53 @@ fn Parser::parse_var_like(
       )
     _ => ()
   }
+  // Whether the FIRST declarator carries a written type annotation. Even
+  // `: any` retypes a destructuring source (`var { a2 }: any = {}` is
+  // legal), but the annotation and its absence both reach the checker as
+  // `Any`, so the distinction only exists here at the token level.
+  let first_decl_annotated = self.check(Colon)
   let type_ = self.parse_var_decl_type()
   let stmts = self.parse_var_decl_list_from(binding, type_, kind)
+  // TS2339: `var { x, y } = {}` — a non-defaulted pattern property that
+  // the syntactic object-literal initializer provably lacks. Only the
+  // first declarator is judged (later declarators parse their own
+  // annotations inside the list). Spread / computed / synthetic entries
+  // make the key set unknowable, so the pattern abstains.
+  if !first_decl_annotated && stmts.length() >= 1 {
+    match stmts[0] {
+      Var(Object(ob), _, ObjectLit(entries))
+      | Let(Object(ob), _, ObjectLit(entries))
+      | Const(Object(ob), _, ObjectLit(entries)) => {
+        let keys : Map[String, Bool] = {}
+        let mut keys_known = true
+        for e in entries {
+          if e.0.has_prefix("@@spread") || e.0.has_prefix("<") {
+            keys_known = false
+          }
+          match e.1 {
+            ComputedProp(_, _) => keys_known = false
+            _ => ()
+          }
+          keys[e.0] = true
+        }
+        if keys_known {
+          for prop in ob.props {
+            if prop.default is None &&
+              prop.key_expr is None &&
+              !prop.key.has_prefix("<") &&
+              !keys.contains(prop.key) {
+              self.grammar_misuses.push(
+                "property `" +
+                prop.key +
+                "` does not exist on the object-literal source",
+              )
+            }
+          }
+        }
+      }
+      _ => ()
+    }
+  }
   // TS1262: `await` used as a top-level declaration name. Only an error
   // when the file is a module; the checker pairs this marker with the
   // module-syntax evidence (`<module-syntax>` / export markers / imports).

--- a/src/parser/parser_type.mbt
+++ b/src/parser/parser_type.mbt
@@ -1199,6 +1199,14 @@ fn Parser::parse_primary_type(self : Parser) -> @ast.TsType raise ParseError {
     // Ident or generic type: Foo, Array<T>
     Ident(name) => {
       let _ = self.advance()
+      // TS2552: inside an `async` context `await` is a reserved word, so a
+      // type reference spelled `await` (`var v: await`) can never resolve
+      // (tsc suggests `Awaited`). Outside async it is a legal type name.
+      if name == "await" && self.in_async {
+        self.grammar_misuses.push(
+          "cannot find name `await`. Did you mean `Awaited`?",
+        )
+      }
       match self.local_type_param_bound(name) {
         // A `T extends object` bound erases to `Any`, not `NonPrimitiveObject`:
         // the constraint promises "some object type", so treating a value of

--- a/src/parser/parser_type.mbt
+++ b/src/parser/parser_type.mbt
@@ -920,13 +920,18 @@ fn Parser::parse_primary_type(self : Parser) -> @ast.TsType raise ParseError {
         Void
       }
     }
-    // Template literal type: `bg${ForegroundColorName}`. Falls back to
-    // `String_` for non-interpolating templates so the prior conservative
-    // behavior is preserved.
+    // Template literal type: `bg${ForegroundColorName}`. A
+    // non-interpolating template is the string *literal* type of its text
+    // (tsc semantics) — also keeps the `as`-cast reliability split from
+    // firing on the ASI `as `Hello world`` mis-parse (asOperatorASI).
     Template(cooked_parts, _, expr_sources) => {
       let _ = self.advance()
       if expr_sources.length() == 0 {
-        String_
+        if cooked_parts.length() >= 1 {
+          Literal(cooked_parts[0])
+        } else {
+          String_
+        }
       } else {
         let type_args : Array[@ast.TsType] = []
         for src in expr_sources {


### PR DESCRIPTION
## Summary

Three more batches of practical (non-parser-edge) conformance work, continuing from #192. Whole-corpus true positives rise **2136 → 2155** with the CI soundness invariant held at **0 false positives** (`scripts/checker_conformance_oracle.sh --max-fp 0`).

### Batch AI — TS2352 cast overlap (TP 2136 → 2140)
- Revived the `as`-cast overlap diagnostic whose message was blanket-suppressed in permissive mode. Reliable subsets now emit unfiltered: cross-family primitive casts (`a as string` where `a: number`; keyword-primitive asserted types only, so the ASI `as \`Hello world\`` mis-parse stays silent) and nullish sources under strictNullChecks against primitive targets.
- TS2352 between object shapes: flag when each direction has a required property entirely missing on the other side (full extends-chain field maps; intersections merge; generics/index signatures/computed members abstain).
- Parser: a non-interpolating template literal in type position is now the string *literal* type of its text (tsc semantics).

### Batch AJ — destructuring literal misses, globalThis (TP 2140 → 2144)
- **TS2339** for destructuring from a syntactic object literal: a non-defaulted pattern property the literal provably lacks. Assignment form checks in the checker; declaration form is recorded by the *parser*, because `var { a2 }: any = {}` is legal but the annotation and its absence both reach the checker as `Any`.
- **TS2339** for `globalThis.<name>` where `<name>` is a top-level `let`/`const` (block-scoped declarations never become globalThis properties), and on `Window & typeof globalThis` receivers for undeclared names.

### Batch AK — static-block TDZ, spread overwrite, enum readonly, await type (TP 2144 → 2155)
Cluster selection came from three parallel corpus-analysis passes over the remaining TS2322/TS2345/small-code misses, which also produced a ranked queue of feasible follow-ups and marked ~56 files as requiring unmodelable machinery (generic inference chains, lib member signatures, flow narrowing).
- **TS2448**: a top-level class's static block reading/writing a block-scoped variable declared later at top level. Statement order between classes and consts is erased by module lowering, so the parser records `<sb-read:X>` / `<letconst-decl:X>` markers whose relative order in the append-only `grammar_misuses` channel is parse order; the checker pairs them.
- **TS2783**: an explicitly-written object-literal property that a later spread always overwrites; optional members, unions, generics, and spread-vs-spread abstain.
- **TS2540**: enum members are read-only (`E.B++` with an unshadowed enum receiver).
- **TS2552**: `await` as a type reference inside an async context. Landing this exposed a real parser bug: both `parse_function` sites reset `in_async = false` before parsing the body, so `async function` *declaration* bodies parsed as non-async; they now propagate `is_async`.

## Testing

- `moon test --target native` — 2449 tests, all passing (one whitebox test block per batch).
- `scripts/checker_conformance_oracle.sh --max-fp 0` — TP 2155 / FP 0 / TN 1406 over 4092 classified conformance cases.
- Every new check was counter-probed with legal-pattern files; gate-caught FPs (ASI `as` template, annotated-`any` destructuring, `win.<top-level var>`) are fixed and documented in TODO.md (T185–T187).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr)_