### PR TITLE
checker: NoInfer intrinsic as an inference barrier (TP 2581 → 2582)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2295,6 +2295,31 @@ conformance sources (`.errors.txt` baseline = ground truth):
     the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
     698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
 
+2026-07-08 (T193)  714/815 (88 %)        414/414 ( 0 FP)   Generic inference: NoInfer intrinsic: TP 2581 -> 2582
+
+  T193 -- generic call-site inference, round 1 (user-directed pivot to
+    the generic-inference blocker).
+    - `NoInfer<T>` intrinsic: two halves. (a) Inference barrier —
+      `solve_generic_bindings` erases `NoInfer<…>` subtrees to `Any`
+      before candidate collection (`strip_noinfer_positions`), so `T`
+      pins from the other argument positions and the NoInfer argument
+      is CHECKED against the pinned binding instead of contributing to
+      it. (b) Checking transparency — `Resolver::unwrap` resolves
+      `Applied("NoInfer", [inner])` to `inner` (unless the module
+      shadows the name with its own alias), so every downstream
+      assignability / member check sees through it. Catches
+      `assertEqual(g, { x: 3 })` (missing `y`), contravariant-default
+      `doSomething(new Dog(), () => new Animal())`, and
+      `doWork(comp, {})` (missing `foo`); literal-vs-literal pins
+      (`foo1('foo', 'bar')`) still widen and stay missed. noInfer.ts.
+    Surveyed and deferred (multi-stage machinery): generic rest tuple
+    inference from callback parameter lists (genericRestArity*),
+    method-chain constraint propagation
+    (wrappedAndRecursiveConstraints4), generator inference
+    (generatorTypeCheck62/63), iterator-element inference through lib
+    types (iteratorSpreadInCall7/8/9).
+    Whole-corpus TP 2581 -> 2582 @ 0 FP, PFLEGAL 1, TN 1414. 2455 tests.
+
 2026-07-07 (T192)  714/815 (88 %)        414/414 ( 0 FP)   Grammar clusters under the new spec: TP 2562 -> 2581
 
   T192 -- the new classification surfaced grammar clusters that

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -1097,6 +1097,11 @@ fn Resolver::unwrap(self : Resolver, ty : @ast.TsType) -> @ast.TsType {
               }
           }
         }
+      // The `NoInfer<T>` intrinsic is an inference barrier only — for
+      // every checking purpose it IS its argument (unless the module
+      // shadows the name with its own alias, handled below).
+      Applied("NoInfer", [inner]) if !self.type_aliases.contains("NoInfer") =>
+        cur = inner
       Applied(n, args) =>
         if seen.contains(n) {
           keep_going = false
@@ -6579,6 +6584,11 @@ fn solve_generic_bindings(
   args : Array[@ast.TsExpr],
   sig : Array[@ast.TsParam]?,
 ) -> Map[String, @ast.TsType] {
+  // `NoInfer<T>` positions are inference barriers (the intrinsic's whole
+  // purpose): erase them to `Any` for candidate collection, so `T` pins
+  // from the other positions and the NoInfer argument is CHECKED against
+  // the pinned binding instead of contributing to it (noInfer.ts).
+  let params = params.map(fn(p) { strip_noinfer_positions(p) })
   let bindings : Map[String, @ast.TsType] = {}
   for tp in type_params {
     bindings[tp] = @ast.TsType::Any
@@ -6651,6 +6661,37 @@ fn solve_generic_bindings(
     i = i + 1
   }
   bindings
+}
+
+///|
+/// Erase `NoInfer<…>` subtrees to `Any` for inference-candidate collection
+/// (checking still sees them — `Resolver::unwrap` is NoInfer-transparent).
+fn strip_noinfer_positions(t : @ast.TsType) -> @ast.TsType {
+  match t {
+    Applied("NoInfer", _) => Any
+    Array(e) => Array(strip_noinfer_positions(e))
+    Rest(e) => Rest(strip_noinfer_positions(e))
+    Applied(n, args) =>
+      Applied(n, args.map(fn(a) { strip_noinfer_positions(a) }))
+    Union(ms) => Union(ms.map(fn(m) { strip_noinfer_positions(m) }))
+    Intersection(ms) =>
+      Intersection(ms.map(fn(m) { strip_noinfer_positions(m) }))
+    Func(ps, r) =>
+      Func(
+        ps.map(fn(p) { strip_noinfer_positions(p) }),
+        strip_noinfer_positions(r),
+      )
+    Constructor(ps, r, a) =>
+      Constructor(
+        ps.map(fn(p) { strip_noinfer_positions(p) }),
+        strip_noinfer_positions(r),
+        a,
+      )
+    Object(fields) =>
+      Object(fields.map(fn(f) { (f.0, strip_noinfer_positions(f.1)) }))
+    Tuple(items) => Tuple(items.map(fn(i) { strip_noinfer_positions(i) }))
+    other => other
+  }
 }
 
 ///|

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -12782,3 +12782,32 @@ test "expr_check: ambient declare, dup accessibility, non-generator yield, dts s
     0,
   )
 }
+
+///|
+test "expr_check: NoInfer inference barrier (batch AQ)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // T pins from the non-NoInfer position; the NoInfer argument is checked
+  // against the pinned binding.
+  assert_true(
+    issues(
+      "declare function assertEqual<T>(actual: T, expected: NoInfer<T>): boolean;\nconst g = { x: 3, y: 2 };\nassertEqual(g, { x: 3 });",
+    ) >
+    0,
+  )
+  assert_true(
+    issues(
+      "declare class Animal { move(): void }\ndeclare class Dog extends Animal { woof(): void }\ndeclare function doSomething<T>(value: T, getDefault: () => NoInfer<T>): void;\ndoSomething(new Dog(), () => new Animal());",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "declare function assertEqual<T>(actual: T, expected: NoInfer<T>): boolean;\nassertEqual({ x: 1 }, { x: 3 });\ndeclare class Animal { move(): void }\ndeclare class Dog extends Animal { woof(): void }\ndeclare function doSomething<T>(value: T, getDefault: () => NoInfer<T>): void;\ndoSomething(new Animal(), () => new Dog());",
+    ),
+    0,
+  )
+  // NoInfer in a type alias position is transparent for checking.
+  @test.assert_eq(issues("type N2 = NoInfer<string>;\nvar s2: N2 = \"ok\";"), 0)
+}


### PR DESCRIPTION
## Summary

Round 1 of the generic-inference push (continuing from #194): implements the TS 5.4 `NoInfer<T>` intrinsic in two halves.

- **Inference barrier** (the intrinsic's purpose): `solve_generic_bindings` erases `NoInfer<…>` subtrees to `Any` before candidate collection (`strip_noinfer_positions`), so the type parameter pins from the other argument positions and the NoInfer argument is *checked* against the pinned binding instead of contributing to it.
- **Checking transparency**: `Resolver::unwrap` resolves `Applied("NoInfer", [inner])` to `inner` (unless the module shadows the name with its own alias), so every downstream assignability / member check sees through it.

Catches from `noInfer.ts`: `assertEqual(g, { x: 3 })` (missing required `y`), the contravariant default `doSomething(new Dog(), () => new Animal())`, and `doWork(comp, {})` (missing `foo`). Literal-vs-literal pins (`foo1('foo', 'bar')`) still widen and stay missed — noted in TODO.md.

Surveyed and deferred as multi-stage inference work (recorded in TODO.md T193): generic rest tuple inference from callback parameter lists (`genericRestArity*`), method-chain constraint propagation (`wrappedAndRecursiveConstraints4`), generator inference (`generatorTypeCheck62/63`), and iterator-element inference through lib types (`iteratorSpreadInCall7/8/9`).

## Testing

- `moon test --target native` — 2455 tests, all passing (new whitebox block for the NoInfer error and legal cases).
- `scripts/checker_conformance_oracle.sh --max-fp 0 --max-legal-parsefail 1` — TP 2582 (397 via parse rejection) / FP 0 / PFLEGAL 1 / TN 1414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr)_