### PR TITLE
checker: type-predicate narrowing from any (TP 2582 → 2583)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2295,6 +2295,29 @@ conformance sources (`.errors.txt` baseline = ground truth):
     the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
     698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
 
+2026-07-08 (T194)  714/815 (88 %)        414/414 ( 0 FP)   Flow narrowing: predicate narrowing from `any`: TP 2582 -> 2583
+
+  T194 -- flow narrowing, round 1 (user-directed pivot).
+    - Type-predicate narrowing from `any`: `narrow_keep(Any, …)` passes
+      `any` through unchanged, so `if (isFoo(x)) { … }` never narrowed
+      an `any`-typed x and every member check inside abstained.
+      `apply_type_predicate_narrowing` now special-cases an `Any`
+      source: it narrows straight to the predicate target — EXCEPT
+      `Function` / `Object` targets, which tsc deliberately leaves as
+      `any` (narrowFromAnyWithTypePredicate: `x is {}` then
+      `x.method()` flags on the empty object).
+    - Catch-clause bindings already enter the env as `Any`, so the same
+      path serves `catch (err) { if (isFooError(err)) … }` — but the
+      member-miss on `{ type: 'foo'; dontPanic() }`-shaped receivers is
+      still permissively suppressed (`does not exist on `{…}`` render),
+      so narrowExceptionVariableInCatchClause stays missed. Lifting
+      that suppression for narrowing-derived object shapes is the next
+      step and needs care (the filter can't currently see provenance).
+    - Surveyed: instanceof-from-any already narrows (batch earlier);
+      Error / Date member typos (TS2551) need lib member models;
+      loop back-edge widening and `||`-RHS narrowing chains deferred.
+    Whole-corpus TP 2582 -> 2583 @ 0 FP, PFLEGAL 1, TN 1414. 2456 tests.
+
 2026-07-08 (T193)  714/815 (88 %)        414/414 ( 0 FP)   Generic inference: NoInfer intrinsic: TP 2581 -> 2582
 
   T193 -- generic call-site inference, round 1 (user-directed pivot to

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -12442,13 +12442,20 @@ fn apply_type_predicate_narrowing(
       // not just to `target`, so subsequent calls expecting `cur` still
       // accept the narrowed value.
       let then_ty = narrow_keep(cur, fn(v) { is_assignable_to(v, target) })
-      let then_resolved = match then_ty {
-        Never =>
-          match cur {
-            Any => target
-            _ => @ast.TsType::Intersection([cur, target])
+      let then_resolved = match cur {
+        // From `any`, a positive predicate narrows straight to the target
+        // — except `Function` / `Object`, which tsc deliberately leaves
+        // as `any` (narrowFromAnyWithTypePredicate).
+        Any =>
+          match target {
+            Named("Function") | Named("Object") => @ast.TsType::Any
+            _ => target
           }
-        _ => then_ty
+        _ =>
+          match then_ty {
+            Never => @ast.TsType::Intersection([cur, target])
+            _ => then_ty
+          }
       }
       pair_pos.push((arg_name, then_resolved))
       // Negative: strip members that fit T.

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -12811,3 +12811,24 @@ test "expr_check: NoInfer inference barrier (batch AQ)" {
   // NoInfer in a type alias position is transparent for checking.
   @test.assert_eq(issues("type N2 = NoInfer<string>;\nvar s2: N2 = \"ok\";"), 0)
 }
+
+///|
+test "expr_check: predicate narrowing from any (batch AR)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // `any` narrows to the predicate target; `{}` has no members.
+  assert_true(
+    issues(
+      "// @strict: false\ndeclare var x: any;\ndeclare function isAnything(x): x is {};\nif (isAnything(x)) {\n  x.method();\n}",
+    ) >
+    0,
+  )
+  // `Function` / `Object` predicate targets leave `any` unnarrowed.
+  @test.assert_eq(
+    issues(
+      "// @strict: false\ndeclare var x: any;\ndeclare function isFunction(x): x is Function;\ndeclare function isObject(x): x is Object;\nif (isFunction(x)) { x(); x.prop; }\nif (isObject(x)) { x.method(); }",
+    ),
+    0,
+  )
+}


### PR DESCRIPTION
## Summary

Round 1 of the flow-narrowing push (continuing from #195).

`narrow_keep` passes `any` through unchanged, so `if (isFoo(x))` never narrowed an `any`-typed `x` and every member check inside the guard abstained. `apply_type_predicate_narrowing` now special-cases an `Any` source: it narrows straight to the predicate target — **except** `Function` / `Object` targets, which tsc deliberately leaves as `any` (`narrowFromAnyWithTypePredicate`: `x is {}` then `x.method()` now flags on the empty object type).

Catch-clause bindings already enter the env as `Any`, so the same path serves `catch (err) { if (isFooError(err)) … }`; the member-miss on `{ type: 'foo'; dontPanic() }`-shaped receivers is still permissively suppressed (the filter can't see narrowing provenance), so `narrowExceptionVariableInCatchClause` stays missed — recorded in TODO.md T194 as the follow-up, together with the other surveyed narrowing gaps (lib member models for Error/Date typo detection, loop back-edge widening, `||`-RHS narrowing chains).

## Testing
- `moon test --target native` — 2456 tests, all passing.
- `scripts/checker_conformance_oracle.sh --max-fp 0 --max-legal-parsefail 1` — TP 2583 (397 via parse rejection) / FP 0 / PFLEGAL 1 / TN 1414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr)_