### PR TITLE
parser: keyword member names in object types (TP 2583 → 2584 + soundness fix)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2295,6 +2295,24 @@ conformance sources (`.errors.txt` baseline = ground truth):
     the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
     698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
 
+2026-07-08 (T196)  714/815 (88 %)        414/414 ( 0 FP)   Parser: keyword member names generalized: TP 2584 (soundness)
+
+  T196 -- generalize T195 beyond `type`. A probe sweep showed EVERY
+    keyword-token member name (`function:`, `class:`, `in:`, `of:`,
+    `typeof:`, `declare:`, …) combined with a method-signature member
+    collapsed the object-type annotation to `Any` through the same
+    primary-parser gap, and `{ new: string }` additionally misparsed as
+    a construct signature (swallowing the property). Fix: a
+    `keyword_member_name` token->spelling table feeds a guarded
+    member-name arm (next token must prove a member key), and the `New`
+    arm distinguishes a `new:`-property from a construct-signature head
+    the same way. Interfaces were already correct (separate parser).
+    No corpus TP delta this round — the corpus rarely puts keyword keys
+    on checked paths — but the annotation soundness hole is closed for
+    real-world inputs (`type`-discriminated unions were the visible
+    case in T195).
+    Whole-corpus TP 2584 @ 0 FP, PFLEGAL 1, TN 1414. 2458 tests.
+
 2026-07-08 (T195)  714/815 (88 %)        414/414 ( 0 FP)   Parser: keyword member names in object types: TP 2583 -> 2584
 
   T195 -- the T194 reach gap, root-caused and fixed. The trail:

--- a/TODO.md
+++ b/TODO.md
@@ -2295,6 +2295,28 @@ conformance sources (`.errors.txt` baseline = ground truth):
     the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
     698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
 
+2026-07-08 (T195)  714/815 (88 %)        414/414 ( 0 FP)   Parser: keyword member names in object types: TP 2583 -> 2584
+
+  T195 -- the T194 reach gap, root-caused and fixed. The trail:
+    provenance branch didn't fire -> a DIRECT `declare var v: { type:
+    string; dontPanic(): void }; v.doPanic();` was also silent -> the
+    annotation itself parsed as `Any`. `type` lexes as its own token,
+    the primary object-type member parser had no keyword-key arm (falls
+    back to `None` -> conservative parser), and the FALLBACK object
+    parser handles plain `type: string` properties but not
+    method-signature members — so exactly the combination
+    `{ type: …; m(): … }` collapsed the whole annotation to `Any`,
+    silencing every member check behind it (this was the real
+    narrowExceptionVariableInCatchClause blocker, NOT the permissive
+    filter). Fix: the member-name match accepts a `Type` keyword token
+    when the following token proves it's a member key (`:`, `?`, `;`,
+    `,`, `(`, `}`). The provenance-aware record branch prototyped in
+    T194 turned out unnecessary — with the type parsed, the normal
+    member-miss path fires (top-level `declare var` receivers render as
+    object-literal shapes, which the permissive filter allows through
+    the `{}` carve-out family).
+    Whole-corpus TP 2583 -> 2584 @ 0 FP, PFLEGAL 1, TN 1414. 2457 tests.
+
 2026-07-08 (T194)  714/815 (88 %)        414/414 ( 0 FP)   Flow narrowing: predicate narrowing from `any`: TP 2582 -> 2583
 
   T194 -- flow narrowing, round 1 (user-directed pivot).
@@ -2311,14 +2333,8 @@ conformance sources (`.errors.txt` baseline = ground truth):
       member-miss on `{ type: 'foo'; dontPanic() }`-shaped receivers is
       still permissively suppressed (`does not exist on `{…}`` render),
       so narrowExceptionVariableInCatchClause stays missed.
-      FOLLOW-UP FINDING (post-merge probe): the suppression isn't the
-      (only) blocker — a DIRECT `declare var v2: { type: string;
-      dontPanic(): void }; v2.doPanic();` is also silent, so the
-      MethodCall member-miss check never reaches its record for
-      Object-with-method-field receivers at all. A provenance-aware
-      record_unfiltered branch was prototyped and reverted (dead until
-      the reach problem is found); next step is tracing the MethodCall
-      dispatch path for that receiver shape.
+      FOLLOW-UP FINDING (post-merge probe): the suppression wasn't the
+      blocker at all — RESOLVED in T195 below.
     - Surveyed: instanceof-from-any already narrows (batch earlier);
       Error / Date member typos (TS2551) need lib member models;
       loop back-edge widening and `||`-RHS narrowing chains deferred.

--- a/TODO.md
+++ b/TODO.md
@@ -2310,9 +2310,15 @@ conformance sources (`.errors.txt` baseline = ground truth):
       path serves `catch (err) { if (isFooError(err)) … }` — but the
       member-miss on `{ type: 'foo'; dontPanic() }`-shaped receivers is
       still permissively suppressed (`does not exist on `{…}`` render),
-      so narrowExceptionVariableInCatchClause stays missed. Lifting
-      that suppression for narrowing-derived object shapes is the next
-      step and needs care (the filter can't currently see provenance).
+      so narrowExceptionVariableInCatchClause stays missed.
+      FOLLOW-UP FINDING (post-merge probe): the suppression isn't the
+      (only) blocker — a DIRECT `declare var v2: { type: string;
+      dontPanic(): void }; v2.doPanic();` is also silent, so the
+      MethodCall member-miss check never reaches its record for
+      Object-with-method-field receivers at all. A provenance-aware
+      record_unfiltered branch was prototyped and reverted (dead until
+      the reach problem is found); next step is tracing the MethodCall
+      dispatch path for that receiver shape.
     - Surveyed: instanceof-from-any already narrows (batch earlier);
       Error / Date member typos (TS2551) need lib member models;
       loop back-edge widening and `||`-RHS narrowing chains deferred.

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -12861,3 +12861,32 @@ test "expr_check: keyword member names in object types (batch AS)" {
     0,
   )
 }
+
+///|
+test "expr_check: generalized keyword member names (batch AT)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Keyword-keyed members no longer collapse the annotation to Any, so
+  // member misses behind them surface.
+  assert_true(
+    issues(
+      "// @strict: false\ndeclare var a: { function: string; m(): void };\na.other();",
+    ) >
+    0,
+  )
+  assert_true(
+    issues(
+      "// @strict: false\ndeclare var c: { new: string; m(): void };\nc.other();",
+    ) >
+    0,
+  )
+  // Legal uses of keyword-keyed members, and construct/call signatures
+  // keep their meaning.
+  @test.assert_eq(
+    issues(
+      "// @strict: false\ndeclare var a: { function: string; class: number; in: boolean; m(): void };\na.m();\nvar s: string = a.function;\nvar n: number = a.class;\ndeclare var h: { new (x: number): string };\nvar inst = new h(1);",
+    ),
+    0,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -12832,3 +12832,32 @@ test "expr_check: predicate narrowing from any (batch AR)" {
     0,
   )
 }
+
+///|
+test "expr_check: keyword member names in object types (batch AS)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // `type` lexes as its own token; as an object-type member name followed
+  // by a method-signature member it used to collapse the whole annotation
+  // to Any, hiding every member check behind it.
+  assert_true(
+    issues(
+      "// @strict: false\ndeclare var v: { type: string; dontPanic(): void };\nv.doPanic();",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "// @strict: false\ndeclare var v: { type: string; dontPanic(): void };\nv.dontPanic();\nvar s: string = v.type;",
+    ),
+    0,
+  )
+  // The narrowing chain this unblocks: catch-var + predicate guard.
+  assert_true(
+    issues(
+      "// @strict: false\ndeclare function isFooError(x: any): x is { type: string; dontPanic(): void };\nfunction t() {\n  try { } catch (err) {\n    if (isFooError(err)) {\n      err.dontPanic();\n      err.doPanic();\n    }\n  }\n}",
+    ) >
+    0,
+  )
+}

--- a/src/parser/parser_type.mbt
+++ b/src/parser/parser_type.mbt
@@ -578,6 +578,15 @@ fn Parser::try_parse_object_type_with_members(self : Parser) -> @ast.TsType? {
           let _ = self.advance()
           n
         }
+        // Keyword-token member names (`{ type: string; … }` — `type`
+        // lexes as its own token). Only when the next token proves this
+        // is a member key, so `readonly` / call-signature shapes above
+        // keep their meaning.
+        Type if self.peek_at(1).kind
+          is (Colon | Question | Semicolon | Comma | LParen | RBrace) => {
+          let _ = self.advance()
+          "type"
+        }
         Str(s) => {
           let _ = self.advance()
           s

--- a/src/parser/parser_type.mbt
+++ b/src/parser/parser_type.mbt
@@ -3,6 +3,59 @@
 // ============================================
 
 ///|
+/// The member-name spelling of a keyword token, for object-type members
+/// whose key happens to be a keyword (`{ type: T }`, `{ function: T }`).
+/// `New` is handled separately (construct-signature ambiguity).
+fn keyword_member_name(kind : TokenKind) -> String? {
+  match kind {
+    Type => Some("type")
+    Function => Some("function")
+    Class => Some("class")
+    Extends => Some("extends")
+    Var => Some("var")
+    Let => Some("let")
+    Const => Some("const")
+    Return => Some("return")
+    If => Some("if")
+    Else => Some("else")
+    Switch => Some("switch")
+    Case => Some("case")
+    Default => Some("default")
+    With => Some("with")
+    Debugger => Some("debugger")
+    Import => Some("import")
+    Export => Some("export")
+    From => Some("from")
+    As => Some("as")
+    While => Some("while")
+    Do => Some("do")
+    For => Some("for")
+    Break => Some("break")
+    Continue => Some("continue")
+    Try => Some("try")
+    Catch => Some("catch")
+    Finally => Some("finally")
+    Throw => Some("throw")
+    Yield => Some("yield")
+    Typeof => Some("typeof")
+    Delete => Some("delete")
+    Instanceof => Some("instanceof")
+    Interface => Some("interface")
+    Of => Some("of")
+    In => Some("in")
+    Declare => Some("declare")
+    Null => Some("null")
+    Bool(true) => Some("true")
+    Bool(false) => Some("false")
+    NumberType => Some("number")
+    BooleanType => Some("boolean")
+    StringType => Some("string")
+    VoidType => Some("void")
+    _ => None
+  }
+}
+
+///|
 /// Check if current token is an identifier
 fn Parser::is_ident(self : Parser) -> Bool {
   match self.peek().kind {
@@ -520,10 +573,18 @@ fn Parser::try_parse_object_type_with_members(self : Parser) -> @ast.TsType? {
           self.skip_type_params()
           "<call>"
         }
-        New => {
-          let _ = self.advance()
-          "<new>"
-        }
+        // `new` followed by a member-key token is a PROPERTY named
+        // `new` (`{ new: string }`); otherwise it heads a construct
+        // signature.
+        New =>
+          if self.peek_at(1).kind
+            is (Colon | Question | Semicolon | Comma | RBrace) {
+            let _ = self.advance()
+            "new"
+          } else {
+            let _ = self.advance()
+            "<new>"
+          }
         LBracket => {
           // Index signature `[k: K]: V`. The checker / mangle passes
           // encode these inside `Object` as a field keyed by the *key
@@ -578,14 +639,15 @@ fn Parser::try_parse_object_type_with_members(self : Parser) -> @ast.TsType? {
           let _ = self.advance()
           n
         }
-        // Keyword-token member names (`{ type: string; … }` — `type`
-        // lexes as its own token). Only when the next token proves this
-        // is a member key, so `readonly` / call-signature shapes above
-        // keep their meaning.
-        Type if self.peek_at(1).kind
+        // Keyword-token member names (`{ type: string; … }`,
+        // `{ function: T }`, … — these lex as their own tokens). Only
+        // when the next token proves this is a member key, so
+        // `readonly` / call-signature shapes above keep their meaning.
+        k if keyword_member_name(k) is Some(kw) &&
+          self.peek_at(1).kind
           is (Colon | Question | Semicolon | Comma | LParen | RBrace) => {
           let _ = self.advance()
-          "type"
+          kw
         }
         Str(s) => {
           let _ = self.advance()


### PR DESCRIPTION
## Summary

Three commits closing the flow-narrowing "reach gap" from #196 — which turned out to be a parser soundness hole, not a checker one.

### The investigation trail (batch AS)
The provenance-aware member-miss branch prototyped after #196 never fired. Bisecting with probes: a *direct* `declare var v: { type: string; dontPanic(): void }; v.doPanic();` was also silent (no narrowing involved) → the same code inside a function body flagged fine → the AST dump showed **the annotation itself parsed as `Any`**.

Root cause: `type` lexes as its own token; the primary object-type member parser had no keyword-key arm (fell back to the conservative parser), and the *fallback* parser handles plain `type: string` properties but not method-signature members. So exactly the combination `{ type: …; m(): … }` collapsed the whole annotation to `Any`, silencing every member check behind it. This — not the permissive filter — was the real `narrowExceptionVariableInCatchClause` blocker.

### The fixes
- **`type` member keys** (batch AS): the member-name match accepts a `Type` keyword token when the following token proves it's a member key (`:` `?` `;` `,` `(` `}`). With the type parsed, the normal member-miss path fires and the catch-var + predicate-guard chain from #196 lands end-to-end. TP 2583 → 2584.
- **Generalized to every keyword** (batch AT): a probe sweep showed the same hole for `function:`, `class:`, `in:`, `of:`, `typeof:`, `declare:`, … and `{ new: string }` additionally misparsed as a *construct signature*. A `keyword_member_name` token→spelling table feeds the guarded arm, and the `New` arm distinguishes a `new:`-property from a construct-signature head the same way. Interfaces were already correct (separate parser). No corpus TP delta, but the annotation-soundness hole is closed for real-world inputs — `type`-discriminated unions being the everyday case.
- **Docs**: TODO.md records the T194 dead-end (provenance branch), its resolution, and the remaining narrowing queue (loop back-edge widening, `||`-RHS chains) as design work.

## Testing
- `moon test --target native` — 2458 tests, all passing (whitebox blocks for the keyword-key error and legal cases, construct/call signatures preserved).
- `scripts/checker_conformance_oracle.sh --max-fp 0 --max-legal-parsefail 1` — TP 2584 (397 via parse rejection) / FP 0 / PFLEGAL 1 / TN 1414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr)_