### PR TITLE
checker/parser: TS2428, template folding, TS1163 yield contexts, generic inference (TP 2584 → 2607)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2295,6 +2295,30 @@ conformance sources (`.errors.txt` baseline = ground truth):
     the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
     698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
 
+2026-07-10 (T198)  714/815 (88 %)        414/414 ( 0 FP)   Constant template folding feeds TS2367/TS2678: TP 2588 -> 2592
+
+  T198 -- interpolated template literals with literal-constant
+    substitutions now fold to their string-literal type in `infer_expr`
+    (`` `abc${0}abc` `` is `Literal("abc0abc")`), matching the fresh
+    pre-widening literal type tsc uses for comparisons. That feeds the
+    EXISTING TS2367 equality-overlap check (templateStringInEqualityChecks
+    x2) and — unplanned bonus — the existing switch/case comparability
+    check (templateStringInSwitchAndCase x2, TS2678). Folding is
+    deliberately narrow: string/bool literals, `IntLit`, and
+    integer-valued `NumberLit` below 1e15 (JS shortest-round-trip and
+    exponent formatting for fractional/huge numbers stays out of scope:
+    `${0.5}` does NOT fold — pinned); nested constant templates fold
+    recursively; anything else keeps the template at `string`.
+    Parity pin: a folded init behaves exactly like the same string as a
+    plain literal init (`var x = `a${0}`; x = "other"` asserts EQUAL issue
+    counts with the `"a0"` spelling, not zero — top-level var literal
+    inits don't widen on reassignment in the current checker for ANY
+    literal spelling; pre-existing, corpus-clean, noted for a future
+    widening pass). Whole-corpus TP 2588 -> 2592 @ 0 FP, PFLEGAL 1,
+    TN 1414. 2460 tests. Deferred from the TS2367 cluster: intersection
+    comparability (`I1 & I3` vs `I2`, `T & number` vs `string`) — needs
+    structural comparability analysis, not literal folding.
+
 2026-07-10 (T197)  714/815 (88 %)        414/414 ( 0 FP)   TS2428 interface merge type-param identity: TP 2584 -> 2588
 
   T197 -- TS2428 ("All declarations of 'X' must have identical type

--- a/TODO.md
+++ b/TODO.md
@@ -2295,6 +2295,40 @@ conformance sources (`.errors.txt` baseline = ground truth):
     the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
     698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
 
+2026-07-10 (T197)  714/815 (88 %)        414/414 ( 0 FP)   TS2428 interface merge type-param identity: TP 2584 -> 2588
+
+  T197 -- TS2428 ("All declarations of 'X' must have identical type
+    parameters."). Same-scope interface declarations of one name merge in
+    tsc only when their type-parameter lists are identical: same arity,
+    same names positionally, and identical constraints — with tsc's
+    relaxation that a declaration OMITTING a constraint is exempt from the
+    comparison (`interface C<T>` merges with `interface C<T extends
+    number>`; pinned). `check_interface_merge_type_params` runs per module
+    scope from the layered walker, which matches tsc's declaration spaces
+    for free: namespace bodies re-parse into per-BLOCK `TsModule`s, so two
+    non-exported interfaces in separate blocks of one namespace are never
+    compared (pinned ok-case). Constraint identity is staged to keep
+    spelling differences silent: raw AST `==`, alias-`unwrap` `==`,
+    canonical `identity_key` comparison (sorts unions, folds `T[]` ==
+    `Array<T>`), then a nominal fallback for refs the canonicalizer can't
+    expand (lib names like `Date` / `Number` have no module declaration):
+    different `Named` heads, different/argwise-different `Applied` heads,
+    and `any` vs a concrete ref. Known miss (documented): EXPORTED
+    interfaces across merged namespace blocks (`namespace M3 { export
+    interface A<T> }` x2) — needs an export marker for namespace interface
+    members; all 4 corpus files also error at top level, so no TP left
+    behind. Batch AU also audited class/interface bodies for the T195/T196
+    keyword-member-name hole: both already parse keyword keys correctly.
+    One real gap found and deliberately skipped: nonexistent METHOD CALLS
+    on primitive receivers (`n.bogus()`) are unchecked while property
+    access is — only 1 corpus file hinges on it and our prototype tables
+    are incomplete (FP risk), documented here instead.
+    Whole-corpus TP 2584 -> 2588 @ 0 FP, PFLEGAL 1, TN 1414 (unchanged).
+    The 4 new TPs are exactly the declarationMerging fixtures. 2459 tests.
+    Note: `moon check --deny-warn` fails on PRE-EXISTING deprecated-API
+    warnings (226, e.g. StringView `to_string`) on clean main too —
+    toolchain drift, not introduced by any batch; tests are the gate.
+
 2026-07-08 (T196)  714/815 (88 %)        414/414 ( 0 FP)   Parser: keyword member names generalized: TP 2584 (soundness)
 
   T196 -- generalize T195 beyond `type`. A probe sweep showed EVERY

--- a/TODO.md
+++ b/TODO.md
@@ -2295,6 +2295,35 @@ conformance sources (`.errors.txt` baseline = ground truth):
     the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
     698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
 
+2026-07-10 (T199)  714/815 (88 %)        414/414 ( 0 FP)   TS1163 yield contexts + temp-parser misuse hand-off: TP 2592 -> 2597
+
+  T199 -- TS1163 ("A 'yield' expression is only allowed in a generator
+    body") for `yield` in contexts nested INSIDE a generator that do not
+    inherit its [Yield] grammar: arrow bodies (block and expression form),
+    class field initializers (instance and static), non-generator function
+    EXPRESSIONS, and non-generator class METHODS. Three parser context
+    fixes, same family as the T193-era `parse_function` bug: (1) function
+    expressions and (2) class method bodies only SET `in_generator = true`
+    for generators and never reset it to false for non-generators nested
+    in one — both now assign `is_generator` unconditionally; (3) all 16
+    arrow-body parse sites (8 block + 8 expression) now save/clear/restore
+    `in_generator` (arrows are never generators). Class field initializers
+    clear it around the initializer expression only. Deliberately NOT
+    reset (pinned): class decorator arguments and computed member keys —
+    both evaluate in the enclosing scope, so `@decorator(yield 0)` and
+    `[yield 0]() {}` inside a generator are LEGAL (generatorTypeCheck39's
+    only baseline error is the field init, not the decorator).
+    Root-caused along the way: `({ b: yield 2 })` still missed because
+    parenthesized expressions parse through a TEMP parser whose
+    `grammar_misuses` were dropped on success — both temp-parser helpers
+    (paren inner + parse-until-terminator) now hand their recordings back
+    to the real parser in parse order. That hole silently ate EVERY
+    grammar misuse recorded inside parentheses, not just yield.
+    Corpus fixtures: YieldExpression20_es6, generatorTypeCheck39/57/58,
+    plus awaitAndYieldInProperty as an unplanned bonus (object-literal
+    property initializers hit the same contexts). Whole-corpus TP 2592 ->
+    2597 @ 0 FP, PFLEGAL 1, TN 1414, no lost TPs. 2461 tests.
+
 2026-07-10 (T198)  714/815 (88 %)        414/414 ( 0 FP)   Constant template folding feeds TS2367/TS2678: TP 2588 -> 2592
 
   T198 -- interpolated template literals with literal-constant

--- a/TODO.md
+++ b/TODO.md
@@ -2295,6 +2295,47 @@ conformance sources (`.errors.txt` baseline = ground truth):
     the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
     698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
 
+2026-07-10 (T200)  714/815 (88 %)        414/414 ( 0 FP)   Generic inference (user-priority theme): TP 2597 -> 2606
+
+  T200 -- batch AW, the user-designated HIGH theme (multi-stage generic
+    inference), landed in two FP-gated stages.
+    STAGE 1 (TP 2597 -> 2602): (a) iterator-class spread element
+    inference — a hand-rolled iterator class ([Symbol.iterator]() +
+    next() yielding { value: V }) spread into a rest param contributes V,
+    read from the annotated next() return or the returned object literal
+    (`Symbol()` mapped to `symbol` directly — infer_expr has no global
+    call model for it). Spread contributions flow through the iterable
+    protocol — a NESTED tsc inference position — so they pin type params
+    FIRST-WINS; direct rest arguments still union (`foo(1, "a")` pinned
+    legal). Root-caused via bindings dump: the old soft=true unioned
+    `symbol | string` and swallowed the mismatch. Array-literal spread
+    inference (`[...new It]`) also folds iterator elements
+    (iteratorSpreadInCall7/8/9). (b) `new Foo(...)` now runs
+    solve_generic_bindings over constructor signatures. (c) An
+    unannotated rest param destructured by a fixed-length array pattern
+    pins exact arity (iterableArrayPattern25). (d) Single-declaration
+    interface methods have exact arity — bypass the permissive arity
+    suppression (arraySpreadInCall's `action.run(...[100, 'foo'])`).
+    STAGE 2 (TP 2602 -> 2606): (e) lib `Map` constructor with a mixed
+    entry array (`new Map([["", true], ["", 0]])`) matches no overload —
+    fires only on the bare `New` shape (explicit `new Map<K, V>(...)`
+    parses into a TypeArgs wrapper and never reaches it; user-declared
+    Map shadows abstain) — for-of39, iterableArrayPattern28. (f) direct
+    calls passing an ARRAY LITERAL to a TemplateStringsArray tag-function
+    overload set fail every overload (`raw` can't exist on literals);
+    the overload set is registered at ingestion (>= 2 bodyless
+    TemplateStringsArray-first signatures, <= 1 implementation) because
+    the ingested Union includes the implementation signature and can't be
+    classified post-hoc (taggedTemplateStringsWithOverloadResolution1 x2).
+    DROPPED after root-causing: genericRestArity's variadic-handler shape
+    — the PARSER erases constrained type params to their bounds
+    (`TS extends unknown[]` -> `Array(Unknown)` in both the handler's
+    param list and the rest param), making the generic and non-generic
+    spellings indistinguishable at check time; un-erasing is a parser
+    design work item (would also unlock constraint-carrying inference).
+    Whole-corpus TP 2597 -> 2606 @ 0 FP, PFLEGAL 1, TN 1414, no lost
+    TPs. 579 checker wbtests.
+
 ## Release checkpoint (2026-07-10, post-T199)
 
 State at this cut: whole-corpus TP 2597 (397 via parse rejection) / FP 0 /

--- a/TODO.md
+++ b/TODO.md
@@ -2295,7 +2295,7 @@ conformance sources (`.errors.txt` baseline = ground truth):
     the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
     698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
 
-2026-07-10 (T200)  714/815 (88 %)        414/414 ( 0 FP)   Generic inference (user-priority theme): TP 2597 -> 2606
+2026-07-10 (T200)  714/815 (88 %)        414/414 ( 0 FP)   Generic inference (user-priority theme): TP 2597 -> 2607
 
   T200 -- batch AW, the user-designated HIGH theme (multi-stage generic
     inference), landed in two FP-gated stages.
@@ -2327,6 +2327,13 @@ conformance sources (`.errors.txt` baseline = ground truth):
     TemplateStringsArray-first signatures, <= 1 implementation) because
     the ingested Union includes the implementation signature and can't be
     classified post-hoc (taggedTemplateStringsWithOverloadResolution1 x2).
+    STAGE 3 (TP 2606 -> 2607): (g) `new Map([uniform entries])` infers
+    `Map<K, V>` from the literal-widened first pair (mixed pairs stay
+    `Any` — flagged by (e)), so `for_of_element_type`'s existing
+    `Map<K, V> -> [K, V]` arm feeds the spread-element check:
+    `...new Map([["", true]])` against `[string, number][]` is TS2345
+    (iterableArrayPattern29). Pinned legal: matching element types, and
+    for-of destructuring over the inferred map.
     DROPPED after root-causing: genericRestArity's variadic-handler shape
     — the PARSER erases constrained type params to their bounds
     (`TS extends unknown[]` -> `Array(Unknown)` in both the handler's

--- a/TODO.md
+++ b/TODO.md
@@ -2295,6 +2295,44 @@ conformance sources (`.errors.txt` baseline = ground truth):
     the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
     698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
 
+## Release checkpoint (2026-07-10, post-T199)
+
+State at this cut: whole-corpus TP 2597 (397 via parse rejection) / FP 0 /
+PFLEGAL 1 (parser768531 only) / TN 1414; 2461 unit tests; standing gate
+`--max-fp 0 --max-legal-parsefail 1` green. Session arc: TP 1761 -> 2597
+across PRs #191-#197 plus three unmerged commits (TS2428 merge identity,
+constant template folding, TS1163 yield contexts + temp-parser hand-off).
+
+Remaining 486 misses, sorted by real-world likelihood (what a bridge user
+would actually hit), so the release notes can state known limitations:
+
+  HIGH -- multi-stage generic inference (~40-60 files spanning TS2345 /
+    TS2322 / TS2554 / TS2769). Callback parameter types derived from a
+    sibling argument, overloaded call resolution (fetch-style APIs, tagged
+    templates), iterator / generator element inference. One design work
+    item, already scoped in T-entries; the single highest-leverage post-
+    release investment.
+  HIGH -- contextual typing gaps (TS7006 x7, TS7053 x6): contextually
+    typed IIFEs, class-expression methods, union call signatures.
+    Un-annotated callbacks are ubiquitous in real code.
+  MEDIUM -- lib surface models: nonexistent METHOD CALLS on primitive
+    receivers are unchecked (property access IS checked; needs complete
+    String/Number prototype tables to stay FP-free — T197 notes), and
+    Error / Date member models for TS2551 typo suggestions (x2).
+  MEDIUM -- flow narrowing tails: loop back-edge widening, `||`-RHS
+    chains, `T & primitive` disjointness (intersectionNarrowing). Common
+    in app code, rare in declaration files.
+  LOW (edge; acceptable release cuts) -- computed property names /
+    well-known symbols (TS2411 x13, TS2464/2466), parser-recovery
+    baselines (TS1005 x12), declaration-merging exotica, `using`
+    declarations (TS2851/TS1492), variant-baseline oracle artifacts
+    (NOBASE x12).
+
+Known non-blockers to note in a release: `moon check --deny-warn` fails on
+pre-existing deprecated-API warnings from toolchain drift (T197 note; tests
+are the gate), and parser768531's regex/division ambiguity is the one
+budgeted legal parse failure.
+
 2026-07-10 (T199)  714/815 (88 %)        414/414 ( 0 FP)   TS1163 yield contexts + temp-parser misuse hand-off: TP 2592 -> 2597
 
   T199 -- TS1163 ("A 'yield' expression is only allowed in a generator

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -5984,6 +5984,40 @@ fn infer_expr(
           for a in args {
             let _ = infer_expr(env, resolver, a)
           }
+          // Lib `Map` with a uniform entry array infers `Map<K, V>` from
+          // the literal-widened first pair, so downstream iteration /
+          // spread checks see `[K, V]` elements
+          // (`...new Map([["", true]])` against `[string, number][]` is
+          // TS2345 — iterableArrayPattern29). Mixed pairs (flagged
+          // separately as a constructor-overload failure) stay `Any`.
+          if class_name == "Map" &&
+            resolver.classes.get("Map") is None &&
+            resolver.interfaces.get("Map") is None &&
+            args.length() == 1 &&
+            args[0] is ArrayLit(entries) &&
+            entries.length() > 0 {
+            let mut k0 : @ast.TsType = Any
+            let mut v0 : @ast.TsType = Any
+            let mut uniform = true
+            for i, e in entries {
+              match e {
+                ArrayLit([k, v]) => {
+                  let kt = widen_literal(infer_expr(env, resolver, k))
+                  let vt = widen_literal(infer_expr(env, resolver, v))
+                  if i == 0 {
+                    k0 = kt
+                    v0 = vt
+                  } else if kt != k0 || vt != v0 {
+                    uniform = false
+                  }
+                }
+                _ => uniform = false
+              }
+            }
+            if uniform && is_checkable(k0) && is_checkable(v0) {
+              return @ast.TsType::Applied("Map", [k0, v0])
+            }
+          }
           @ast.TsType::Any
         }
       }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -5811,7 +5811,13 @@ fn infer_expr(
                 }
                 u
               }
-              _ => @ast.TsType::Any
+              // `[...new StringIterator]` — spreading a hand-rolled
+              // iterator class yields its `next()` element type.
+              other =>
+                match iterator_class_element_type(resolver, other) {
+                  Some(el) => el
+                  None => @ast.TsType::Any
+                }
             }
           _ => infer_expr(env, resolver, item)
         }
@@ -6688,7 +6694,25 @@ fn solve_generic_bindings(
         let actual = infer_expr(env, resolver, args[i])
         match args[i] {
           Spread(_) =>
-            infer_param_bindings(type_params, rest_arr, actual, bindings, true)
+            // A spread of a hand-rolled iterator class contributes its
+            // ELEMENT type (`foo(...new SymbolIterator)` binds `T` to
+            // `symbol`), not the class itself. The contribution flows
+            // through the iterable protocol — a nested inference position
+            // in tsc — so it PINS first-wins rather than widening into a
+            // union: the second spread's mismatching element is an error
+            // (iteratorSpreadInCall7), unlike plain rest arguments.
+            match iterator_class_element_type(resolver, actual) {
+              Some(el) =>
+                infer_param_bindings(type_params, elem, el, bindings, false)
+              None =>
+                // Array-typed spreads (`...[...it]`, `...arr`) infer
+                // `number[] -> T[]` — a NESTED position, so they pin
+                // first-wins too (iteratorSpreadInCall9); only direct rest
+                // arguments union across positions.
+                infer_param_bindings(
+                  type_params, rest_arr, actual, bindings, false,
+                )
+            }
           _ => infer_param_bindings(type_params, elem, actual, bindings, true)
         }
         i = i + 1
@@ -6708,6 +6732,82 @@ fn solve_generic_bindings(
     i = i + 1
   }
   bindings
+}
+
+///|
+/// Element type produced by iterating a hand-rolled iterator class: one that
+/// declares `[Symbol.iterator]()` and whose `next()` yields `{ value: V }`.
+/// `V` comes from the annotated return type when present, otherwise from a
+/// `return { value: ..., done: ... }` object literal in the body (inferred
+/// in a fresh env and literal-widened, matching how tsc spreads
+/// `...new SymbolIterator` as `symbol`s). Returns `None` for anything the
+/// shape doesn't pin down exactly: base classes, generics, interface
+/// merges, or a missing/opaque `next`.
+fn iterator_class_element_type(
+  resolver : Resolver,
+  t : @ast.TsType,
+) -> @ast.TsType? {
+  guard resolver.unwrap(t) is Named(n) else { return None }
+  guard resolver.classes.get(n) is Some(cls) else { return None }
+  guard cls.base_names.length() == 0 &&
+    cls.base_expr is None &&
+    cls.type_params.length() == 0 &&
+    resolver.interfaces.get(n) is None else {
+    return None
+  }
+  let mut has_sym_iter = false
+  for m in cls.methods {
+    if !m.is_static &&
+      m.name == "<computed>" &&
+      m.key_expr is Some(PropAccess(Var("Symbol"), "iterator")) {
+      has_sym_iter = true
+    }
+  }
+  guard has_sym_iter else { return None }
+  for m in cls.methods {
+    if m.is_static || m.name != "next" {
+      continue
+    }
+    // Annotated `next(): { value: V; done: boolean }`.
+    match m.return_type {
+      Object(fields) =>
+        for f in fields {
+          if f.0 is Literal("value") {
+            return Some(f.1)
+          }
+        }
+      _ => ()
+    }
+    // Unannotated: read the returned object literal's `value` property.
+    match m.body {
+      Some(b) =>
+        for st in b.stmts {
+          match st {
+            Return(Some(ObjectLit(props))) =>
+              for kv in props {
+                if kv.0 == "value" {
+                  // `Symbol()` has no global call model in `infer_expr`
+                  // (the lib global isn't a function value there), so map
+                  // it directly — the iterator fixtures build symbol
+                  // elements this way.
+                  match kv.1 {
+                    Call("Symbol", _) => return Some(@ast.TsType::Symbol)
+                    other =>
+                      return Some(
+                        widen_literal(
+                          infer_expr(ExprEnv::new(), resolver, other),
+                        ),
+                      )
+                  }
+                }
+              }
+            _ => ()
+          }
+        }
+      None => ()
+    }
+  }
+  None
 }
 
 ///|
@@ -10949,6 +11049,67 @@ fn check_arguments(
 }
 
 ///|
+/// True when `meth` on receiver type `recv` resolves to a method declared
+/// EXACTLY ONCE across a module-declared interface and its (depth-limited)
+/// extends chain, with no rest parameter and no generic method type params.
+/// Such a signature's arity is exact — interfaces cannot declare parameter
+/// defaults, and `?` optionality is widened into the parameter type — so an
+/// arity diagnostic against it is reliable. Classes are excluded (method
+/// implementations may carry defaults the recorded types don't show).
+fn interface_method_arity_reliable(
+  resolver : Resolver,
+  recv : @ast.TsType,
+  meth : String,
+) -> Bool {
+  guard resolver.unwrap(recv) is Named(n) else { return false }
+  let mut count = 0
+  let mut sig_ty : @ast.TsType? = None
+  let mut generic = false
+  fn walk(name : String, depth : Int) -> Unit {
+    if depth > 8 {
+      count += 2 // force-bail on suspiciously deep chains
+      return
+    }
+    match resolver.interfaces.get(name) {
+      Some(iface) => {
+        for f in iface.fields {
+          if f.0 == meth {
+            count += 1
+            sig_ty = Some(f.1)
+          }
+        }
+        for pair in iface.method_type_params {
+          if pair.0 == meth && pair.1.length() > 0 {
+            generic = true
+          }
+        }
+        for base in iface.extends_names {
+          walk(base, depth + 1)
+        }
+      }
+      None =>
+        // An unresolvable base could contribute overloads we can't see.
+        count += 2
+    }
+  }
+  walk(n, 0)
+  if count != 1 || generic {
+    return false
+  }
+  match sig_ty {
+    Some(Func(ps, _)) => {
+      for p in ps {
+        if p is Rest(_) {
+          return false
+        }
+      }
+      true
+    }
+    _ => false
+  }
+}
+
+///|
 /// Variant of `check_arguments` that takes the rich `TsParam` list when
 /// available, so optional / default / rest parameters are honored on arity
 /// checks. `param_types` is the simplified types array (already lifted out
@@ -11156,9 +11317,47 @@ fn check_arguments_with_sig(
           has_rest = true
         }
       }
-      let min_ = required_arity(ps)
-      let max_ = if has_rest { -1 } else { ps.length() }
-      (min_, max_)
+      // An UNANNOTATED rest parameter destructured by a fixed-length array
+      // pattern (`function f(...[[k1, v1], [k2, v2]]) {}`) behaves as
+      // exactly that many required parameters — tsc reports "Expected 2
+      // arguments", not an open-ended rest. A declared tuple type on the
+      // rest param can carry its own optionality, so only the
+      // annotation-free form pins the count.
+      let mut fixed_rest_len = -1
+      if has_rest && ps.length() > 0 && ps[ps.length() - 1].is_rest {
+        let last = ps[ps.length() - 1]
+        if last.type_ is Any {
+          match last.binding {
+            Some(Array(ab)) =>
+              if ab.rest is None {
+                let mut fixed = true
+                let mut n = 0
+                for it in ab.items {
+                  match it {
+                    Some(el) => {
+                      if el.default is Some(_) {
+                        fixed = false
+                      }
+                      n += 1
+                    }
+                    None => fixed = false
+                  }
+                }
+                if fixed && n > 0 {
+                  fixed_rest_len = n
+                }
+              }
+            _ => ()
+          }
+        }
+      }
+      if fixed_rest_len >= 0 {
+        (required_arity(ps) + fixed_rest_len, ps.length() - 1 + fixed_rest_len)
+      } else {
+        let min_ = required_arity(ps)
+        let max_ = if has_rest { -1 } else { ps.length() }
+        (min_, max_)
+      }
     }
     None => {
       // No rich `TsParam` metadata (e.g. calling a value typed as
@@ -14473,7 +14672,26 @@ fn check_call_args_in_expr(
             let pruned = prune_nullish(ctx.resolver, recv_ty)
             match ctx.resolver.lookup_method_sig(pruned, meth) {
               Some((params, _)) =>
-                check_arguments(env, params, args, ctx, "call `\{meth}`")
+                // A method declared exactly once on a module-declared
+                // INTERFACE has an exact arity: interfaces can't carry
+                // parameter defaults, `?` optionality is widened into the
+                // type, and overloads would appear as repeated fields.
+                // That makes the count reliable enough to bypass the
+                // permissive arity suppression (`action.run(...[100,
+                // 'foo'])` against `run(event?: unknown)` is TS2554).
+                check_arguments_with_sig(
+                  env,
+                  params,
+                  None,
+                  args,
+                  ctx,
+                  "call `\{meth}`",
+                  arity_reliable=interface_method_arity_reliable(
+                    ctx.resolver,
+                    pruned,
+                    meth,
+                  ),
+                )
               None =>
                 // If the receiver has a concrete shape and we can't find the
                 // method, flag it — but be conservative and skip Any/primitives
@@ -14532,9 +14750,28 @@ fn check_call_args_in_expr(
       }
       match ctx.resolver.lookup_constructor_sig(class_name) {
         Some((params, sig)) => {
+          // Generic class: infer the constructor's type-param bindings from
+          // the arguments (mirroring the direct-call path) so `new Foo(...
+          // new SymbolIterator, ...new _StringIterator)` with
+          // `constructor(...s: T[])` pins `T` from the first argument and
+          // checks the rest against it.
+          let substituted_params = match ctx.resolver.classes.get(class_name) {
+            Some(cls) if cls.type_params.length() > 0 => {
+              let bindings = solve_generic_bindings(
+                env,
+                ctx.resolver,
+                cls.type_params,
+                params,
+                args,
+                Some(sig),
+              )
+              substitute_params_array(params, bindings)
+            }
+            _ => params
+          }
           check_arguments_with_sig(
             env,
-            params,
+            substituted_params,
             Some(sig),
             args,
             ctx,

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -20457,6 +20457,129 @@ fn check_structural_duplicates(module_ : @ast.TsModule) -> Array[ExprIssue] {
 }
 
 ///|
+/// TS2428: every declaration of a merged interface must carry an identical
+/// type parameter list — same arity, same names in the same order, and (when
+/// both declarations constrain a parameter) identical constraints. tsc
+/// relaxes the constraint comparison when one declaration omits it
+/// (`interface C<T>` merges fine with `interface C<T extends number>`), so a
+/// one-sided bound never flags. Runs per module scope: the caller invokes it
+/// once per namespace layer, which matches tsc's declaration spaces — two
+/// non-exported interfaces in *separate* blocks of the same namespace do not
+/// merge and are never compared here.
+fn check_interface_merge_type_params(
+  module_ : @ast.TsModule,
+  resolver : Resolver,
+) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  let first : Map[String, @ast.TsInterface] = {}
+  let reported : Map[String, Bool] = {}
+  for iface in module_.interfaces {
+    match first.get(iface.name) {
+      None => first[iface.name] = iface
+      Some(prev) =>
+        if !(reported.get(iface.name) is Some(_)) &&
+          !interface_type_params_identical(resolver, prev, iface) {
+          reported[iface.name] = true
+          issues.push({
+            path: "interface \{iface.name}",
+            message: "all declarations of `\{iface.name}` must have identical type parameters",
+          })
+        }
+    }
+  }
+  issues
+}
+
+///|
+fn interface_type_params_identical(
+  resolver : Resolver,
+  a : @ast.TsInterface,
+  b : @ast.TsInterface,
+) -> Bool {
+  if a.type_params.length() != b.type_params.length() {
+    return false
+  }
+  for i, tp in a.type_params {
+    if b.type_params[i] != tp {
+      return false
+    }
+  }
+  for tp in a.type_params {
+    match (interface_param_bound(a, tp), interface_param_bound(b, tp)) {
+      (Some(x), Some(y)) =>
+        if interface_bound_differs(resolver, x, y) {
+          return false
+        }
+      // One-sided constraint: tsc skips the comparison entirely.
+      _ => ()
+    }
+  }
+  true
+}
+
+///|
+fn interface_param_bound(
+  iface : @ast.TsInterface,
+  param : String,
+) -> @ast.TsType? {
+  for pair in iface.type_param_bounds {
+    if pair.0 == param {
+      return Some(pair.1)
+    }
+  }
+  None
+}
+
+///|
+/// True when two interface type-parameter constraints are *definitely*
+/// non-identical. Spelling differences must never flag, so identity is
+/// decided in stages: raw AST equality, alias-unwrapped equality, canonical
+/// `identity_key` comparison, and finally a nominal head comparison for
+/// reference types the canonicalizer can't expand (lib names like `Date` /
+/// `Number` have no module declaration, so their keys are `None` — but two
+/// different unresolvable names are distinct types to tsc).
+fn interface_bound_differs(
+  resolver : Resolver,
+  x : @ast.TsType,
+  y : @ast.TsType,
+) -> Bool {
+  if x == y {
+    return false
+  }
+  let ux = resolver.unwrap(x)
+  let uy = resolver.unwrap(y)
+  if ux == uy {
+    return false
+  }
+  match (identity_key(ux, resolver, 0), identity_key(uy, resolver, 0)) {
+    (Some(a), Some(b)) => a != b
+    _ =>
+      match (ux, uy) {
+        (Named(a), Named(b)) => a != b
+        (Applied(a, xs), Applied(b, ys)) =>
+          if a != b {
+            true
+          } else if xs.length() != ys.length() {
+            true
+          } else {
+            let mut differs = false
+            for i, xa in xs {
+              if interface_bound_differs(resolver, xa, ys[i]) {
+                differs = true
+                break
+              }
+            }
+            differs
+          }
+        // A parsed literal `any` bound against a concrete reference:
+        // tsc's identity relation only equates `any` with itself.
+        (Named(_), Any) | (Any, Named(_)) => true
+        _ => false
+      }
+  }
+}
+
+///|
 /// True when `name` is a single uppercase ASCII letter (`T`, `U`, `K`, …).
 /// Such names are, by overwhelming convention, generic type parameters —
 /// never library / global types — so an *unresolved* one is reliably an
@@ -21878,6 +22001,9 @@ fn check_module_function_bodies_layered(
     all.push(issue)
   }
   for issue in check_structural_duplicates(module_) {
+    all.push(issue)
+  }
+  for issue in check_interface_merge_type_params(module_, resolver) {
     all.push(issue)
   }
   // TS2304 for single-letter out-of-scope type parameters. Run once at the

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -5652,6 +5652,46 @@ fn equality_primitive_family(t : @ast.TsType) -> String? {
 }
 
 ///|
+/// The compile-time string value of an interpolated template literal whose
+/// substitutions are all literal constants, or `None` when any substitution
+/// is non-constant or its JS string rendering isn't reproducible here
+/// (non-integer numbers keep JS `Number.prototype.toString` formatting
+/// edge cases out of scope).
+fn fold_constant_template(
+  parts : Array[String],
+  exprs : Array[@ast.TsExpr],
+) -> String? {
+  if parts.length() != exprs.length() + 1 {
+    return None
+  }
+  let buf = StringBuilder::new()
+  for i, e in exprs {
+    buf.write_string(parts[i])
+    match e {
+      StringLit(s) => buf.write_string(s)
+      BoolLit(b) => buf.write_string(if b { "true" } else { "false" })
+      IntLit(n) => buf.write_string(n.to_string())
+      NumberLit(d) =>
+        // Only integers render identically in JS and here; fractional /
+        // huge values hit exponent and shortest-round-trip formatting.
+        if d >= 0.0 && d < 1.0e15 && d == d.floor() {
+          buf.write_string(d.to_int64().to_string())
+        } else {
+          return None
+        }
+      TemplateLiteral(inner_parts, inner_exprs) =>
+        match fold_constant_template(inner_parts, inner_exprs) {
+          Some(s) => buf.write_string(s)
+          None => return None
+        }
+      _ => return None
+    }
+  }
+  buf.write_string(parts[parts.length() - 1])
+  Some(buf.to_string())
+}
+
+///|
 fn wrap_async_return(is_async : Bool, ret : @ast.TsType) -> @ast.TsType {
   if !is_async {
     return ret
@@ -6285,7 +6325,14 @@ fn infer_expr(
       if exprs.length() == 0 && parts.length() == 1 {
         @ast.TsType::Literal(parts[0])
       } else {
-        @ast.TsType::String_
+        // tsc folds a template whose substitutions are all literal
+        // constants into the resulting string-literal type before
+        // widening (`` `abc${0}abc` `` is `"abc0abc"` in a comparison),
+        // which is what feeds the TS2367 overlap check.
+        match fold_constant_template(parts, exprs) {
+          Some(s) => @ast.TsType::Literal(s)
+          None => @ast.TsType::String_
+        }
       }
     // `x as T` — forced cast; result type is `T`. We still walk `inner` so
     // any nested call sites are validated.

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -71,6 +71,12 @@ priv struct Resolver {
   // as unknown and abstain.
   namespace_value_decls : Map[String, Map[String, Bool]]
   namespace_exports : Map[String, Map[String, Bool]]
+  // Names of overloaded tag functions: >= 2 bodyless overload signatures
+  // whose first parameter is the lib `TemplateStringsArray`, plus at most
+  // one implementation. A direct (non-template) call passing an array
+  // literal fails every overload (the `raw` member only exists on
+  // engine-created template objects), which is TS2769/TS2345.
+  template_tag_funcs : Map[String, Bool]
 }
 
 ///|
@@ -89,6 +95,7 @@ fn Resolver::empty() -> Resolver {
     private_brand_decls: {},
     namespace_value_decls: {},
     namespace_exports: {},
+    template_tag_funcs: {},
   }
 }
 
@@ -658,6 +665,31 @@ fn Resolver::ingest_module(
     r.func_const_type_params[prefix + f.name] = f.const_type_params
     if f.type_param_bounds.length() > 0 {
       r.func_type_param_bounds[prefix + f.name] = f.type_param_bounds
+    }
+  }
+  // Tag-function overload sets (see the `template_tag_funcs` field doc):
+  // group same-name declarations into bodyless overload signatures vs
+  // implementations; register only the unambiguous
+  // all-TemplateStringsArray shape.
+  let tag_groups : Map[String, (Int, Int, Bool)] = {}
+  for f in module_.funcs {
+    let is_sig_only = f.body.stmts.length() == 0
+    let tsa_first = f.params.length() > 0 &&
+      !f.params[0].is_rest &&
+      f.params[0].type_ is Named("TemplateStringsArray")
+    let cur = match tag_groups.get(f.name) {
+      Some(v) => v
+      None => (0, 0, true)
+    }
+    tag_groups[f.name] = (
+      cur.0 + (if is_sig_only { 1 } else { 0 }),
+      cur.1 + (if is_sig_only { 0 } else { 1 }),
+      cur.2 && (tsa_first || !is_sig_only),
+    )
+  }
+  for name, g in tag_groups {
+    if g.0 >= 2 && g.1 <= 1 && g.2 {
+      r.template_tag_funcs[prefix + name] = true
     }
   }
   for ns in module_.namespaces {
@@ -14548,6 +14580,25 @@ fn check_call_args_in_expr(
             Some(params) =>
               check_arguments(env, params, args, ctx, "call `\{name}`")
             None => {
+              // TS2345 for a direct (non-template) call to a tag-function
+              // overload set: every overload's first parameter is the lib
+              // `TemplateStringsArray`, and no array literal can satisfy
+              // it (the `raw` property only exists on engine-created
+              // template objects), so `foo([])` / `foo([], 1)` fail every
+              // overload (taggedTemplateStringsWithOverloadResolution1).
+              // A module-declared `TemplateStringsArray` interface or a
+              // local binding shadowing the function name abstains.
+              if args.length() > 0 &&
+                args[0] is ArrayLit(_) &&
+                env.lookup(name) is None &&
+                ctx.resolver.interfaces.get("TemplateStringsArray") is None &&
+                ctx.resolver.template_tag_funcs.get(name) is Some(_) {
+                record(
+                  ctx,
+                  "call `\{name}`",
+                  "an array literal is not assignable to parameter of type `TemplateStringsArray`",
+                )
+              }
               // Overload sets also ingest as a `Union` of `Func`s; a call
               // needs only ONE overload to match, so the every-member arity
               // rule applies solely to union-typed *values* (names with no
@@ -14747,6 +14798,58 @@ fn check_call_args_in_expr(
           "variable `\{class_name}` is used before being assigned",
         )
         let _ = ctx.unassigned.remove(class_name)
+      }
+      // TS2769 for the lib `Map` constructor with a mixed entry array:
+      // `new Map([["", true], ["", 0]])` has no single (K, V)
+      // instantiation, so no constructor overload matches (for-of39,
+      // iterableArrayPattern28). Explicit type arguments (`new Map<K, V>
+      // (...)`) parse into a `TypeArgs` wrapper and never reach this bare
+      // `New` shape, so a widening annotation can't false-positive here.
+      // A user-declared `Map` class or binding shadows the lib type and
+      // abstains.
+      if class_name == "Map" &&
+        ctx.resolver.classes.get("Map") is None &&
+        ctx.resolver.interfaces.get("Map") is None &&
+        env.lookup("Map") is None &&
+        args.length() == 1 &&
+        args[0] is ArrayLit(entries) &&
+        entries.length() >= 2 {
+        let mut all_pairs = true
+        let pairs : Array[(@ast.TsType, @ast.TsType)] = []
+        for e in entries {
+          match e {
+            ArrayLit([k, v]) => {
+              let kt = widen_literal(infer_expr(env, ctx.resolver, k))
+              let vt = widen_literal(infer_expr(env, ctx.resolver, v))
+              pairs.push((kt, vt))
+            }
+            _ => all_pairs = false
+          }
+        }
+        if all_pairs && pairs.length() >= 2 {
+          let (k0, v0) = pairs[0]
+          let mut mixed = false
+          for idx in 1..<pairs.length() {
+            let (ki, vi) = pairs[idx]
+            if is_checkable(k0) &&
+              is_checkable(ki) &&
+              !is_assignable_to(ki, k0) &&
+              !is_assignable_to(k0, ki) {
+              mixed = true
+            }
+            if is_checkable(v0) &&
+              is_checkable(vi) &&
+              !is_assignable_to(vi, v0) &&
+              !is_assignable_to(v0, vi) {
+              mixed = true
+            }
+          }
+          if mixed {
+            record(
+              ctx, "new `Map`", "no overload of the `Map` constructor matches this mixed entry array",
+            )
+          }
+        }
       }
       match ctx.resolver.lookup_constructor_sig(class_name) {
         Some((params, sig)) => {

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -13153,3 +13153,47 @@ test "expr_check: generic inference stage 1 (batch AW)" {
     0,
   )
 }
+
+///|
+test "expr_check: generic inference stage 2 — Map entries + tag funcs (batch AW)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Mixed (K, V) entry array: no Map constructor overload matches
+  // (for-of39 / iterableArrayPattern28, TS2769).
+  assert_true(
+    issues("// @strict: false\nvar map = new Map([[\"\", true], [\"\", 0]]);") >
+    0,
+  )
+  // Uniform entries stay legal.
+  @test.assert_eq(
+    issues("// @strict: false\nvar map = new Map([[\"\", 0], [\"hello\", 1]]);"),
+    0,
+  )
+  // Literal-widened uniform entries too.
+  @test.assert_eq(
+    issues("// @strict: false\nvar m2 = new Map([[1, \"a\"], [2, \"b\"]]);"),
+    0,
+  )
+  // A user-declared Map shadows the lib constructor: abstain.
+  @test.assert_eq(
+    issues(
+      "// @strict: false\nclass Map { constructor(x: any) {} }\nvar m = new Map([[\"\", true], [\"\", 0]]);",
+    ),
+    0,
+  )
+  // Direct call to a TemplateStringsArray tag-function overload set with
+  // an array literal fails every overload (TS2345/TS2769).
+  let tag_decl = "function foo(strs: TemplateStringsArray): number;\nfunction foo(strs: TemplateStringsArray, x: number): string;\nfunction foo(...stuff: any[]): any {\n    return undefined;\n}\n"
+  assert_true(issues("// @strict: false\n" + tag_decl + "var a = foo([]);") > 0)
+  assert_true(
+    issues("// @strict: false\n" + tag_decl + "var b = foo([], 1);") > 0,
+  )
+  // The template form is the legal use.
+  @test.assert_eq(
+    issues(
+      "// @strict: false\n" + tag_decl + "var u = foo ``;\nvar v = foo `${1}`;",
+    ),
+    0,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -13004,3 +13004,79 @@ test "expr_check: constant template folding feeds TS2367 (batch AU)" {
   // Fractional / huge numbers are not folded (JS formatting edge cases).
   @test.assert_eq(issues("// @strict: false\nvar x = `a${0.5}` === `a`;"), 0)
 }
+
+///|
+test "expr_check: TS1163 yield contexts inside generators (batch AV)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Arrow bodies never inherit the generator context.
+  assert_true(
+    issues(
+      "// @strict: false\nfunction* g() {\n  return () => ({ b: yield 2 });\n}",
+    ) >
+    0,
+  )
+  assert_true(
+    issues("// @strict: false\nfunction* g() {\n  var f = x => yield 2;\n}") > 0,
+  )
+  // Class field initializers (instance and static) are their own context.
+  assert_true(
+    issues(
+      "// @strict: false\nfunction* g() {\n  class C {\n    x = yield 0;\n  }\n}",
+    ) >
+    0,
+  )
+  assert_true(
+    issues(
+      "// @strict: false\nfunction* g() {\n  class C {\n    static x = yield 0;\n  }\n}",
+    ) >
+    0,
+  )
+  // A non-generator function expression / method inside a generator.
+  assert_true(
+    issues(
+      "// @strict: false\nfunction* g() {\n  var f = function () {\n    var a = yield 0;\n  };\n}",
+    ) >
+    0,
+  )
+  assert_true(
+    issues(
+      "// @strict: false\nfunction* g() {\n  class C {\n    m() {\n      var a = yield 0;\n    }\n  }\n}",
+    ) >
+    0,
+  )
+  // Pins: contexts where yield stays legal.
+  // Plain yield in the generator body itself.
+  @test.assert_eq(
+    issues("// @strict: false\nfunction* g() {\n  var a = yield 0;\n}"),
+    0,
+  )
+  // Parenthesized yield in the generator body (temp-parser hand-off must
+  // not double- or mis-record).
+  @test.assert_eq(
+    issues("// @strict: false\nfunction* g() {\n  var a = (yield 0);\n}"),
+    0,
+  )
+  // Class decorators and computed keys evaluate in the enclosing
+  // (generator) scope.
+  @test.assert_eq(
+    issues(
+      "// @strict: false\nfunction* g() {\n  class C {\n    [yield 0]() {}\n  }\n}",
+    ),
+    0,
+  )
+  // A generator METHOD of a class inside a generator keeps its own
+  // generator context.
+  @test.assert_eq(
+    issues(
+      "// @strict: false\nfunction* g() {\n  class C {\n    *m() {\n      var a = yield 0;\n    }\n  }\n}",
+    ),
+    0,
+  )
+  // yield as a plain identifier in non-generator code stays legal.
+  @test.assert_eq(
+    issues("// @strict: false\nfunction f() {\n  var yield_ok = 1;\n}"),
+    0,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -12890,3 +12890,82 @@ test "expr_check: generalized keyword member names (batch AT)" {
     0,
   )
 }
+
+///|
+test "expr_check: TS2428 interface merge type-param identity (batch AU)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Generic + non-generic declarations of one name never merge.
+  assert_true(
+    issues(
+      "// @strict: false\ninterface A { foo: string; }\ninterface A<T> { bar: T; }",
+    ) >
+    0,
+  )
+  // Same arity, different parameter names.
+  assert_true(
+    issues(
+      "// @strict: false\ninterface A<T> { x: T; }\ninterface A<U> { y: U; }",
+    ) >
+    0,
+  )
+  // Different arity.
+  assert_true(
+    issues(
+      "// @strict: false\ninterface A<T> { x: T; }\ninterface A<T, U> { y: U; }",
+    ) >
+    0,
+  )
+  // Both constrained, different constraints.
+  assert_true(
+    issues(
+      "// @strict: false\ninterface A<T extends Date> { x: T; }\ninterface A<T extends Number> { y: T; }",
+    ) >
+    0,
+  )
+  // Same head, one argument `any` vs a concrete reference.
+  assert_true(
+    issues(
+      "// @strict: false\ninterface B<T> { x: T; }\ninterface C<T extends B<Date>> { x: T; }\ninterface C<T extends B<any>> { y: T; }",
+    ) >
+    0,
+  )
+  // Pins: legal merges stay silent.
+  // Identical lists merge.
+  @test.assert_eq(
+    issues(
+      "// @strict: false\ninterface A<T> { x: T; }\ninterface A<T> { y: T; }",
+    ),
+    0,
+  )
+  // One-sided constraint is exempt from the comparison (both directions).
+  @test.assert_eq(
+    issues(
+      "// @strict: false\ninterface B<T extends number> { u: T; }\ninterface B<T> { x: T; }\ninterface C<T> { x: T; }\ninterface C<T extends number> { y: T; }",
+    ),
+    0,
+  )
+  // Alias spelling of the same constraint is identical after unwrap.
+  @test.assert_eq(
+    issues(
+      "// @strict: false\ntype N = number;\ninterface I<T extends N> { x: T; }\ninterface I<T extends number> { y: T; }",
+    ),
+    0,
+  )
+  // Union member order is canonicalized before comparing.
+  @test.assert_eq(
+    issues(
+      "// @strict: false\ninterface J<T extends string | number> { x: T; }\ninterface J<T extends number | string> { y: T; }",
+    ),
+    0,
+  )
+  // Non-exported interfaces in separate blocks of one namespace do not
+  // merge (different declaration spaces).
+  @test.assert_eq(
+    issues(
+      "// @strict: false\nnamespace M2 { interface A { foo: string; } }\nnamespace M2 { interface A<T> { bar: T; } }",
+    ),
+    0,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -12969,3 +12969,38 @@ test "expr_check: TS2428 interface merge type-param identity (batch AU)" {
     0,
   )
 }
+
+///|
+test "expr_check: constant template folding feeds TS2367 (batch AU)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Literal substitutions fold to the resulting string-literal type, so
+  // disjoint comparisons surface (templateStringInEqualityChecks).
+  assert_true(issues("// @strict: false\nvar x = `abc${0}abc` === `abc`;") > 0)
+  assert_true(issues("// @strict: false\nvar x = `abc` !== `abc${0}abc`;") > 0)
+  assert_true(
+    issues("// @strict: false\nvar x = `a${\"b\"}c` === \"other\";") > 0,
+  )
+  // Pins: identical folds overlap; non-constant substitutions stay
+  // `string` (never flagged); widening keeps reassignment legal.
+  @test.assert_eq(
+    issues("// @strict: false\nvar x = `abc${0}abc` == \"abc0abc\";"),
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "// @strict: false\ndeclare var n: number;\nvar x = `abc${n}abc` === `abc`;",
+    ),
+    0,
+  )
+  // Parity pin: a folded template init behaves exactly like the same
+  // string written as a plain literal init — folding introduces no new
+  // reassignment behavior on top of the existing literal handling.
+  @test.assert_eq(
+    issues("// @strict: false\nvar x = `a${0}`;\nx = \"other\";"),
+    issues("// @strict: false\nvar x = \"a0\";\nx = \"other\";"),
+  )
+  // Fractional / huge numbers are not folded (JS formatting edge cases).
+  @test.assert_eq(issues("// @strict: false\nvar x = `a${0.5}` === `a`;"), 0)
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -13197,3 +13197,32 @@ test "expr_check: generic inference stage 2 — Map entries + tag funcs (batch A
     0,
   )
 }
+
+///|
+test "expr_check: uniform Map<K, V> inference (batch AW stage 3)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Uniform-map spread element vs a tuple-typed rest param
+  // (iterableArrayPattern29, TS2345).
+  assert_true(
+    issues(
+      "// @strict: false\nfunction takeFirstTwoEntries(...[[k1, v1], [k2, v2]]: [string, number][]) { }\ntakeFirstTwoEntries(...new Map([[\"\", true], [\"hello\", true]]));",
+    ) >
+    0,
+  )
+  // Matching element type stays legal.
+  @test.assert_eq(
+    issues(
+      "// @strict: false\nfunction takeFirstTwoEntries(...[[k1, v1], [k2, v2]]: [string, number][]) { }\ntakeFirstTwoEntries(...new Map([[\"\", 0], [\"hello\", 1]]));",
+    ),
+    0,
+  )
+  // for-of over an inferred Map<K, V> stays legal.
+  @test.assert_eq(
+    issues(
+      "// @strict: false\nvar m = new Map([[\"a\", 1], [\"b\", 2]]);\nfor (var [k, v] of m) {\n  var s: string = k;\n  var n: number = v;\n}",
+    ),
+    0,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -13080,3 +13080,76 @@ test "expr_check: TS1163 yield contexts inside generators (batch AV)" {
     0,
   )
 }
+
+///|
+test "expr_check: generic inference stage 1 (batch AW)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Exact array-literal spread against an interface method's optional
+  // param: too many arguments (arraySpreadInCall / TS2554).
+  assert_true(
+    issues(
+      "// @strict: false\ninterface IAction { run(event?: unknown): unknown; }\ndeclare const action: IAction;\naction.run(...[100, \"foo\"]);",
+    ) >
+    0,
+  )
+  // Rest param destructured by a fixed-length tuple pattern pins arity
+  // (iterableArrayPattern25 / TS2554).
+  assert_true(
+    issues(
+      "// @strict: false\nfunction takeFirstTwoEntries(...[[k1, v1], [k2, v2]]) { }\ntakeFirstTwoEntries(new Map([[\"\", 0], [\"hello\", 1]]));",
+    ) >
+    0,
+  )
+  // Iterator-class spreads pin the rest type param first-wins
+  // (iteratorSpreadInCall7/8/9 / TS2345).
+  let iter_classes = "class SymbolIterator {\n  next() { return { value: Symbol(), done: false }; }\n  [Symbol.iterator]() { return this; }\n}\nclass _StringIterator {\n  next() { return { value: \"\", done: false }; }\n  [Symbol.iterator]() { return this; }\n}\n"
+  assert_true(
+    issues(
+      "// @strict: false\nfunction foo<T>(...s: T[]) { return s[0]; }\n" +
+      iter_classes +
+      "foo(...new SymbolIterator, ...new _StringIterator);",
+    ) >
+    0,
+  )
+  assert_true(
+    issues(
+      "// @strict: false\nclass Foo<T> { constructor(...s: T[]) { } }\n" +
+      iter_classes +
+      "new Foo(...new SymbolIterator, ...[...new _StringIterator]);",
+    ) >
+    0,
+  )
+  // Pins: legal patterns stay silent.
+  // Same-element iterator spreads agree.
+  @test.assert_eq(
+    issues(
+      "// @strict: false\nfunction foo<T>(...s: T[]) { return s[0]; }\n" +
+      iter_classes +
+      "foo(...new SymbolIterator, ...new SymbolIterator);",
+    ),
+    0,
+  )
+  // Direct mixed rest arguments still union (no pin): tsc accepts.
+  @test.assert_eq(
+    issues(
+      "// @strict: false\nfunction foo<T>(...s: T[]) { return s[0]; }\nfoo(1, \"a\");",
+    ),
+    0,
+  )
+  // Interface method calls with exact arity stay silent, incl. optional.
+  @test.assert_eq(
+    issues(
+      "// @strict: false\ninterface IAction { run(event?: unknown): unknown; }\ndeclare const action: IAction;\naction.run();\naction.run(1);\naction.run(...[100]);",
+    ),
+    0,
+  )
+  // Tuple-annotated rest params keep their own optionality (no pattern pin).
+  @test.assert_eq(
+    issues(
+      "// @strict: false\nfunction g(...args: [number, string?]) { }\ng(1);\ng(1, \"a\");",
+    ),
+    0,
+  )
+}

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -2129,12 +2129,13 @@ fn Parser::parse_class_body(
         // signature; we don't enforce overload/implementation pairing.
         @ast.TsBlock::{ stmts: [], stmt_positions: [] }
       } else {
-        // Save and set function context for method body
+        // Save and set function context for method body. Assign (not
+        // just set-when-true): a non-generator method of a class declared
+        // inside a generator function must NOT inherit the outer
+        // generator context — `yield <operand>` in its body is TS1163.
         let prev_generator = self.in_generator
         let prev_function = self.in_function
-        if is_generator {
-          self.in_generator = true
-        }
+        self.in_generator = is_generator
         self.in_function = true
         let body = self.parse_block()
         self.in_generator = prev_generator
@@ -2265,7 +2266,15 @@ fn Parser::parse_class_body(
         field_type
       }
       let init : @ast.TsExpr? = if self.match_(Eq) {
-        Some(self.parse_assignment())
+        // A field initializer is its own function-like context: `yield
+        // <operand>` inside one is TS1163 even when the class sits in a
+        // generator body (class DECORATORS and computed KEYS, by
+        // contrast, evaluate in the enclosing scope and stay legal).
+        let prev_generator = self.in_generator
+        self.in_generator = false
+        let e = self.parse_assignment()
+        self.in_generator = prev_generator
+        Some(e)
       } else {
         None
       }

--- a/src/parser/parser_expr.mbt
+++ b/src/parser/parser_expr.mbt
@@ -550,9 +550,10 @@ fn Parser::parse_object_method_value(
   let prev_generator = self.in_generator
   let prev_function = self.in_function
   let prev_async = self.in_async
-  if is_generator {
-    self.in_generator = true
-  }
+  // Assign (not just set-when-true): a non-generator function expression
+  // inside a generator body must not inherit the outer generator context
+  // (`yield <operand>` in its body is TS1163).
+  self.in_generator = is_generator
   self.in_function = true
   self.in_async = is_async
   let body = self.parse_block()
@@ -684,7 +685,10 @@ fn Parser::parse_single_param_arrow(
     while self.labels.length() > 0 {
       let _ = self.labels.pop()
     }
+    let prev_generator = self.in_generator
+    self.in_generator = false
     let block = self.parse_block()
+    self.in_generator = prev_generator
     self.in_function = prev_function
     self.in_iteration = prev_iteration
     self.in_switch = prev_switch
@@ -696,7 +700,10 @@ fn Parser::parse_single_param_arrow(
     }
     @ast.TsArrowBody::ArrowBlock(block)
   } else {
+    let prev_generator = self.in_generator
+    self.in_generator = false
     let expr = self.parse_assignment()
+    self.in_generator = prev_generator
     ArrowExpr(expr)
   }
   ArrowFunc(
@@ -1196,6 +1203,13 @@ fn Parser::parse_parenthesized_expr(
   if !temp.check(Eof) {
     raise ParseError("Expected RParen, got \{temp.peek().kind}")
   }
+  // The temp parser records grammar misuses into its own channel; without
+  // this hand-off a misuse inside a parenthesized expression (`({ b:
+  // yield 2 })` in a non-generator context) silently vanishes. Appending
+  // here keeps the parse-order position the emission loop relies on.
+  for gm in temp.grammar_misuses {
+    self.grammar_misuses.push(gm)
+  }
   self.pos = end_idx + 1
   expr
 }
@@ -1268,6 +1282,11 @@ fn Parser::parse_expr_until_top_level(
   let expr = temp.parse_expr()
   if !temp.check(Eof) {
     raise ParseError("Expected \{terminator}, got \{temp.peek().kind}")
+  }
+  // Same grammar-misuse hand-off as the parenthesized-expression helper
+  // above: the temp parser's recordings would otherwise vanish.
+  for gm in temp.grammar_misuses {
+    self.grammar_misuses.push(gm)
   }
   self.pos = end_idx
   expr
@@ -2514,7 +2533,10 @@ fn Parser::parse_generic_arrow_function(
     while self.labels.length() > 0 {
       let _ = self.labels.pop()
     }
+    let prev_generator = self.in_generator
+    self.in_generator = false
     let block = self.parse_block()
+    self.in_generator = prev_generator
     self.in_function = prev_function
     self.in_iteration = prev_iteration
     self.in_switch = prev_switch
@@ -2526,7 +2548,10 @@ fn Parser::parse_generic_arrow_function(
     }
     @ast.TsArrowBody::ArrowBlock(block)
   } else {
+    let prev_generator = self.in_generator
+    self.in_generator = false
     let expr = self.parse_assignment()
+    self.in_generator = prev_generator
     ArrowExpr(expr)
   }
   ArrowFunc(params, return_type, body, false)
@@ -2825,7 +2850,10 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
           while self.labels.length() > 0 {
             let _ = self.labels.pop()
           }
+          let prev_generator = self.in_generator
+          self.in_generator = false
           let block = self.parse_block()
+          self.in_generator = prev_generator
           self.in_function = prev_function
           self.in_iteration = prev_iteration
           self.in_switch = prev_switch
@@ -2838,7 +2866,10 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
           }
           @ast.TsArrowBody::ArrowBlock(block)
         } else {
+          let prev_generator = self.in_generator
+          self.in_generator = false
           let expr = self.parse_assignment()
+          self.in_generator = prev_generator
           ArrowExpr(expr)
         }
         ArrowFunc(
@@ -2927,7 +2958,10 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
               while self.labels.length() > 0 {
                 let _ = self.labels.pop()
               }
+              let prev_generator = self.in_generator
+              self.in_generator = false
               let block = self.parse_block()
+              self.in_generator = prev_generator
               self.in_function = prev_function
               self.in_iteration = prev_iteration
               self.in_switch = prev_switch
@@ -2940,7 +2974,10 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
               }
               @ast.TsArrowBody::ArrowBlock(block)
             } else {
+              let prev_generator = self.in_generator
+              self.in_generator = false
               let expr = self.parse_assignment()
+              self.in_generator = prev_generator
               ArrowExpr(expr)
             }
             ArrowFunc(params, return_type, body, false)
@@ -2976,7 +3013,10 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
             while self.labels.length() > 0 {
               let _ = self.labels.pop()
             }
+            let prev_generator = self.in_generator
+            self.in_generator = false
             let block = self.parse_block()
+            self.in_generator = prev_generator
             self.in_function = prev_function
             self.in_iteration = prev_iteration
             self.in_switch = prev_switch
@@ -2989,7 +3029,10 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
             }
             @ast.TsArrowBody::ArrowBlock(block)
           } else {
+            let prev_generator = self.in_generator
+            self.in_generator = false
             let expr = self.parse_assignment()
+            self.in_generator = prev_generator
             ArrowExpr(expr)
           }
           ArrowFunc(params, return_type, body, false)
@@ -3025,7 +3068,10 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
           while self.labels.length() > 0 {
             let _ = self.labels.pop()
           }
+          let prev_generator = self.in_generator
+          self.in_generator = false
           let block = self.parse_block()
+          self.in_generator = prev_generator
           self.in_function = prev_function
           self.in_iteration = prev_iteration
           self.in_switch = prev_switch
@@ -3038,7 +3084,10 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
           }
           @ast.TsArrowBody::ArrowBlock(block)
         } else {
+          let prev_generator = self.in_generator
+          self.in_generator = false
           let expr = self.parse_assignment()
+          self.in_generator = prev_generator
           ArrowExpr(expr)
         }
         ArrowFunc(params, return_type, body, false)
@@ -4111,7 +4160,10 @@ fn Parser::parse_async_arrow_function(
         while self.labels.length() > 0 {
           let _ = self.labels.pop()
         }
+        let prev_generator = self.in_generator
+        self.in_generator = false
         let block = self.parse_block()
+        self.in_generator = prev_generator
         self.in_function = prev_function
         self.in_iteration = prev_iteration
         self.in_switch = prev_switch
@@ -4123,7 +4175,10 @@ fn Parser::parse_async_arrow_function(
         }
         @ast.TsArrowBody::ArrowBlock(block)
       } else {
+        let prev_generator = self.in_generator
+        self.in_generator = false
         let expr = self.parse_assignment()
+        self.in_generator = prev_generator
         ArrowExpr(expr)
       }
       self.in_async = prev_async
@@ -4181,7 +4236,10 @@ fn Parser::parse_async_arrow_function(
     while self.labels.length() > 0 {
       let _ = self.labels.pop()
     }
+    let prev_generator = self.in_generator
+    self.in_generator = false
     let block = self.parse_block()
+    self.in_generator = prev_generator
     self.in_function = prev_function
     self.in_iteration = prev_iteration
     self.in_switch = prev_switch
@@ -4193,7 +4251,10 @@ fn Parser::parse_async_arrow_function(
     }
     @ast.TsArrowBody::ArrowBlock(block)
   } else {
+    let prev_generator = self.in_generator
+    self.in_generator = false
     let expr = self.parse_assignment()
+    self.in_generator = prev_generator
     ArrowExpr(expr)
   }
   self.in_async = prev_async


### PR DESCRIPTION
# Summary

Seven commits raising conformance-corpus true positives **2584 → 2607** while holding the CI invariant of **0 false positives** (gate `--max-fp 0 --max-legal-parsefail 1` green throughout, PFLEGAL 1 / TN 1414 unchanged, 2464 unit tests).

## TS2428: interface merge type-parameter identity (2584 → 2588)

Same-scope interface declarations of one name must carry identical type-parameter lists (arity, names, constraints — with tsc's relaxation that a declaration *omitting* a constraint is exempt). Runs per module scope from the layered walker, which matches tsc's declaration spaces for free: namespace bodies re-parse into per-block modules, so non-exported interfaces in separate blocks never merge (pinned). Constraint identity is staged (raw AST equality → alias unwrap → canonical `identity_key` → nominal fallback) so spelling differences never flag.

## Constant template folding feeds TS2367/TS2678 (2588 → 2592)

`` `abc${0}abc` `` folds to the string-literal type `"abc0abc"` when all substitutions are literal constants, matching the fresh pre-widening literal tsc uses in comparisons. Feeds the existing equality-overlap check *and* the switch/case comparability check. Deliberately narrow: integers below 1e15 only — JS float formatting stays out of scope (`${0.5}` does not fold; pinned).

## TS1163 yield contexts + temp-parser hand-off (2592 → 2597)

`yield` in contexts nested inside a generator that do not inherit its [Yield] grammar now records TS1163: arrow bodies (all 16 parse sites), class field initializers, non-generator function expressions and class methods (the latter two only *set* `in_generator = true` and never reset it). Class decorator arguments and computed keys evaluate in the enclosing scope and stay legal (pinned). Root-caused along the way: parenthesized expressions parse through a temp parser whose `grammar_misuses` were dropped on success — every grammar misuse recorded inside parentheses silently vanished; both temp-parser helpers now hand recordings back in parse order.

## Generic inference — the user-priority HIGH theme (2597 → 2607)

- **Iterator-class spread elements**: a hand-rolled iterator class (`[Symbol.iterator]()` + `next()` yielding `{ value: V }`) spread into a rest parameter contributes element type `V`, pinned **first-wins** (nested tsc inference position) — `foo(...new SymbolIterator, ...new _StringIterator)` is TS2345 `string` vs `symbol`. Direct rest arguments still union (`foo(1, "a")` pinned legal).
- **Generic class constructors** run `solve_generic_bindings`, mirroring the direct-call path.
- **Tuple-destructured rest params** (`...[[k1, v1], [k2, v2]]`, unannotated) pin exact arity.
- **Single-declaration interface methods** have exact arity — `action.run(...[100, 'foo'])` against `run(event?: unknown)` is TS2554.
- **Lib `Map` constructor with mixed entries** (`new Map([["", true], ["", 0]])`) matches no overload (TS2769); explicit `new Map<K, V>(...)` parses into a `TypeArgs` wrapper and never reaches the check.
- **Array literals passed to TemplateStringsArray tag-function overload sets** fail every overload (`raw` only exists on engine-created template objects); the overload set is registered at resolver ingestion because the ingested union includes the implementation signature.
- **Uniform `new Map([...])` infers `Map<K, V>`**, feeding the existing `[K, V]` spread-element check.

Dropped after root-causing (documented in TODO.md T200): genericRestArity's variadic-handler shape — the parser erases constrained type params to their bounds, making the generic and non-generic spellings indistinguishable at check time.

## Docs

TODO.md gains T197–T200 and a release checkpoint ranking the remaining 476 misses by real-world likelihood (generic inference remainder, contextual typing, lib surface models, narrowing tails, edge cuts).

## Verification

- Whole-corpus oracle after every stage: TP 2607 / FP 0 / PFLEGAL 1 / TN 1414, no lost TPs at any step
- `moon test --target native`: 2464/2464
- Each check carries whitebox tests with legal-pattern pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr)_