### PR TITLE
checker: generator TReturn + construct-overload resolution (TP 2607 → 2610)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2295,6 +2295,42 @@ conformance sources (`.errors.txt` baseline = ground truth):
     the expression walker. Whole-corpus TP 1759 -> 1760, 0 FP. Pinned recall
     698 -> 699 (classAbstractSuperCalls). Whitebox-tested.
 
+2026-07-10 (T201)  714/815 (88 %)        414/414 ( 0 FP)   Generator TReturn + construct overloads: TP 2607 -> 2610
+
+  T201 -- batch AX, the generic-inference theme's remaining two shapes
+    (user-selected continuation).
+    (a) Generator TReturn: a `function*` LITERAL argument whose body
+    contains `return <value>` is not assignable to a callback parameter
+    returning `IterableIterator<..., void>` / `Generator<..., void, ...>`
+    — the explicit `void` TReturn slot means the callback must not return
+    anything (generatorTypeCheck62 x2 errors, 63 x3 errors — counts match
+    tsc's per-line diagnostics). `return;` / `return undefined;` and an
+    UNWRITTEN TReturn slot (default `any`) never flag. Walks the body
+    statement tree without descending into nested functions; a NEW
+    walker pair (`generator_body_returns_value`) rather than the existing
+    `block_has_value_return`, which counts `return undefined` as a value
+    (fine for its arrow-void consumer, an FP here). Note: the constrained
+    type param in `strategy<T extends StrategicState>` is bound-erased by
+    the parser (T199/T200 note), which is exactly why the void slot
+    survives to the checker — erasure helps this once.
+    (b) TS2769 construct overloads: a construct-signature set (>= 2
+    overloads collected via collect_construct_signatures) whose params
+    are ALL concrete primitives rejects a call whose (decidably-typed)
+    arguments fail every overload — `new fn1({})` against
+    `new (s: string)` / `new (s: number)`
+    (overloadResolutionConstructors). Generic signatures, non-primitive
+    params, spreads, and undecidable argument types abstain; nullish
+    arguments count as matching (strict-mode misses cost recall, never
+    precision — `new fn1(undefined)` is tsc's legal ambiguous-pick-first
+    and stays silent, pinned).
+    Remaining in the theme (documented): genericCallToOverloadedMethod-
+    WithOverloadedArguments (method overloads over generic receivers),
+    controlFlowIterationErrors (loop narrowing x overloads),
+    es2020IntlAPIs (Intl lib surface), unionTypeReduction2 (union
+    signature reduction), taggedTemplateContextualTyping2.
+    Whole-corpus TP 2607 -> 2610 @ 0 FP, PFLEGAL 1, TN 1414. 581 checker
+    wbtests.
+
 2026-07-10 (T200)  714/815 (88 %)        414/414 ( 0 FP)   Generic inference (user-priority theme): TP 2597 -> 2607
 
   T200 -- batch AW, the user-designated HIGH theme (multi-stage generic

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -11558,6 +11558,7 @@ fn check_arguments_with_sig(
     if rest_index >= 0 && i >= rest_index {
       check_expr_against(env, args[i], rest_elem_type, ctx, sub_path)
     } else if i < params.length() {
+      check_generator_arg_treturn(ctx, args[i], params[i], sub_path)
       check_expr_against(env, args[i], params[i], ctx, sub_path)
       // TS2345: an unannotated array-destructuring parameter is tuple-like
       // (`function fun([a, b]) {}` types as `[any, any]`), so an iterable
@@ -11644,6 +11645,95 @@ fn check_arguments_with_sig(
         _ => ()
       }
     }
+  }
+}
+
+///|
+/// TS2345 for a generator-literal argument whose body RETURNS a value when
+/// the parameter's callback return type is `IterableIterator<..., void>` /
+/// `Generator<..., void, ...>` — a `void` TReturn slot means the callback
+/// must not return anything (`strategy("x", function*(s) { return s; })`,
+/// generatorTypeCheck62/63). `return;` and `return undefined;` stay legal,
+/// and an unwritten TReturn slot (whose default is `any`) never flags.
+fn check_generator_arg_treturn(
+  ctx : CheckCtx,
+  arg : @ast.TsExpr,
+  param_ty : @ast.TsType,
+  sub_path : String,
+) -> Unit {
+  guard arg is FuncExpr(f) && f.is_generator else { return }
+  let ret = match ctx.resolver.unwrap(param_ty) {
+    Func(_, r) => r
+    _ => return
+  }
+  match ctx.resolver.unwrap(ret) {
+    Applied("IterableIterator", targs) | Applied("Generator", targs) =>
+      if !(targs.length() >= 2 && targs[1] is Void) {
+        return
+      }
+    _ => return
+  }
+  if generator_body_returns_value(f.body) {
+    record(
+      ctx, sub_path, "a generator returning a value is not assignable to a parameter returning `IterableIterator<..., void>`",
+    )
+  }
+}
+
+///|
+/// True when the block contains a `return <operand>` (other than
+/// `undefined` / `void ...`) outside any nested function.
+fn generator_body_returns_value(b : @ast.TsBlock) -> Bool {
+  for st in b.stmts {
+    if generator_stmt_returns_value(st) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn generator_stmt_returns_value(st : @ast.TsStmt) -> Bool {
+  match st {
+    Return(Some(e)) =>
+      match e {
+        Var("undefined") | UnaryOp(Void, _) => false
+        _ => true
+      }
+    Return(None) => false
+    Block(b) => generator_body_returns_value(b)
+    If(_, then_, else_) =>
+      generator_body_returns_value(then_) ||
+      (match else_ {
+        Some(b) => generator_body_returns_value(b)
+        None => false
+      })
+    While(_, body) | DoWhile(_, body) | With(_, body) =>
+      generator_body_returns_value(body)
+    For(_, _, _, body) => generator_body_returns_value(body)
+    ForIn(_, _, _, _, body)
+    | ForOf(_, _, _, _, body)
+    | ForAwaitOf(_, _, _, _, body) => generator_body_returns_value(body)
+    Try(b, _, catch_, finally_) =>
+      generator_body_returns_value(b) ||
+      (match catch_ {
+        Some(c) => generator_body_returns_value(c)
+        None => false
+      }) ||
+      (match finally_ {
+        Some(fb) => generator_body_returns_value(fb)
+        None => false
+      })
+    Label(_, inner) => generator_stmt_returns_value(inner)
+    Switch(_, cases) => {
+      for c in cases {
+        if generator_body_returns_value(c.body) {
+          return true
+        }
+      }
+      false
+    }
+    _ => false
   }
 }
 
@@ -14936,7 +15026,98 @@ fn check_call_args_in_expr(
           match union_common_construct_params(callee_ty, ctx.resolver) {
             Some(params) =>
               check_arguments(env, params, args, ctx, "new `\{class_name}`")
-            None => ()
+            None => {
+              // TS2769 for a construct-overload set whose signatures are
+              // all concrete primitives: a call whose arguments fail every
+              // overload matches nothing (`new fn1({})` against
+              // `new (s: string)` / `new (s: number)`,
+              // overloadResolutionConstructors). Any generic signature,
+              // non-primitive parameter, spread argument, or undecidable
+              // argument type abstains.
+              let sigs = collect_construct_signatures(callee_ty, ctx.resolver)
+              if sigs.length() >= 2 &&
+                !args.iter().any(fn(a) { a is Spread(_) }) {
+                let mut decidable = true
+                let sig_params : Array[Array[@ast.TsType]] = []
+                for s in sigs {
+                  match s {
+                    Func(ps, _) | Constructor(ps, _, _) => {
+                      for p in ps {
+                        match ctx.resolver.unwrap(p) {
+                          String_
+                          | Number
+                          | Int
+                          | Boolean
+                          | BigInt
+                          | Literal(_)
+                          | NumberLiteral(_)
+                          | BooleanLiteral(_) => ()
+                          _ => decidable = false
+                        }
+                      }
+                      sig_params.push(ps)
+                    }
+                    _ => decidable = false
+                  }
+                }
+                let arg_types : Array[@ast.TsType] = []
+                if decidable {
+                  for a in args {
+                    let t = ctx.resolver.unwrap(
+                      infer_expr(env, ctx.resolver, a),
+                    )
+                    match t {
+                      String_
+                      | Number
+                      | Int
+                      | Boolean
+                      | BigInt
+                      | Literal(_)
+                      | NumberLiteral(_)
+                      | BooleanLiteral(_)
+                      | Object(_)
+                      | Struct(_, _)
+                      | Undefined
+                      | Null => arg_types.push(t)
+                      _ => decidable = false
+                    }
+                  }
+                }
+                if decidable {
+                  let mut any_matches = false
+                  for ps in sig_params {
+                    if arg_types.length() > ps.length() ||
+                      arg_types.length() < required_arity_from_types(ps) {
+                      continue
+                    }
+                    let mut ok = true
+                    for i, at in arg_types {
+                      // Nullish arguments satisfy anything outside
+                      // strictNullChecks; a strict-mode miss here only
+                      // costs recall, never precision.
+                      if at is (Undefined | Null) {
+                        continue
+                      }
+                      if !is_assignable_to(at, ps[i]) {
+                        ok = false
+                        break
+                      }
+                    }
+                    if ok {
+                      any_matches = true
+                      break
+                    }
+                  }
+                  if !any_matches {
+                    record(
+                      ctx,
+                      "new `\{class_name}`",
+                      "no construct overload matches this call",
+                    )
+                  }
+                }
+              }
+            }
           }
           for a in args {
             check_call_args_in_expr(env, a, ctx)

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -13226,3 +13226,52 @@ test "expr_check: uniform Map<K, V> inference (batch AW stage 3)" {
     0,
   )
 }
+
+///|
+test "expr_check: generator TReturn + construct overloads (batch AX)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  let strategy_decl = "interface StrategicState { lastStrategyApplied?: string; }\nfunction strategy<T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T | undefined, void>): (a: T) => IterableIterator<T | undefined, void> { return null; }\ninterface State extends StrategicState { foo: number; }\n"
+  // A generator argument RETURNING a value vs a void TReturn slot
+  // (generatorTypeCheck62/63, TS2345).
+  assert_true(
+    issues(
+      "// @strict: false\n" +
+      strategy_decl +
+      "var Nothing1 = strategy(\"Nothing\", function*(state: State) {\n  return state;\n});",
+    ) >
+    0,
+  )
+  assert_true(
+    issues(
+      "// @strict: false\n" +
+      strategy_decl +
+      "var Nothing3 = strategy(\"Nothing\", function*(state: State) {\n  yield state;\n  return 1;\n});",
+    ) >
+    0,
+  )
+  // Pins: yield-only and empty generators stay legal; so does
+  // `return undefined` (void accepts undefined).
+  @test.assert_eq(
+    issues(
+      "// @strict: false\n" +
+      strategy_decl +
+      "var Nothing2 = strategy(\"Nothing\", function*(state: State) {\n  yield state;\n});\nvar Nothing1 = strategy(\"Nothing\", function*(state: State) {\n});\nvar NothingU = strategy(\"Nothing\", function*(state: State) {\n  return undefined;\n});",
+    ),
+    0,
+  )
+  // Construct-overload set with all-primitive signatures: an object
+  // literal matches no overload (overloadResolutionConstructors, TS2769).
+  let fn1_decl = "interface fn1 {\n  new (s: string): string;\n  new (s: number): number;\n}\ndeclare var fn1: fn1;\n"
+  assert_true(issues("// @strict: false\n" + fn1_decl + "new fn1({});") > 0)
+  // Pins: a matching overload and the ambiguous nullish pick stay legal.
+  @test.assert_eq(
+    issues(
+      "// @strict: false\n" +
+      fn1_decl +
+      "var s = new fn1(\"a\");\nvar n = new fn1(4);\nvar u = new fn1(undefined);",
+    ),
+    0,
+  )
+}


### PR DESCRIPTION
# Summary

The generic-inference theme's remaining two tractable shapes. Whole-corpus TP **2607 → 2610** at **0 FP** (PFLEGAL 1 / TN 1414 unchanged, no lost TPs), 2465 unit tests.

## Generator TReturn (generatorTypeCheck62/63)

A `function*` literal argument whose body contains `return <value>` is not assignable to a callback parameter returning `IterableIterator<..., void>` / `Generator<..., void, ...>` — the explicit `void` TReturn slot means the callback must not return anything. Per-line detection counts match tsc (2 in file 62, 3 in file 63). `return;` / `return undefined;` and an unwritten TReturn slot (default `any`) never flag. Uses a new statement walker that treats `return undefined` as void — the existing `block_has_value_return` counts it as a value, which is correct for its arrow-void consumer but would be a false positive here.

## TS2769 construct overloads (overloadResolutionConstructors)

A construct-signature set (≥ 2 overloads) whose parameters are all concrete primitives rejects a call whose decidably-typed arguments fail every overload — `new fn1({})` against `new (s: string)` / `new (s: number)`. Generic signatures, non-primitive params, spreads, and undecidable argument types abstain. Nullish arguments count as matching, so tsc's legal ambiguous-pick-first `new fn1(undefined)` stays silent (pinned).

TODO.md T201 documents the batch and the theme's remaining deep shapes (method overloads over generic receivers, loop-narrowing × overload composites, Intl lib surface, union signature reduction).

## Verification

- Whole-corpus oracle: TP 2610 / FP 0 / PFLEGAL 1 / TN 1414, no lost TPs
- `moon test --target native`: 2465/2465
- Whitebox tests with legal-pattern pins for both checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr)_