### PR TITLE
checker/parser: TS7 miss mining batches BE–BL (TP 2152 → 2296) + CI fix

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1031,7 +1031,7 @@ v7.0.2). Truth comes from vendored name manifests
 variant is NOTRUN, and the TS6-era deprecated-compiler-option
 diagnostics (TS5107/TS5101) were removed from the checker accordingly.
 
-State: whole-corpus **TP 2242 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 492 /
+State: whole-corpus **TP 2266 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 468 /
 NOTRUN 14** via `scripts/checker_conformance_oracle.sh --max-fp 0
 --max-legal-parsefail 3`.
 
@@ -1108,6 +1108,23 @@ implicit-any `this` — as a dedicated context-tracking walker
   marker), `@strict: false`, and the `@ts-ignore` whole-file marker.
 Permissive-path only. One stale wbtest pin (`this` in a method-nested
 function expr expected 0) was updated to the TS7 verdict.
+Batch BI (+24 TP, TP 2266 / MISS 468) took the small syntactic
+clusters from the general miss pool:
+- TS1049/TS1054: a `set` accessor takes exactly one parameter, a `get`
+  accessor none — recorded at the parse sites for both object-literal
+  accessors (both parse paths) and class accessors.
+- TS1031: `export` / `declare` cannot modify class elements (incl.
+  `declare constructor`). The `export` arm consumes the token only in
+  MODIFIER position via `can_consume_class_modifier` — `class C {
+  export; }` declares a field NAMED export
+  (propertyNamesOfReservedWords went PFLEGAL until guarded).
+- TS1124: a numeric exponent needs at least one digit (`1e`, `1e+`).
+- TS2466: `super` cannot be referenced in a computed property name —
+  member chains and `super()` inside comma chains
+  (computedPropertyNames24/27). computedPropertyNames30 stays a MISS:
+  strada raises TS2466 for `this` in an object-literal computed key
+  inside a typed constructor arrow, which our typed-context model
+  deliberately treats as legal.
 Remaining TS7-only clusters (documented, unattempted): nested
 class-expression computed keys (the parser lowers class expressions to
 IIFEs, erasing the member structure), TS2339 Corsa behavior changes. (Final TS6 state for reference: TP 2669 /

--- a/TODO.md
+++ b/TODO.md
@@ -1031,7 +1031,7 @@ v7.0.2). Truth comes from vendored name manifests
 variant is NOTRUN, and the TS6-era deprecated-compiler-option
 diagnostics (TS5107/TS5101) were removed from the checker accordingly.
 
-State: whole-corpus **TP 2203 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 531 /
+State: whole-corpus **TP 2222 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 512 /
 NOTRUN 14** via `scripts/checker_conformance_oracle.sh --max-fp 0
 --max-legal-parsefail 3`.
 
@@ -1060,10 +1060,26 @@ by the oracle switch:
 Sweep round-trip: the first BE sweep surfaced 10 FPs (bare-return
 getters, legacy-mode ambient decorators, stacked decorators before
 class expressions); all root-caused and fixed before landing.
-Remaining TS7-only clusters (documented, unattempted): TS2683/TS2465
-(`this` typing in plain functions / computed keys — needs enclosing-
-callable context tracking), TS2339 Corsa behavior changes, TS1125/
-TS1121/TS1198 escape-sequence lexing, TS1166 ambient computed keys. (Final TS6 state for reference: TP 2669 /
+Batch BF (+19 TP, TP 2222 / MISS 512) continued the mining:
+- TS2465/TS1166: `this` in a class member's computed property name
+  (direct refs only — nested callables rebind), and computed FIELD keys
+  through a declared-`any` call (no literal type — autoAccessor5).
+  Whole-file abstention when the source carries `@ts-ignore` /
+  `@ts-expect-error` (the parser pushes a `<ts-suppression-present>`
+  marker; our issues aren't line-anchored, so file granularity is the
+  FP-safe choice — esDecorators-classDeclaration-outerThisReference).
+- TS1125/TS1198: `\u{...}` escapes in STRING literals — missing /
+  non-hex digits and values past 0x10FFFF (accumulator clamped against
+  32-bit wrap). Template literals deliberately NOT counted: tagged
+  templates accept invalid escapes (ES2018) and the lexer can't see
+  taggedness.
+- TS1121: legacy octal integer literals (`01`).
+Remaining TS7-only clusters (documented, unattempted): template /
+regex escape variants (need tagged-exemption plumbing through token
+metadata and `u`-flag gating in the regex scanner), nested
+class-expression computed keys (the parser lowers class expressions to
+IIFEs, erasing the member structure), TS2683 `this`-context typing,
+TS2339 Corsa behavior changes. (Final TS6 state for reference: TP 2669 /
 FP 0 / TN 1414 / MISS 414 — the TS7 renumbering reflects dropped es5
 variants and Corsa behavior changes, not checker regressions; the
 582 misses include ~170 new TS7-only opportunities.)

--- a/TODO.md
+++ b/TODO.md
@@ -1031,7 +1031,7 @@ v7.0.2). Truth comes from vendored name manifests
 variant is NOTRUN, and the TS6-era deprecated-compiler-option
 diagnostics (TS5107/TS5101) were removed from the checker accordingly.
 
-State: whole-corpus **TP 2233 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 501 /
+State: whole-corpus **TP 2242 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 492 /
 NOTRUN 14** via `scripts/checker_conformance_oracle.sh --max-fp 0
 --max-legal-parsefail 3`.
 
@@ -1088,10 +1088,29 @@ remainder:
   the postfix path. Escapes inside `${...}` interpolation sub-parses
   are lost (sub-parser array discarded) — a known miss, not an FP.
 - Strings additionally validate `\x` (exactly two hex digits).
+Batch BH (+9 TP, TP 2242 / MISS 492) implemented TS2683 —
+implicit-any `this` — as a dedicated context-tracking walker
+(`check_implicit_any_this` + `ts2683_walk_expr/stmts`):
+- IMPLICIT contexts: plain function declarations/expressions without a
+  `this` parameter (including ones nested in methods and static-field
+  initializer function exprs), namespace top-level statements (a
+  namespace body is an IIFE), and class-declaration decorators inside
+  namespaces.
+- TYPED/EXEMPT contexts: methods/accessors/constructors at their top
+  level, arrows (inherit), object-literal FUNCTION values (contextual),
+  function exprs in CALL-ARGUMENT position (callee may declare `this` —
+  esDecorators-contextualTypes.2), property/index/compound-assignment
+  RHS (`Element.prototype.remove ??= function () {…}` —
+  thisPrototypeMethodCompoundAssignment), ANNOTATED binding
+  initializers, `<class>`-named IIFE lowerings of class expressions,
+  true top level (`globalThis`), and `this`-parameter functions.
+- Opt-outs: `@noImplicitThis: false` (new `<noimplicitthis-off>`
+  marker), `@strict: false`, and the `@ts-ignore` whole-file marker.
+Permissive-path only. One stale wbtest pin (`this` in a method-nested
+function expr expected 0) was updated to the TS7 verdict.
 Remaining TS7-only clusters (documented, unattempted): nested
 class-expression computed keys (the parser lowers class expressions to
-IIFEs, erasing the member structure), TS2683 `this`-context typing,
-TS2339 Corsa behavior changes. (Final TS6 state for reference: TP 2669 /
+IIFEs, erasing the member structure), TS2339 Corsa behavior changes. (Final TS6 state for reference: TP 2669 /
 FP 0 / TN 1414 / MISS 414 — the TS7 renumbering reflects dropped es5
 variants and Corsa behavior changes, not checker regressions; the
 582 misses include ~170 new TS7-only opportunities.)

--- a/TODO.md
+++ b/TODO.md
@@ -1031,7 +1031,7 @@ v7.0.2). Truth comes from vendored name manifests
 variant is NOTRUN, and the TS6-era deprecated-compiler-option
 diagnostics (TS5107/TS5101) were removed from the checker accordingly.
 
-State: whole-corpus **TP 2266 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 468 /
+State: whole-corpus **TP 2278 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 456 /
 NOTRUN 14** via `scripts/checker_conformance_oracle.sh --max-fp 0
 --max-legal-parsefail 3`.
 
@@ -1125,6 +1125,32 @@ clusters from the general miss pool:
   strada raises TS2466 for `this` in an object-literal computed key
   inside a typed constructor arrow, which our typed-context model
   deliberately treats as legal.
+Batch BJ (+12 TP, TP 2278 / MISS 456) took the TS2454/TS2488/TS2403
+type clusters:
+- ASI vs declaration heads: `namespace` / `module` head a declaration
+  only when the NAME sits on the same line (`is_namespace_decl_start`
+  rejects a newline-separated follower), and a statement-level `declare`
+  with a line break after it is a plain identifier reference (TS's
+  modifier ASI rule). `namespace\nn\n{}` is then three statements whose
+  reads hit the existing TS2454 unassigned tracking
+  (asiPreventsParsingAsNamespace01/02,
+  asiPreventsParsingAsAmbientExternalModule01).
+- TS2488 beyond class instances (`check_forof_non_iterable`): a for-of
+  source that is a non-iterable primitive (`for (const v of 0)`), a
+  union with a non-iterable primitive member (`string | number`), or an
+  object type whose `[Symbol.iterator]` member is OPTIONAL; plus an
+  array-destructuring pattern over a primitive element type
+  (`for (var [a = 0] of [2, 3])`, syntactic array-literal sources only).
+  The optional-iterator case rides a new parser encoding: STANDARD
+  well-known `[Symbol.x]` keys in object-type literals parse as `@@x`
+  members instead of degrading the whole literal to `any`
+  (user-augmented `Symbol.foo` keys keep the legacy fallback —
+  symbolProperty61 FP'd until restricted).
+- TS2403 vs lib declarations (`check_lib_global_redeclaration`): a
+  script-level initializer-less `var` redeclaring a runtime global
+  (`var Symbol: any` / `{ iterator: string }`) must carry the matching
+  `*Constructor` interface annotation; module files and `typeof`
+  annotations abstain (ES5SymbolProperty3/4/7 vs ES5SymbolProperty1).
 Remaining TS7-only clusters (documented, unattempted): nested
 class-expression computed keys (the parser lowers class expressions to
 IIFEs, erasing the member structure), TS2339 Corsa behavior changes. (Final TS6 state for reference: TP 2669 /

--- a/TODO.md
+++ b/TODO.md
@@ -1031,7 +1031,7 @@ v7.0.2). Truth comes from vendored name manifests
 variant is NOTRUN, and the TS6-era deprecated-compiler-option
 diagnostics (TS5107/TS5101) were removed from the checker accordingly.
 
-State: whole-corpus **TP 2222 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 512 /
+State: whole-corpus **TP 2233 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 501 /
 NOTRUN 14** via `scripts/checker_conformance_oracle.sh --max-fp 0
 --max-legal-parsefail 3`.
 
@@ -1074,9 +1074,21 @@ Batch BF (+19 TP, TP 2222 / MISS 512) continued the mining:
   templates accept invalid escapes (ES2018) and the lexer can't see
   taggedness.
 - TS1121: legacy octal integer literals (`01`).
-Remaining TS7-only clusters (documented, unattempted): template /
-regex escape variants (need tagged-exemption plumbing through token
-metadata and `u`-flag gating in the regex scanner), nested
+Batch BG (+11 TP, TP 2233 / MISS 501) closed the escape-sequence
+remainder:
+- Regex `\u{...}` under the `u` / `v` flags: `scan_regex` collects the
+  body and `validate_regex_unicode_escapes` requires hex digits and a
+  value within 0x0..0x10FFFF (accumulator clamped against 32-bit wrap).
+  Without the flag, `\u{2}` is a quantified `u` and stays legal.
+- Untagged-template invalid `\u` / `\x` escapes (incl. overflow): the
+  lexer records each escape's source position in
+  `template_invalid_escape_positions`; the parser counts entries inside
+  the Template token's span at the UNTAGGED primary parse site only —
+  tagged templates accept invalid escapes (ES2018) and parse through
+  the postfix path. Escapes inside `${...}` interpolation sub-parses
+  are lost (sub-parser array discarded) — a known miss, not an FP.
+- Strings additionally validate `\x` (exactly two hex digits).
+Remaining TS7-only clusters (documented, unattempted): nested
 class-expression computed keys (the parser lowers class expressions to
 IIFEs, erasing the member structure), TS2683 `this`-context typing,
 TS2339 Corsa behavior changes. (Final TS6 state for reference: TP 2669 /

--- a/TODO.md
+++ b/TODO.md
@@ -1031,7 +1031,7 @@ v7.0.2). Truth comes from vendored name manifests
 variant is NOTRUN, and the TS6-era deprecated-compiler-option
 diagnostics (TS5107/TS5101) were removed from the checker accordingly.
 
-State: whole-corpus **TP 2278 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 456 /
+State: whole-corpus **TP 2289 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 445 /
 NOTRUN 14** via `scripts/checker_conformance_oracle.sh --max-fp 0
 --max-legal-parsefail 3`.
 
@@ -1151,6 +1151,34 @@ type clusters:
   (`var Symbol: any` / `{ iterator: string }`) must carry the matching
   `*Constructor` interface annotation; module files and `typeof`
   annotations abstain (ES5SymbolProperty3/4/7 vs ES5SymbolProperty1).
+Batch BK (+11 TP, TP 2289 / MISS 445) mixed scoping, parser-recovery,
+and call-modeling slices:
+- Block scoping in the TS2304 hoisting backstop: a `let` / `const`
+  for-of/for-in head is LOOP-scoped (only `var` heads hoist —
+  for-of7), and an assign-form loop's body contributes only `var`s
+  (`for (v of xs) { let v; }` cannot declare the head — for-of6).
+  Closures inside the loop still see the head binding via the env walk.
+- `new Date<A;`: type arguments are only consumed when a balanced `>`
+  exists; otherwise the cursor restores and `<` parses as a comparison,
+  so `A` surfaces through the normal undefined-name path
+  (parserConstructorAmbiguity1/2/4).
+- TS2345: `f.apply(x, arguments)` where `f` is a zero-parameter
+  function — `IArguments` is never assignable to the empty tuple `[]`
+  (asyncArrowFunctionCapturesArguments_es5/es6/es2017). Functions WITH
+  parameters abstain.
+- TS1005: reserved-word and literal object-binding shorthands need a
+  `: alias` (`var { while } = …`, `var { "while" } = …` —
+  objectBindingPatternKeywordIdentifiers01/03), and `void` cannot head
+  a qualified type name (`var v: void.x` — parservoidInQualifiedName1).
+Documented dead ends from this round: YieldExpression10_es6 (an
+object-literal method's name in the backstop is indistinguishable from
+a legal self-referential named function expression property);
+symbolProperty3/59 (need the `Symbol` VALUE modeled as
+`SymbolConstructor`); computedPropertyNames9 (needs overload+generic
+call inference to pick `boolean`); the TS2403 identity cluster
+(spreadUnion2 / typeOfThisGeneral etc. need inferred-initializer
+identity; unionTypeEquivalence needs non-reducing union identity over
+subtype-related classes).
 Remaining TS7-only clusters (documented, unattempted): nested
 class-expression computed keys (the parser lowers class expressions to
 IIFEs, erasing the member structure), TS2339 Corsa behavior changes. (Final TS6 state for reference: TP 2669 /

--- a/TODO.md
+++ b/TODO.md
@@ -1031,7 +1031,7 @@ v7.0.2). Truth comes from vendored name manifests
 variant is NOTRUN, and the TS6-era deprecated-compiler-option
 diagnostics (TS5107/TS5101) were removed from the checker accordingly.
 
-State: whole-corpus **TP 2289 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 445 /
+State: whole-corpus **TP 2296 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 438 /
 NOTRUN 14** via `scripts/checker_conformance_oracle.sh --max-fp 0
 --max-legal-parsefail 3`.
 
@@ -1170,6 +1170,24 @@ and call-modeling slices:
   `: alias` (`var { while } = …`, `var { "while" } = …` —
   objectBindingPatternKeywordIdentifiers01/03), and `void` cannot head
   a qualified type name (`var v: void.x` — parservoidInQualifiedName1).
+Batch BL (+7 TP, TP 2296 / MISS 438) worked the TS2339 cluster:
+- Object patterns over PRIMITIVE for-of elements flag their props
+  (`for (var {x: a = 0} of [2, 3])` — ES5For-of27/29; prototype members
+  like `toString` stay legal), mirroring BJ's array-pattern TS2488.
+- An object sub-pattern under a REST element draws its keys from the
+  array surface: non-numeric keys outside `array_prototype_member` (+ a
+  small always-legal extra set) flag on Array/Tuple sources, in both
+  declaration and assignment forms (restElementWithBindingPattern2,
+  restElementWithAssignmentPattern2/4).
+- The pattern-vs-object-literal key check (parser AND checker copies)
+  now folds spreads of syntactic object literals recursively instead of
+  abstaining (`const { g } = { ...{ ...{ c: 0 } } , f: 0 }` —
+  destructuringSpread); getter/setter entries provide their names.
+- `new SharedArrayBuffer(...)` keeps its Named type, the instance table
+  gained the ES2024 members (`growable` / `maxByteLength` / `grow`, and
+  ArrayBuffer's `resizable` / `detached` / `resize`), and the surface
+  registers as fully modeled so member misses are definite
+  (`sab.length` — useSharedArrayBuffer6).
 Documented dead ends from this round: YieldExpression10_es6 (an
 object-literal method's name in the backstop is indistinguishable from
 a legal self-referential named function expression property);

--- a/TODO.md
+++ b/TODO.md
@@ -1031,9 +1031,39 @@ v7.0.2). Truth comes from vendored name manifests
 variant is NOTRUN, and the TS6-era deprecated-compiler-option
 diagnostics (TS5107/TS5101) were removed from the checker accordingly.
 
-State: whole-corpus **TP 2152 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 582 /
+State: whole-corpus **TP 2203 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 531 /
 NOTRUN 14** via `scripts/checker_conformance_oracle.sh --max-fp 0
---max-legal-parsefail 3`. (Final TS6 state for reference: TP 2669 /
+--max-legal-parsefail 3`.
+
+Batch BE (TS7-only miss mining, +51 TP) worked the misses newly exposed
+by the oracle switch:
+- TS5102: `downlevelIteration` was REMOVED in TS7 — its presence-based
+  recording now surfaces as an error (every ran conformance case
+  carrying the directive errors under tsgo; none is accepted).
+- TS2378: a class `get` accessor whose body contains NO return, throw,
+  or loop must return a value (empty bodies parse as `body: None`;
+  ambient / abstract accessors and any explicit `return;` abstain — a
+  written `(): any` is indistinguishable from no annotation).
+- TS1206: decorators on constructors flag in both modes; on `abstract` /
+  `declare` members only under STANDARD decorators (legacy mode accepts
+  them — decoratorInAmbientContext); parameter decorators flag only
+  without `@experimentaldecorators` and only when the decorator chain's
+  last follower is not `class` (a paren'd decorated class expression
+  enters the arrow-params trial — esDecorators-classExpression-*).
+- TS2373/TS2372: a parameter default (or binding-pattern computed key /
+  element default, or class-expression heritage inside one) may not
+  reference the parameter itself, a later parameter, or a body-declared
+  name (`var` hoisted anywhere, `let`/`const` top-level). Nested
+  callables defer evaluation and abstain. Covers module functions,
+  class constructors/methods, top-level callable initializers, and
+  IIFE arrows.
+Sweep round-trip: the first BE sweep surfaced 10 FPs (bare-return
+getters, legacy-mode ambient decorators, stacked decorators before
+class expressions); all root-caused and fixed before landing.
+Remaining TS7-only clusters (documented, unattempted): TS2683/TS2465
+(`this` typing in plain functions / computed keys — needs enclosing-
+callable context tracking), TS2339 Corsa behavior changes, TS1125/
+TS1121/TS1198 escape-sequence lexing, TS1166 ambient computed keys. (Final TS6 state for reference: TP 2669 /
 FP 0 / TN 1414 / MISS 414 — the TS7 renumbering reflects dropped es5
 variants and Corsa behavior changes, not checker regressions; the
 582 misses include ~170 new TS7-only opportunities.)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -178,9 +178,10 @@ pub fn build_app() -> @hono.Hono {
 ///|
 pub fn serve(app : @hono.Hono, port : Int) -> Unit {
   let opts = make_serve_options(app, port)
-  let _ = @node_server.serve(opts, fn(_info) {
-    println("listening on http://localhost:\{port}")
-  })
+  let _ = @node_server.serve(
+    opts,
+    Some(fn(_info) { println("listening on http://localhost:\{port}") }),
+  )
 
 }
 

--- a/examples/typescript-to-moonbit/hono-server/smoke/main.mbt
+++ b/examples/typescript-to-moonbit/hono-server/smoke/main.mbt
@@ -25,5 +25,5 @@ fn main {
   )
   let _ = app.get("/", fn(c) { c.text("hello", None, None) })
   let opts = make_serve_options(app, 0)
-  let _ = @sut_node_server.serve(opts, fn(_info) { smoke_exit_ok() })
+  let _ = @sut_node_server.serve(opts, Some(fn(_info) { smoke_exit_ok() }))
 }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -14290,6 +14290,49 @@ fn check_iterable_class_protocol(
 }
 
 ///|
+/// A type that provably has no `[Symbol.iterator]()`: the non-iterable
+/// primitives. `string` is iterable (chars), arrays / tuples are, and
+/// anything named / generic / `any` could be — only these are safe calls.
+fn is_non_iterable_primitive(t : @ast.TsType) -> Bool {
+  match t {
+    Number | Boolean | Symbol | BigInt => true
+    NumberLiteral(_) | BooleanLiteral(_) | BigIntLiteral(_) => true
+    _ => false
+  }
+}
+
+///|
+/// TS2488 for provably non-iterable `for-of` sources beyond class
+/// instances: a non-iterable primitive (`for (const v of 0)` —
+/// ES5For-ofTypeCheck12), a union with a non-iterable primitive member
+/// (`string | number` — ES5For-ofTypeCheck7/9), and an object type whose
+/// `[Symbol.iterator]` member is optional and may thus be absent
+/// (for-of29).
+fn check_forof_non_iterable(ctx : CheckCtx, iter_ty : @ast.TsType) -> Unit {
+  let msg = "type `\{type_display(iter_ty)}` must have a `[Symbol.iterator]()` method that returns an iterator"
+  match ctx.resolver.unwrap(iter_ty) {
+    Union(ms) => {
+      let mut bad = false
+      for m in ms {
+        if is_non_iterable_primitive(ctx.resolver.unwrap(m)) {
+          bad = true
+        }
+      }
+      if bad {
+        record(ctx, "for-of iterable", msg)
+      }
+    }
+    Object(fields) =>
+      for f in fields {
+        if f.0 is Literal("@@iterator") && type_accepts_undefined(f.1) {
+          record(ctx, "for-of iterable", msg)
+        }
+      }
+    t => if is_non_iterable_primitive(t) { record(ctx, "for-of iterable", msg) }
+  }
+}
+
+///|
 /// TS2339 for object destructuring from a syntactic object literal: a
 /// pattern property with no default whose key is provably absent from the
 /// literal (`var { x } = {}`, `({ x } = {})`). A defaulted property is
@@ -14745,6 +14788,7 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
       // method returning an iterator (extracted; also used for array
       // spreads and assignment-form destructuring).
       check_iterable_class_protocol(ctx, iter_ty, "for-of iterable")
+      check_forof_non_iterable(ctx, iter_ty)
       let inferred_elem = for_of_element_type(ctx.resolver, iter_ty)
       let elem_ty = if is_checkable(declared) {
         // Validate the declared annotation against the actual element type.
@@ -14762,6 +14806,20 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
         declared
       } else {
         inferred_elem
+      }
+      // TS2488 on the PATTERN: array-destructuring an element that is a
+      // non-iterable primitive (`for (var [a = 0, b = 1] of [2, 3])` —
+      // the elements are `number`s; ES5For-of26/28). Restricted to a
+      // syntactic array-literal source so the element type is exact.
+      if binding is @ast.TsBinding::Array(_) && iter is ArrayLit(_) {
+        let ew = ctx.resolver.unwrap(widen_literal(elem_ty))
+        if is_non_iterable_primitive(ew) {
+          record(
+            ctx,
+            "for-of pattern",
+            "type `\{type_display(ew)}` must have a `[Symbol.iterator]()` method that returns an iterator",
+          )
+        }
       }
       let pre = env.full_snapshot()
       // TS2454: same reasoning as for-in — the loop variable is assigned
@@ -24278,6 +24336,82 @@ fn check_var_redeclaration_types(
 }
 
 ///|
+/// The lib interface a runtime-global's `var` declaration must carry to
+/// merge cleanly (`var Symbol: SymbolConstructor`). Only names with a
+/// dedicated `*Constructor` interface participate — `Math` / `JSON` /
+/// `Reflect` have namespace-shaped types we don't model.
+fn lib_global_ctor_type_name(name : String) -> String? {
+  match name {
+    "Symbol" => Some("SymbolConstructor")
+    "Object" => Some("ObjectConstructor")
+    "Function" => Some("FunctionConstructor")
+    "Array" => Some("ArrayConstructor")
+    "String" => Some("StringConstructor")
+    "Number" => Some("NumberConstructor")
+    "Boolean" => Some("BooleanConstructor")
+    "BigInt" => Some("BigIntConstructor")
+    "Date" => Some("DateConstructor")
+    "RegExp" => Some("RegExpConstructor")
+    "Error" => Some("ErrorConstructor")
+    "Promise" => Some("PromiseConstructor")
+    "Proxy" => Some("ProxyConstructor")
+    "Map" => Some("MapConstructor")
+    "Set" => Some("SetConstructor")
+    "WeakMap" => Some("WeakMapConstructor")
+    "WeakSet" => Some("WeakSetConstructor")
+    _ => None
+  }
+}
+
+///|
+/// TS2403 against the LIB declaration: a script-level initializer-less
+/// `var` that redeclares a runtime-provided global merges with the lib's
+/// declaration, so its annotation must be the matching constructor
+/// interface (`var Symbol: SymbolConstructor` is legal —
+/// ES5SymbolProperty1 — while `var Symbol: any` / `{ iterator: string }`
+/// is TS2403 — ES5SymbolProperty3/4/7). Module files (import / export
+/// syntax) declare a fresh module-local binding instead, so they abstain,
+/// as do `typeof` annotations we can't compare.
+fn check_lib_global_redeclaration(module_ : @ast.TsModule) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  let mut has_module_syntax = module_.imports.length() > 0
+  for gm in module_.grammar_misuses {
+    if gm == "<module-syntax>" ||
+      gm.has_prefix("<export-value>") ||
+      gm.has_prefix("<export-default>") ||
+      gm.has_prefix("<export-eq>") {
+      has_module_syntax = true
+    }
+  }
+  if has_module_syntax {
+    return issues
+  }
+  for stmt in module_.top_level_stmts {
+    match stmt {
+      Var(@ast.TsBinding::Ident(n), ty, Var("__ts_no_init__")) =>
+        match lib_global_ctor_type_name(n) {
+          Some(expected) => {
+            let ok = match ty {
+              Named(t) => t == expected
+              TypeOf(_) => true
+              _ => false
+            }
+            if !ok {
+              issues.push({
+                path: "var \{n}",
+                message: "subsequent variable declaration must have the same type as the lib declaration (`\{expected}`)",
+              })
+            }
+          }
+          None => ()
+        }
+      _ => ()
+    }
+  }
+  issues
+}
+
+///|
 fn check_duplicate_index_signatures(
   module_ : @ast.TsModule,
 ) -> Array[ExprIssue] {
@@ -24782,6 +24916,10 @@ fn check_module_function_bodies_layered(
       all.push(issue)
     }
     for issue in check_unresolved_signature_type_refs(module_) {
+      all.push(issue)
+    }
+    // TS2403 for lib-global `var` redeclarations (script scope only).
+    for issue in check_lib_global_redeclaration(module_) {
       all.push(issue)
     }
   }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -360,12 +360,21 @@ fn collect_stmt_value_names(
       // The assignment form (`for (v of xs)` with no `let`/`var`/`const`)
       // declares nothing -- it *reads* an existing binding, so its name must
       // not enter the hoisting backstop (that would mask the TS2304 on an
-      // undeclared target).
-      if !(kind is @ast.TsForOfKind::Assign) {
+      // undeclared target). A `let` / `const` head is LOOP-scoped, so it
+      // must not suppress module-level reads either (`v; for (let v of …)`
+      // — for-of7); only a `var` head hoists.
+      if kind is @ast.TsForOfKind::Var {
         collect_binding_value_names(b, out)
       }
       collect_expr_value_names(e, out)
-      collect_block_value_names(body, out)
+      // For the assign form, a block-scoped declaration in the body cannot
+      // provide the head's binding (`for (v of xs) { let v; }` — for-of6),
+      // so only `var`s (which hoist past the block) enter the backstop.
+      if kind is @ast.TsForOfKind::Assign {
+        collect_block_var_names_only(body, out)
+      } else {
+        collect_block_value_names(body, out)
+      }
     }
     Switch(e, cases) => {
       collect_expr_value_names(e, out)
@@ -407,6 +416,24 @@ fn collect_block_value_names(
 ) -> Unit {
   for s in block.stmts {
     collect_stmt_value_names(s, out)
+  }
+}
+
+///|
+/// Hoisting-backstop walk over a block that keeps only `var` binding names
+/// (which hoist past the block) — direct `let` / `const` bindings are
+/// block-scoped and skipped. Initializer expressions and nested statements
+/// still contribute their names (nested callables introduce their own
+/// scopes, which the full walker already over-approximates).
+fn collect_block_var_names_only(
+  block : @ast.TsBlock,
+  out : Map[String, Bool],
+) -> Unit {
+  for s in block.stmts {
+    match s {
+      Let(_, _, init) | Const(_, _, init) => collect_expr_value_names(init, out)
+      _ => collect_stmt_value_names(s, out)
+    }
   }
 }
 
@@ -15565,6 +15592,20 @@ fn check_call_args_in_expr(
       check_private_name_access(ctx, meth)
       check_member_accessibility(env, ctx, receiver, meth)
       check_super_abstract_access(ctx, receiver, meth)
+      // TS2345 (strict bind/call/apply): `f.apply(x, arguments)` where `f`
+      // is a ZERO-parameter function — `IArguments` is never assignable to
+      // the empty parameter tuple `[]`
+      // (asyncArrowFunctionCapturesArguments_*). Functions with parameters
+      // abstain (their tuple shape needs full apply modeling).
+      if meth == "apply" && args.length() == 2 && args[1] is Var("arguments") {
+        match ctx.resolver.unwrap(infer_expr(env, ctx.resolver, receiver)) {
+          Func([], _) =>
+            record(
+              ctx, "call `apply`", "argument of type `IArguments` is not assignable to parameter of type `[]`",
+            )
+          _ => ()
+        }
+      }
       // Static-namespace dispatch: `Math.max(...)`, `JSON.stringify(...)`.
       // Recognised by the bare-identifier shape of the receiver. Also handle
       // a static method called through the class name (`A.s(args)`), whose

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -19457,6 +19457,316 @@ fn check_param_forward_refs(module_ : @ast.TsModule) -> Array[ExprIssue] {
 /// callable binds that callable's own receiver. Class EXPRESSIONS
 /// nested in static-field initializers are walked too (`static bar =
 /// class Inner { [this.c] = 1 }`).
+/// TS2683: `this` implicitly has type `any` inside a PLAIN function
+/// (function declaration / expression with no `this` parameter) under
+/// noImplicitThis. Arrows inherit the enclosing context; object-literal
+/// function VALUES are contextually `this`-typed and abstain; methods /
+/// accessors / constructors / static initializers are typed at their top
+/// level but a nested plain function expression flips back to implicit
+/// (typeOfThisInStaticMembers8's `static x = function () { this.f }`).
+/// Class-declaration decorator expressions evaluate in the enclosing
+/// scope — inside a NAMESPACE that scope's `this` is implicit any
+/// (decoratorOnClassMethod11); at true top level it is `globalThis` and
+/// stays legal. Whole-file abstention under `@ts-ignore` suppression.
+fn check_implicit_any_this(
+  module_ : @ast.TsModule,
+  in_namespace : Bool,
+) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  if !module_.no_implicit_any {
+    return issues
+  }
+  if module_.grammar_misuses.contains("<ts-suppression-present>") ||
+    module_.grammar_misuses.contains("<noimplicitthis-off>") {
+    return issues
+  }
+  for f in module_.funcs {
+    let plain = !(f.params.length() > 0 && f.params[0].name == "this")
+    ts2683_walk_stmts(issues, f.body.stmts, plain, "function \{f.name}")
+  }
+  // A true top level's `this` is `globalThis` (legal); a NAMESPACE
+  // body is an IIFE whose `this` is implicit any
+  // (computedPropertyNames19_ES5's `[this.bar]` inside `namespace M`).
+  for st in module_.top_level_stmts {
+    match st {
+      @ast.TsStmt::Expr(e)
+      | @ast.TsStmt::Var(_, _, e)
+      | @ast.TsStmt::Let(_, _, e)
+      | @ast.TsStmt::Const(_, _, e) =>
+        ts2683_walk_expr(issues, e, in_namespace, "top-level")
+      _ => ()
+    }
+  }
+  for cls in module_.classes {
+    match cls.constructor_body {
+      Some(b) =>
+        ts2683_walk_stmts(
+          issues,
+          b.stmts,
+          false,
+          "class \{cls.name}.constructor",
+        )
+      None => ()
+    }
+    for m in cls.methods {
+      match m.body {
+        Some(b) =>
+          ts2683_walk_stmts(
+            issues,
+            b.stmts,
+            false,
+            "class \{cls.name}.\{m.name}",
+          )
+        None => ()
+      }
+    }
+    for init in cls.static_field_inits {
+      ts2683_walk_expr(issues, init.1, false, "class \{cls.name}.\{init.0}")
+    }
+    // Class-declaration decorators evaluate in the enclosing scope: a
+    // namespace body's `this` is implicit any; true top level is
+    // `globalThis` and legal.
+    if in_namespace {
+      for d in cls.decorators {
+        ts2683_walk_expr(issues, d, true, "class \{cls.name} decorator")
+      }
+    }
+  }
+  issues
+}
+
+///|
+fn ts2683_walk_expr(
+  issues : Array[ExprIssue],
+  e : @ast.TsExpr,
+  in_plain : Bool,
+  owner : String,
+) -> Unit {
+  match e {
+    Var("this") =>
+      if in_plain {
+        issues.push({
+          path: owner,
+          message: "`this` implicitly has type `any` because it does not have a type annotation",
+        })
+      }
+    // Arrows inherit `this` from the enclosing context.
+    ArrowFunc(_, _, abody, _) =>
+      match abody {
+        ArrowExpr(inner) => ts2683_walk_expr(issues, inner, in_plain, owner)
+        ArrowBlock(b) => ts2683_walk_stmts(issues, b.stmts, in_plain, owner)
+      }
+    // A plain function expression rebinds `this` to implicit any —
+    // unless it declares a `this` parameter. The parser lowers class
+    // declarations/expressions to `<class>`-named IIFE emulations whose
+    // synthesized bodies write `this.field` freely — those are typed
+    // class contexts, never implicit any.
+    FuncExpr(f2) => {
+      if f2.name == "<class>" {
+        return
+      }
+      let plain = !(f2.params.length() > 0 && f2.params[0].name == "this")
+      ts2683_walk_stmts(issues, f2.body.stmts, plain, owner)
+    }
+    // Object-literal FUNCTION values are contextually `this`-typed by
+    // the literal — skip their bodies. Arrow values still inherit the
+    // outer context.
+    ObjectLit(entries) =>
+      for en in entries {
+        match en.1 {
+          FuncExpr(_) => ()
+          other => ts2683_walk_expr(issues, other, in_plain, owner)
+        }
+      }
+    ComputedProp(k, v) => {
+      ts2683_walk_expr(issues, k, in_plain, owner)
+      match v {
+        FuncExpr(_) => ()
+        other => ts2683_walk_expr(issues, other, in_plain, owner)
+      }
+    }
+    // Class expressions carry their own member rules; abstain inside.
+    NativeClassExpr(_, _) => ()
+    BinOp(_, a, b) | Seq(a, b) | IndexAccess(a, b) => {
+      ts2683_walk_expr(issues, a, in_plain, owner)
+      ts2683_walk_expr(issues, b, in_plain, owner)
+    }
+    PropAssignExpr(a, _, b) => {
+      ts2683_walk_expr(issues, a, in_plain, owner)
+      match b {
+        FuncExpr(_) => ()
+        other => ts2683_walk_expr(issues, other, in_plain, owner)
+      }
+    }
+    // A function expression assigned to a PROPERTY / index slot may be
+    // `this`-typed by the target's declared signature
+    // (`Element.prototype.remove ??= function () { this… }` —
+    // thisPrototypeMethodCompoundAssignment) — skip those bodies too.
+    IndexAssignExpr(a, b, c) => {
+      ts2683_walk_expr(issues, a, in_plain, owner)
+      ts2683_walk_expr(issues, b, in_plain, owner)
+      match c {
+        FuncExpr(_) => ()
+        other => ts2683_walk_expr(issues, other, in_plain, owner)
+      }
+    }
+    CompoundAssignExpr(a, _, c) => {
+      ts2683_walk_expr(issues, a, in_plain, owner)
+      match c {
+        FuncExpr(_) => ()
+        other => ts2683_walk_expr(issues, other, in_plain, owner)
+      }
+    }
+    Cond(c, t, f3) => {
+      ts2683_walk_expr(issues, c, in_plain, owner)
+      ts2683_walk_expr(issues, t, in_plain, owner)
+      ts2683_walk_expr(issues, f3, in_plain, owner)
+    }
+    // Function expressions in CALL-ARGUMENT position may receive a
+    // contextual `this` from the callee's signature
+    // (`context.addInitializer(function () { this… })` —
+    // esDecorators-contextualTypes.2) — skip their bodies. IIFE callees
+    // are never contextually typed and keep walking.
+    Call(_, args) | New(_, args) =>
+      for a in args {
+        match a {
+          FuncExpr(_) => ()
+          other => ts2683_walk_expr(issues, other, in_plain, owner)
+        }
+      }
+    CallExpr(callee, args) | NewExpr(callee, args) => {
+      ts2683_walk_expr(issues, callee, in_plain, owner)
+      for a in args {
+        match a {
+          FuncExpr(_) => ()
+          other => ts2683_walk_expr(issues, other, in_plain, owner)
+        }
+      }
+    }
+    MethodCall(recv, _, args) => {
+      ts2683_walk_expr(issues, recv, in_plain, owner)
+      for a in args {
+        match a {
+          FuncExpr(_) => ()
+          other => ts2683_walk_expr(issues, other, in_plain, owner)
+        }
+      }
+    }
+    ArrayLit(items) =>
+      for it in items {
+        ts2683_walk_expr(issues, it, in_plain, owner)
+      }
+    TemplateLiteral(_, exprs) =>
+      for ex in exprs {
+        ts2683_walk_expr(issues, ex, in_plain, owner)
+      }
+    AssignExpr(_, v) =>
+      match v {
+        FuncExpr(_) => ()
+        other => ts2683_walk_expr(issues, other, in_plain, owner)
+      }
+    UnaryOp(_, a)
+    | PropAccess(a, _)
+    | Spread(a)
+    | As(a, _)
+    | Satisfies(a, _)
+    | NonNull(a)
+    | OptionalChain(a)
+    | Await(a)
+    | TypeArgs(_, a) => ts2683_walk_expr(issues, a, in_plain, owner)
+    Yield(opt) =>
+      match opt {
+        Some(a) => ts2683_walk_expr(issues, a, in_plain, owner)
+        None => ()
+      }
+    _ => ()
+  }
+}
+
+///|
+fn ts2683_walk_stmts(
+  issues : Array[ExprIssue],
+  stmts : Array[@ast.TsStmt],
+  in_plain : Bool,
+  owner : String,
+) -> Unit {
+  for st in stmts {
+    match st {
+      Expr(e) | Return(Some(e)) | Throw(e) =>
+        ts2683_walk_expr(issues, e, in_plain, owner)
+      // An ANNOTATED binding contextually types a function-expression
+      // initializer (its declared type may carry a `this` parameter) —
+      // skip those; unannotated initializers keep the implicit-any
+      // verdict.
+      Var(_, ty, init) | Let(_, ty, init) | Const(_, ty, init) =>
+        match init {
+          FuncExpr(_) =>
+            if !is_checkable(ty) {
+              ts2683_walk_expr(issues, init, in_plain, owner)
+            }
+          _ => ts2683_walk_expr(issues, init, in_plain, owner)
+        }
+      Assign(_, e) =>
+        match e {
+          FuncExpr(_) => ()
+          other => ts2683_walk_expr(issues, other, in_plain, owner)
+        }
+      PropAssign(r, _, v) => {
+        ts2683_walk_expr(issues, r, in_plain, owner)
+        match v {
+          FuncExpr(_) => ()
+          other => ts2683_walk_expr(issues, other, in_plain, owner)
+        }
+      }
+      IndexAssign(r, i, v) => {
+        ts2683_walk_expr(issues, r, in_plain, owner)
+        ts2683_walk_expr(issues, i, in_plain, owner)
+        match v {
+          FuncExpr(_) => ()
+          other => ts2683_walk_expr(issues, other, in_plain, owner)
+        }
+      }
+      If(c, a, b) => {
+        ts2683_walk_expr(issues, c, in_plain, owner)
+        ts2683_walk_stmts(issues, a.stmts, in_plain, owner)
+        match b {
+          Some(blk) => ts2683_walk_stmts(issues, blk.stmts, in_plain, owner)
+          None => ()
+        }
+      }
+      While(c, b) | DoWhile(c, b) => {
+        ts2683_walk_expr(issues, c, in_plain, owner)
+        ts2683_walk_stmts(issues, b.stmts, in_plain, owner)
+      }
+      For(_, _, _, b)
+      | ForOf(_, _, _, _, b)
+      | ForAwaitOf(_, _, _, _, b)
+      | ForIn(_, _, _, _, b)
+      | With(_, b) => ts2683_walk_stmts(issues, b.stmts, in_plain, owner)
+      Try(a, _, c, f4) => {
+        ts2683_walk_stmts(issues, a.stmts, in_plain, owner)
+        match c {
+          Some(blk) => ts2683_walk_stmts(issues, blk.stmts, in_plain, owner)
+          None => ()
+        }
+        match f4 {
+          Some(blk) => ts2683_walk_stmts(issues, blk.stmts, in_plain, owner)
+          None => ()
+        }
+      }
+      Switch(d, cases) => {
+        ts2683_walk_expr(issues, d, in_plain, owner)
+        for cse in cases {
+          ts2683_walk_stmts(issues, cse.body.stmts, in_plain, owner)
+        }
+      }
+      Block(b) => ts2683_walk_stmts(issues, b.stmts, in_plain, owner)
+      _ => ()
+    }
+  }
+}
+
+///|
 fn check_this_in_computed_keys(
   module_ : @ast.TsModule,
   resolver : Resolver,
@@ -24443,6 +24753,13 @@ fn check_module_function_bodies_layered(
   for issue in check_this_in_computed_keys(module_, resolver) {
     all.push(issue)
   }
+  // TS2683: implicit-any `this` in plain functions (permissive path
+  // only — strict unit-test snippets use bare functions freely).
+  if permissive {
+    for issue in check_implicit_any_this(module_, outer_modules.length() > 0) {
+      all.push(issue)
+    }
+  }
   for issue in check_reserved_class_names(module_) {
     all.push(issue)
   }
@@ -24788,7 +25105,7 @@ fn check_module_function_bodies_layered(
       }
       // Marker, not an error: the @noImplicitOverride directive flag,
       // consumed by the override-modifier checks.
-      if gm == "<ts-suppression-present>" {
+      if gm == "<ts-suppression-present>" || gm == "<noimplicitthis-off>" {
         continue
       }
       if gm == "<noimplicitoverride-on>" {

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -19115,6 +19115,436 @@ fn any_expr_uses_super_property(es : Array[@ast.TsExpr]) -> Bool {
 /// Compound statements (`if` / loops / `try` / blocks) before `super` are
 /// treated conservatively as "super may have run" so the check never produces
 /// a false positive — at the cost of not catching `this` buried inside them.
+/// TS2373 / TS2372: a parameter default may not reference the parameter
+/// itself, a parameter declared after it, or a name the function BODY
+/// declares (`function f6(n = m) { var m = 4; }`). References inside
+/// nested callables are exempt — their evaluation is deferred
+/// (`a = function () { return b; }` is legal —
+/// parameterInitializersForwardReferencing). Outer-scope declarations
+/// only matter when the body redeclares the name, so unknown names
+/// abstain unless the body declares them.
+fn check_param_forward_refs(module_ : @ast.TsModule) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  fn default_ref_names(e : @ast.TsExpr, out : Array[String]) -> Unit {
+    match e {
+      Var(n) => out.push(n)
+      // Deferred-evaluation boundaries.
+      ArrowFunc(_, _, _, _) | FuncExpr(_) => ()
+      BinOp(_, a, b) | Seq(a, b) | IndexAccess(a, b) => {
+        default_ref_names(a, out)
+        default_ref_names(b, out)
+      }
+      Cond(c, t, f2) => {
+        default_ref_names(c, out)
+        default_ref_names(t, out)
+        default_ref_names(f2, out)
+      }
+      Call(callee, args) => {
+        out.push(callee)
+        for a in args {
+          default_ref_names(a, out)
+        }
+      }
+      CallExpr(callee, args) => {
+        default_ref_names(callee, out)
+        for a in args {
+          default_ref_names(a, out)
+        }
+      }
+      MethodCall(recv, _, args) => {
+        default_ref_names(recv, out)
+        for a in args {
+          default_ref_names(a, out)
+        }
+      }
+      ArrayLit(items) =>
+        for it in items {
+          default_ref_names(it, out)
+        }
+      ObjectLit(entries) =>
+        for en in entries {
+          default_ref_names(en.1, out)
+        }
+      TemplateLiteral(_, exprs) =>
+        for ex in exprs {
+          default_ref_names(ex, out)
+        }
+      UnaryOp(_, a) | PropAccess(a, _) | Spread(a) | OptionalChain(a) =>
+        default_ref_names(a, out)
+      // A class expression evaluates its heritage clause immediately
+      // (`{ [class extends C { … }.x]: b }` reads `C` —
+      // classWithStaticFieldInParameterBindingPattern.2).
+      NativeClassExpr(decl, _) => {
+        for bn in decl.base_names {
+          if bn != "<expr-base>" {
+            out.push(bn)
+          }
+        }
+        match decl.base_expr {
+          Some(be) => default_ref_names(be, out)
+          None => ()
+        }
+      }
+      _ => ()
+    }
+  }
+
+  // References evaluated by a binding PATTERN itself: computed keys and
+  // element defaults (`{ [k(1)]: x } = …` runs `k` at bind time).
+  fn binding_ref_names(b : @ast.TsBinding, out : Array[String]) -> Unit {
+    match b {
+      Ident(_) | Target(_) => ()
+      Array(ab) => {
+        for item in ab.items {
+          match item {
+            Some(el) => {
+              match el.default {
+                Some(d) => default_ref_names(d, out)
+                None => ()
+              }
+              binding_ref_names(el.binding, out)
+            }
+            None => ()
+          }
+        }
+        match ab.rest {
+          Some(r) => binding_ref_names(r, out)
+          None => ()
+        }
+      }
+      Object(ob) =>
+        for pr in ob.props {
+          match pr.key_expr {
+            Some(k) => default_ref_names(k, out)
+            None => ()
+          }
+          match pr.default {
+            Some(d) => default_ref_names(d, out)
+            None => ()
+          }
+          binding_ref_names(pr.binding, out)
+        }
+    }
+  }
+
+  fn binding_idents(b : @ast.TsBinding, out : Array[String]) -> Unit {
+    match b {
+      Ident(n) => out.push(n)
+      Array(ab) => {
+        for item in ab.items {
+          match item {
+            Some(el) => binding_idents(el.binding, out)
+            None => ()
+          }
+        }
+        match ab.rest {
+          Some(r) => binding_idents(r, out)
+          None => ()
+        }
+      }
+      Object(ob) => {
+        for pr in ob.props {
+          binding_idents(pr.binding, out)
+        }
+        match ob.rest {
+          Some(n) => out.push(n)
+          None => ()
+        }
+      }
+      Target(_) => ()
+    }
+  }
+
+  // `var` declarations hoist to function scope (walk every nested block);
+  // `let` / `const` count only at the body's top level. Nested callable
+  // bodies are separate scopes and never walked (they only appear inside
+  // expressions, which this statement walk does not descend into).
+  fn body_decl_names(
+    stmts : Array[@ast.TsStmt],
+    out : Array[String],
+    top : Bool,
+  ) -> Unit {
+    for st in stmts {
+      match st {
+        Var(b, _, _) => binding_idents(b, out)
+        Let(b, _, _) | Const(b, _, _) => if top { binding_idents(b, out) }
+        If(_, a, b2) => {
+          body_decl_names(a.stmts, out, false)
+          match b2 {
+            Some(blk) => body_decl_names(blk.stmts, out, false)
+            None => ()
+          }
+        }
+        While(_, b2)
+        | DoWhile(_, b2)
+        | With(_, b2)
+        | For(_, _, _, b2)
+        | ForOf(_, _, _, _, b2)
+        | ForAwaitOf(_, _, _, _, b2)
+        | ForIn(_, _, _, _, b2) => body_decl_names(b2.stmts, out, false)
+        Try(a, _, c, f2) => {
+          body_decl_names(a.stmts, out, false)
+          match c {
+            Some(blk) => body_decl_names(blk.stmts, out, false)
+            None => ()
+          }
+          match f2 {
+            Some(blk) => body_decl_names(blk.stmts, out, false)
+            None => ()
+          }
+        }
+        Switch(_, cases) =>
+          for c in cases {
+            body_decl_names(c.body.stmts, out, false)
+          }
+        Block(b2) => body_decl_names(b2.stmts, out, false)
+        _ => ()
+      }
+    }
+  }
+
+  fn check_one(
+    names : Array[String],
+    defaults : Array[@ast.TsExpr?],
+    body : @ast.TsBlock?,
+    owner : String,
+    bindings : Array[@ast.TsBinding?],
+  ) -> Unit {
+    let body_decls : Array[String] = []
+    match body {
+      Some(b) => body_decl_names(b.stmts, body_decls, true)
+      None => ()
+    }
+    for i, d in defaults {
+      let refs : Array[String] = []
+      if i < bindings.length() {
+        match bindings[i] {
+          Some(bd) => binding_ref_names(bd, refs)
+          None => ()
+        }
+      }
+      match d {
+        Some(expr) => default_ref_names(expr, refs)
+        None => ()
+      }
+      if refs.length() > 0 {
+        let expr = ()
+        ignore(expr)
+        for r in refs {
+          let mut later = false
+          for j, pn in names {
+            if j >= i && pn == r {
+              later = true
+            }
+          }
+          if later || body_decls.contains(r) {
+            let pname = if i < names.length() { names[i] } else { "?" }
+            issues.push({
+              path: owner,
+              message: "parameter `\{pname}` cannot reference identifier `\{r}` declared after it",
+            })
+          }
+        }
+      }
+    }
+  }
+
+  fn scan_callable_expr(e : @ast.TsExpr, owner : String) -> Unit {
+    match e {
+      ArrowFunc(ps, _, abody, _) => {
+        let names : Array[String] = []
+        let defaults : Array[@ast.TsExpr?] = []
+        let bindings : Array[@ast.TsBinding?] = []
+        for p in ps {
+          names.push(p.name)
+          defaults.push(p.default)
+          bindings.push(p.binding)
+        }
+        let blk : @ast.TsBlock? = match abody {
+          ArrowBlock(b) => Some(b)
+          ArrowExpr(_) => None
+        }
+        check_one(names, defaults, blk, owner, bindings)
+      }
+      FuncExpr(f2) => {
+        let names : Array[String] = []
+        let defaults : Array[@ast.TsExpr?] = []
+        let bindings : Array[@ast.TsBinding?] = []
+        for p in f2.params {
+          names.push(p.name)
+          defaults.push(p.default)
+          bindings.push(p.binding)
+        }
+        check_one(names, defaults, Some(f2.body), owner, bindings)
+      }
+      // An IIFE evaluates its callee's parameter list right here
+      // (`((b = a() ?? "d") => { var a; })()` —
+      // nullishCoalescingOperatorInParameterInitializer.2).
+      CallExpr(callee, _) => scan_callable_expr(callee, owner)
+      _ => ()
+    }
+  }
+
+  for f in module_.funcs {
+    let names : Array[String] = []
+    let defaults : Array[@ast.TsExpr?] = []
+    let bindings : Array[@ast.TsBinding?] = []
+    for p in f.params {
+      names.push(p.name)
+      defaults.push(p.default)
+      bindings.push(p.binding)
+    }
+    check_one(names, defaults, Some(f.body), "function \{f.name}", bindings)
+    for st in f.body.stmts {
+      match st {
+        Var(_, _, init) | Let(_, _, init) | Const(_, _, init) | Expr(init) =>
+          scan_callable_expr(init, "function \{f.name}")
+        _ => ()
+      }
+    }
+  }
+  for st in module_.top_level_stmts {
+    match st {
+      @ast.TsStmt::Var(_, _, init)
+      | @ast.TsStmt::Let(_, _, init)
+      | @ast.TsStmt::Const(_, _, init)
+      | @ast.TsStmt::Expr(init) => scan_callable_expr(init, "top-level")
+      _ => ()
+    }
+  }
+  for cls in module_.classes {
+    match cls.constructor_params {
+      Some(cps) => {
+        let names : Array[String] = []
+        for p in cps {
+          names.push(p.0)
+        }
+        check_one(
+          names,
+          cls.constructor_param_defaults,
+          cls.constructor_body,
+          "class \{cls.name}.constructor",
+          [],
+        )
+      }
+      None => ()
+    }
+    for m in cls.methods {
+      if m.param_defaults.length() == 0 {
+        continue
+      }
+      let names : Array[String] = []
+      for p in m.params {
+        names.push(p.0)
+      }
+      check_one(
+        names,
+        m.param_defaults,
+        m.body,
+        "class \{cls.name}.\{m.name}",
+        [],
+      )
+    }
+  }
+  issues
+}
+
+///|
+/// TS2378: a `get` accessor must return a value. Flagged only for the
+/// provable shape — a class getter body with NO value-returning `return`,
+/// no `throw`, and no loop statement anywhere (a throwing getter is legal,
+/// and a non-terminating body makes the fall-off endpoint unreachable, so
+/// both abstain). All thirteen TS7 conformance hits are trivial empty
+/// bodies (`get Foo() { }` — parserAccessors / parserMemberAccessor
+/// clusters, computedPropertyNames2_ES5).
+fn check_getter_returns_value(module_ : @ast.TsModule) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  fn stmts_have_throw_or_loop(stmts : Array[@ast.TsStmt]) -> Bool {
+    for st in stmts {
+      match st {
+        Throw(_) => return true
+        // A bare `return;` under an undefined-accepting annotation
+        // (`get x(): any { return; }` — asyncMethodWithSuper_es6) is
+        // legal, and a written `: any` is indistinguishable from no
+        // annotation — any explicit return abstains.
+        Return(None) => return true
+        While(_, _)
+        | DoWhile(_, _)
+        | For(_, _, _, _)
+        | ForOf(_, _, _, _, _)
+        | ForAwaitOf(_, _, _, _, _)
+        | ForIn(_, _, _, _, _) => return true
+        If(_, a, b) => {
+          if stmts_have_throw_or_loop(a.stmts) {
+            return true
+          }
+          match b {
+            Some(blk) => if stmts_have_throw_or_loop(blk.stmts) { return true }
+            None => ()
+          }
+        }
+        Try(a, _, c, f) => {
+          if stmts_have_throw_or_loop(a.stmts) {
+            return true
+          }
+          match c {
+            Some(blk) => if stmts_have_throw_or_loop(blk.stmts) { return true }
+            None => ()
+          }
+          match f {
+            Some(blk) => if stmts_have_throw_or_loop(blk.stmts) { return true }
+            None => ()
+          }
+        }
+        Switch(_, cases) =>
+          for c in cases {
+            if stmts_have_throw_or_loop(c.body.stmts) {
+              return true
+            }
+          }
+        Block(b) => if stmts_have_throw_or_loop(b.stmts) { return true }
+        _ => ()
+      }
+    }
+    false
+  }
+
+  for cls in module_.classes {
+    // Ambient classes and abstract accessors legitimately have no body;
+    // an overload signature is impossible for accessors, so a runtime
+    // class getter with `body: None` is exactly the empty-body form
+    // (`get Foo() { }` — the parser stores empty blocks as `None`).
+    for m in cls.methods {
+      if m.accessor != "get" {
+        continue
+      }
+      if cls.is_declare || cls.abstract_members.contains(m.name) {
+        continue
+      }
+      // A declared return type that accepts `undefined` (`(): any`,
+      // `(): void`, `T | undefined`) makes a bare `return;` well-typed —
+      // tsc does not raise TS2378 there (asyncMethodWithSuper_es6's
+      // `get getter(): any { return; }`).
+      if is_checkable(m.return_type) && type_accepts_undefined(m.return_type) {
+        continue
+      }
+      let bad = match m.body {
+        None => true
+        Some(b) =>
+          !block_has_value_return(b.stmts) && !stmts_have_throw_or_loop(b.stmts)
+      }
+      if bad {
+        issues.push({
+          path: "class \{cls.name}.\{m.name}",
+          message: "a `get` accessor must return a value",
+        })
+      }
+    }
+  }
+  issues
+}
+
+///|
 fn check_super_before_this(module_ : @ast.TsModule) -> Array[ExprIssue] {
   let issues : Array[ExprIssue] = []
   for cls in module_.classes {
@@ -23909,6 +24339,14 @@ fn check_module_function_bodies_layered(
   for issue in check_super_before_this(module_) {
     all.push(issue)
   }
+  // TS2378: getters must return a value.
+  for issue in check_getter_returns_value(module_) {
+    all.push(issue)
+  }
+  // TS2373: parameter defaults referencing later declarations.
+  for issue in check_param_forward_refs(module_) {
+    all.push(issue)
+  }
   for issue in check_reserved_class_names(module_) {
     all.push(issue)
   }
@@ -24076,7 +24514,18 @@ fn check_module_function_bodies_layered(
     // the TypeScript 7 oracle: typescript-go dropped the ES3/ES5 targets
     // entirely and never runs those test variants, so `@target: es5`
     // headers no longer produce errors. The parser still records
-    // `deprecated_compiler_options`; nothing surfaces them.
+    // `deprecated_compiler_options`; only options TS7 REMOVED (TS5102 —
+    // an error, not a deprecation) surface. Corpus evidence covers
+    // exactly `downlevelIteration`: every ran conformance case carrying
+    // the directive errors under tsgo v7.0.2, none is accepted.
+    for opt in module_.deprecated_compiler_options {
+      if opt == "downlevelIteration" {
+        all.push({
+          path: "compiler options",
+          message: "option `\{opt}` has been removed",
+        })
+      }
+    }
     // TS2369: a parameter property (`public` / `private` / `protected` /
     // `readonly` on a parameter) is only allowed in a constructor
     // implementation. The parser records each one it saw outside a

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -19450,6 +19450,98 @@ fn check_param_forward_refs(module_ : @ast.TsModule) -> Array[ExprIssue] {
 }
 
 ///|
+/// TS2465 / TS1166: `this` cannot be referenced in a computed property
+/// name of a class member (`class C { [this.bar()]() { } }` —
+/// computedPropertyNames21_ES5, typeOfThisInStaticMembers12/13,
+/// autoAccessor5). Direct references only — a `this` inside a nested
+/// callable binds that callable's own receiver. Class EXPRESSIONS
+/// nested in static-field initializers are walked too (`static bar =
+/// class Inner { [this.c] = 1 }`).
+fn check_this_in_computed_keys(
+  module_ : @ast.TsModule,
+  resolver : Resolver,
+) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  // `@ts-ignore` / `@ts-expect-error` can suppress exactly these lines
+  // (esDecorators-classDeclaration-outerThisReference ignores its
+  // `[f(this)]` keys); without line-anchored issues the safe granularity
+  // is whole-file abstention.
+  if module_.grammar_misuses.contains("<ts-suppression-present>") {
+    return issues
+  }
+  fn check_class(decl : @ast.TsClassDecl) -> Unit {
+    for ke in decl.computed_field_keys {
+      if expr_uses_this_outside_fn(ke) {
+        issues.push({
+          path: "class \{decl.name}",
+          message: "`this` cannot be referenced in a computed property name",
+        })
+      }
+      // TS1166: a computed class-property key must have a simple literal
+      // (or unique symbol) type. A CALL through a declared-`any` callee
+      // never does (`declare var f: any; class C2 { accessor [f()] = 1 }`
+      // — autoAccessor5). Only the declared-any-callee form decides;
+      // unresolved callees abstain.
+      match ke {
+        CallExpr(Var(cn), _) | Call(cn, _) =>
+          if resolver.globals.get(cn) is Some(Any) {
+            issues.push({
+              path: "class \{decl.name}",
+              message: "a computed property name in a class property declaration must have a simple literal type",
+            })
+          }
+        _ => ()
+      }
+    }
+    for m in decl.methods {
+      match m.key_expr {
+        Some(ke) =>
+          if expr_uses_this_outside_fn(ke) {
+            issues.push({
+              path: "class \{decl.name}",
+              message: "`this` cannot be referenced in a computed property name",
+            })
+          }
+        None => ()
+      }
+    }
+    fn scan_expr(e : @ast.TsExpr) -> Unit {
+      match e {
+        NativeClassExpr(inner, _) => check_class(inner)
+        ArrayLit(items) =>
+          for it in items {
+            scan_expr(it)
+          }
+        ObjectLit(entries) =>
+          for en in entries {
+            scan_expr(en.1)
+          }
+        CallExpr(c, args) => {
+          scan_expr(c)
+          for a in args {
+            scan_expr(a)
+          }
+        }
+        BinOp(_, a, b) => {
+          scan_expr(a)
+          scan_expr(b)
+        }
+        _ => ()
+      }
+    }
+
+    for init in decl.static_field_inits {
+      scan_expr(init.1)
+    }
+  }
+
+  for cls in module_.classes {
+    check_class(cls)
+  }
+  issues
+}
+
+///|
 /// TS2378: a `get` accessor must return a value. Flagged only for the
 /// provable shape — a class getter body with NO value-returning `return`,
 /// no `throw`, and no loop statement anywhere (a throwing getter is legal,
@@ -24347,6 +24439,10 @@ fn check_module_function_bodies_layered(
   for issue in check_param_forward_refs(module_) {
     all.push(issue)
   }
+  // TS2465: `this` in a class member's computed property name.
+  for issue in check_this_in_computed_keys(module_, resolver) {
+    all.push(issue)
+  }
   for issue in check_reserved_class_names(module_) {
     all.push(issue)
   }
@@ -24692,6 +24788,9 @@ fn check_module_function_bodies_layered(
       }
       // Marker, not an error: the @noImplicitOverride directive flag,
       // consumed by the override-modifier checks.
+      if gm == "<ts-suppression-present>" {
+        continue
+      }
       if gm == "<noimplicitoverride-on>" {
         continue
       }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -19767,6 +19767,47 @@ fn ts2683_walk_stmts(
 }
 
 ///|
+/// Direct `super` reference inside a computed-key expression (member
+/// access / call receivers only — computed keys can't contain nested
+/// callables that would rebind it meaningfully for TS2466's purposes).
+fn computed_key_mentions_super(e : @ast.TsExpr) -> Bool {
+  match e {
+    Var("super") => true
+    // `super(…)` calls (`[(super(), "prop")]` — computedPropertyNames27).
+    Call("super", _) => true
+    Seq(a, b) =>
+      computed_key_mentions_super(a) || computed_key_mentions_super(b)
+    PropAccess(a, _) | UnaryOp(_, a) | NonNull(a) | OptionalChain(a) =>
+      computed_key_mentions_super(a)
+    MethodCall(r, _, args) => {
+      if computed_key_mentions_super(r) {
+        return true
+      }
+      for a in args {
+        if computed_key_mentions_super(a) {
+          return true
+        }
+      }
+      false
+    }
+    CallExpr(c, args) => {
+      if computed_key_mentions_super(c) {
+        return true
+      }
+      for a in args {
+        if computed_key_mentions_super(a) {
+          return true
+        }
+      }
+      false
+    }
+    BinOp(_, a, b) | IndexAccess(a, b) =>
+      computed_key_mentions_super(a) || computed_key_mentions_super(b)
+    _ => false
+  }
+}
+
+///|
 fn check_this_in_computed_keys(
   module_ : @ast.TsModule,
   resolver : Resolver,
@@ -19787,6 +19828,14 @@ fn check_this_in_computed_keys(
           message: "`this` cannot be referenced in a computed property name",
         })
       }
+      // TS2466: `super` is equally banned in computed property names
+      // (computedPropertyNames24/27/30's `[super.bar()]`).
+      if computed_key_mentions_super(ke) {
+        issues.push({
+          path: "class \{decl.name}",
+          message: "`super` cannot be referenced in a computed property name",
+        })
+      }
       // TS1166: a computed class-property key must have a simple literal
       // (or unique symbol) type. A CALL through a declared-`any` callee
       // never does (`declare var f: any; class C2 { accessor [f()] = 1 }`
@@ -19805,13 +19854,20 @@ fn check_this_in_computed_keys(
     }
     for m in decl.methods {
       match m.key_expr {
-        Some(ke) =>
+        Some(ke) => {
           if expr_uses_this_outside_fn(ke) {
             issues.push({
               path: "class \{decl.name}",
               message: "`this` cannot be referenced in a computed property name",
             })
           }
+          if computed_key_mentions_super(ke) {
+            issues.push({
+              path: "class \{decl.name}",
+              message: "`super` cannot be referenced in a computed property name",
+            })
+          }
+        }
         None => ()
       }
     }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -1941,6 +1941,17 @@ fn Resolver::lookup_field_core(
           | ("SharedArrayBuffer", "byteLength")
           | ("DataView", "byteLength")
           | ("DataView", "byteOffset") => return Some(@ast.TsType::Number)
+          ("ArrayBuffer", "maxByteLength")
+          | ("SharedArrayBuffer", "maxByteLength") =>
+            return Some(@ast.TsType::Number)
+          ("ArrayBuffer", "resizable")
+          | ("ArrayBuffer", "detached")
+          | ("SharedArrayBuffer", "growable") =>
+            return Some(@ast.TsType::Boolean)
+          ("ArrayBuffer", "resize") | ("SharedArrayBuffer", "grow") =>
+            return Some(
+              @ast.TsType::Func([@ast.TsType::Number], @ast.TsType::Void),
+            )
           ("ArrayBuffer", "slice") | ("SharedArrayBuffer", "slice") =>
             return Some(
               @ast.TsType::Func(
@@ -2834,7 +2845,7 @@ fn error_prototype_member(field : String) -> @ast.TsType? {
 /// module-declared interface or class of the same name merges with (or
 /// shadows) the lib surface, so those abstain.
 fn lib_member_surface_complete(resolver : Resolver, n : String) -> Bool {
-  (n == "Error" || n == "Date") &&
+  (n == "Error" || n == "Date" || n == "SharedArrayBuffer") &&
   resolver.interfaces.get(n) is None &&
   resolver.classes.get(n) is None
 }
@@ -6237,6 +6248,14 @@ fn infer_expr(
         None => {
           for a in args {
             let _ = infer_expr(env, resolver, a)
+          }
+          // A lib `SharedArrayBuffer` instance keeps its Named type so the
+          // fully-table-modeled member surface applies (`foge.length` —
+          // useSharedArrayBuffer6).
+          if class_name == "SharedArrayBuffer" &&
+            resolver.classes.get(class_name) is None &&
+            resolver.interfaces.get(class_name) is None {
+            return @ast.TsType::Named("SharedArrayBuffer")
           }
           // Lib `Map` with a uniform entry array infers `Map<K, V>` from
           // the literal-widened first pair, so downstream iteration /
@@ -12591,9 +12610,71 @@ fn bind_array_pattern(
         Array(t) => @ast.TsType::Array(t)
         _ => @ast.TsType::Any
       }
+      check_object_pattern_over_array(ctx, rest_binding, rest_ty)
       bind_pattern(env, ctx, rest_binding, rest_ty)
     }
     None => ()
+  }
+}
+
+///|
+/// TS2339 for an OBJECT pattern destructuring an array / tuple (a rest
+/// element's object sub-pattern: `var [...{ 0: a, b }] = [0, 1]` — `b`
+/// does not exist on `number[]`; restElementWithBindingPattern2 /
+/// restElementWithAssignmentPattern4). Numeric keys and the array surface
+/// (`length`, methods) stay legal.
+fn check_object_pattern_over_array(
+  ctx : CheckCtx,
+  binding : @ast.TsBinding,
+  source : @ast.TsType,
+) -> Unit {
+  fn all_digits(s : String) -> Bool {
+    if s.length() == 0 {
+      return false
+    }
+    for c in s {
+      if c < '0' || c > '9' {
+        return false
+      }
+    }
+    true
+  }
+  fn array_surface_member(name : String) -> Bool {
+    if array_prototype_member(@ast.TsType::Any, name) is Some(_) {
+      return true
+    }
+    match name {
+      // Names the modeled surface may lack but real arrays have.
+      "constructor"
+      | "valueOf"
+      | "toLocaleString"
+      | "at"
+      | "copyWithin"
+      | "reduceRight"
+      | "toReversed"
+      | "toSorted"
+      | "toSpliced"
+      | "with" => true
+      _ => false
+    }
+  }
+  match binding {
+    @ast.TsBinding::Object(ob) =>
+      if ctx.resolver.unwrap(source) is (Array(_) | Tuple(_)) {
+        for prop in ob.props {
+          if !prop.key.has_prefix("<") &&
+            prop.key_expr is None &&
+            !all_digits(prop.key) &&
+            !array_surface_member(prop.key) {
+            record(
+              ctx,
+              "destructuring `\{prop.key}`",
+              "property `\{prop.key}` does not exist on type `\{type_display(source)}`",
+            )
+          }
+        }
+      }
+    _ => ()
   }
 }
 
@@ -14372,15 +14453,35 @@ fn check_object_pattern_from_literal(
   entries : Array[(String, @ast.TsExpr)],
 ) -> Unit {
   let keys : Map[String, Bool] = {}
-  for e in entries {
-    if e.0.has_prefix("@@spread") || e.0.has_prefix("<") {
-      return
+  // A spread of a syntactic object LITERAL keeps the key set knowable —
+  // fold its keys in recursively (`{ ...{ a: 0 } , x: 0 }` provides `a`
+  // and `x`; destructuringSpread). Any other spread source abstains.
+  fn collect(es : Array[(String, @ast.TsExpr)]) -> Bool {
+    for e in es {
+      if e.0.has_prefix("@@spread") {
+        match e.1 {
+          ObjectLit(inner) => if !collect(inner) { return false }
+          _ => return false
+        }
+        continue
+      }
+      if e.0.has_prefix("@@get:") || e.0.has_prefix("@@set:") {
+        keys[e.0.substring(start=6)] = true
+        continue
+      }
+      if e.0.has_prefix("<") || e.0.has_prefix("@@") {
+        return false
+      }
+      match e.1 {
+        ComputedProp(_, _) => return false
+        _ => ()
+      }
+      keys[e.0] = true
     }
-    match e.1 {
-      ComputedProp(_, _) => return
-      _ => ()
-    }
-    keys[e.0] = true
+    true
+  }
+  if !collect(entries) {
+    return
   }
   for prop in ob.props {
     if prop.default is None &&
@@ -14846,6 +14947,37 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
             "for-of pattern",
             "type `\{type_display(ew)}` must have a `[Symbol.iterator]()` method that returns an iterator",
           )
+        }
+      }
+      // TS2339 on the PATTERN: object-destructuring a primitive element
+      // (`for (var {x: a = 0} of [2, 3])` — `x` does not exist on `number`;
+      // ES5For-of27). Same syntactic array-literal restriction; prototype
+      // members (`toString`, `valueOf`, …) stay legal.
+      if binding is @ast.TsBinding::Object(ob) && iter is ArrayLit(_) {
+        let ew = ctx.resolver.unwrap(widen_literal(elem_ty))
+        let proto_member : (String) -> Bool = match ew {
+          Number =>
+            fn(f) {
+              number_prototype_member(f) is Some(_) || f == "constructor"
+            }
+          Boolean =>
+            fn(f) {
+              boolean_prototype_member(f) is Some(_) || f == "constructor"
+            }
+          _ => fn(_f) { true }
+        }
+        if ew is (Number | Boolean) {
+          for prop in ob.props {
+            if !prop.key.has_prefix("<") &&
+              prop.key_expr is None &&
+              !proto_member(prop.key) {
+              record(
+                ctx,
+                "for-of pattern",
+                "property `\{prop.key}` does not exist on type `\{type_display(ew)}`",
+              )
+            }
+          }
         }
       }
       let pre = env.full_snapshot()
@@ -16867,7 +16999,7 @@ fn check_call_args_in_expr(
         // never iterable, so assignment-form array destructuring from one
         // always fails (iterableArrayPattern23/24). Computed keys could be
         // `[Symbol.iterator]`, so they silence the check.
-        @ast.TsBinding::Array(_) =>
+        @ast.TsBinding::Array(ab2) => {
           match v {
             ObjectLit(src_entries) =>
               if !src_entries
@@ -16881,6 +17013,34 @@ fn check_call_args_in_expr(
               }
             _ => ()
           }
+          // TS2339: an object sub-pattern under a rest element must draw
+          // its keys from the ARRAY surface
+          // (`[...{ 0: a = "", b }] = tuple` —
+          // restElementWithAssignmentPattern4).
+          match ab2.rest {
+            Some(rb) => {
+              let src = ctx.resolver.unwrap(infer_expr(env, ctx.resolver, v))
+              let rest_ty : @ast.TsType? = match src {
+                Tuple(items) => {
+                  let remaining : Array[@ast.TsType] = []
+                  let mut j = ab2.items.length()
+                  while j < items.length() {
+                    remaining.push(items[j])
+                    j = j + 1
+                  }
+                  Some(@ast.TsType::Tuple(remaining))
+                }
+                Array(t) => Some(@ast.TsType::Array(t))
+                _ => None
+              }
+              match rest_ty {
+                Some(rt) => check_object_pattern_over_array(ctx, rb, rt)
+                None => ()
+              }
+            }
+            None => ()
+          }
+        }
         _ => ()
       }
       // TS2322: assignment-form array destructuring writes the source's

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -14229,3 +14229,42 @@ test "expr_check: implicit-any this (batch BH)" {
     0,
   )
 }
+
+///|
+test "expr_check: accessor arity, member modifiers, exponents, super keys (batch BI)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // TS1049/TS1054: setter takes exactly one parameter, getter none —
+  // object literals and classes.
+  assert_true(issues("var v = { set foo() { } };") > 0)
+  assert_true(issues("class A { set foo() { } }") > 0)
+  assert_true(issues("class A { get foo(x: number) { return x; } }") > 0)
+  @test.assert_eq(
+    issues(
+      "var v = { get a() { return 1; }, set a(n) { } };\nclass B { get b() { return 1; } set b(n: number) { } }",
+    ),
+    0,
+  )
+  // TS1031: `export` / `declare` cannot modify class elements.
+  assert_true(issues("class C {\n  export constructor() { }\n}") > 0)
+  assert_true(issues("class C {\n  declare constructor() { }\n}") > 0)
+  @test.assert_eq(issues("class C {\n  declare x: number;\n}"), 0)
+  // TS1124: an exponent needs at least one digit.
+  assert_true(issues("var n = 1e;") > 0)
+  @test.assert_eq(issues("var a = 1e3;\nvar b = 1e+3;\nvar c = 1.5e-2;"), 0)
+  // TS2466: `super` (including `super()` in a comma chain) cannot be
+  // referenced in a computed property name.
+  assert_true(
+    issues(
+      "class Base { bar() { return \"\"; } }\nclass C extends Base {\n  [super.bar()]() { }\n}",
+    ) >
+    0,
+  )
+  assert_true(
+    issues(
+      "class Base { }\nclass C extends Base {\n  [(super(), \"prop\")]() { }\n}",
+    ) >
+    0,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -14326,3 +14326,52 @@ test "expr_check: ASI namespace/declare, for-of TS2488, lib-global TS2403 (batch
   // Module files declare a fresh local binding — no TS2403.
   @test.assert_eq(issues("var Symbol: any;\nexport { };"), 0)
 }
+
+///|
+test "expr_check: block-scoped hoisting, new<, apply arguments, binding keys (batch BK)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // TS2304: a `let` for-of head is loop-scoped (for-of7) and a body `let`
+  // can't provide an assign-form head's binding (for-of6).
+  assert_true(issues("v;\nfor (let v of [0]) { }") > 0)
+  assert_true(issues("for (v of [0]) { let v; }") > 0)
+  // `var` head / body still hoist — no error.
+  @test.assert_eq(issues("for (var w of [0]) { }\nw;"), 0)
+  @test.assert_eq(issues("for (u of [0]) { var u; }"), 0)
+  // Loop-head lets stay visible to closures inside the loop.
+  @test.assert_eq(issues("for (let v of [0]) { const g = () => v; g(); }"), 0)
+  // TS2304 via `new Date<A;` — no balanced `>` means `<` is a comparison
+  // and `A` is an (undeclared) value read (parserConstructorAmbiguity1-4).
+  assert_true(issues("new Date<A;") > 0)
+  assert_true(issues("new Date<A ? B : C;") > 0)
+  @test.assert_eq(issues("var m = new Map<string, Array<number>>();"), 0)
+  // TS2345: `f.apply(x, arguments)` with a zero-parameter target
+  // (asyncArrowFunctionCapturesArguments_*).
+  assert_true(
+    issues(
+      "class C {\n  method() {\n    function other() {}\n    var fn = async () => await other.apply(this, arguments);\n  }\n}",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "class C {\n  method() {\n    function other(...xs: any[]) {}\n    var fn = () => other.apply(this, [1]);\n  }\n}",
+    ),
+    0,
+  )
+  // TS1005: reserved-word / literal object-binding shorthands need `: alias`
+  // (objectBindingPatternKeywordIdentifiers01/03); aliased forms stay legal.
+  assert_true(issues("var { while } = { while: 1 };") > 0)
+  assert_true(issues("var { \"while\" } = { while: 1 };") > 0)
+  @test.assert_eq(
+    issues(
+      "var { while: w } = { while: 1 };\nvar { a, b = 1 } = { a: 0, b: 2 };",
+    ),
+    0,
+  )
+  // TS1005: `void` cannot head a qualified type name
+  // (parservoidInQualifiedName1).
+  assert_true(issues("var v : void.x;") > 0)
+  @test.assert_eq(issues("var v : void;"), 0)
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -14268,3 +14268,61 @@ test "expr_check: accessor arity, member modifiers, exponents, super keys (batch
     0,
   )
 }
+
+///|
+test "expr_check: ASI namespace/declare, for-of TS2488, lib-global TS2403 (batch BJ)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // TS2454 via ASI: `namespace` / `module` / `declare` followed by a
+  // newline are identifier references, not declaration heads
+  // (asiPreventsParsingAsNamespace01/02, ...AmbientExternalModule01).
+  assert_true(
+    issues("var namespace: number;\nvar n: string;\nnamespace\nn\n{ }") > 0,
+  )
+  assert_true(
+    issues(
+      "var declare: number;\nvar module: string;\ndeclare\nmodule\n\"my external module\"\n{ }",
+    ) >
+    0,
+  )
+  // Same-line namespace / module declarations stay legal.
+  @test.assert_eq(issues("namespace M { export var x = 1; }"), 0)
+  @test.assert_eq(issues("declare module \"foo\" { export var x: number; }"), 0)
+  // TS2488: non-iterable for-of sources — a union with a non-iterable
+  // primitive member, a bare numeric literal, an array-destructuring
+  // pattern over primitive elements, and an OPTIONAL `[Symbol.iterator]`
+  // member (ES5For-ofTypeCheck7/12, ES5For-of26, for-of29).
+  assert_true(
+    issues("declare var u: string | number;\nfor (var v of u) { }") > 0,
+  )
+  assert_true(issues("for (const v of 0) { }") > 0)
+  assert_true(issues("for (var [a = 0, b = 1] of [2, 3]) { }") > 0)
+  assert_true(
+    issues(
+      "declare var it: { [Symbol.iterator]?(): Iterator<string> };\nfor (var v of it) { }",
+    ) >
+    0,
+  )
+  // Iterable sources stay legal: arrays, strings, arrays-of-arrays under
+  // a pattern, and a REQUIRED `[Symbol.iterator]` member.
+  @test.assert_eq(
+    issues(
+      "declare var xs: number[];\nfor (var v of xs) { }\nfor (var c of \"abc\") { }\nfor (var [a, b] of [[1, 2]]) { }",
+    ),
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "declare var it: { [Symbol.iterator](): Iterator<string> };\nfor (var v of it) { }",
+    ),
+    0,
+  )
+  // TS2403: a script-level `var` redeclaring a lib global needs the
+  // matching constructor-interface annotation (ES5SymbolProperty1 vs 3/4).
+  assert_true(issues("var Symbol: any;") > 0)
+  assert_true(issues("var Symbol: { iterator: string };") > 0)
+  @test.assert_eq(issues("var Symbol: SymbolConstructor;"), 0)
+  // Module files declare a fresh local binding — no TS2403.
+  @test.assert_eq(issues("var Symbol: any;\nexport { };"), 0)
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -14110,3 +14110,45 @@ test "expr_check: TS7-only miss clusters (batch BE)" {
     0,
   )
 }
+
+///|
+test "expr_check: TS7 lexical clusters (batch BF)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // TS2465: `this` in a class member's computed property name; TS1166:
+  // a computed field key through a declared-`any` call has no literal
+  // type. Well-known-symbol and literal keys stay legal.
+  assert_true(
+    issues("class C {\n  bar() { return 0; }\n  [this.bar()]() { }\n}") > 0,
+  )
+  assert_true(
+    issues("declare var f: any;\nclass C2 {\n  accessor [f()] = 1;\n}") > 0,
+  )
+  @test.assert_eq(
+    issues(
+      "const k = \"a\";\nclass D {\n  [Symbol.iterator]() { return null as any; }\n  [\"lit\"] = 1;\n  [k] = 2;\n}",
+    ),
+    0,
+  )
+  // TS1125 / TS1198: invalid `\u{...}` escapes in STRING literals —
+  // missing / non-hex digits and out-of-range values. Valid escapes
+  // stay silent.
+  assert_true(issues("var x = \"\\u{}\";") > 0)
+  assert_true(issues("var x = \"\\u{-DDDD}\";") > 0)
+  assert_true(issues("var x = \"\\u{110000}\";") > 0)
+  assert_true(issues("var x = \"\\u{FFFFFFFF}\";") > 0)
+  @test.assert_eq(
+    issues(
+      "var a = \"\\u{0}\";\nvar b = \"\\u{10FFFF}\";\nvar c = \"\\u0041\";",
+    ),
+    0,
+  )
+  // TS1121: legacy octal integer literals; modern radix forms stay
+  // legal.
+  assert_true(issues("var o = 01;") > 0)
+  @test.assert_eq(
+    issues("var a = 0o777;\nvar b = 0;\nvar c = 0.5;\nvar d = 08.5;"),
+    0,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -14375,3 +14375,40 @@ test "expr_check: block-scoped hoisting, new<, apply arguments, binding keys (ba
   assert_true(issues("var v : void.x;") > 0)
   @test.assert_eq(issues("var v : void;"), 0)
 }
+
+///|
+test "expr_check: patterns over primitives/arrays, spread folding, SharedArrayBuffer (batch BL)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // TS2339: object pattern over a primitive for-of element (ES5For-of27);
+  // prototype members stay legal.
+  assert_true(issues("for (var {x: a = 0, y: b = 1} of [2, 3]) { }") > 0)
+  @test.assert_eq(issues("for (var {toString: t} of [2, 3]) { }"), 0)
+  @test.assert_eq(issues("for (var {x: a} of [{ x: 1 }]) { }"), 0)
+  // TS2339: object sub-pattern under a rest element draws from the ARRAY
+  // surface (restElementWithBindingPattern2 / AssignmentPattern4).
+  assert_true(issues("var [...{0: a, b }] = [0, 1];") > 0)
+  assert_true(
+    issues(
+      "var a: string, b: number;\nvar tuple: [string, number] = [\"\", 1];\n[...{ 0: a = \"\", b }] = tuple;",
+    ) >
+    0,
+  )
+  @test.assert_eq(issues("var [...{ 0: a, length: n }] = [0, 1];"), 0)
+  // TS2339: spread of syntactic object literals keeps pattern keys knowable
+  // (destructuringSpread); provided keys stay legal.
+  assert_true(
+    issues("const { c, g } = { ...{ ...{ c: 0 }, d: 0 }, f: 0 };") > 0,
+  )
+  @test.assert_eq(issues("const { z, a, b } = { z: 0, ...{ a: 0, b: 0 } };"), 0)
+  // TS2339: the SharedArrayBuffer instance surface is table-modeled
+  // (useSharedArrayBuffer6); real members stay legal.
+  assert_true(issues("var sab = new SharedArrayBuffer(1024);\nsab.length;") > 0)
+  @test.assert_eq(
+    issues(
+      "var sab = new SharedArrayBuffer(8);\nvar n: number = sab.byteLength;\nvar s2 = sab.slice(0, 4);",
+    ),
+    0,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -12752,11 +12752,19 @@ test "expr_check: decorator/tagged-template parse recoveries (batch AO)" {
     ),
     0,
   )
-  // Parameter decorators with parenthesized expression heads.
+  // Parameter decorators with parenthesized expression heads parse
+  // cleanly under LEGACY decorators; without the pragma the same form is
+  // a TS1206 (standard decorators have no parameter form — batch BE).
   @test.assert_eq(
     issues(
-      "// @strict: false\nclass D { constructor(@((t, k, i) => {}) p: any) {} }",
+      "// @strict: false\n// @experimentaldecorators: true\nclass D { constructor(@((t, k, i) => {}) p: any) {} }",
     ),
+    0,
+  )
+  assert_true(
+    issues(
+      "// @strict: false\nclass D { constructor(@((t, k, i) => {}) p: any) {} }",
+    ) >
     0,
   )
 }
@@ -14045,4 +14053,60 @@ test "expr_check: TS7 oracle switch fixes (batch BD)" {
   // (destructuringEvaluationOrder); a genuinely unannotated one is.
   @test.assert_eq(issues("let f = (n: any): any => n;"), 0)
   assert_true(issues("let f = n => n;") > 0)
+}
+
+///|
+test "expr_check: TS7-only miss clusters (batch BE)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // TS5102: `downlevelIteration` was REMOVED in TS7 — its presence is an
+  // error (ES5For-of* cluster). Other recorded legacy options stay silent.
+  assert_true(
+    issues("// @downlevelIteration: true\nfor (var v of ['a']) { }") > 0,
+  )
+  @test.assert_eq(issues("// @module: amd\nvar x: number = 1;"), 0)
+  // TS2378: a `get` accessor must return a value — empty bodies parse as
+  // `body: None`; throwing / looping / declare / abstract forms abstain.
+  assert_true(issues("class C { get Foo() { } }") > 0)
+  @test.assert_eq(
+    issues(
+      "class G {\n  get a() { return 1; }\n  get b() { throw new Error(\"x\"); }\n  get c(): number { while (true) {} }\n  set d(v: number) { }\n}\ndeclare class DG { get e(): number; }\nabstract class AG { abstract get f(): number; }",
+    ),
+    0,
+  )
+  // TS1206: decorators are invalid on constructors and abstract/ambient
+  // members; parameter decorators require legacy decorators.
+  assert_true(
+    issues(
+      "// @experimentaldecorators: true\ndeclare function dec(t: any, k?: any, d?: any): any;\nclass C {\n  @dec constructor() {}\n}",
+    ) >
+    0,
+  )
+  assert_true(
+    issues(
+      "declare let dec: any;\nabstract class C {\n  @dec(1) abstract field1: number;\n}",
+    ) >
+    0,
+  )
+  assert_true(
+    issues("declare let dec: any;\nclass C {\n  m(@dec x: number) { }\n}") > 0,
+  )
+  @test.assert_eq(
+    issues(
+      "// @experimentaldecorators: true\ndeclare function dec(t: any, k?: any, d?: any): any;\nclass L {\n  @dec m(@dec x: number) { }\n  @dec f: number = 1;\n  @dec get g() { return 1; }\n}",
+    ),
+    0,
+  )
+  // TS2373: parameter defaults may not reference later parameters or
+  // body-declared names; deferred (closure) references are legal.
+  assert_true(issues("function right(a = b, b = a) { a; b; }") > 0)
+  assert_true(issues("function inside(a = b) { var b; }") > 0)
+  assert_true(issues("((b = a() ?? \"d\") => { var a; })();") > 0)
+  @test.assert_eq(
+    issues(
+      "function left(a: any, b = a, c = b) { }\nfunction ok2(a = function () { return b; }, b = 1) { }\nfunction ok3(a = () => () => b, b = 3) { }\nvar outerv = 1;\nfunction ok4(n = outerv) { }",
+    ),
+    0,
+  )
 }

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -14152,3 +14152,34 @@ test "expr_check: TS7 lexical clusters (batch BF)" {
     0,
   )
 }
+
+///|
+test "expr_check: template and regex escape validation (batch BG)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Regex `\u{...}` under the `u` flag: hex digits required, value
+  // capped at 0x10FFFF. Without the flag the same body is a quantified
+  // `u` and stays legal.
+  assert_true(issues("var x = /\\u{-DDDD}/gu;") > 0)
+  assert_true(issues("var x = /\\u{110000}/u;") > 0)
+  @test.assert_eq(
+    issues(
+      "var a = /\\u{10FFFF}/u;\nvar b = /\\u{2}/;\nvar c = /[\\u{0}-\\u{FF}]/u;",
+    ),
+    0,
+  )
+  // UNTAGGED template literals reject invalid `\u` / `\x` escapes;
+  // TAGGED templates accept them (ES2018).
+  assert_true(issues("var y = `\\u{hello} \\xtraordinary \\uworld`;") > 0)
+  assert_true(issues("var y = `\\u{110000}`;") > 0)
+  @test.assert_eq(
+    issues(
+      "declare function tag(s: any, ...a: any[]): any;\nvar z = tag`\\u{hello} \\xtraordinary \\uworld`;\nvar w = `\\u{48}ello`;",
+    ),
+    0,
+  )
+  // Strings reject `\x` with missing hex digits too.
+  assert_true(issues("var s = \"\\xZZ\";") > 0)
+  @test.assert_eq(issues("var s = \"\\x41\";"), 0)
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -11024,9 +11024,17 @@ test "expr_check: function-valued expression bodies are walked" {
     ),
     0,
   )
-  // `this` inside a function expression is dynamically bound -> `any`.
+  // `this` inside a plain function expression is implicit `any` — a
+  // TS2683 under noImplicitThis (batch BH). A written `this` parameter
+  // types it and keeps the member access tolerant.
+  assert_true(
+    issues("class C { m() { var g = function () { return this.anything; }; } }") >
+    0,
+  )
   @test.assert_eq(
-    issues("class C { m() { var g = function () { return this.anything; }; } }"),
+    issues(
+      "class C { m() { var g = function (this: any) { return this.anything; }; } }",
+    ),
     0,
   )
   // A contextually-checked callback argument is not double-reported.
@@ -14182,4 +14190,42 @@ test "expr_check: template and regex escape validation (batch BG)" {
   // Strings reject `\x` with missing hex digits too.
   assert_true(issues("var s = \"\\xZZ\";") > 0)
   @test.assert_eq(issues("var s = \"\\x41\";"), 0)
+}
+
+///|
+test "expr_check: implicit-any this (batch BH)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // Plain functions (incl. nested in methods, static-init function
+  // exprs, namespace bodies) give `this` an implicit `any`.
+  assert_true(issues("function plain() { return this; }") > 0)
+  assert_true(
+    issues(
+      "class C {\n  method() {\n    function fn() { return this; }\n  }\n}",
+    ) >
+    0,
+  )
+  assert_true(
+    issues("class C {\n  static x = function () { return this; };\n}") > 0,
+  )
+  assert_true(issues("namespace M {\n  var obj = { [this.bar]: 0 };\n}") > 0)
+  // Typed contexts stay silent: this-params, methods, object-literal
+  // function values, arrows in static inits, classes nested in plain
+  // functions (IIFE lowering), true top level, and the
+  // `@noImplicitThis: false` opt-out.
+  @test.assert_eq(
+    issues(
+      "function tf(this: Window) { this.name; }\nvar obj = { m: function() { return this; }, n() { this; } };\nvar top1 = this;\nclass K { m() { return this; } static s = () => this; }\nfunction outer() {\n  class A { x = 1; m() { return this.x; } }\n  return new A();\n}",
+    ),
+    0,
+  )
+  @test.assert_eq(
+    issues("// @noImplicitThis: false\nfunction plain() { return this; }"),
+    0,
+  )
+  @test.assert_eq(
+    issues("// @strict: false\nfunction plain() { return this; }"),
+    0,
+  )
 }

--- a/src/parser/lexer.mbt
+++ b/src/parser/lexer.mbt
@@ -705,6 +705,14 @@ fn Lexer::scan_number(self : Lexer) -> TokenKind {
             }
             _ => ()
           }
+          // TS1124: the exponent needs at least one digit (`1e`, `1e+`
+          // — scannerNumericLiteral4/6, scannerES3NumericLiteral4/6).
+          match self.peek() {
+            Some(d) if d >= '0' && d <= '9' => ()
+            _ =>
+              self.invalid_radix_digit_count = self.invalid_radix_digit_count +
+                1
+          }
         } else {
           break
         }

--- a/src/parser/lexer.mbt
+++ b/src/parser/lexer.mbt
@@ -160,6 +160,11 @@ pub struct Lexer {
   mut unicode_escape_overflow_count : Int
   // TS1121: a legacy octal integer literal (`01`) — banned in TS.
   mut legacy_octal_literal_count : Int
+  // Absolute source positions of invalid `\u` / `\x` escapes inside
+  // TEMPLATE literals. Tagged templates accept invalid escapes (ES2018)
+  // and taggedness is a parse-time fact, so the lexer only records —
+  // the parser counts entries inside each UNTAGGED template's span.
+  template_invalid_escape_positions : Array[Int]
   // TS1160: a template literal ran to EOF without its closing backtick.
   mut unterminated_template : Bool
   src : String
@@ -229,6 +234,7 @@ pub fn Lexer::new(src : String) -> Lexer {
     invalid_unicode_escape_count: 0,
     unicode_escape_overflow_count: 0,
     legacy_octal_literal_count: 0,
+    template_invalid_escape_positions: [],
     unterminated_template: false,
     src,
     // Skip a UTF-8/UTF-16 byte-order mark. Without this the BOM reaches
@@ -1263,6 +1269,9 @@ fn Lexer::scan_string(self : Lexer, quote : Char) -> TokenKind {
               if ok {
                 write_codepoint(buf, code)
               } else {
+                // TS1125: `\x` demands exactly two hex digits in a string.
+                self.invalid_unicode_escape_count = self.invalid_unicode_escape_count +
+                  1
                 buf.write_char('x')
               }
             }
@@ -1510,6 +1519,59 @@ fn Lexer::skip_regex_body(self : Lexer) -> Unit {
 }
 
 ///|
+/// TS1125 / TS1198: under the `u` / `v` flags, `\u{...}` escapes in a
+/// regex body must carry hex digits and stay within 0x0..0x10FFFF
+/// (unicodeExtendedEscapesInRegularExpressions07-19). Without the flag,
+/// `\u{2}` is a quantified `u` and stays legal.
+fn Lexer::validate_regex_unicode_escapes(self : Lexer, bs : String) -> Unit {
+  let n = bs.length()
+  let mut i = 0
+  while i + 2 < n {
+    if bs[i].to_int() == '\\'.to_int() &&
+      bs[i + 1].to_int() == 'u'.to_int() &&
+      bs[i + 2].to_int() == '{'.to_int() {
+      let mut j = i + 3
+      let mut code = 0
+      let mut digits = 0
+      let mut ok = true
+      while j < n && bs[j].to_int() != '}'.to_int() {
+        let ch = bs[j].to_int()
+        let d = if ch >= '0'.to_int() && ch <= '9'.to_int() {
+          ch - '0'.to_int()
+        } else if ch >= 'a'.to_int() && ch <= 'f'.to_int() {
+          ch - 'a'.to_int() + 10
+        } else if ch >= 'A'.to_int() && ch <= 'F'.to_int() {
+          ch - 'A'.to_int() + 10
+        } else {
+          -1
+        }
+        if d < 0 {
+          ok = false
+          break
+        }
+        if code <= 0x10FFFF {
+          code = code * 16 + d
+        }
+        digits = digits + 1
+        j = j + 1
+      }
+      if j >= n {
+        ok = false
+      }
+      if !ok || digits == 0 {
+        self.invalid_unicode_escape_count = self.invalid_unicode_escape_count +
+          1
+      } else if code > 0x10FFFF {
+        self.unicode_escape_overflow_count = self.unicode_escape_overflow_count +
+          1
+      }
+      i = j
+    }
+    i = i + 1
+  }
+}
+
+///|
 fn Lexer::skip_template_expr(self : Lexer) -> Unit {
   let mut depth = 1
   let mut prev_sig : Char? = Some('{')
@@ -1739,6 +1801,7 @@ fn Lexer::scan_template_parts_with_raw(
               if ok {
                 write_codepoint(cooked_buf, code)
               } else {
+                self.template_invalid_escape_positions.push(self.pos)
                 cooked_buf.write_char('x')
               }
             }
@@ -1748,7 +1811,9 @@ fn Lexer::scan_template_parts_with_raw(
               let mut code = 0
               let mut ok = true
               let mut digits = 0
+              let mut braced = false
               if self.peek() == Some('{') {
+                braced = true
                 let _ = self.advance()
                 raw_buf.write_char('{')
                 while true {
@@ -1761,7 +1826,9 @@ fn Lexer::scan_template_parts_with_raw(
                     Some(_) =>
                       match self.read_hex_digit() {
                         Some(d) => {
-                          code = code * 16 + d
+                          if code <= 0x10FFFF {
+                            code = code * 16 + d
+                          }
                           digits = digits + 1
                           let hex_char = if d < 10 {
                             (d + '0'.to_int()).unsafe_to_char()
@@ -1802,8 +1869,16 @@ fn Lexer::scan_template_parts_with_raw(
                 }
               }
               if ok && digits > 0 {
-                write_codepoint(cooked_buf, code)
+                // Overflow (`\u{110000}`) is recorded like a malformed
+                // escape — the untagged-template parse site surfaces it.
+                if braced && (code > 0x10FFFF || code < 0) {
+                  self.template_invalid_escape_positions.push(self.pos)
+                  cooked_buf.write_char('u')
+                } else {
+                  write_codepoint(cooked_buf, code)
+                }
               } else {
+                self.template_invalid_escape_positions.push(self.pos)
                 cooked_buf.write_char('u')
               }
             }
@@ -2105,7 +2180,11 @@ fn Lexer::scan_regex(self : Lexer) -> TokenKind {
       None => break
     }
   }
-  Regex(buf.to_string(), flags.to_string())
+  let flag_str = flags.to_string()
+  if flag_str.contains("u") || flag_str.contains("v") {
+    self.validate_regex_unicode_escapes(buf.to_string())
+  }
+  Regex(buf.to_string(), flag_str)
 }
 
 ///|

--- a/src/parser/lexer.mbt
+++ b/src/parser/lexer.mbt
@@ -151,6 +151,15 @@ pub struct Lexer {
   // digit outside its radix (`0b1102110`, `0o13334823`). tsc surfaces
   // parser-recovery errors there; one count per offending literal.
   mut invalid_radix_digit_count : Int
+  // TS1125: a `\u{...}` / `\uXXXX` escape in a STRING literal with a
+  // missing / non-hex digit (`"\u{}"`, `"\u{-DDDD}"`, `"\u{"`).
+  // Template literals are NOT counted here — tagged templates accept
+  // invalid escapes (ES2018), so the parser decides those.
+  mut invalid_unicode_escape_count : Int
+  // TS1198: a `\u{...}` escape whose value exceeds 0x10FFFF.
+  mut unicode_escape_overflow_count : Int
+  // TS1121: a legacy octal integer literal (`01`) — banned in TS.
+  mut legacy_octal_literal_count : Int
   // TS1160: a template literal ran to EOF without its closing backtick.
   mut unterminated_template : Bool
   src : String
@@ -217,6 +226,9 @@ pub fn Lexer::new(src : String) -> Lexer {
   {
     invalid_char_count: 0,
     invalid_radix_digit_count: 0,
+    invalid_unicode_escape_count: 0,
+    unicode_escape_overflow_count: 0,
+    legacy_octal_literal_count: 0,
     unterminated_template: false,
     src,
     // Skip a UTF-8/UTF-16 byte-order mark. Without this the BOM reaches
@@ -642,6 +654,9 @@ fn Lexer::scan_number(self : Lexer) -> TokenKind {
           }
         }
         if is_pure_octal {
+          // TS1121: legacy octal integer literals (`01`) are banned in
+          // TypeScript regardless of target (scannerNumericLiteral2/3/8).
+          self.legacy_octal_literal_count = self.legacy_octal_literal_count + 1
           // Recalculate as octal
           let mut octal_value = 0
           let mut mult = 1
@@ -1256,7 +1271,9 @@ fn Lexer::scan_string(self : Lexer, quote : Char) -> TokenKind {
               let mut code = 0
               let mut ok = true
               let mut digits = 0
+              let mut braced = false
               if self.peek() == Some('{') {
+                braced = true
                 let _ = self.advance()
                 while true {
                   match self.peek() {
@@ -1296,8 +1313,20 @@ fn Lexer::scan_string(self : Lexer, quote : Char) -> TokenKind {
                 }
               }
               if ok && digits > 0 {
-                write_codepoint(buf, code)
+                // TS1198: a braced escape past the Unicode range. `code`
+                // may have wrapped a 32-bit Int on long inputs
+                // (`\u{FFFFFFFF}`), so a negative accumulation counts too.
+                if braced && (code > 0x10FFFF || code < 0) {
+                  self.unicode_escape_overflow_count = self.unicode_escape_overflow_count +
+                    1
+                  buf.write_char('u')
+                } else {
+                  write_codepoint(buf, code)
+                }
               } else {
+                // TS1125: missing / non-hex digits (`\u{}`, `\u{-D}`, `\u{`).
+                self.invalid_unicode_escape_count = self.invalid_unicode_escape_count +
+                  1
                 buf.write_char('u')
               }
             }

--- a/src/parser/parser_binding.mbt
+++ b/src/parser/parser_binding.mbt
@@ -409,6 +409,14 @@ fn Parser::parse_binding_object(
         }
         break
       }
+      // A literal key token (string / number / boolean / null) can never be
+      // a SHORTHAND binding — it needs the `: alias` form. Captured before
+      // the key parse erases the token kind
+      // (objectBindingPatternKeywordIdentifiers01/03).
+      let key_is_literal_token = match self.peek().kind {
+        Str(_) | Number(_) | Int(_) | Bool(_) | Null => true
+        _ => false
+      }
       let (key, key_expr) = if self.match_(LBracket) {
         let expr = self.parse_assignment()
         let _ = self.expect(RBracket)
@@ -428,6 +436,16 @@ fn Parser::parse_binding_object(
         match key_expr {
           Some(_) => raise ParseError("Expected Colon, got \{self.peek().kind}")
           None => {
+            // Shorthand: the key IS the binding name. A hard-reserved word
+            // (`var { while } = …`) or a literal key (`var { "while" } = …`)
+            // is only legal with a `: alias` (TS1005).
+            if key_is_literal_token {
+              self.grammar_misuses.push(
+                "a literal object-binding key needs a `:` alias",
+              )
+            } else {
+              self.record_reserved_binding_name(key)
+            }
             let mut default : @ast.TsExpr? = None
             if self.match_(Eq) {
               default = Some(self.parse_assignment())

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -1903,6 +1903,21 @@ fn Parser::parse_class_body(
     while has_modifier {
       has_modifier = false
       match self.peek().kind {
+        // TS1031: `export` / `import` never modify class elements
+        // (`class C { export constructor() {} }` —
+        // parserConstructorDeclaration3/4, parserMemberFunction/
+        // VariableDeclaration4). Consume it so the member still parses.
+        Export =>
+          // Only a MODIFIER position consumes it — `class C { export; }`
+          // declares a field NAMED `export`
+          // (propertyNamesOfReservedWords).
+          if self.can_consume_class_modifier() {
+            let _ = self.advance()
+            self.grammar_misuses.push(
+              "`export` modifier cannot appear on a class element",
+            )
+            has_modifier = true
+          }
         Ident(n) if n == "static" =>
           if self.can_consume_class_modifier() {
             let _ = self.advance()
@@ -2090,6 +2105,16 @@ fn Parser::parse_class_body(
         self.invalid_decorator_uses.push("constructor")
       }
     }
+    // TS1031: `declare` cannot modify a constructor implementation
+    // (`class C { declare constructor() {} }` —
+    // parserConstructorDeclaration4).
+    if has_declare &&
+      method_name == "constructor" &&
+      (self.check(LParen) || self.check(Lt)) {
+      self.grammar_misuses.push(
+        "`declare` modifier cannot appear on a constructor",
+      )
+    }
     if method_name != "<computed>" {
       if visibility == "private" {
         private_members.push(method_name)
@@ -2161,6 +2186,24 @@ fn Parser::parse_class_body(
         let params = self.parse_params()
         self.record_implicit_any_params = prev_record_nia
         let _ = self.expect(RParen)
+        // TS1054 / TS1049: accessors have fixed arities — a getter takes
+        // no parameters, a setter exactly one (parserAccessors8/9,
+        // parserMemberAccessorDeclaration13/14).
+        match accessor_kind {
+          Some("get") =>
+            if params.length() != 0 {
+              self.grammar_misuses.push(
+                "a `get` accessor cannot have parameters",
+              )
+            }
+          Some("set") =>
+            if params.length() != 1 {
+              self.grammar_misuses.push(
+                "a `set` accessor must have exactly one parameter",
+              )
+            }
+          _ => ()
+        }
         params
       } else {
         []

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -1878,9 +1878,11 @@ fn Parser::parse_class_body(
         _ => ()
       }
     }
+    let deco_before = self.pending_decorators.length()
     while self.check(At) {
       self.skip_decorator()
     }
+    let member_decorated = self.pending_decorators.length() > deco_before
     if self.match_(Semicolon) {
       continue
     }
@@ -2072,6 +2074,22 @@ fn Parser::parse_class_body(
     let is_generator = self.match_(Star)
     let key = self.parse_class_method_key()
     let method_name = class_key_name(key)
+    // TS1206: decorators are not valid on a constructor
+    // (decoratorOnClassConstructor1), nor on `abstract` or ambient
+    // (`declare`) members (esDecorators-classDeclaration-*-nonStatic
+    // Abstract / -Ambient) — in both decorator modes.
+    if member_decorated {
+      // Legacy (`experimentalDecorators`) mode ACCEPTS decorators on
+      // `declare` / `abstract` members (decoratorInAmbientContext);
+      // only standard ES decorators reject them. Constructor
+      // decoration is invalid in both modes.
+      if (is_abstract_member || has_declare) && !self.experimental_decorators {
+        self.invalid_decorator_uses.push("class member")
+      } else if method_name == "constructor" &&
+        (self.check(LParen) || self.check(Lt)) {
+        self.invalid_decorator_uses.push("constructor")
+      }
+    }
     if method_name != "<computed>" {
       if visibility == "private" {
         private_members.push(method_name)

--- a/src/parser/parser_core.mbt
+++ b/src/parser/parser_core.mbt
@@ -124,6 +124,10 @@ pub struct Parser {
   // `@noImplicitAny: false` opt out, an explicit `@noImplicitAny: true`
   // opts back in over `@strict: false`.
   no_implicit_any : Bool
+  // True when the test header carries `@experimentaldecorators: true`
+  // (legacy decorators). Parameter decorators are only legal in that
+  // mode — under standard (ES) decorators they are TS1206.
+  experimental_decorators : Bool
   // Armed only while parsing a *function declaration's* parameter list --
   // the one position where an unannotated parameter can never be
   // contextually typed, so the implicit-any verdict is reliable.
@@ -271,6 +275,7 @@ pub fn Parser::new_with_strict_and_jsx(
     no_bound_inline: false,
     target_es6_plus: false,
     no_implicit_any: false,
+    experimental_decorators: true,
     record_implicit_any_params: false,
     class_decl_no_heritage: false,
     in_class_expr_body: false,
@@ -364,6 +369,7 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
     no_bound_inline: false,
     target_es6_plus: detect_target_es6_plus(src),
     no_implicit_any: detect_no_implicit_any(src),
+    experimental_decorators: detect_experimental_decorators(src),
     record_implicit_any_params: false,
     class_decl_no_heritage: false,
     in_class_expr_body: false,
@@ -751,4 +757,24 @@ fn detect_allow_unreachable_code(src : String) -> Bool {
 /// case variant) -- i.e. a multi-file test concatenated into one parse.
 fn detect_filename_directives(src : String) -> Bool {
   src.to_lower().contains("@filename:")
+}
+
+///|
+/// True when the leading test-header directives enable legacy decorators
+/// (`// @experimentaldecorators: true`). Parameter decorators are legal
+/// only in that mode.
+fn detect_experimental_decorators(src : String) -> Bool {
+  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
+  let head = src[:head_len].to_owned().to_lower()
+  match head.find("@experimentaldecorators:") {
+    Some(idx) => {
+      let after = head[idx + "@experimentaldecorators:".length():].to_owned()
+      let line = match after.find("\n") {
+        Some(nl) => after[:nl].to_owned()
+        None => after
+      }
+      line.trim().to_owned().has_prefix("true")
+    }
+    None => false
+  }
 }

--- a/src/parser/parser_core.mbt
+++ b/src/parser/parser_core.mbt
@@ -150,6 +150,11 @@ pub struct Parser {
   // same-named unannotated param elsewhere is then exempt too — a safe
   // MISS, never an FP).
   written_any_params : Map[String, Unit]
+  // Source positions of invalid `\u` / `\x` escapes inside template
+  // literals (from the lexer). Tagged templates accept invalid escapes
+  // (ES2018), so only the UNTAGGED template parse site counts the
+  // entries inside its token span.
+  template_invalid_escape_positions : Array[Int]
   // Conformance-header strict directive (`@alwaysStrict: true` / `@strict:
   // true`). Unlike `in_strict` it does NOT change parsing behaviour (octal
   // handling, statement restrictions, ...) -- it only arms the strict-misuse
@@ -280,6 +285,7 @@ pub fn Parser::new_with_strict_and_jsx(
     class_decl_no_heritage: false,
     in_class_expr_body: false,
     written_any_params: {},
+    template_invalid_escape_positions: [],
     directive_strict: false,
     param_optional_initializer_misuses: [],
     interface_member_modifier_misuses: [],
@@ -388,6 +394,7 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
     target_es6_plus: detect_target_es6_plus(src),
     no_implicit_any: detect_no_implicit_any(src),
     experimental_decorators: detect_experimental_decorators(src),
+    template_invalid_escape_positions: lexer.template_invalid_escape_positions,
     record_implicit_any_params: false,
     class_decl_no_heritage: false,
     in_class_expr_body: false,

--- a/src/parser/parser_core.mbt
+++ b/src/parser/parser_core.mbt
@@ -318,8 +318,26 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
   if lexer.unterminated_template {
     grammar_misuses.push("unterminated template literal")
   }
+  // Marker: the file uses `@ts-ignore` / `@ts-expect-error` suppression
+  // comments somewhere. Our issues carry no line positions, so rules
+  // whose corpus counter-examples are suppressed lines (the computed-key
+  // TS2465/TS1166 family) abstain for the whole file when set.
+  if src.contains("@ts-ignore") || src.contains("@ts-expect-error") {
+    grammar_misuses.push("<ts-suppression-present>")
+  }
   for _i in 0..<lexer.invalid_radix_digit_count {
     grammar_misuses.push("invalid digit in a binary or octal numeric literal")
+  }
+  for _i in 0..<lexer.invalid_unicode_escape_count {
+    grammar_misuses.push("hexadecimal digit expected in a unicode escape")
+  }
+  for _i in 0..<lexer.unicode_escape_overflow_count {
+    grammar_misuses.push(
+      "an extended unicode escape value must be between 0x0 and 0x10FFFF inclusive",
+    )
+  }
+  for _i in 0..<lexer.legacy_octal_literal_count {
+    grammar_misuses.push("octal literals are not allowed")
   }
   // Module-scoped flag marker for the override checks (TS4114 fires only
   // under `@noImplicitOverride: true`); TS4112/TS4113 are unconditional.

--- a/src/parser/parser_core.mbt
+++ b/src/parser/parser_core.mbt
@@ -331,6 +331,12 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
   if src.contains("@ts-ignore") || src.contains("@ts-expect-error") {
     grammar_misuses.push("<ts-suppression-present>")
   }
+  // TS2683 opt-out: `@noImplicitThis: false` disables the implicit-any
+  // `this` diagnostics for the file.
+  if src.to_lower().contains("@noimplicitthis: false") ||
+    src.to_lower().contains("@noimplicitthis:false") {
+    grammar_misuses.push("<noimplicitthis-off>")
+  }
   for _i in 0..<lexer.invalid_radix_digit_count {
     grammar_misuses.push("invalid digit in a binary or octal numeric literal")
   }

--- a/src/parser/parser_expr.mbt
+++ b/src/parser/parser_expr.mbt
@@ -3271,7 +3271,18 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
           if self.check(Lt) {
             match self.try_parse_simple_type_args() {
               Some(targs) => new_type_args = targs
-              None => self.skip_type_args()
+              None => {
+                // Only treat `<...>` as type arguments when a balanced
+                // closing `>` exists. `new Date<A;` never closes — TS
+                // parses it as the comparison `new Date < A`, so restore
+                // the cursor and let the binary-operator machinery read
+                // `A` as a value reference (parserConstructorAmbiguity1-4
+                // expect the TS2304 on `A`).
+                let saved = self.pos
+                if !self.try_skip_type_args() {
+                  self.pos = saved
+                }
+              }
             }
           }
         }

--- a/src/parser/parser_expr.mbt
+++ b/src/parser/parser_expr.mbt
@@ -2833,7 +2833,20 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
       New("RegExp", args)
     }
     Template(cooked_parts, _, expr_sources) => {
+      let tpl_pos = self.peek().pos
       let _ = self.advance()
+      // TS1125: an UNTAGGED template carrying an invalid `\u` / `\x`
+      // escape is an error; tagged templates accept them (ES2018) and
+      // parse through the postfix path, never here. One diagnostic per
+      // recorded escape inside this token's span.
+      let next_pos = self.peek().pos
+      for p in self.template_invalid_escape_positions {
+        if p >= tpl_pos && (next_pos <= tpl_pos || p < next_pos) {
+          self.grammar_misuses.push(
+            "hexadecimal digit expected in a unicode escape",
+          )
+        }
+      }
       // Parse expression sources into AST expressions. Each `${…}`
       // interpolation is captured as a raw source string by the
       // lexer and parsed here via a fresh sub-parser. The sub-

--- a/src/parser/parser_expr.mbt
+++ b/src/parser/parser_expr.mbt
@@ -3660,6 +3660,20 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
             let _ = self.expect(LParen)
             let params = self.parse_params()
             let _ = self.expect(RParen)
+            // TS1054 / TS1049: a `get` accessor takes no parameters; a
+            // `set` accessor takes exactly one (parserAccessors8's
+            // `{ set foo() { } }`).
+            if is_getter {
+              if params.length() != 0 {
+                self.grammar_misuses.push(
+                  "a `get` accessor cannot have parameters",
+                )
+              }
+            } else if params.length() != 1 {
+              self.grammar_misuses.push(
+                "a `set` accessor must have exactly one parameter",
+              )
+            }
             let return_type = if self.check(Colon) {
               let _ = self.advance()
               self.parse_type()
@@ -4015,6 +4029,20 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
             let _ = self.expect(LParen)
             let params = self.parse_params()
             let _ = self.expect(RParen)
+            // TS1054 / TS1049: a `get` accessor takes no parameters; a
+            // `set` accessor takes exactly one (parserAccessors8's
+            // `{ set foo() { } }`).
+            if is_getter {
+              if params.length() != 0 {
+                self.grammar_misuses.push(
+                  "a `get` accessor cannot have parameters",
+                )
+              }
+            } else if params.length() != 1 {
+              self.grammar_misuses.push(
+                "a `set` accessor must have exactly one parameter",
+              )
+            }
             let return_type = if self.check(Colon) {
               let _ = self.advance()
               self.parse_type()

--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -5,6 +5,14 @@
 ///|
 fn Parser::skip_param_decorators(self : Parser) -> Unit raise ParseError {
   while self.match_(At) {
+    // TS1206: parameter decorators exist only under legacy
+    // (`experimentalDecorators`) semantics; standard ES decorators have
+    // no parameter form (esDecorators-classDeclaration-parameterDecorators).
+    // Recorded AFTER the decorator expression is consumed: a following
+    // `class` keyword means this is really a decorated CLASS EXPRESSION
+    // inside parens (`(@dec class { … })`) that the arrow-params trial
+    // will abandon — never a parameter decorator.
+    let record_at = !self.experimental_decorators
     // `@(expr)` decorator heads (`(@((t, k, i) => {}) p: any)` —
     // legacyDecorators-contextualTypes) go straight to the balanced
     // paren skip below; identifier heads consume their member chain.
@@ -57,6 +65,12 @@ fn Parser::skip_param_decorators(self : Parser) -> Unit raise ParseError {
           }
         }
       }
+    }
+    // A following `@` means another stacked decorator — defer the verdict
+    // to the LAST decorator in the chain, whose follower reveals whether
+    // the chain precedes a class expression or a real parameter.
+    if record_at && !self.check(Class) && !self.check(At) {
+      self.invalid_decorator_uses.push("parameter")
     }
   }
 }

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -3330,10 +3330,13 @@ fn Parser::parse_module_with_seeded_const_values_internal(
         }
       }
     } else if self.check(Declare) &&
-      !(self.peek_at(1).kind is Template(_, _, _)) {
+      !(self.peek_at(1).kind is Template(_, _, _)) &&
+      !self.peek_at(1).has_newline_before {
       // (`declare `template`` is a tagged-template CALL of a function
       // named `declare`, not an ambient declaration —
-      // taggedTemplateStringsWithTagNamedDeclare.)
+      // taggedTemplateStringsWithTagNamedDeclare. A newline right after
+      // `declare` triggers ASI, so it is a plain identifier reference —
+      // asiPreventsParsingAsAmbientExternalModule01.)
       let _ = self.advance() // consume 'declare'
       // TS1038: a `declare` modifier inside an already-ambient context
       // (`declare namespace M { declare function F(); }`).

--- a/src/parser/parser_stmt.mbt
+++ b/src/parser/parser_stmt.mbt
@@ -350,17 +350,38 @@ fn Parser::parse_var_like(
       | Let(Object(ob), _, ObjectLit(entries))
       | Const(Object(ob), _, ObjectLit(entries)) => {
         let keys : Map[String, Bool] = {}
-        let mut keys_known = true
-        for e in entries {
-          if e.0.has_prefix("@@spread") || e.0.has_prefix("<") {
-            keys_known = false
+        // A spread of a syntactic object LITERAL keeps the key set
+        // knowable — fold its keys in recursively
+        // (`const { g } = { ...{ c: 0 }, f: 0 }` — destructuringSpread).
+        // Any other spread / computed / synthetic entry abstains.
+        fn collect(es : Array[(String, @ast.TsExpr)]) -> Bool {
+          for e in es {
+            if e.0.has_prefix("@@spread") {
+              match e.1 {
+                @ast.TsExpr::ObjectLit(inner) =>
+                  if !collect(inner) {
+                    return false
+                  }
+                _ => return false
+              }
+              continue
+            }
+            if e.0.has_prefix("@@get:") || e.0.has_prefix("@@set:") {
+              keys[e.0.substring(start=6)] = true
+              continue
+            }
+            if e.0.has_prefix("<") || e.0.has_prefix("@@") {
+              return false
+            }
+            match e.1 {
+              @ast.TsExpr::ComputedProp(_, _) => return false
+              _ => ()
+            }
+            keys[e.0] = true
           }
-          match e.1 {
-            ComputedProp(_, _) => keys_known = false
-            _ => ()
-          }
-          keys[e.0] = true
+          true
         }
+        let keys_known = collect(entries)
         if keys_known {
           for prop in ob.props {
             if prop.default is None &&

--- a/src/parser/parser_stmt.mbt
+++ b/src/parser/parser_stmt.mbt
@@ -17,12 +17,20 @@ fn Parser::is_namespace_decl_start(self : Parser) -> Bool {
       match name {
         "global" => self.peek_at(1).kind == LBrace
         "namespace" | "module" =>
-          match self.peek_at(1).kind {
-            Ident(_) | Str(_) | LBrace => true
-            // Primitive type keywords are legal namespace names
-            // (`namespace number {}` — parserModuleDeclaration6/7).
-            NumberType | StringType | BooleanType | IntType => true
-            _ => false
+          // ASI: TS only treats `namespace` / `module` as a declaration
+          // keyword when the name follows on the SAME line
+          // (asiPreventsParsingAsNamespace01/02). A newline makes it a
+          // plain identifier reference.
+          if self.peek_at(1).has_newline_before {
+            false
+          } else {
+            match self.peek_at(1).kind {
+              Ident(_) | Str(_) | LBrace => true
+              // Primitive type keywords are legal namespace names
+              // (`namespace number {}` — parserModuleDeclaration6/7).
+              NumberType | StringType | BooleanType | IntType => true
+              _ => false
+            }
           }
         _ => false
       }

--- a/src/parser/parser_type.mbt
+++ b/src/parser/parser_type.mbt
@@ -1050,6 +1050,12 @@ fn Parser::parse_primary_type(self : Parser) -> @ast.TsType raise ParseError {
     VoidType => {
       let _ = self.advance()
       if self.check(Dot) {
+        // `void` can never head a qualified type name (`var v: void.x` —
+        // TS1005, parservoidInQualifiedName1). Parse through for recovery
+        // but record the misuse.
+        self.grammar_misuses.push(
+          "`void` cannot be used in a qualified type name",
+        )
         self.parse_named_type_tail("void")
       } else {
         Void

--- a/src/parser/parser_type.mbt
+++ b/src/parser/parser_type.mbt
@@ -538,6 +538,33 @@ fn Parser::try_parse_simple_object_type(self : Parser) -> @ast.TsType? {
 }
 
 ///|
+/// The standard well-known symbols of `SymbolConstructor`. Mirrors the
+/// checker's `is_well_known_symbol_name`; the parser needs its own copy
+/// (package boundary) to decide which `[Symbol.x]` type-literal keys are
+/// safe to encode as `@@x` members.
+fn is_standard_well_known_symbol(name : String) -> Bool {
+  match name {
+    "iterator"
+    | "asyncIterator"
+    | "hasInstance"
+    | "isConcatSpreadable"
+    | "match"
+    | "matchAll"
+    | "replace"
+    | "search"
+    | "species"
+    | "split"
+    | "toPrimitive"
+    | "toStringTag"
+    | "unscopables"
+    | "dispose"
+    | "asyncDispose"
+    | "metadata" => true
+    _ => false
+  }
+}
+
+///|
 /// Parse an object type literal that may include method signatures
 /// (`m(x): T`), call signatures (`(x): T`), construct signatures
 /// (`new (x): T`), index signatures (`[k: K]: V`), and ordinary
@@ -594,46 +621,68 @@ fn Parser::try_parse_object_type_with_members(self : Parser) -> @ast.TsType? {
           // mangle-safety relies on). Anything that isn't the canonical
           // `[ident: Type]: Type` shape (computed keys, etc.) falls back.
           let _ = self.advance()
-          let is_index_sig = match self.peek().kind {
-            Ident(_) => self.peek_at(1).kind == Colon
-            _ => false
+          // Well-known symbol member key (`[Symbol.iterator]?(): T`):
+          // encode with the toolchain's `@@name` convention so the
+          // checker can reason about the iteration protocol (for-of29).
+          // Only the STANDARD well-known symbols participate — a
+          // user-augmented `Symbol.foo` (symbolProperty61) keeps the
+          // legacy fall-back so we never invent a required member the
+          // checker can't match structurally.
+          let well_known_sym : String? = match
+            (self.peek().kind, self.peek_at(1).kind, self.peek_at(2).kind) {
+            (Ident("Symbol"), Dot, Ident(sym)) if self.peek_at(3).kind ==
+              RBracket &&
+              is_standard_well_known_symbol(sym) => Some(sym)
+            _ => None
           }
-          if !is_index_sig {
-            // TS2304: a computed key in a *type* literal (`{ [e]: number }`,
-            // `{ [e](): T }`) references the value namespace. Record the
-            // bare-identifier shape so the checker can flag a provably
-            // undeclared name. Dotted keys (`[Symbol.iterator]`) don't match
-            // the single-token shape, and function bodies are skipped (the
-            // name may be a local we can't resolve at module level).
-            match self.peek().kind {
-              Ident(key) if self.peek_at(1).kind == RBracket &&
-                !self.in_function =>
-                self.grammar_misuses.push("<computed-type-key>" + key)
-              _ => ()
-            }
-            self.pos = saved_pos
-            return None
-          }
-          let _ = self.advance() // index name
-          let _ = self.expect(Colon)
-          let key_type = self.parse_type()
-          let _ = self.expect(RBracket)
-          let _ = self.match_(Question)
-          // Consume the value type to advance the cursor, but record the
-          // signature with an `Any` value. Keeping the index signature
-          // (key typed `String_` / `Number`) preserves the "any key"
-          // meaning the mangle-safety and TS2454 passes need; widening
-          // the value to `Any` keeps us from driving value-assignability
-          // checks off an anonymous index signature, where our checker's
-          // object-literal getter modelling (`get x()` rendered as
-          // `() => T`) would otherwise produce spurious mismatches.
-          if self.check(Colon) {
+          if well_known_sym is Some(sym) {
             let _ = self.advance()
-            let _ = self.parse_type()
+            let _ = self.advance()
+            let _ = self.advance()
+            let _ = self.advance()
+            "@@" + sym
+          } else {
+            let is_index_sig = match self.peek().kind {
+              Ident(_) => self.peek_at(1).kind == Colon
+              _ => false
+            }
+            if !is_index_sig {
+              // TS2304: a computed key in a *type* literal (`{ [e]: number }`,
+              // `{ [e](): T }`) references the value namespace. Record the
+              // bare-identifier shape so the checker can flag a provably
+              // undeclared name. Dotted keys (`[Symbol.iterator]`) don't match
+              // the single-token shape, and function bodies are skipped (the
+              // name may be a local we can't resolve at module level).
+              match self.peek().kind {
+                Ident(key) if self.peek_at(1).kind == RBracket &&
+                  !self.in_function =>
+                  self.grammar_misuses.push("<computed-type-key>" + key)
+                _ => ()
+              }
+              self.pos = saved_pos
+              return None
+            }
+            let _ = self.advance() // index name
+            let _ = self.expect(Colon)
+            let key_type = self.parse_type()
+            let _ = self.expect(RBracket)
+            let _ = self.match_(Question)
+            // Consume the value type to advance the cursor, but record the
+            // signature with an `Any` value. Keeping the index signature
+            // (key typed `String_` / `Number`) preserves the "any key"
+            // meaning the mangle-safety and TS2454 passes need; widening
+            // the value to `Any` keeps us from driving value-assignability
+            // checks off an anonymous index signature, where our checker's
+            // object-literal getter modelling (`get x()` rendered as
+            // `() => T`) would otherwise produce spurious mismatches.
+            if self.check(Colon) {
+              let _ = self.advance()
+              let _ = self.parse_type()
+            }
+            fields.push((key_type, @ast.TsType::Any))
+            let _ = self.match_(Semicolon) || self.match_(Comma)
+            continue
           }
-          fields.push((key_type, @ast.TsType::Any))
-          let _ = self.match_(Semicolon) || self.match_(Comma)
-          continue
         }
         Ident(n) => {
           let _ = self.advance()

--- a/src/parser/pkg.generated.mbti
+++ b/src/parser/pkg.generated.mbti
@@ -137,6 +137,7 @@ pub struct Parser {
   mut no_bound_inline : Bool
   target_es6_plus : Bool
   no_implicit_any : Bool
+  experimental_decorators : Bool
   mut record_implicit_any_params : Bool
   mut class_decl_no_heritage : Bool
   mut in_class_expr_body : Bool

--- a/src/parser/pkg.generated.mbti
+++ b/src/parser/pkg.generated.mbti
@@ -80,6 +80,9 @@ pub(all) enum JsdocTag {
 pub struct Lexer {
   mut invalid_char_count : Int
   mut invalid_radix_digit_count : Int
+  mut invalid_unicode_escape_count : Int
+  mut unicode_escape_overflow_count : Int
+  mut legacy_octal_literal_count : Int
   mut unterminated_template : Bool
   src : String
   mut pos : Int

--- a/src/parser/pkg.generated.mbti
+++ b/src/parser/pkg.generated.mbti
@@ -83,6 +83,7 @@ pub struct Lexer {
   mut invalid_unicode_escape_count : Int
   mut unicode_escape_overflow_count : Int
   mut legacy_octal_literal_count : Int
+  template_invalid_escape_positions : Array[Int]
   mut unterminated_template : Bool
   src : String
   mut pos : Int
@@ -145,6 +146,7 @@ pub struct Parser {
   mut class_decl_no_heritage : Bool
   mut in_class_expr_body : Bool
   written_any_params : Map[String, Unit]
+  template_invalid_escape_positions : Array[Int]
   directive_strict : Bool
   param_optional_initializer_misuses : Array[String]
   interface_member_modifier_misuses : Array[String]


### PR DESCRIPTION
Raises TS7 conformance true positives **2152 → 2296** (FP 0 throughout, PFLEGAL 3, MISS 438) across eight mining batches, and fixes the long-red CI `verify-examples` step.

## Conformance batches

- **BE (+51 TP)**: TS5102 removed `downlevelIteration` option; TS2378 getters must return a value; TS1206 decorator placement (constructors, ambient/abstract members, parameters); TS2373/TS2372 parameter defaults referencing later declarations.
- **BF (+19 TP)**: TS2465/TS1166 `this` and any-callee calls in computed property names (with whole-file `@ts-ignore` abstention); TS1125/TS1198 `\u{...}` string escape validation; TS1121 legacy octal literals.
- **BG (+11 TP)**: regex `\u{...}` validation under `u`/`v` flags; untagged-template invalid `\u`/`\x` escapes; string `\x` validation.
- **BH (+9 TP)**: TS2683 implicit-any `this` in plain functions via a dedicated context-tracking walker (arrows inherit, call-argument/assignment-RHS/annotated contexts exempt).
- **BI (+24 TP)**: TS1049/TS1054 accessor arity; TS1031 `export`/`declare` on class elements; TS1124 empty exponents; TS2466 `super` in computed keys.
- **BJ (+12 TP)**: ASI declaration heads (`namespace`/`module`/`declare` need the same-line follower — the misparse hid TS2454 reads); TS2488 non-iterable for-of sources (primitives, unions with primitive members, optional `[Symbol.iterator]`, array patterns over primitive elements); TS2403 lib-global `var` redeclarations needing the `*Constructor` annotation. Standard well-known `[Symbol.x]` keys in object-type literals now parse as `@@x` members.
- **BK (+11 TP)**: block scoping in the TS2304 hoisting backstop (`let`/`const` loop heads are loop-scoped); `new Date<A;` parses as comparison when no balanced `>` exists; TS2345 `f.apply(x, arguments)` on zero-parameter functions; TS1005 reserved-word/literal binding shorthands and `void` heading a qualified type name.
- **BL (+7 TP)**: TS2339 object patterns over primitive for-of elements and object sub-patterns under rest elements; pattern-key checks fold object-literal spreads recursively; SharedArrayBuffer instance surface fully modeled (incl. ES2024 members).

Each batch landed with a clean full-corpus sweep (FP 0) and legal-pattern pins in `expr_check_wbtest.mbt`. Unit tests: 2490 passing. Dead ends are documented in TODO.md so future rounds don't re-derive them.

## CI fix

`verify-examples` has been failing on main since late June: the bridge generator maps `@hono/node-server`'s optional `listeningListener?` parameter to `((AddressInfo) -> Unit)?`, but the committed hono-server smoke still passed a bare function. Wrapped the callback in `Some(...)` (smoke + quick-start doc snippet). Verified locally end-to-end: `verify_examples.sh` exits 0 (node smoke prints `ok`), and verify-mbti-dts / verify-scaffolds / verify-generated-fixtures / `moon fmt --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr)_