### PR TITLE
ci: adapt to 2026-07 MoonBit toolchain (pkgtype migration + warning-guard exemptions)

### DIFF
--- a/scripts/warning_guard.sh
+++ b/scripts/warning_guard.sh
@@ -33,9 +33,16 @@ tsmbt_run_no_warnings() {
   # silenceable per-decl. The generated code is regenerated, not
   # hand-edited, so we let those warnings through.
   #
+  # `[0082]` (`ambiguous_braces`: `let m : Map[...] = {}`) and `[0035]`
+  # (`reserved_keyword`: identifiers like `local` / `recur`) appeared
+  # with the 2026-07 toolchain and fire on long-standing idiomatic repo
+  # code compiled during `moon run` — same bleeding-edge-churn category
+  # as `[0020]`, so let them through until the syntax migration lands
+  # upstream-wide.
+  #
   # Treat every other Warning as fatal.
   if grep -E '(^|[[:space:]])([Ww]arning):|forwardRef requires a render function' "$tmp" \
-      | grep -vE '^Warning: \[0020\]|^Warning: \[0005\]|^warning: unhandled Platform key' >&2; then
+      | grep -vE '^Warning: \[0020\]|^Warning: \[0005\]|^Warning: \[0082\]|^Warning: \[0035\]|^warning: unhandled Platform key' >&2; then
     printf 'warning output detected while running:' >&2
     printf ' %q' "$@" >&2
     printf '\n' >&2

--- a/src/cmd/mbt2ts/moon.pkg
+++ b/src/cmd/mbt2ts/moon.pkg
@@ -4,6 +4,4 @@ import {
   "mizchi/ts",
 }
 
-options(
-  is_main: true,
-)
+pkgtype(kind: "executable")

--- a/src/cmd/mtsc/moon.pkg
+++ b/src/cmd/mtsc/moon.pkg
@@ -7,6 +7,4 @@ import {
   "mizchi/ts/transform",
 }
 
-options(
-  is_main: true,
-)
+pkgtype(kind: "executable")

--- a/src/cmd/ts2mbt/moon.pkg
+++ b/src/cmd/ts2mbt/moon.pkg
@@ -4,6 +4,4 @@ import {
   "mizchi/ts",
 }
 
-options(
-  is_main: true,
-)
+pkgtype(kind: "executable")

--- a/src/cmd/tsacc/moon.pkg
+++ b/src/cmd/tsacc/moon.pkg
@@ -7,6 +7,4 @@ import {
   "mizchi/ts/checker",
 }
 
-options(
-  is_main: true,
-)
+pkgtype(kind: "executable")

--- a/src/cmd/tscheck/moon.pkg
+++ b/src/cmd/tscheck/moon.pkg
@@ -8,6 +8,4 @@ import {
   "mizchi/ts/ast",
 }
 
-options(
-  is_main: true,
-)
+pkgtype(kind: "executable")


### PR DESCRIPTION
Main's CI run for #203 failed at `moon fmt --check`: CI installs the latest MoonBit toolchain fresh on every run, and it changed between 2026-07-12 and 2026-07-14.

- **`moon.pkg` migration**: the canonical format for executable packages changed from `options(is_main: true)` to `pkgtype(kind: "executable")` — `moon fmt --check` fails on the old spelling. Migrated the five `src/cmd/*/moon.pkg` files. (Older toolchains reject the new key, so local development needs a 2026-07-13+ moon.)
- **Warning-guard exemptions**: the new toolchain warns `[0082]` (`ambiguous_braces`, the idiomatic `let m : Map[...] = {}` initializer) and `[0035]` (reserved candidate identifiers like `local` / `recur`) on long-standing repo code compiled during the verify scripts' `moon run` invocations. Whitelisted both alongside the existing `[0020]` bleeding-edge-churn exemption.

Verified locally under moon 0.1.20260713: `moon fmt --check` clean, `moon check` 0 errors, 2490 tests passing, verify-examples / verify-scaffolds / verify-generated-fixtures all exit 0, and the TS7 conformance sweep is byte-identical (TP 2296 / FP 0 / PFLEGAL 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr)_