### PR TITLE
checker/parser: batches BM–BP (TP 2296 → 2329) + bridge generic-arrow member fix

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1031,7 +1031,7 @@ v7.0.2). Truth comes from vendored name manifests
 variant is NOTRUN, and the TS6-era deprecated-compiler-option
 diagnostics (TS5107/TS5101) were removed from the checker accordingly.
 
-State: whole-corpus **TP 2311 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 423 /
+State: whole-corpus **TP 2323 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 411 /
 NOTRUN 14** via `scripts/checker_conformance_oracle.sh --max-fp 0
 --max-legal-parsefail 3`.
 
@@ -1235,6 +1235,27 @@ handler parameter (`call<TS extends unknown[]>(handler: (...args: TS)
 => void, ...args: TS)` — expected count = 1 + handler params), which
 requires threading callee type-params into the arity checker;
 unionTypeReduction2 needs union call-signature reduction.
+Batch BO (+12 TP, TP 2323 / MISS 411) continued the small clusters:
+- TS2491: the left side of `for...in` is never a destructuring pattern,
+  declaration or assignment form (for-inStatementsDestructuring/2/3/4,
+  parserForInStatement8 — always-error, `record_unfiltered`).
+- TS2854: a TOP-LEVEL `await using` requires target >= es2017 — new
+  `<top-level-await-using>` and `<target-below-es2017>` parser markers
+  (multi-target conformance directives list pre-es2017 variants —
+  awaitUsingDeclarations.1; .2/.3 parse through other shapes and stay
+  misses).
+- TS2550: `Object.values` / `Object.entries` need the es2017 lib
+  surface, `Atomics.waitAsync` needs es2024 — `<lib-lacks-es2017>` /
+  `<lib-lacks-es2024>` markers (explicit `@lib:` lacking the year, or
+  no `@lib:` with an explicit sub-es2017 `@target:`), threaded through
+  new `Resolver.lib_lacks_es2017/es2024` flags to the MethodCall carve
+  (useObjectValuesAndEntries2/3, es2024SharedMemory).
+- TS2503: an entity-reference import alias (`import X = A.B`) whose
+  ROOT is provably undeclared — `<import-eq-root>` marker, resolved
+  with the same contract as `<export-eq>` (parserImportDeclaration1,
+  scannerImportDeclaration1).
+- TS1003-adjacent: a primitive-type keyword can never be a qualified
+  type-name segment (`var v: x.void` — parservoidInQualifiedName2).
 Documented dead ends from this round: YieldExpression10_es6 (an
 object-literal method's name in the backstop is indistinguishable from
 a legal self-referential named function expression property);

--- a/TODO.md
+++ b/TODO.md
@@ -1031,7 +1031,7 @@ v7.0.2). Truth comes from vendored name manifests
 variant is NOTRUN, and the TS6-era deprecated-compiler-option
 diagnostics (TS5107/TS5101) were removed from the checker accordingly.
 
-State: whole-corpus **TP 2305 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 429 /
+State: whole-corpus **TP 2311 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 423 /
 NOTRUN 14** via `scripts/checker_conformance_oracle.sh --max-fp 0
 --max-legal-parsefail 3`.
 
@@ -1213,6 +1213,28 @@ decorator signatures, and generator interface returns:
   declared return type is an interface extending
   Iterator/IterableIterator/Generator with extra REQUIRED members can
   never satisfy it (generatorTypeCheck7); optional extras abstain.
+Batch BN (+6 TP, TP 2311 / MISS 423) took index keys and lib-era
+signatures:
+- TS7053: a string-literal key indexing a fully-literal-keyed object
+  shape that provably lacks it, gated on the module's `noImplicitAny`
+  (threaded through a new `Resolver.no_implicit_any` flag). Numeric
+  keys fold (`0b11010:` provides `26`), and since OUR lexer folds
+  OVERFLOWING binary/octal literals through a 32-bit wrap while tsc
+  folds to `Infinity`/exponent form, fold-shaped queries abstain when
+  any >9-digit folded key exists — `"0b11010"` contains `b` (never a
+  fold) and stays decidable (binaryIntegerLiteral/ES6,
+  octalIntegerLiteral/ES6).
+- TS2464: `Symbol.keyFor` is a FUNCTION on SymbolConstructor, never a
+  computed property key (symbolProperty59; `Symbol.for` lexes as a
+  keyword and can't reach the match arm).
+- TS2554: `Date.UTC(year)` requires the month argument before es2015 —
+  fires only under the `<lib-lacks-iterable>` (pre-ES2015 lib) marker
+  (es5DateAPIs).
+Deferred: genericRestArity/Strict need tuple-arity inference from the
+handler parameter (`call<TS extends unknown[]>(handler: (...args: TS)
+=> void, ...args: TS)` — expected count = 1 + handler params), which
+requires threading callee type-params into the arity checker;
+unionTypeReduction2 needs union call-signature reduction.
 Documented dead ends from this round: YieldExpression10_es6 (an
 object-literal method's name in the backstop is indistinguishable from
 a legal self-referential named function expression property);

--- a/TODO.md
+++ b/TODO.md
@@ -1031,7 +1031,7 @@ v7.0.2). Truth comes from vendored name manifests
 variant is NOTRUN, and the TS6-era deprecated-compiler-option
 diagnostics (TS5107/TS5101) were removed from the checker accordingly.
 
-State: whole-corpus **TP 2323 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 411 /
+State: whole-corpus **TP 2329 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 405 /
 NOTRUN 14** via `scripts/checker_conformance_oracle.sh --max-fp 0
 --max-legal-parsefail 3`.
 
@@ -1256,6 +1256,22 @@ Batch BO (+12 TP, TP 2323 / MISS 411) continued the small clusters:
   scannerImportDeclaration1).
 - TS1003-adjacent: a primitive-type keyword can never be a qualified
   type-name segment (`var v: x.void` — parservoidInQualifiedName2).
+Batch BP (+6 TP, TP 2329 / MISS 405) took TS2322 subclusters and
+primitive spreads:
+- `SharedArrayBuffer` and `ArrayBuffer` are nominally distinct lib
+  types: `var foo: ArrayBuffer = new SharedArrayBuffer(...)` flags when
+  neither name has a user declaration
+  (assignSharedArrayBufferToArrayBuffer).
+- `new Array<T>(n)` keeps the explicit element type (`Array(T)`), so a
+  mismatched declared annotation flags (parserObjectCreation1).
+- TS2698: an object-literal spread of a provably non-object primitive
+  (string / numeric / template-literal-typed operand) — named /
+  generic / union operands abstain (spreadNonObject1,
+  spreadTypeVariable as a bonus flip).
+- A provably NUMERIC computed key in an object literal checks its
+  value against the target interface's number index signature
+  (`var o: I = { [+"foo"]: "" }` where `[s: number]: boolean` —
+  computedPropertyNamesContextualType10_ES5/ES6).
 Documented dead ends from this round: YieldExpression10_es6 (an
 object-literal method's name in the backstop is indistinguishable from
 a legal self-referential named function expression property);

--- a/TODO.md
+++ b/TODO.md
@@ -1031,7 +1031,7 @@ v7.0.2). Truth comes from vendored name manifests
 variant is NOTRUN, and the TS6-era deprecated-compiler-option
 diagnostics (TS5107/TS5101) were removed from the checker accordingly.
 
-State: whole-corpus **TP 2296 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 438 /
+State: whole-corpus **TP 2305 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 429 /
 NOTRUN 14** via `scripts/checker_conformance_oracle.sh --max-fp 0
 --max-legal-parsefail 3`.
 
@@ -1188,6 +1188,31 @@ Batch BL (+7 TP, TP 2296 / MISS 438) worked the TS2339 cluster:
   ArrayBuffer's `resizable` / `detached` / `resize`), and the surface
   registers as fully modeled so member misses are definite
   (`sab.length` — useSharedArrayBuffer6).
+Batch BM (+9 TP, TP 2305 / MISS 429) took lib-set directives,
+decorator signatures, and generator interface returns:
+- TS2318 via parser markers: `@noLib: true` removes every required
+  global type (parser509698); an explicit `@lib:` list without a
+  full-year ES2015+ lib / `es2015.iterable` lacks `IterableIterator`
+  for generators (generatorReturnTypeFallback.2, types.forAwait); one
+  without `esnext` lacks `Disposable` for `using` declarations
+  (usingDeclarations.9 / awaitUsingDeclarations.9 — the block-scoped
+  `using` lowering records the marker too).
+- TS1238 (`check_class_decorator_signatures`): a CLASS used as a class
+  decorator is not callable (constructableDecoratorOnClass01); a
+  decorator or factory result whose REQUIRED arity exceeds the runtime
+  invocation (1 arg legacy / 2 standard, `<experimental-decorators>`
+  marker) can never resolve (decoratorOnClass8, esDecorators-arguments).
+  Zero-parameter decorators also error in tsc but are deliberately
+  skipped. The parser now captures class decorators BEFORE the body
+  parse — member decorators share `pending_decorators` and previously
+  either leaked onto the next declaration or (after the first fix)
+  masqueraded as class decorators (decoratorOnClassAccessor1 FP'd, and
+  the base-less IIFE route plus `parse_class_stub` never attached them
+  at all).
+- TS2741 (`check_generator_interface_returns`): a generator whose
+  declared return type is an interface extending
+  Iterator/IterableIterator/Generator with extra REQUIRED members can
+  never satisfy it (generatorTypeCheck7); optional extras abstain.
 Documented dead ends from this round: YieldExpression10_es6 (an
 object-literal method's name in the backstop is indistinguishable from
 a legal self-referential named function expression property);

--- a/src/bridge/moonbit_js_ffi.mbt
+++ b/src/bridge/moonbit_js_ffi.mbt
@@ -1155,6 +1155,36 @@ fn ffi_synthesize_inline_union(
 }
 
 ///|
+/// Erase a generic callable's OWN type-parameter names to `Any` (rendered
+/// `JSValue`). MoonBit forbids `extern "js" fn[T]`, so a member typed
+/// `<E>(expected: E) => void` (vitest's `Assertion.toBe`) lowers to its
+/// value shape with `E` widened — without this the whole member degrades
+/// to a `JSValue` property and loses its method wrapper.
+fn ffi_erase_generic_names(
+  t : @ast.TsType,
+  names : Array[String],
+) -> @ast.TsType {
+  fn go(x : @ast.TsType) -> @ast.TsType {
+    ffi_erase_generic_names(x, names)
+  }
+
+  match t {
+    Named(n) => if names.contains(n) { Any } else { t }
+    Array(i) => Array(go(i))
+    Rest(i) => Rest(go(i))
+    Union(items) => Union(items.map(go))
+    Intersection(items) => Intersection(items.map(go))
+    Tuple(items) => Tuple(items.map(go))
+    Func(ps, r) => Func(ps.map(go), go(r))
+    Constructor(ps, r, a) => Constructor(ps.map(go), go(r), a)
+    Applied(n, args) => Applied(n, args.map(go))
+    Object(fields) => Object(fields.map(fn(f) { (f.0, go(f.1)) }))
+    GenericFunc(inner_names, inner) => GenericFunc(inner_names, go(inner))
+    _ => t
+  }
+}
+
+///|
 fn ffi_function_field_type_name(
   state : MoonBitJsFfiState,
   type_ : @ast.TsType,
@@ -1174,6 +1204,10 @@ fn ffi_function_field_type_name(
   }
   match type_ {
     Func(params, return_type) => ffi_func_type_name(state, params, return_type)
+    // A member's own generic binder is erased at the FFI boundary
+    // (`toBe: <E>(expected: E) => void` — vitest's Assertion).
+    GenericFunc(names, inner) =>
+      ffi_function_field_type_name(state, ffi_erase_generic_names(inner, names))
     _ => ffi_type_name(state, type_)
   }
 }
@@ -1221,7 +1255,7 @@ fn ffi_struct_field_type_name(
     Literal(_) | NumberLiteral(_) | BigIntLiteral(_) | BooleanLiteral(_) =>
       ffi_struct_field_type_name(state, @checker.normalize_literal_type(type_))
     Array(inner) => "Array[" + ffi_struct_field_type_name(state, inner) + "]"
-    Func(_, _) => ffi_function_field_type_name(state, type_)
+    Func(_, _) | GenericFunc(_, _) => ffi_function_field_type_name(state, type_)
     Named(name) if ffi_named_type_is_primitive_enum_in(state.enums, name) =>
       ffi_type_identifier(name, "GeneratedEnum")
     Applied(name, _) if ffi_named_type_is_primitive_enum_in(state.enums, name) =>
@@ -1243,6 +1277,11 @@ fn ffi_function_type_parts(
       }
       Some((params, param_types, ffi_type_name(state, return_type)))
     }
+    // A member's own generic binder is erased at the FFI boundary
+    // (`toBe: <E>(expected: E) => void` — vitest's Assertion), matching
+    // the struct-field rendering so `(self.<field>)(args)` type-checks.
+    GenericFunc(names, inner) =>
+      ffi_function_type_parts(state, ffi_erase_generic_names(inner, names))
     _ => None
   }
 }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -81,6 +81,11 @@ priv struct Resolver {
   // threaded through the resolver so expression-level rules (TS7053)
   // can gate without widening `CheckCtx`.
   mut no_implicit_any : Bool
+  // Lib-era evidence from `@lib:` / `@target:` directives (parser
+  // markers): the es2017 object surface (`Object.values`) or the es2024
+  // shared-memory surface (`Atomics.waitAsync`) is missing (TS2550).
+  mut lib_lacks_es2017 : Bool
+  mut lib_lacks_es2024 : Bool
 }
 
 ///|
@@ -101,6 +106,8 @@ fn Resolver::empty() -> Resolver {
     namespace_exports: {},
     template_tag_funcs: {},
     no_implicit_any: false,
+    lib_lacks_es2017: false,
+    lib_lacks_es2024: false,
   }
 }
 
@@ -15075,6 +15082,14 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
       env.restore_from(pre)
     }
     ForIn(_, binding, declared, iter, body) => {
+      // TS2491/TS2461: the left side of `for...in` can never be a
+      // destructuring pattern, in either the declaration or assignment
+      // form (for-inStatementsDestructuring/3/4).
+      if binding is (@ast.TsBinding::Array(_) | @ast.TsBinding::Object(_)) {
+        record_unfiltered(
+          ctx, "for-in binding", "the left-hand side of a `for...in` statement cannot be a destructuring pattern",
+        )
+      }
       // `for (key in obj)` — `key` is always `string` in JS/TS.
       // A declared type that doesn't accept `string` is an error.
       check_call_args_in_expr(env, iter, ctx)
@@ -15729,6 +15744,28 @@ fn check_call_args_in_expr(
       check_private_name_access(ctx, meth)
       check_member_accessibility(env, ctx, receiver, meth)
       check_super_abstract_access(ctx, receiver, meth)
+      // TS2550: es2017+/es2024+ static surface used under an older lib
+      // (parser-marker evidence): `Object.values` / `Object.entries`
+      // arrived in es2017 (useObjectValuesAndEntries2/3), `Atomics.waitAsync`
+      // in es2024 (es2024SharedMemory).
+      if ctx.resolver.lib_lacks_es2017 &&
+        receiver is Var("Object") &&
+        (meth == "values" || meth == "entries") &&
+        ctx.resolver.globals.get("Object") is None {
+        record(
+          ctx,
+          "call `Object.\{meth}`",
+          "property `\{meth}` does not exist on `ObjectConstructor` with the current `lib`",
+        )
+      }
+      if ctx.resolver.lib_lacks_es2024 &&
+        receiver is Var("Atomics") &&
+        meth == "waitAsync" &&
+        ctx.resolver.globals.get("Atomics") is None {
+        record(
+          ctx, "call `Atomics.waitAsync`", "property `waitAsync` does not exist on `Atomics` with the current `lib`",
+        )
+      }
       // TS2345 (strict bind/call/apply): `f.apply(x, arguments)` where `f`
       // is a ZERO-parameter function — `IArguments` is never assignable to
       // the empty parameter tuple `[]`
@@ -24771,6 +24808,25 @@ fn check_lib_directive_globals(module_ : @ast.TsModule) -> Array[ExprIssue] {
       message: "cannot find global type `Disposable` (not in the `lib` set)",
     })
   }
+  // TS2854: a top-level `await using` requires target >= es2017 — the
+  // conformance multi-target directives include pre-es2017 variants
+  // (awaitUsingDeclarations.1-3).
+  let mut tl_await_using = false
+  let mut target_below_2017 = false
+  for gm in module_.grammar_misuses {
+    if gm == "<top-level-await-using>" {
+      tl_await_using = true
+    }
+    if gm == "<target-below-es2017>" {
+      target_below_2017 = true
+    }
+  }
+  if tl_await_using && target_below_2017 {
+    issues.push({
+      path: "top-level `await using`",
+      message: "top-level `await using` statements require `target` es2017 or higher",
+    })
+  }
   issues
 }
 
@@ -25116,6 +25172,14 @@ fn check_module_function_bodies_layered(
   let strict_property_init = strict_root.strict_property_initialization
   let strict_null_checks = strict_root.strict_null_checks
   resolver.no_implicit_any = strict_root.no_implicit_any
+  for gm in strict_root.grammar_misuses {
+    if gm == "<lib-lacks-es2017>" {
+      resolver.lib_lacks_es2017 = true
+    }
+    if gm == "<lib-lacks-es2024>" {
+      resolver.lib_lacks_es2024 = true
+    }
+  }
   // Brand-keyed private declarations recorded by the parser (own layer plus
   // the outermost root -- namespace bodies re-parse with a fresh parser, so
   // their recordings live on their own TsModule). Populated before body
@@ -25851,13 +25915,17 @@ fn check_module_function_bodies_layered(
       if gm == "<allowunreachable-on>" {
         continue
       }
-      // Markers, not errors: lib-set directive evidence and decorator
-      // mode, consumed by `check_lib_directive_globals` and the decorator
-      // signature checks. (`<nolib>` IS the error condition itself, but
-      // it's surfaced there with a proper message.)
+      // Markers, not errors: lib-set / target directive evidence and
+      // decorator mode, consumed by `check_lib_directive_globals` and the
+      // decorator signature checks. (`<nolib>` IS the error condition
+      // itself, but it's surfaced there with a proper message.)
       if gm == "<nolib>" ||
         gm == "<lib-lacks-iterable>" ||
         gm == "<lib-lacks-esnext>" ||
+        gm == "<lib-lacks-es2017>" ||
+        gm == "<lib-lacks-es2024>" ||
+        gm == "<target-below-es2017>" ||
+        gm == "<top-level-await-using>" ||
         gm == "<has-using>" ||
         gm == "<experimental-decorators>" {
         continue
@@ -25890,6 +25958,30 @@ fn check_module_function_bodies_layered(
           all.push({
             path: "export = \{key}",
             message: "cannot find name `\{key}`",
+          })
+        }
+        continue
+      }
+      // TS2503: the ROOT of an entity-reference import alias
+      // (`import X = A.B`) must be a declared namespace / value
+      // (parserImportDeclaration1). Same resolution contract as
+      // `<export-eq>` above.
+      if gm.has_prefix("<import-eq-root>") {
+        let key = gm["<import-eq-root>".length():].to_string()
+        let values = match computed_key_values {
+          Some(v) => v
+          None => {
+            let v = module_value_name_set(module_)
+            computed_key_values = Some(v)
+            v
+          }
+        }
+        if !values.contains(key) &&
+          !is_typeof_value_keyword(key) &&
+          !is_lib_global_value(key) {
+          all.push({
+            path: "import = \{key}",
+            message: "cannot find namespace `\{key}`",
           })
         }
         continue

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -6036,7 +6036,18 @@ fn infer_expr(
   match expr {
     // Explicit type arguments are erased for inference: the call's value
     // type is the inner call's type.
-    TypeArgs(_, inner) => infer_expr(env, resolver, inner)
+    TypeArgs(targs, inner) => {
+      // `new Array<T>(n)` constructs a `T[]` — keep the explicit element
+      // type so a mismatched declared annotation flags
+      // (`var a: number[] = new Array<number[]>(1)` — parserObjectCreation1).
+      if inner is New("Array", _) &&
+        targs.length() == 1 &&
+        resolver.classes.get("Array") is None &&
+        resolver.interfaces.get("Array") is None {
+        return @ast.TsType::Array(targs[0])
+      }
+      infer_expr(env, resolver, inner)
+    }
     NumberLit(_) | IntLit(_) => @ast.TsType::Number
     BigIntLit(_) => @ast.TsType::BigInt
     BoolLit(_) => @ast.TsType::Boolean
@@ -10997,8 +11008,41 @@ fn check_object_lit_against_target(
     // Computed / symbol property keys (`@@computed:N`) can't be matched against
     // declared members by name — TypeScript resolves the computed key to a
     // symbol / literal we don't evaluate, so neither "excess" nor "missing"
-    // applies. Skip them.
+    // applies. But when the computed key is provably NUMERIC and the target
+    // interface declares a number index signature, the VALUE must satisfy
+    // the index value type (`var o: I = { [+"foo"]: "" }` where
+    // `[s: number]: boolean` — computedPropertyNamesContextualType10).
     if key.has_prefix("@@computed:") {
+      match value {
+        ComputedProp(kexpr, vexpr) => {
+          let num_value_ty : @ast.TsType? = match resolver.unwrap(target) {
+            Named(n) =>
+              match resolver.interfaces.get(n) {
+                Some(iface) => {
+                  let mut found : @ast.TsType? = None
+                  for sig in iface.index_signatures {
+                    if sig.0 is (Number | Int) && found is None {
+                      found = Some(sig.1)
+                    }
+                  }
+                  found
+                }
+                None => None
+              }
+            _ => None
+          }
+          match num_value_ty {
+            Some(vt) =>
+              if is_checkable(vt) &&
+                resolver.unwrap(infer_expr(env, resolver, kexpr))
+                is (Number | NumberLiteral(_) | Int) {
+                check_expr_against(env, vexpr, vt, ctx, "\{sub_path}[computed]")
+              }
+            None => ()
+          }
+        }
+        _ => ()
+      }
       continue
     }
     match resolver.lookup_field(target, key) {
@@ -14312,6 +14356,22 @@ fn check_ident_binding_decl(
   // `Any`, which TS doesn't flag either). The stored flag records whether the
   // binding is block-scoped (`let` / `const`); a `var` read inside a computed
   // property key is exempt from TS2454 (see the read sites).
+  // TS2322: `SharedArrayBuffer` and `ArrayBuffer` are nominally distinct
+  // lib types (`var foo: ArrayBuffer = new SharedArrayBuffer(1024)` —
+  // assignSharedArrayBufferToArrayBuffer). Both must be lib-provided
+  // (no user declarations) for the verdict to hold.
+  if init is New("SharedArrayBuffer", _) &&
+    ctx.resolver.unwrap(declared) is Named("ArrayBuffer") &&
+    ctx.resolver.classes.get("ArrayBuffer") is None &&
+    ctx.resolver.interfaces.get("ArrayBuffer") is None &&
+    ctx.resolver.classes.get("SharedArrayBuffer") is None &&
+    ctx.resolver.interfaces.get("SharedArrayBuffer") is None {
+    record(
+      ctx,
+      "binding `\{name}` init",
+      "type `SharedArrayBuffer` is not assignable to type `ArrayBuffer`",
+    )
+  }
   match init {
     Var("__ts_no_init__") =>
       // TS2454 fires only under strict-null-checks (TS treats
@@ -16534,6 +16594,30 @@ fn check_call_args_in_expr(
     ObjectLit(entries) => {
       for ent in entries {
         check_call_args_in_expr(env, ent.1, ctx)
+      }
+      // TS2698: an object-literal spread of a provably NON-OBJECT value
+      // (`{ ...s }` where `s` is a string / template-literal / numeric
+      // type — spreadNonObject1). Named / generic / union operands
+      // abstain.
+      for ent in entries {
+        if ent.0.has_prefix("@@spread") {
+          match ctx.resolver.unwrap(infer_expr(env, ctx.resolver, ent.1)) {
+            String_
+            | Number
+            | Boolean
+            | BigInt
+            | Symbol
+            | Literal(_)
+            | NumberLiteral(_)
+            | BigIntLiteral(_)
+            | BooleanLiteral(_)
+            | TemplateLiteralType(_, _) =>
+              record(
+                ctx, "object spread", "spread types may only be created from object types",
+              )
+            _ => ()
+          }
+        }
       }
       // TS2783: an explicitly-written property that a LATER spread in the
       // same literal always overwrites (`{ b: 1, ...ab }` where `ab`'s type

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -24613,6 +24613,229 @@ fn check_lib_global_redeclaration(module_ : @ast.TsModule) -> Array[ExprIssue] {
 }
 
 ///|
+/// TS2318 from lib-set directives (parser markers): `@noLib: true`
+/// removes every required global type (parser509698); an explicit
+/// `@lib:` list without an iterable-granting entry lacks
+/// `IterableIterator`, which generators require
+/// (generatorReturnTypeFallback.2); one without `esnext` lacks
+/// `Disposable`, which `using` declarations require
+/// (usingDeclarations.9 / awaitUsingDeclarations.9).
+fn check_lib_directive_globals(module_ : @ast.TsModule) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  let mut nolib = false
+  let mut lacks_iterable = false
+  let mut lacks_esnext = false
+  let mut has_using = false
+  for gm in module_.grammar_misuses {
+    if gm == "<nolib>" {
+      nolib = true
+    }
+    if gm == "<lib-lacks-iterable>" {
+      lacks_iterable = true
+    }
+    if gm == "<lib-lacks-esnext>" {
+      lacks_esnext = true
+    }
+    if gm == "<has-using>" {
+      has_using = true
+    }
+  }
+  if nolib {
+    issues.push({
+      path: "lib",
+      message: "cannot find required global types (compiling with `noLib`)",
+    })
+    return issues
+  }
+  if lacks_iterable {
+    let mut has_generator = false
+    for f in module_.funcs {
+      if f.is_generator {
+        has_generator = true
+      }
+    }
+    if has_generator {
+      issues.push({
+        path: "lib",
+        message: "cannot find global type `IterableIterator` (not in the `lib` set)",
+      })
+    }
+  }
+  if lacks_esnext && has_using {
+    issues.push({
+      path: "lib",
+      message: "cannot find global type `Disposable` (not in the `lib` set)",
+    })
+  }
+  issues
+}
+
+///|
+/// Required-parameter count of a callable TYPE: parameters that are
+/// neither rest nor optional (`T | undefined`). `None` when the type
+/// isn't a plain function shape.
+fn callable_required_arity(resolver : Resolver, t : @ast.TsType) -> Int? {
+  match resolver.unwrap(t) {
+    GenericFunc(_, inner) => callable_required_arity(resolver, inner)
+    Func(ps, _) => {
+      let mut required = 0
+      for p in ps {
+        match p {
+          Rest(_) => ()
+          other => if !type_accepts_undefined(other) { required += 1 }
+        }
+      }
+      Some(required)
+    }
+    _ => None
+  }
+}
+
+///|
+/// Required-parameter count of a SYNTACTIC callable (inline decorator
+/// arrows / function expressions).
+fn syntactic_required_arity(params : Array[@ast.TsParam]) -> Int {
+  let mut required = 0
+  for p in params {
+    if !p.is_rest && p.default is None {
+      required += 1
+    }
+  }
+  required
+}
+
+///|
+/// TS1238: a class decorator whose signature cannot match the runtime
+/// invocation. The runtime passes 1 argument under legacy
+/// `experimentalDecorators` and 2 under standard ES decorators, so a
+/// decorator (or decorator-factory RESULT) requiring MORE parameters can
+/// never resolve (esDecorators-arguments, decoratorOnClass8), and a
+/// CLASS used as a decorator is not callable at all
+/// (constructableDecoratorOnClass01). Zero-parameter decorators also
+/// error in tsc but are left alone here (the corpus carries legal-looking
+/// shapes we can't distinguish cheaply).
+fn check_class_decorator_signatures(
+  module_ : @ast.TsModule,
+  resolver : Resolver,
+) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  let mut legacy = false
+  for gm in module_.grammar_misuses {
+    if gm == "<experimental-decorators>" {
+      legacy = true
+    }
+  }
+  let runtime_arity = if legacy { 1 } else { 2 }
+  for cls in module_.classes {
+    for d in cls.decorators {
+      let required : Int? = match d {
+        Var(n) =>
+          if resolver.classes.get(n) is Some(_) &&
+            resolver.globals.get(n) is None {
+            issues.push({
+              path: "class \{cls.name} decorator",
+              message: "unable to resolve signature of class decorator when called as an expression: this expression is not callable",
+            })
+            None
+          } else {
+            match resolver.globals.get(n) {
+              Some(t) => callable_required_arity(resolver, t)
+              None => None
+            }
+          }
+        ArrowFunc(params, _, _, _) => Some(syntactic_required_arity(params))
+        FuncExpr(f) =>
+          if f.name == "<class>" {
+            None
+          } else {
+            Some(syntactic_required_arity(f.params))
+          }
+        Call(n, _) =>
+          match resolver.globals.get(n) {
+            Some(t) =>
+              match resolver.unwrap(t) {
+                GenericFunc(_, Func(_, ret)) | Func(_, ret) =>
+                  callable_required_arity(resolver, ret)
+                _ => None
+              }
+            None => None
+          }
+        CallExpr(Var(n), _) =>
+          match resolver.globals.get(n) {
+            Some(t) =>
+              match resolver.unwrap(t) {
+                GenericFunc(_, Func(_, ret)) | Func(_, ret) =>
+                  callable_required_arity(resolver, ret)
+                _ => None
+              }
+            None => None
+          }
+        _ => None
+      }
+      match required {
+        Some(r) =>
+          if r > runtime_arity {
+            issues.push({
+              path: "class \{cls.name} decorator",
+              message: "unable to resolve signature of class decorator when called as an expression: the runtime will invoke the decorator with \{runtime_arity} arguments, but the decorator expects \{r}",
+            })
+          }
+        None => ()
+      }
+    }
+  }
+  issues
+}
+
+///|
+/// TS2741 for a generator whose DECLARED return type is an interface
+/// extending the iteration protocol with extra REQUIRED members: the
+/// generator object never carries them (`function* g1(): WeirdIter {}` —
+/// generatorTypeCheck7). Optional extras abstain.
+fn check_generator_interface_returns(
+  module_ : @ast.TsModule,
+  resolver : Resolver,
+) -> Array[ExprIssue] {
+  let issues : Array[ExprIssue] = []
+  for f in module_.funcs {
+    if !f.is_generator {
+      continue
+    }
+    let ret_name = match f.return_type {
+      Named(n) => n
+      Applied(n, _) => n
+      _ => continue
+    }
+    match resolver.interfaces.get(ret_name) {
+      Some(iface) => {
+        let mut extends_iter_proto = false
+        for en in iface.extends_names {
+          if en == "IterableIterator" || en == "Iterator" || en == "Generator" {
+            extends_iter_proto = true
+          }
+        }
+        if !extends_iter_proto {
+          continue
+        }
+        for fl in iface.fields {
+          if !fl.0.has_prefix("<") &&
+            !fl.0.has_prefix("@@") &&
+            !type_accepts_undefined(fl.1) {
+            issues.push({
+              path: "function \{f.name}",
+              message: "property `\{fl.0}` is missing in the generator object but required in type `\{ret_name}`",
+            })
+            break
+          }
+        }
+      }
+      None => ()
+    }
+  }
+  issues
+}
+
+///|
 fn check_duplicate_index_signatures(
   module_ : @ast.TsModule,
 ) -> Array[ExprIssue] {
@@ -25123,6 +25346,18 @@ fn check_module_function_bodies_layered(
     for issue in check_lib_global_redeclaration(module_) {
       all.push(issue)
     }
+    // TS2318 from lib-set directives (@noLib / restricted @lib).
+    for issue in check_lib_directive_globals(module_) {
+      all.push(issue)
+    }
+    // TS1238 class-decorator signature mismatches.
+    for issue in check_class_decorator_signatures(module_, resolver) {
+      all.push(issue)
+    }
+    // TS2741 generator returns declared as protocol-extending interfaces.
+    for issue in check_generator_interface_returns(module_, resolver) {
+      all.push(issue)
+    }
   }
   for issue in check_var_redeclaration_types(module_, resolver) {
     all.push(issue)
@@ -25509,6 +25744,17 @@ fn check_module_function_bodies_layered(
       // Marker, not an error: the @allowUnreachableCode directive flag,
       // consumed by the TS2695 comma-operator suppression below.
       if gm == "<allowunreachable-on>" {
+        continue
+      }
+      // Markers, not errors: lib-set directive evidence and decorator
+      // mode, consumed by `check_lib_directive_globals` and the decorator
+      // signature checks. (`<nolib>` IS the error condition itself, but
+      // it's surfaced there with a proper message.)
+      if gm == "<nolib>" ||
+        gm == "<lib-lacks-iterable>" ||
+        gm == "<lib-lacks-esnext>" ||
+        gm == "<has-using>" ||
+        gm == "<experimental-decorators>" {
         continue
       }
       // Markers, not errors: module-syntax evidence and a top-level

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -77,6 +77,10 @@ priv struct Resolver {
   // literal fails every overload (the `raw` member only exists on
   // engine-created template objects), which is TS2769/TS2345.
   template_tag_funcs : Map[String, Bool]
+  // Module-level `noImplicitAny` effective flag (strict directives),
+  // threaded through the resolver so expression-level rules (TS7053)
+  // can gate without widening `CheckCtx`.
+  mut no_implicit_any : Bool
 }
 
 ///|
@@ -96,6 +100,7 @@ fn Resolver::empty() -> Resolver {
     namespace_value_decls: {},
     namespace_exports: {},
     template_tag_funcs: {},
+    no_implicit_any: false,
   }
 }
 
@@ -16819,6 +16824,90 @@ fn check_call_args_in_expr(
           "cannot index into `\{type_display(recv_ty)}`",
         )
       }
+      // TS7053: a string-literal key indexing a fully-literal-keyed object
+      // shape that provably lacks it (`obj1["0b11010"]` where the literal
+      // declared `0b11010:` — the KEY folds to `26`, the string does not;
+      // binaryIntegerLiteral). Only fires under `@strict` (the diagnostic
+      // is a noImplicitAny error) and only when every key is a plain
+      // literal (an index signature / spread / symbol key makes the key
+      // set open).
+      if ctx.resolver.no_implicit_any && idx is StringLit(key) {
+        // Numeric object keys fold to a canonical decimal spelling
+        // (`0b11010:` becomes key `26`, overflowing literals become
+        // `Infinity` / `9.67e+24`). Our fold may differ from tsc's for
+        // the exotic forms, so a key spelling is only "certain" when it
+        // is a short digit run; a QUERY that could itself be a numeric
+        // fold (only `[0-9.eE+-]` chars, or Infinity/NaN) must abstain
+        // whenever an uncertain field key exists. `"0b11010"` contains
+        // `b` — never a fold — so it stays decidable.
+        fn fold_shaped(k : String) -> Bool {
+          if k == "Infinity" || k == "-Infinity" || k == "NaN" {
+            return true
+          }
+          if k.length() == 0 {
+            return false
+          }
+          for c in k {
+            let ok = (c >= '0' && c <= '9') ||
+              c == '.' ||
+              c == 'e' ||
+              c == 'E' ||
+              c == '+' ||
+              c == '-'
+            if !ok {
+              return false
+            }
+          }
+          true
+        }
+
+        // At most 9 digits: our lexer folds OVERFLOWING binary/octal
+        // literals through a 32-bit wrap (tsc folds them to `Infinity` /
+        // exponent form), and those artifacts land in the 10-digit range —
+        // treat them as uncertain spellings.
+        fn short_digits(k : String) -> Bool {
+          if k.length() == 0 || k.length() > 9 {
+            return false
+          }
+          for c in k {
+            if c < '0' || c > '9' {
+              return false
+            }
+          }
+          true
+        }
+
+        match recv_ty {
+          Object(fields) => {
+            let mut all_plain = fields.length() > 0
+            let mut found = false
+            let mut uncertain_fold_key = false
+            for f in fields {
+              match f.0 {
+                Literal(k) => {
+                  if k.has_prefix("<") || k.has_prefix("@@") {
+                    all_plain = false
+                  } else if k == key {
+                    found = true
+                  }
+                  if fold_shaped(k) && !short_digits(k) {
+                    uncertain_fold_key = true
+                  }
+                }
+                _ => all_plain = false
+              }
+            }
+            if all_plain && !found && !(fold_shaped(key) && uncertain_fold_key) {
+              record(
+                ctx,
+                "index access",
+                "element implicitly has an `any` type: `\"\{key}\"` cannot be used to index the object shape",
+              )
+            }
+          }
+          _ => ()
+        }
+      }
       // TS2493 ("Tuple type has no element at index N"): a fixed-length
       // tuple indexed by an out-of-range numeric literal. Tuples that
       // carry a `...rest` element accept any index, so we skip those.
@@ -24660,6 +24749,21 @@ fn check_lib_directive_globals(module_ : @ast.TsModule) -> Array[ExprIssue] {
         message: "cannot find global type `IterableIterator` (not in the `lib` set)",
       })
     }
+    // TS2554 under a pre-ES2015 lib: `Date.UTC` requires the month
+    // argument until es2015 made it optional (`Date.UTC(2017)` —
+    // es5DateAPIs).
+    for stmt in module_.top_level_stmts {
+      match stmt {
+        Expr(MethodCall(Var("Date"), "UTC", args)) =>
+          if args.length() == 1 {
+            issues.push({
+              path: "call `Date.UTC`",
+              message: "expected 2-7 arguments, but got 1 (the `month` argument is required before es2015)",
+            })
+          }
+        _ => ()
+      }
+    }
   }
   if lacks_esnext && has_using {
     issues.push({
@@ -25011,6 +25115,7 @@ fn check_module_function_bodies_layered(
   }
   let strict_property_init = strict_root.strict_property_initialization
   let strict_null_checks = strict_root.strict_null_checks
+  resolver.no_implicit_any = strict_root.no_implicit_any
   // Brand-keyed private declarations recorded by the parser (own layer plus
   // the outermost root -- namespace bodies re-parse with a fresh parser, so
   // their recordings live on their own TsModule). Populated before body

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -14467,3 +14467,39 @@ test "expr_check: lib directives, decorator signatures, generator returns (batch
     0,
   )
 }
+
+///|
+test "expr_check: TS7053 string-literal keys, Symbol.keyFor, es5 Date.UTC (batch BN)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // TS7053: a string-literal key provably absent from a fully-literal
+  // object shape, under @strict (binaryIntegerLiteral). Numeric-key
+  // folding stays legal (`0b11010:` provides key `26`), and an
+  // overflow-folded key makes fold-shaped queries abstain.
+  assert_true(
+    issues(
+      "// @strict: true\nvar o = { 0b11010: \"x\", a: 1 };\no[\"0b11010\"];",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "// @strict: true\nvar o = { 0b11010: \"x\", a: 1 };\no[\"26\"];\no[\"a\"];\no[26];",
+    ),
+    0,
+  )
+  @test.assert_eq(
+    issues("// @strict: false\nvar o = { a: 1 };\no[\"missing\"];"),
+    0,
+  )
+  // TS2464: `Symbol.keyFor` is a function, never a computed key
+  // (symbolProperty59).
+  assert_true(issues("interface I {\n    [Symbol.keyFor]: string;\n}") > 0)
+  @test.assert_eq(issues("interface I {\n    [Symbol.iterator]: string;\n}"), 0)
+  // TS2554: `Date.UTC(year)` requires the month argument before es2015
+  // (es5DateAPIs); modern libs keep it optional.
+  assert_true(issues("// @lib: es5\nDate.UTC(2017);") > 0)
+  @test.assert_eq(issues("Date.UTC(2017);"), 0)
+  @test.assert_eq(issues("// @lib: es5\nDate.UTC(2017, 1);"), 0)
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -14412,3 +14412,58 @@ test "expr_check: patterns over primitives/arrays, spread folding, SharedArrayBu
     0,
   )
 }
+
+///|
+test "expr_check: lib directives, decorator signatures, generator returns (batch BM)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // TS2318: `@noLib` removes every required global type; an explicit
+  // `@lib:` without an iterable-granting entry breaks generators; one
+  // without `esnext` breaks `using` (parser509698,
+  // generatorReturnTypeFallback.2, usingDeclarations.9).
+  assert_true(issues("// @noLib: true\ndeclare function foo(): void;") > 0)
+  assert_true(issues("// @lib: es5\nfunction* f() {\n  yield 1;\n}") > 0)
+  @test.assert_eq(
+    issues("// @lib: es5,es2015.iterable\nfunction* f() {\n  yield 1;\n}"),
+    0,
+  )
+  assert_true(issues("// @lib: es2022\n{\n    using a = null;\n}") > 0)
+  @test.assert_eq(issues("// @lib: esnext\n{\n    using a = null;\n}"), 0)
+  @test.assert_eq(issues("{\n    using a = null;\n}"), 0)
+  // TS1238: a class used as a class decorator is not callable
+  // (constructableDecoratorOnClass01); a decorator (or factory result)
+  // requiring more parameters than the runtime passes cannot resolve
+  // (decoratorOnClass8, esDecorators-arguments). Member decorators and
+  // matching arities stay legal (decoratorOnClassAccessor1).
+  assert_true(issues("class CtorDtor {}\n@CtorDtor\nclass C {}") > 0)
+  assert_true(
+    issues(
+      "// @experimentaldecorators: true\ndeclare function dec(): (target: Function, paramIndex: number) => void;\n@dec()\nclass C {}",
+    ) >
+    0,
+  )
+  assert_true(issues("@((a: any, b: any, c: any) => {})\nclass C1 {}") > 0)
+  @test.assert_eq(issues("@((a: any, b: any) => {})\nclass C2 {}"), 0)
+  @test.assert_eq(
+    issues(
+      "// @experimentaldecorators: true\ndeclare function dec<T>(target: any, propertyKey: string, descriptor: T): T;\nclass C {\n    @dec get accessor() { return 1; }\n}",
+    ),
+    0,
+  )
+  // TS2741: a generator declared to return a protocol-extending interface
+  // with extra REQUIRED members (generatorTypeCheck7); optional extras
+  // abstain.
+  assert_true(
+    issues(
+      "interface WeirdIter extends IterableIterator<number> {\n    hello: string;\n}\nfunction* g1(): WeirdIter { }",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "interface SoftIter extends IterableIterator<number> {\n    hello?: string;\n}\nfunction* g2(): SoftIter { yield 1; }",
+    ),
+    0,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -14558,3 +14558,44 @@ test "expr_check: for-in patterns, lib eras, import-eq roots (batch BO)" {
   // segment (parservoidInQualifiedName2).
   assert_true(issues("var v : x.void;") > 0)
 }
+
+///|
+test "expr_check: buffer nominality, Array targs, primitive spreads, computed index values (batch BP)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // TS2322: SharedArrayBuffer and ArrayBuffer are nominally distinct
+  // (assignSharedArrayBufferToArrayBuffer).
+  assert_true(issues("var foo: ArrayBuffer = new SharedArrayBuffer(1024);") > 0)
+  @test.assert_eq(
+    issues("var foo: SharedArrayBuffer = new SharedArrayBuffer(1024);"),
+    0,
+  )
+  // TS2322: `new Array<T>(n)` keeps the explicit element type
+  // (parserObjectCreation1).
+  assert_true(issues("var autoToken: number[] = new Array<number[]>(1);") > 0)
+  @test.assert_eq(issues("var ok: number[][] = new Array<number[]>(1);"), 0)
+  // TS2698: an object spread of a provably non-object primitive
+  // (spreadNonObject1); object-typed and generic spreads stay legal.
+  assert_true(
+    issues("type S = `${number}`;\ndeclare var s: S;\nvar a = { ...s, y: 6 };") >
+    0,
+  )
+  assert_true(issues("var a = { ...\"str\" };") > 0)
+  @test.assert_eq(issues("var o = { x: 1 };\nvar a = { ...o, y: 6 };"), 0)
+  // TS2322: a provably numeric computed key checks its VALUE against the
+  // target's number index signature
+  // (computedPropertyNamesContextualType10).
+  assert_true(
+    issues(
+      "interface I {\n    [s: number]: boolean;\n}\nvar o: I = {\n    [+\"foo\"]: \"\",\n    [+\"bar\"]: 0\n}",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "interface I {\n    [s: number]: boolean;\n}\nvar o: I = {\n    [+\"foo\"]: true\n}",
+    ),
+    0,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -14503,3 +14503,58 @@ test "expr_check: TS7053 string-literal keys, Symbol.keyFor, es5 Date.UTC (batch
   @test.assert_eq(issues("Date.UTC(2017);"), 0)
   @test.assert_eq(issues("// @lib: es5\nDate.UTC(2017, 1);"), 0)
 }
+
+///|
+test "expr_check: for-in patterns, lib eras, import-eq roots (batch BO)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // TS2491: the left side of for...in is never a destructuring pattern,
+  // declaration or assignment form (for-inStatementsDestructuring/3/4).
+  assert_true(issues("for (var [a, b] in []) {}") > 0)
+  assert_true(issues("var a, b;\nfor ([a, b] in []) { }") > 0)
+  assert_true(issues("var a, b;\nfor ({a, b} in []) { }") > 0)
+  @test.assert_eq(issues("for (var k in { a: 1 }) { }"), 0)
+  // TS2854: top-level `await using` requires target >= es2017
+  // (awaitUsingDeclarations.1).
+  assert_true(
+    issues(
+      "// @target: esnext,es2015\n// @lib: esnext\nawait using d1 = { async [Symbol.asyncDispose]() {} };",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "// @target: esnext\n// @lib: esnext\nawait using d1 = { async [Symbol.asyncDispose]() {} };",
+    ),
+    0,
+  )
+  // TS2550: `Object.values` / `Object.entries` need the es2017 lib
+  // surface (useObjectValuesAndEntries2/3); `Atomics.waitAsync` needs
+  // es2024 (es2024SharedMemory).
+  assert_true(issues("// @lib: es5\nvar o = { a: 1 };\nObject.values(o);") > 0)
+  assert_true(
+    issues("// @target: es6\nvar o = { a: 1 };\nObject.entries(o);") > 0,
+  )
+  @test.assert_eq(
+    issues("// @lib: es2017\nvar o = { a: 1 };\nObject.values(o);"),
+    0,
+  )
+  @test.assert_eq(issues("var o = { a: 1 };\nObject.values(o);"), 0)
+  assert_true(
+    issues(
+      "// @lib: es2022\nAtomics.waitAsync(new Int32Array(new SharedArrayBuffer(4)), 0, 0);",
+    ) >
+    0,
+  )
+  // TS2503: an entity-reference import alias needs a declared root
+  // namespace (parserImportDeclaration1).
+  assert_true(issues("import TypeScript = TypeScriptServices.TypeScript;") > 0)
+  @test.assert_eq(
+    issues("namespace Ns { export var x = 1; }\nimport N = Ns.x;"),
+    0,
+  )
+  // TS1003-adjacent: a primitive keyword can't be a qualified type-name
+  // segment (parservoidInQualifiedName2).
+  assert_true(issues("var v : x.void;") > 0)
+}

--- a/src/parser/parser_class.mbt
+++ b/src/parser/parser_class.mbt
@@ -2503,6 +2503,10 @@ fn Parser::parse_class_body(
 ///|
 fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
   self.last_runtime_class_decl = None
+  // Same pre-capture as `parse_class_decl_with_abstract`: only decorators
+  // pending BEFORE the body parse are class decorators; member decorators
+  // pushed during the body parse are erased.
+  let class_decorators = self.take_pending_decorators()
   let _ = self.expect(Class)
   let mut class_name = ""
   let _ = match self.peek().kind {
@@ -2725,11 +2729,12 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
       )
       let pending_base_expr = self.pending_class_base_expr
       self.pending_class_base_expr = None
+      let _ = self.take_pending_decorators()
       let decorated : @ast.TsClassDecl = {
         ..runtime_decl,
         base_names: [base_name],
         base_expr: pending_base_expr,
-        decorators: self.take_pending_decorators(),
+        decorators: class_decorators,
         is_declare: false,
       }
       self.last_runtime_class_decl = Some(decorated)
@@ -2872,7 +2877,10 @@ fn Parser::parse_class_stub(self : Parser) -> @ast.TsExpr raise ParseError {
     static_index_signatures: runtime_decl.static_index_signatures,
     is_abstract: runtime_decl.is_abstract,
     is_constructible: runtime_decl.is_constructible,
-    decorators: self.take_pending_decorators(),
+    decorators: {
+      let _ = self.take_pending_decorators()
+      class_decorators
+    },
     is_declare: false,
     private_members: runtime_decl.private_members,
     protected_members: runtime_decl.protected_members,
@@ -3293,6 +3301,12 @@ fn Parser::parse_class_decl_with_abstract(
   is_abstract : Bool,
 ) -> @ast.TsStmt raise ParseError {
   self.last_runtime_class_decl = None
+  // Capture CLASS-declaration decorators before the body parse: member
+  // decorators accumulate into the same `pending_decorators` (they're
+  // erased, not modeled) and must not masquerade as class decorators
+  // (decoratorOnClassAccessor1 — an accessor decorator's 3-parameter
+  // signature is legal, a class decorator's is not).
+  let class_decorators = self.take_pending_decorators()
   let _ = self.expect(Class)
   // A class named with a predefined-type keyword (`class void {}`,
   // `class string {}`, …) is always a TS error (TS1005 / TS2414). These
@@ -3483,6 +3497,15 @@ fn Parser::parse_class_decl_with_abstract(
       (runtime_decl.name, runtime_decl.duplicate_member_names),
     )
   }
+  // Attach the class-declaration decorators captured before the body
+  // parse (the checker's TS1238 decorator-signature rules read
+  // `decl.decorators`), and drain any MEMBER decorators the body parse
+  // pushed so they don't leak onto the next declaration.
+  let _ = self.take_pending_decorators()
+  let runtime_decl : @ast.TsClassDecl = {
+    ..runtime_decl,
+    decorators: class_decorators,
+  }
   self.last_runtime_class_decl = Some(runtime_decl)
   // When the class extends another class, the IIFE desugar below
   // produces a `super(…)` call outside a real class body — V8
@@ -3585,7 +3608,6 @@ fn Parser::parse_class_decl_with_abstract(
         ..runtime_decl,
         base_names: [base_name],
         base_expr: pending_base_expr2,
-        decorators: self.take_pending_decorators(),
         is_declare: false,
       }
       // Static field initializers: stash them on the AST so the

--- a/src/parser/parser_core.mbt
+++ b/src/parser/parser_core.mbt
@@ -374,7 +374,32 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
       if !libs.contains("esnext") {
         grammar_misuses.push("<lib-lacks-esnext>")
       }
+      if !lib_list_grants_year(libs, 2017) {
+        grammar_misuses.push("<lib-lacks-es2017>")
+      }
+      if !lib_list_grants_year(libs, 2024) {
+        grammar_misuses.push("<lib-lacks-es2024>")
+      }
     }
+    None =>
+      // No explicit `@lib:` — the default lib follows the target, so an
+      // explicit `@target:` list capped below es2017 also lacks the
+      // es2017 surface (useObjectValuesAndEntries3's `@target: es6`).
+      match detect_target_list(src) {
+        Some(targets) =>
+          if !target_list_reaches_es2017(targets) {
+            grammar_misuses.push("<lib-lacks-es2017>")
+          }
+        None => ()
+      }
+  }
+  // TS2854 evidence: a top-level `await using` needs target >= es2017;
+  // conformance files list their variant targets in one directive.
+  match detect_target_list(src) {
+    Some(targets) =>
+      if target_list_has_below_es2017(targets) {
+        grammar_misuses.push("<target-below-es2017>")
+      }
     None => ()
   }
   // Decorator-mode marker so checker-side decorator signature rules can
@@ -869,6 +894,90 @@ fn lib_list_grants_iterable(libs : String) -> Bool {
       t == "es2015.generator" ||
       (t.has_prefix("es20") && !t.contains(".")) {
       return true
+    }
+  }
+  false
+}
+
+///|
+/// The raw (lower-cased, comma-separated) `@target:` directive value, if
+/// present.
+fn detect_target_list(src : String) -> String? {
+  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
+  let head = src[:head_len].to_owned().to_lower()
+  match head.find("@target:") {
+    Some(idx) => {
+      let after = head[idx + "@target:".length():].to_owned()
+      let line = match after.find("\n") {
+        Some(nl) => after[:nl].to_owned()
+        None => after
+      }
+      Some(line.trim().to_owned())
+    }
+    None => None
+  }
+}
+
+///|
+/// Year number of an `es20NN` token; `es6` maps to 2015, `esnext` to 9999.
+/// `None` for anything else (`es5`, `es3`, dotted slices, `dom`, ...).
+fn es_token_year(t : String) -> Int? {
+  if t == "esnext" {
+    return Some(9999)
+  }
+  if t == "es6" {
+    return Some(2015)
+  }
+  if t.has_prefix("es20") && !t.contains(".") && t.length() == 6 {
+    let mut y = 0
+    for c in t.substring(start=2) {
+      if c < '0' || c > '9' {
+        return None
+      }
+      y = y * 10 + (c.to_int() - '0'.to_int())
+    }
+    return Some(y)
+  }
+  None
+}
+
+///|
+/// Whether an explicit `@lib:` list provides the ES-`year` surface: a
+/// full-year lib at or past `year`, `esnext`, or a dotted slice of that
+/// exact year (`es2017.object` grants 2017).
+fn lib_list_grants_year(libs : String, year : Int) -> Bool {
+  for tok in libs.split(",") {
+    let t = tok.to_string().trim().to_owned()
+    match es_token_year(t) {
+      Some(y) => if y >= year { return true }
+      None => if t.has_prefix("es" + year.to_string() + ".") { return true }
+    }
+  }
+  false
+}
+
+///|
+fn target_list_reaches_es2017(targets : String) -> Bool {
+  for tok in targets.split(",") {
+    let t = tok.to_string().trim().to_owned()
+    match es_token_year(t) {
+      Some(y) => if y >= 2017 { return true }
+      None => ()
+    }
+  }
+  false
+}
+
+///|
+fn target_list_has_below_es2017(targets : String) -> Bool {
+  for tok in targets.split(",") {
+    let t = tok.to_string().trim().to_owned()
+    if t == "es5" || t == "es3" {
+      return true
+    }
+    match es_token_year(t) {
+      Some(y) => if y < 2017 { return true }
+      None => ()
     }
   }
   false

--- a/src/parser/parser_core.mbt
+++ b/src/parser/parser_core.mbt
@@ -356,6 +356,32 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
   if detect_no_implicit_override(src) {
     grammar_misuses.push("<noimplicitoverride-on>")
   }
+  // TS2318 evidence: lib-set directives that provably remove global types
+  // the checker requires. `@noLib: true` removes ALL of them (every ran
+  // conformance case carrying it errors — parser509698); an explicit
+  // `@lib:` list without a full-year ES2015+ lib (or `es2015.iterable`)
+  // lacks `IterableIterator` (needed by generators —
+  // generatorReturnTypeFallback.2), and one without `esnext` lacks
+  // `Disposable` (needed by `using` — usingDeclarations.9).
+  if detect_nolib(src) {
+    grammar_misuses.push("<nolib>")
+  }
+  match detect_lib_list(src) {
+    Some(libs) => {
+      if !lib_list_grants_iterable(libs) {
+        grammar_misuses.push("<lib-lacks-iterable>")
+      }
+      if !libs.contains("esnext") {
+        grammar_misuses.push("<lib-lacks-esnext>")
+      }
+    }
+    None => ()
+  }
+  // Decorator-mode marker so checker-side decorator signature rules can
+  // pick the runtime invocation arity (legacy = 1 arg, standard = 2).
+  if detect_experimental_decorators(src) {
+    grammar_misuses.push("<experimental-decorators>")
+  }
   // Marker for the TS2695 comma-operator check, which tsc disables under
   // `@allowUnreachableCode: true`.
   if detect_allow_unreachable_code(src) {
@@ -794,6 +820,61 @@ fn detect_filename_directives(src : String) -> Bool {
 /// True when the leading test-header directives enable legacy decorators
 /// (`// @experimentaldecorators: true`). Parameter decorators are legal
 /// only in that mode.
+fn detect_nolib(src : String) -> Bool {
+  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
+  let head = src[:head_len].to_owned().to_lower()
+  match head.find("@nolib:") {
+    Some(idx) => {
+      let after = head[idx + "@nolib:".length():].to_owned()
+      let line = match after.find("\n") {
+        Some(nl) => after[:nl].to_owned()
+        None => after
+      }
+      line.trim().to_owned().has_prefix("true")
+    }
+    None => false
+  }
+}
+
+///|
+/// The raw (lower-cased, comma-separated) `@lib:` directive value from the
+/// test-header comment block, if present.
+fn detect_lib_list(src : String) -> String? {
+  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
+  let head = src[:head_len].to_owned().to_lower()
+  match head.find("@lib:") {
+    Some(idx) => {
+      let after = head[idx + "@lib:".length():].to_owned()
+      let line = match after.find("\n") {
+        Some(nl) => after[:nl].to_owned()
+        None => after
+      }
+      Some(line.trim().to_owned())
+    }
+    None => None
+  }
+}
+
+///|
+/// Whether an explicit `@lib:` list provides `IterableIterator`: any
+/// full-year ES2015+ lib (`es2015` .. `es2024`, no dot suffix), `es6`,
+/// `esnext`, or the targeted `es2015.iterable` / `es2015.generator`
+/// slices. `es5` / `es2015.promise` etc. do NOT.
+fn lib_list_grants_iterable(libs : String) -> Bool {
+  for tok in libs.split(",") {
+    let t = tok.to_string().trim().to_owned()
+    if t == "es6" ||
+      t == "esnext" ||
+      t == "es2015.iterable" ||
+      t == "es2015.generator" ||
+      (t.has_prefix("es20") && !t.contains(".")) {
+      return true
+    }
+  }
+  false
+}
+
+///|
 fn detect_experimental_decorators(src : String) -> Bool {
   let head_len = if src.length() < 1024 { src.length() } else { 1024 }
   let head = src[:head_len].to_owned().to_lower()

--- a/src/parser/parser_function.mbt
+++ b/src/parser/parser_function.mbt
@@ -1409,6 +1409,14 @@ pub fn Parser::parse_interface(
         let mut symbol_name : String? = None
         match (self.peek().kind, self.peek_at(2).kind, self.peek_at(3).kind) {
           (Ident("Symbol"), Ident(sym), RBracket) if self.peek_at(1).kind == Dot => {
+            // TS2464: `Symbol.for` / `Symbol.keyFor` are FUNCTIONS on
+            // SymbolConstructor, not symbols — they can never be a
+            // computed property key (symbolProperty59).
+            if sym == "keyFor" || sym == "for" {
+              self.grammar_misuses.push(
+                "a computed property name must be of type `string`, `number`, `symbol`, or `any` — `Symbol.\{sym}` is a function",
+              )
+            }
             let _ = self.advance()
             let _ = self.advance()
             let _ = self.advance()

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -867,6 +867,14 @@ fn Parser::parse_import_equals_decl(
     }
     spec
   } else {
+    // Entity-reference alias (`import X = A.B.C`): record the ROOT name so
+    // the checker can flag a provably undeclared namespace (TS2503 —
+    // parserImportDeclaration1).
+    match self.peek().kind {
+      Ident(root) if self.peek_at(1).kind == Dot =>
+        self.grammar_misuses.push("<import-eq-root>" + root)
+      _ => ()
+    }
     self.skip_until_semicolon()
     ""
   }

--- a/src/parser/parser_stmt.mbt
+++ b/src/parser/parser_stmt.mbt
@@ -308,6 +308,9 @@ fn Parser::parse_var_like(
   //   keys provably lacks a `[Symbol.dispose]()` / `[Symbol.asyncDispose]()`
   //   method (symbol-keyed / computed / spread entries abstain).
   if using_kw != "" {
+    // Marker for the lib-directive TS2318 rule: a `using` declaration
+    // requires the `Disposable` global type (usingDeclarations.9).
+    self.grammar_misuses.push("<has-using>")
     for st in stmts {
       match st {
         Var(b, _, init) | Let(b, _, init) | Const(b, _, init) => {
@@ -1224,6 +1227,10 @@ pub fn Parser::parse_block(self : Parser) -> @ast.TsBlock raise ParseError {
       let init = self.parse_expr()
       let _ = self.match_(Semicolon)
       let using_kw = if is_await_using { "await using" } else { "using" }
+      // Marker for the lib-directive TS2318 rule (`Disposable` global —
+      // usingDeclarations.9's block-scoped form lowers here, not through
+      // `parse_var_like`).
+      self.grammar_misuses.push("<has-using>")
       // Later declarators of a multi-declarator `using` land inside the
       // init as a comma chain (`using a = null, [b] = null, c = null`
       // parses `null, ([b] = null), (c = null)`). A destructuring

--- a/src/parser/parser_stmt.mbt
+++ b/src/parser/parser_stmt.mbt
@@ -311,6 +311,11 @@ fn Parser::parse_var_like(
     // Marker for the lib-directive TS2318 rule: a `using` declaration
     // requires the `Disposable` global type (usingDeclarations.9).
     self.grammar_misuses.push("<has-using>")
+    // TS2854 evidence: a TOP-LEVEL `await using` requires target >=
+    // es2017 (awaitUsingDeclarations.1-3 run pre-es2017 variants).
+    if using_kw == "await using" && !self.in_function {
+      self.grammar_misuses.push("<top-level-await-using>")
+    }
     for st in stmts {
       match st {
         Var(b, _, init) | Let(b, _, init) | Const(b, _, init) => {

--- a/src/parser/parser_type.mbt
+++ b/src/parser/parser_type.mbt
@@ -940,6 +940,15 @@ fn Parser::parse_named_type_tail(
   let mut full_name = first_name
   while self.check(Dot) && self.is_qualified_type_name_part(1) {
     let _ = self.advance()
+    // A primitive-type KEYWORD can never be a qualified type-name segment
+    // (`var v: x.void` — parservoidInQualifiedName2, TS1003/TS2503).
+    match self.peek().kind {
+      VoidType | StringType | NumberType | BooleanType =>
+        self.grammar_misuses.push(
+          "a primitive type keyword cannot appear in a qualified type name",
+        )
+      _ => ()
+    }
     let next_name = self.parse_binding_ident()
     full_name = full_name + "." + next_name
   }


### PR DESCRIPTION
Raises TS7 conformance true positives **2296 → 2329** (FP 0 throughout, PFLEGAL 3, MISS 405) across four mining batches, and fixes the bridge-generator regression that has been silently failing verify-examples' vitest greps.

## Bridge fix (unblocks CI)

vitest 4.x declares matchers as generic arrow properties (`toBe: <E>(expected: E) => void`), which the parser lowers to `GenericFunc`. The FFI emitter only matched plain `Func`, so those members degraded to bare `JSValue` properties and lost their method wrappers — the vitest greps in verify-examples have been failing silently (masked by `>/dev/null` generation and a `tail`-pipe exit-code readback). The emitter now erases the member's own type binder (MoonBit forbids `extern "js" fn[T]`) and lowers the inner callable, restoring `pub fn[T] Assertion::toBe(...)`. Full `verify_examples.sh` now genuinely exits 0 (verified on node 22 and 24), as do verify-scaffolds / verify-generated-fixtures / verify-mbti-dts.

## Conformance batches

- **BM (+9 TP)**: TS2318 lib-set directives (`@noLib`, `@lib:` without iterable → generators, without `esnext` → `using`); TS1238 class-decorator signatures (class-as-decorator not callable; required arity beyond the runtime's 1-arg legacy / 2-arg standard invocation) — the parser now captures class decorators BEFORE the body parse so member decorators can't masquerade as class decorators; TS2741 generators declared to return protocol-extending interfaces with extra required members.
- **BN (+6 TP)**: TS7053 string-literal keys provably absent from fully-literal object shapes under `noImplicitAny` (with overflow-folded-key abstention — our lexer wraps at 32 bits where tsc folds to `Infinity`); TS2464 `[Symbol.keyFor]` as a computed key; TS2554 `Date.UTC(year)` under pre-es2015 libs.
- **BO (+12 TP)**: TS2491 destructuring patterns as the left side of `for...in`; TS2854 top-level `await using` with pre-es2017 targets; TS2550 `Object.values`/`entries` (es2017) and `Atomics.waitAsync` (es2024) under older libs; TS2503 import-equals aliases with undeclared root namespaces; primitive keywords in qualified type names (`x.void`).
- **BP (+6 TP)**: SharedArrayBuffer/ArrayBuffer nominality; `new Array<T>(n)` explicit element types; TS2698 object spreads of non-object primitives (incl. template-literal types); numeric computed keys checked against number index signatures.

Each batch landed with a clean full-corpus sweep (FP 0) and legal-pattern pins in `expr_check_wbtest.mbt`. Unit tests: 2494 passing. Dead ends and deferred cases (genericRestArity tuple-arity inference, unionTypeReduction2) are documented in TODO.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr)_