### PR TITLE
bridge generics + checker BQ + parser BR: polymorphic this, generic fn export, TS7057/TS2554, PFLEGAL 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,11 +348,19 @@ Supported surface:
   trait impl relationships.
 - Opt-in facade wrappers for local non-generic methods and constructors via
   `mbt2ts facade-scaffold`, including async constructors and methods.
+- Unconstrained generic free functions (`pub fn[T] identity(T) -> T`) export
+  through a monomorphized glue wrapper: each type parameter is instantiated
+  at an opaque `TsMbtGenericAny` boundary type (values cross the JS boundary
+  unchanged) while the emitted `.d.ts` keeps the full generic signature.
+  Bare `T?` returns unwrap to `value | undefined` at the boundary.
 
 Unsupported or limited surface:
 
-- Generic methods, generic constructors, trait methods, and generic functions
-  are not exported directly by JS autolink.
+- Generic methods, generic constructors, trait methods, and generic
+  functions with trait bounds are not exported by JS autolink. Generic free
+  functions whose type parameters appear inside tuples or non-top-level
+  `Option` payloads also stay omitted (their runtime representation would
+  not match the declared TypeScript signature).
 - Public members omitted from the runtime export surface are listed in
   `AUTOLINK_DIAGNOSTICS.md`.
 - External MoonBit imports are left as bare TypeScript imports unless an

--- a/TODO.md
+++ b/TODO.md
@@ -1013,6 +1013,26 @@ augmentation, React `HTMLAttributes` index signatures.
   literal widening when any of the component's type parameters carries
   the modifier.
 
+### 8. Polymorphic `this` keeps fluent chains typed (done 2026-07-15)
+
+Patterns: zod `ZodType.check(...): this` / `optional(): ZodOptional<this>`,
+builder chains like jose `SignJWT.setIssuedAt(): this`, generic classes
+with `merge(other: this): this`.
+
+- [x] `this` in interface members and class methods now lowers to the
+  owning declaration applied to its own type parameters
+  (`Schema[Output, Input, Internals]`) instead of `Named(owner)` +
+  the `JSValue` arity filler (`Schema[JSValue, JSValue, JSValue]`).
+  The substitution is root-scoped: members merged in from `extends`
+  expansion also resolve `this` to the derived struct, matching TS
+  semantics and keeping every substituted param in scope.
+  Implemented in `decl_this_owner_type` / `decl_replace_this_type`
+  (now recursing through `Func` params and returns as well, so
+  `apply((this) => R)`-style callback params stop leaking a raw
+  `This` opaque type). zod: SCAFFOLD JSValue fallback entries
+  748 -> 648; the whole fluent core (`check` / `clone` / `optional` /
+  `nullable` / `describe` / ...) keeps `Schema[Output, Input, Internals]`.
+
 ### Non-Goals (still)
 
 - [ ] Do not turn this list into a checklist for "all of TypeScript". Each item

--- a/TODO.md
+++ b/TODO.md
@@ -1033,6 +1033,33 @@ with `merge(other: this): this`.
   748 -> 648; the whole fluent core (`check` / `clone` / `optional` /
   `nullable` / `describe` / ...) keeps `Schema[Output, Input, Internals]`.
 
+### 9. Generic free functions export via monomorphized glue (done 2026-07-15)
+
+Previously every `pub fn[T] ...` free function was omitted from
+`link.js.exports` and listed in `AUTOLINK_DIAGNOSTICS.md`.
+
+- [x] Unconstrained generic free functions now export through autolink
+  glue: type parameters are instantiated at an opaque
+  `#external pub type TsMbtGenericAny` (values cross the JS boundary
+  unchanged, which is exactly parametric behavior), the glue wrapper is
+  therefore non-generic and exportable, and the emitted `.d.ts` keeps the
+  original generic signature (`export function identity<T>(value: T): T`).
+- [x] Bare `T?` returns unwrap to `value | undefined` via a
+  `tsmbt_generic_undefined()` extern, because `Option[TsMbtGenericAny]`
+  crosses the boundary in the boxed `{_0}` representation.
+- [x] Eligibility is decided by `mbti_generic_glue_return_plan` and shared
+  by the glue emitter, the runtime-inaccessible screening, and the
+  diagnostics list. Ineligible (stay omitted): trait bounds (`[T : Show]`),
+  type params inside tuples (MoonBit tuples are not JS arrays), type params
+  under `Option` anywhere except the bare top-level return, and optional
+  params (`name? : T`).
+- Runtime verified with a node smoke: `identity(obj) === obj`,
+  `identity(undefined) === undefined`, `first([]) === undefined`,
+  `first([10, 20]) === 10`; `tsc --strict` accepts a typed generic consumer
+  of the emitted `.d.ts`.
+- Next increments: generic methods on non-generic owners (same
+  monomorphization through the facade path), then generic owners.
+
 ### Non-Goals (still)
 
 - [ ] Do not turn this list into a checklist for "all of TypeScript". Each item

--- a/TODO.md
+++ b/TODO.md
@@ -1088,9 +1088,11 @@ v7.0.2). Truth comes from vendored name manifests
 variant is NOTRUN, and the TS6-era deprecated-compiler-option
 diagnostics (TS5107/TS5101) were removed from the checker accordingly.
 
-State: whole-corpus **TP 2335 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 399 /
+State: whole-corpus **TP 2335 / FP 0 / PFLEGAL 0 / TN 1750 / MISS 399 /
 NOTRUN 14** via `scripts/checker_conformance_oracle.sh --max-fp 0
---max-legal-parsefail 3`.
+--max-legal-parsefail 0`. Batch BR emptied the legal-parse-failure
+budget (decoratorOnClass3, defaultExportWithOverloads01, parser768531)
+and the gate now enforces 0.
 
 Batch BE (TS7-only miss mining, +51 TP) worked the misses newly exposed
 by the oracle switch:

--- a/TODO.md
+++ b/TODO.md
@@ -1088,7 +1088,7 @@ v7.0.2). Truth comes from vendored name manifests
 variant is NOTRUN, and the TS6-era deprecated-compiler-option
 diagnostics (TS5107/TS5101) were removed from the checker accordingly.
 
-State: whole-corpus **TP 2329 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 405 /
+State: whole-corpus **TP 2335 / FP 0 / PFLEGAL 3 / TN 1747 / MISS 399 /
 NOTRUN 14** via `scripts/checker_conformance_oracle.sh --max-fp 0
 --max-legal-parsefail 3`.
 
@@ -1329,6 +1329,25 @@ primitive spreads:
   value against the target interface's number index signature
   (`var o: I = { [+"foo"]: "" }` where `[s: number]: boolean` —
   computedPropertyNamesContextualType10_ES5/ES6).
+Batch BQ (+6 TP, TP 2335 / MISS 399) took the TS7057 generator cluster
+and the deferred genericRestArity tuple arity:
+- TS7057: in a generator lacking a return-type annotation (under
+  noImplicitAny), a `yield` whose RESULT is consumed with no contextual
+  type — three syntactically decidable shapes: unannotated Ident
+  binding (`const value = yield`), a generic call argument whose
+  matching parameter is a bare type param with no explicit type args
+  (`f(yield)`), and `yield yield`. Unused results, annotated bindings,
+  destructuring targets, and `f<string>(yield)` abstain
+  (generatorImplicitAny, generatorTypeCheck50,
+  generatorReturnTypeInference + NonStrict).
+- TS2554 generic-rest-tuple arity: `call<TS extends unknown[]>(handler:
+  (...args: TS) => void, ...args: TS)` needs exactly 1 + handler-param
+  count arguments. The parser substitutes the tuple param with its
+  bound, so the carve keys on the substituted single-type-param shape
+  (`(...args: unknown[]/any[]) => R` + same-bound rest) with a
+  syntactic all-required arrow handler (genericRestArity,
+  genericRestArityStrict). A non-generic `unknown[]`-rest signature
+  abstains.
 Documented dead ends from this round: YieldExpression10_es6 (an
 object-literal method's name in the backstop is indistinguishable from
 a legal self-referential named function expression property);

--- a/TODO.md
+++ b/TODO.md
@@ -889,6 +889,16 @@ valibot.
     all 24 corpus entries; per-package `JSValue` cause budgets, function
     counts, and unsupported-export budgets now reflect the actual
     generated output, including the new heterogeneous-union diagnostics.
+- [ ] Drive the `heterogeneous-union-widened` budget in
+  `scripts/bridge_quality_report.sh` back to 0 (currently 5, added
+  2026-07-15: hono `Child = string | number | JSX.Element`, react
+  `ElementType`, vitest `CancelReason` / `TestArtifact`, drizzle
+  `NeonAuthToken`). All five widen because a member has no
+  runtime-discriminable constructor name — qualified names like
+  `JSX.Element` don't resolve to a PascalCase constructor. The aliases
+  stay runtime-safe (widened to JSValue with diagnostics); the fix is
+  either resolving qualified member names to their canonical local
+  declarations before discriminability, or discriminating structurally.
 
 ### 2. Method-level generics preserved through bridge
 

--- a/fixtures/mbti_typescript/generic_free_fn.pkg.generated.mbti
+++ b/fixtures/mbti_typescript/generic_free_fn.pkg.generated.mbti
@@ -1,0 +1,21 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "demo/generic"
+
+// Values
+pub fn[T : Show] describe(T) -> String
+
+pub fn[T] first(Array[T]) -> T?
+
+pub fn[T] identity(T) -> T
+
+pub fn[T, U] map_pair((T, U)) -> (U, T)
+
+pub fn plain_add(Int, Int) -> Int
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/fixtures/resolver/project/types/generic-this-chain-entry.d.ts
+++ b/fixtures/resolver/project/types/generic-this-chain-entry.d.ts
@@ -1,0 +1,15 @@
+export interface Box<A, B> {
+  value: A;
+  check(...checks: string[]): this;
+  optional(): Wrap<this>;
+  pair(other: B): this;
+}
+export interface Wrap<T> {
+  inner: T;
+}
+export declare class Chain<A, B> {
+  value: A;
+  push(item: A): this;
+  wrap(): Wrap<this>;
+  merge(other: this): this;
+}

--- a/justfile
+++ b/justfile
@@ -118,7 +118,7 @@ checker-conformance-oracle *ARGS:
 # false positives on the conformance corpus.
 verify-checker-soundness:
     moon build --target native
-    bash scripts/checker_conformance_oracle.sh --max-fp 0
+    bash scripts/checker_conformance_oracle.sh --max-fp 0 --max-legal-parsefail 0
 
 # Full CI check
 ci: fmt check test verify-mbti-dts verify-scaffolds verify-generated-fixtures verify-examples verify-checker-soundness

--- a/scripts/bridge_quality_report.sh
+++ b/scripts/bridge_quality_report.sh
@@ -12,6 +12,13 @@ unsupported_details_file="$report_root/unsupported-exports.tsv"
 ambiguous_unsupported_export_budget=1
 namespace_omitted_unsupported_export_budget=0
 namespace_widened_unsupported_export_budget=0
+# Heterogeneous unions whose members carry no runtime-discriminable
+# constructor name (e.g. hono `Child = string | number | JSX.Element`,
+# vitest `CancelReason` / `TestArtifact`, react `ElementType`, drizzle
+# `NeonAuthToken`). The alias widens to JSValue and stays runtime-safe;
+# driving this back to 0 is roadmap item "Heterogeneous union ->
+# auto-enum" in TODO.md.
+heterogeneous_union_unsupported_export_budget=5
 
 rm -rf "$report_root"
 mkdir -p "$log_root"
@@ -147,6 +154,7 @@ collect_unsupported_export_counts() {
   local ambiguous=0
   local namespace_omitted=0
   local namespace_widened=0
+  local heterogeneous_union=0
   local unbudgeted=0
   local file
   local line
@@ -174,6 +182,9 @@ collect_unsupported_export_counts() {
       elif [[ "$line" == *"namespace export is widened to JSValue." ]]; then
         classification="namespace-widened"
         namespace_widened=$((namespace_widened + 1))
+      elif [[ "$line" == *"heterogeneous union member is not runtime-discriminable"* ]]; then
+        classification="heterogeneous-union-widened"
+        heterogeneous_union=$((heterogeneous_union + 1))
       else
         unbudgeted=$((unbudgeted + 1))
       fi
@@ -186,11 +197,12 @@ collect_unsupported_export_counts() {
     done < "$file"
   done < <(find_metric_files 'bridge.mbti')
 
-  printf '%s|%s|%s|%s|%s\n' \
+  printf '%s|%s|%s|%s|%s|%s\n' \
     "$total" \
     "$ambiguous" \
     "$namespace_omitted" \
     "$namespace_widened" \
+    "$heterogeneous_union" \
     "$unbudgeted"
 }
 
@@ -277,6 +289,7 @@ IFS='|' read -r \
   ambiguous_unsupported_exports \
   namespace_omitted_unsupported_exports \
   namespace_widened_unsupported_exports \
+  heterogeneous_union_unsupported_exports \
   unbudgeted_unsupported_exports < <(collect_unsupported_export_counts "$unsupported_details_file")
 moonbit_declared_functions="$(count_matching_files 'bridge.mbti' '^declare pub fn ')"
 moonbit_declared_types="$(count_matching_files 'bridge.mbti' '^declare pub type ')"
@@ -311,6 +324,9 @@ fi
 if [ "$namespace_widened_unsupported_exports" -gt "$namespace_widened_unsupported_export_budget" ]; then
   overall="fail"
 fi
+if [ "$heterogeneous_union_unsupported_exports" -gt "$heterogeneous_union_unsupported_export_budget" ]; then
+  overall="fail"
+fi
 
 {
   printf '# Bridge Quality Report\n\n'
@@ -343,6 +359,7 @@ fi
   printf '| budgeted ambiguous unsupported exports | %s / %s |\n' "$ambiguous_unsupported_exports" "$ambiguous_unsupported_export_budget"
   printf '| budgeted namespace-runtime omitted exports | %s / %s |\n' "$namespace_omitted_unsupported_exports" "$namespace_omitted_unsupported_export_budget"
   printf '| budgeted namespace-widened exports | %s / %s |\n' "$namespace_widened_unsupported_exports" "$namespace_widened_unsupported_export_budget"
+  printf '| budgeted heterogeneous-union widened exports | %s / %s |\n' "$heterogeneous_union_unsupported_exports" "$heterogeneous_union_unsupported_export_budget"
   printf '| unbudgeted unsupported exports | %s |\n' "$unbudgeted_unsupported_exports"
   printf '| JSValue refs | %s |\n' "$jsvalue_refs"
   printf '| JSValue surface lines | %s |\n' "$jsvalue_surface_lines"

--- a/src/bridge/mbti_typescript_decl.mbt
+++ b/src/bridge/mbti_typescript_decl.mbt
@@ -133,6 +133,14 @@ priv struct MbtiAutolinkGlueDecl {
   runtime_export_name : String
   ts_decl : String
   mbt_decl : String
+  // True when the glue wrapper monomorphizes an unconstrained generic
+  // function through the opaque `TsMbtGenericAny` boundary type; the
+  // rendered glue file declares that type once when any decl needs it.
+  uses_generic_any : Bool
+  // True when the wrapper unwraps a bare `T?` return to
+  // `value | undefined`; the rendered glue file declares the
+  // `tsmbt_generic_undefined` extern once when any decl needs it.
+  uses_generic_undefined : Bool
 }
 
 ///|
@@ -914,6 +922,7 @@ fn parse_mbti_imports(source : String) -> Array[MbtiImportRef] {
 ///|
 fn collect_mbti_omitted_autolink_members(source : String) -> Array[String] {
   let members : Array[String] = []
+  let imports = parse_mbti_imports(source)
   for line_view in source.split("\n") {
     let line = line_view.to_owned()
     match strip_mbti_public_prefix(line, "fn") {
@@ -929,7 +938,15 @@ fn collect_mbti_omitted_autolink_members(source : String) -> Array[String] {
             } else {
               rest[:open_idx].trim().to_owned()
             }
+            // Glue-eligible generic free functions now get a monomorphized
+            // wrapper, so they are no longer omitted. Ones that use
+            // private types are re-added by the runtime-inaccessible
+            // screening below.
+            let has_generic_glue = !name.contains("::") &&
+              rest.has_prefix("[") &&
+              mbti_line_is_glue_eligible_generic_free_fn(line, imports)
             if (name.contains("::") || rest.has_prefix("[")) &&
+              !has_generic_glue &&
               !members.contains(name) {
               members.push(name)
             }
@@ -945,6 +962,30 @@ fn collect_mbti_omitted_autolink_members(source : String) -> Array[String] {
     }
   }
   members
+}
+
+///|
+fn mbti_line_is_glue_eligible_generic_free_fn(
+  line : String,
+  imports : Array[MbtiImportRef],
+) -> Bool {
+  let parsed = parse_mbti_function_signature(line.trim().to_owned(), imports, []) catch {
+    _ => return false
+  }
+  match parsed {
+    Some((None, _, fn_type_params, params_src, return_src, _)) => {
+      if fn_type_params.length() == 0 {
+        return false
+      }
+      let raw_params = match parse_mbti_raw_facade_params(params_src, "") {
+        Some(params) => params
+        None => return false
+      }
+      mbti_generic_glue_return_plan(fn_type_params, raw_params, return_src)
+      is Some(_)
+    }
+    _ => false
+  }
 }
 
 ///|
@@ -969,18 +1010,12 @@ fn collect_runtime_inaccessible_free_function_names(
           fn_name,
           fn_type_params,
           params_src,
-          _return_src,
+          return_src,
           _is_async,
         ) = signature
         match owner_name {
           None => {
             let export_name = sanitize_ts_identifier(fn_name, "fn")
-            if fn_type_params.length() > 0 {
-              if !names.contains(export_name) {
-                names.push(export_name)
-              }
-              continue
-            }
             let raw_params = match
               parse_mbti_raw_facade_params(params_src, "") {
               Some(params) => params
@@ -990,6 +1025,21 @@ fn collect_runtime_inaccessible_free_function_names(
                 }
                 continue
               }
+            }
+            if fn_type_params.length() > 0 &&
+              mbti_generic_glue_return_plan(
+                fn_type_params, raw_params, return_src,
+              )
+              is None {
+              // No monomorphized glue wrapper exists for this generic
+              // shape (trait bound, tuple, or non-top-level Option), so
+              // it stays runtime-inaccessible. Glue-eligible generics
+              // fall through to the same private-type screening as
+              // non-generic functions.
+              if !names.contains(export_name) {
+                names.push(export_name)
+              }
+              continue
             }
             let fn_type_param_names = type_param_names(fn_type_params)
             let return_src_with_effect = mbti_return_source_with_effect_from_function_line(
@@ -1213,6 +1263,228 @@ fn mbti_qualify_root_type_refs_for_glue(
         prev != Some('.') &&
         prev != Some('@') {
         rendered += "@\{source_alias}.\{ident}"
+      } else {
+        rendered += ident
+      }
+    } else {
+      rendered += c.to_string()
+      idx += 1
+    }
+  }
+  rendered
+}
+
+///|
+/// Name of the opaque `#external` boundary type used to monomorphize
+/// unconstrained generic functions for the JS runtime export surface.
+/// Values pass through the JS boundary unchanged, so instantiating an
+/// unconstrained type parameter at this type preserves the function's
+/// runtime behavior while the TypeScript declaration keeps the generic
+/// signature.
+const MBTI_GENERIC_ANY_TYPE_NAME : String = "TsMbtGenericAny"
+
+///|
+/// A generic function is glue-eligible only when every type parameter is
+/// unconstrained: a bound like `[T : Show]` would make the `TsMbtGenericAny`
+/// instantiation fail to compile.
+fn mbti_type_params_are_unbounded(type_params : Array[MbtiTypeParam]) -> Bool {
+  for type_param in type_params {
+    if type_param.extends_ty is Some(_) {
+      return false
+    }
+  }
+  true
+}
+
+///|
+priv enum MbtiGenericGlueReturn {
+  MbtiGenericGlueReturnDirect
+  MbtiGenericGlueReturnOptionUnwrap
+}
+
+///|
+/// Decide whether an unconstrained generic free function can cross the
+/// JS autolink boundary through a `TsMbtGenericAny` monomorphized glue
+/// wrapper, and how its return value must be handled.
+///
+/// Type parameters may appear bare, inside `Array[...]`, inside function
+/// types, or inside applied type constructors. Two contexts are rejected
+/// because the runtime representation would not match the declared
+/// TypeScript signature once the parameter is instantiated at the opaque
+/// boundary type:
+/// - tuples (`(T, U)` crosses as an opaque MoonBit value, not a JS array)
+/// - `Option` (`T?` boxes as `{_0}` when the payload can itself be
+///   `undefined`), except a bare `T?` at the top level of the return
+///   type, where the wrapper unwraps to `value | undefined` explicitly.
+fn mbti_generic_glue_return_plan(
+  fn_type_params : Array[MbtiTypeParam],
+  raw_params : Array[MbtiRawFacadeParam],
+  return_src : String,
+) -> MbtiGenericGlueReturn? {
+  if fn_type_params.length() == 0 {
+    return None
+  }
+  if !mbti_type_params_are_unbounded(fn_type_params) {
+    return None
+  }
+  let names = type_param_names(fn_type_params)
+  for param in raw_params {
+    if !mbti_src_mentions_type_param(param.ty_src, names) {
+      continue
+    }
+    if param.optional {
+      // `name? : T` crosses as `T | undefined` on the JS side but the
+      // glue would receive it as a boxed Option payload.
+      return None
+    }
+    if !mbti_generic_type_src_is_boundary_safe(param.ty_src, names) {
+      return None
+    }
+  }
+  let trimmed_return = return_src.trim().to_owned()
+  if trimmed_return.has_suffix("?") {
+    let inner = trimmed_return[:trimmed_return.length() - 1].trim().to_owned()
+    if !mbti_src_mentions_type_param(inner, names) {
+      return Some(MbtiGenericGlueReturnDirect)
+    }
+    if names.contains(inner) {
+      return Some(MbtiGenericGlueReturnOptionUnwrap)
+    }
+    return None
+  }
+  if mbti_src_mentions_type_param(trimmed_return, names) &&
+    !mbti_generic_type_src_is_boundary_safe(trimmed_return, names) {
+    return None
+  }
+  Some(MbtiGenericGlueReturnDirect)
+}
+
+///|
+fn mbti_src_mentions_type_param(
+  source : String,
+  type_param_names : Array[String],
+) -> Bool {
+  let mut idx = 0
+  while idx < source.length() {
+    let c = mbti_char_at(source, idx)
+    if mbti_is_identifier_start(c) {
+      let start = idx
+      idx += 1
+      while idx < source.length() &&
+            mbti_is_identifier_continue(mbti_char_at(source, idx)) {
+        idx += 1
+      }
+      let ident = source[start:idx].to_owned()
+      let prev = if start > 0 {
+        Some(mbti_char_at(source, start - 1))
+      } else {
+        None
+      }
+      if type_param_names.contains(ident) &&
+        prev != Some('.') &&
+        prev != Some('@') {
+        return true
+      }
+    } else {
+      idx += 1
+    }
+  }
+  false
+}
+
+///|
+fn mbti_generic_type_src_is_boundary_safe(
+  source : String,
+  type_param_names : Array[String],
+) -> Bool {
+  if !mbti_src_mentions_type_param(source, type_param_names) {
+    return true
+  }
+  // Coarse but conservative: any Option marker or tuple anywhere in a
+  // type-parameter-carrying source rejects the whole function.
+  if source.contains("?") {
+    return false
+  }
+  !mbti_src_contains_tuple(source)
+}
+
+///|
+/// Detects a tuple type anywhere in the source: a parenthesized group
+/// with a top-level comma that is not immediately followed by `->`
+/// (which would make it a function parameter list instead).
+fn mbti_src_contains_tuple(source : String) -> Bool {
+  let mut idx = 0
+  while idx < source.length() {
+    if mbti_char_at(source, idx) == '(' {
+      match find_matching(source, idx, '(', ')') {
+        Some(close_idx) => {
+          let mut depth = 0
+          let mut has_top_level_comma = false
+          let mut inner_idx = idx + 1
+          while inner_idx < close_idx {
+            let c = mbti_char_at(source, inner_idx)
+            if c == '(' || c == '[' {
+              depth += 1
+            } else if c == ')' || c == ']' {
+              depth -= 1
+            } else if c == ',' && depth == 0 {
+              has_top_level_comma = true
+            }
+            inner_idx += 1
+          }
+          if has_top_level_comma {
+            let mut after_idx = close_idx + 1
+            while after_idx < source.length() &&
+                  mbti_char_at(source, after_idx) == ' ' {
+              after_idx += 1
+            }
+            let is_fn_params = after_idx + 1 < source.length() &&
+              mbti_char_at(source, after_idx) == '-' &&
+              mbti_char_at(source, after_idx + 1) == '>'
+            if !is_fn_params {
+              return true
+            }
+          }
+        }
+        None => ()
+      }
+    }
+    idx += 1
+  }
+  false
+}
+
+///|
+/// Replace identifier occurrences of function-level type parameters with
+/// the opaque boundary type, leaving qualified refs (`@pkg.T` / `x.T`)
+/// untouched. Mirrors the tokenizer in
+/// `mbti_qualify_root_type_refs_for_glue`.
+fn replace_mbti_type_param_refs(
+  source : String,
+  type_param_names : Array[String],
+  replacement : String,
+) -> String {
+  let mut rendered = ""
+  let mut idx = 0
+  while idx < source.length() {
+    let c = mbti_char_at(source, idx)
+    if mbti_is_identifier_start(c) {
+      let start = idx
+      idx += 1
+      while idx < source.length() &&
+            mbti_is_identifier_continue(mbti_char_at(source, idx)) {
+        idx += 1
+      }
+      let ident = source[start:idx].to_owned()
+      let prev = if start > 0 {
+        Some(mbti_char_at(source, start - 1))
+      } else {
+        None
+      }
+      if type_param_names.contains(ident) &&
+        prev != Some('.') &&
+        prev != Some('@') {
+        rendered += replacement
       } else {
         rendered += ident
       }
@@ -1594,7 +1866,14 @@ fn collect_mbti_autolink_glue_decls(
         )
         match owner_name {
           None => {
-            if fn_type_params.length() > 0 {
+            // Unconstrained generic free functions get a monomorphized
+            // glue wrapper: every type parameter is instantiated at the
+            // opaque `TsMbtGenericAny` boundary type (values pass through
+            // the JS boundary unchanged), while the public .d.ts keeps
+            // the generic signature. Bounded generics stay omitted — the
+            // boundary type cannot satisfy a trait bound.
+            let is_generic = fn_type_params.length() > 0
+            if is_generic && !mbti_type_params_are_unbounded(fn_type_params) {
               continue
             }
             let raw_params = match
@@ -1607,32 +1886,103 @@ fn collect_mbti_autolink_glue_decls(
               ) {
               continue
             }
+            let mut option_unwrap_return = false
+            if is_generic {
+              match
+                mbti_generic_glue_return_plan(
+                  fn_type_params, raw_params, glue_return_src,
+                ) {
+                Some(MbtiGenericGlueReturnOptionUnwrap) =>
+                  option_unwrap_return = true
+                Some(MbtiGenericGlueReturnDirect) => ()
+                None => continue
+              }
+            }
+            let glue_type_param_names = if is_generic {
+              []
+            } else {
+              fn_type_param_names
+            }
+            let glue_return_src = if is_generic {
+              replace_mbti_type_param_refs(
+                glue_return_src,
+                fn_type_param_names,
+                MBTI_GENERIC_ANY_TYPE_NAME,
+              )
+            } else {
+              glue_return_src
+            }
+            let glue_return_src_with_effect = if is_generic {
+              replace_mbti_type_param_refs(
+                glue_return_src_with_effect,
+                fn_type_param_names,
+                MBTI_GENERIC_ANY_TYPE_NAME,
+              )
+            } else {
+              glue_return_src_with_effect
+            }
+            let raw_params = if is_generic {
+              let substituted : Array[MbtiRawFacadeParam] = []
+              for param in raw_params {
+                substituted.push({
+                  name: param.name,
+                  ty_src: replace_mbti_type_param_refs(
+                    param.ty_src,
+                    fn_type_param_names,
+                    MBTI_GENERIC_ANY_TYPE_NAME,
+                  ),
+                  optional: param.optional,
+                })
+              }
+              substituted
+            } else {
+              raw_params
+            }
+            let type_param_suffix = if is_generic {
+              ""
+            } else {
+              type_param_suffix
+            }
             let return_ty = mbti_qualify_root_type_refs_for_glue(
-              glue_return_src, local_type_names, fn_type_param_names, source_alias,
+              glue_return_src, local_type_names, glue_type_param_names, source_alias,
             )
             let rendered_mbt_params = render_mbt_glue_params(
-              raw_params, local_type_names, fn_type_param_names, source_alias,
+              raw_params, local_type_names, glue_type_param_names, source_alias,
             )
             let call_args = render_mbt_glue_call_args(raw_params)
             let async_prefix = if is_async { "async " } else { "" }
             let effect_suffix = mbti_qualified_effect_suffix_for_glue(
-              glue_return_src_with_effect, local_type_names, fn_type_param_names,
+              glue_return_src_with_effect, local_type_names, glue_type_param_names,
               source_alias,
             )
             let export_name = sanitize_ts_identifier(fn_name, "fn")
             let runtime_export_name = runtime_export_prefix + export_name
-            let body_expr = if call_args == "" {
+            let call_expr = if call_args == "" {
               "@\{source_alias}.\{fn_name}()"
             } else {
               "@\{source_alias}.\{fn_name}(\{call_args})"
             }
-            let mbt_decl = "pub \{async_prefix}fn\{type_param_suffix} \{runtime_export_name}(\{rendered_mbt_params}) -> \{return_ty}\{effect_suffix} {\n  \{body_expr}\n}"
+            let mbt_decl = if option_unwrap_return {
+              // Return a bare `T?` payload as `value | undefined` so the
+              // JS side sees what the .d.ts declares instead of the boxed
+              // Option representation.
+              let unwrapped_return_ty = if return_ty.has_suffix("?") {
+                return_ty[:return_ty.length() - 1].to_owned()
+              } else {
+                return_ty
+              }
+              "pub \{async_prefix}fn \{runtime_export_name}(\{rendered_mbt_params}) -> \{unwrapped_return_ty}\{effect_suffix} {\n  match \{call_expr} {\n    Some(value) => value\n    None => tsmbt_generic_undefined()\n  }\n}"
+            } else {
+              "pub \{async_prefix}fn\{type_param_suffix} \{runtime_export_name}(\{rendered_mbt_params}) -> \{return_ty}\{effect_suffix} {\n  \{call_expr}\n}"
+            }
             decls.push({
               package_name,
               export_name,
               runtime_export_name,
               ts_decl: "",
               mbt_decl,
+              uses_generic_any: is_generic,
+              uses_generic_undefined: option_unwrap_return,
             })
             free_function_names.push(export_name)
           }
@@ -1735,6 +2085,8 @@ fn collect_mbti_autolink_glue_decls(
                   runtime_export_name: runtime_unique_export_name,
                   ts_decl: facade_ts_decl,
                   mbt_decl: facade_mbt_decl,
+                  uses_generic_any: false,
+                  uses_generic_undefined: false,
                 })
               }
               None => ()
@@ -1869,6 +2221,30 @@ fn render_autolink_glue_mbt(decls : Array[MbtiAutolinkGlueDecl]) -> String {
   sections.push(
     "/// Auto-generated glue wrappers for MoonBit JS package output.",
   )
+  if decls.any(fn(decl) { decl.uses_generic_any }) {
+    sections.push("")
+    sections.push(
+      (
+        #|///|
+        #|/// Opaque boundary type used to monomorphize unconstrained generic
+        #|/// functions for the JS runtime export surface. Values cross the JS
+        #|/// boundary unchanged; the TypeScript declaration keeps the generic
+        #|/// signature.
+        #|#external
+        #|pub type
+      ) +
+      " " +
+      MBTI_GENERIC_ANY_TYPE_NAME,
+    )
+  }
+  if decls.any(fn(decl) { decl.uses_generic_undefined }) {
+    sections.push("")
+    sections.push(
+      "///|\nextern \"js\" fn tsmbt_generic_undefined() -> " +
+      MBTI_GENERIC_ANY_TYPE_NAME +
+      " =\n  \"() => undefined\"",
+    )
+  }
   for decl in decls {
     sections.push("")
     sections.push(decl.mbt_decl)
@@ -5056,6 +5432,7 @@ fn strip_runtime_inaccessible_typescript_members(
   source : String,
   inaccessible_function_names : Array[String],
   runtime_export_names : Array[String],
+  generic_glue_export_names : Array[String],
 ) -> String {
   let lines : Array[String] = []
   let mut in_interface = false
@@ -5099,7 +5476,16 @@ fn strip_runtime_inaccessible_typescript_members(
         if runtime_export_names.contains(name) {
           lines.push(line)
         }
-      _ => {
+      Some(name) => {
+        // Generic function declarations survive only when a monomorphized
+        // glue wrapper gives them a runtime export.
+        if ts_decl_line_is_runtime_inaccessible_function(line) &&
+          !generic_glue_export_names.contains(name) {
+          continue
+        }
+        lines.push(line)
+      }
+      None => {
         if ts_decl_line_is_runtime_inaccessible_function(line) {
           continue
         }
@@ -5138,6 +5524,7 @@ fn strip_runtime_inaccessible_typescript_package_files(
   loaded : LoadedMbtiPackageSources,
   files : Array[MbtiTypescriptPackageFile],
   runtime_export_names? : Array[String] = [],
+  generic_glue_export_names? : Array[String] = [],
 ) -> Array[MbtiTypescriptPackageFile] {
   let inaccessible_by_path : Map[String, Array[String]] = {}
   for package_name in loaded.ordered_packages {
@@ -5167,6 +5554,7 @@ fn strip_runtime_inaccessible_typescript_package_files(
         file.content,
         inaccessible_function_names,
         runtime_export_names,
+        generic_glue_export_names,
       ),
     })
   }
@@ -5289,8 +5677,12 @@ pub async fn emit_typescript_scaffold_bundle_from_mbti_path_with_import_rewrites
   let root_package_name = loaded.root_package_name
   let glue_decls = collect_mbti_bundle_autolink_glue_decls(loaded, false)
   let export_names : Array[String] = []
+  let generic_glue_export_names : Array[String] = []
   for decl in glue_decls {
     export_names.push(decl.runtime_export_name)
+    if decl.uses_generic_any {
+      generic_glue_export_names.push(decl.export_name)
+    }
   }
   let moon_pkg = render_moonbit_js_glue_moon_pkg(loaded, export_names)
   let files = strip_runtime_inaccessible_typescript_package_files(
@@ -5299,6 +5691,7 @@ pub async fn emit_typescript_scaffold_bundle_from_mbti_path_with_import_rewrites
       root_file_path, external_import_spec_rewrites,
     ),
     runtime_export_names=export_names,
+    generic_glue_export_names~,
   )
   let files_with_runtime : Array[MbtiTypescriptPackageFile] = []
   for file in files {
@@ -5345,9 +5738,13 @@ pub async fn emit_typescript_facade_scaffold_bundle_from_mbti_path_with_import_r
   let root_package_name = loaded.root_package_name
   let glue_decls = collect_mbti_bundle_autolink_glue_decls(loaded, true)
   let facade_export_names : Array[String] = []
+  let generic_glue_export_names : Array[String] = []
   let facade_ts_decls_by_path : Map[String, Array[String]] = {}
   for decl in glue_decls {
     facade_export_names.push(decl.runtime_export_name)
+    if decl.uses_generic_any {
+      generic_glue_export_names.push(decl.export_name)
+    }
     if decl.ts_decl != "" {
       match mbti_local_package_segments(root_package_name, decl.package_name) {
         Some(segments) => {
@@ -5368,6 +5765,7 @@ pub async fn emit_typescript_facade_scaffold_bundle_from_mbti_path_with_import_r
       root_file_path, external_import_spec_rewrites,
     ),
     runtime_export_names=facade_export_names,
+    generic_glue_export_names~,
   )
   let files_with_facades : Array[MbtiTypescriptPackageFile] = []
   for file in files {

--- a/src/bridge/mbti_typescript_decl_wbtest.mbt
+++ b/src/bridge/mbti_typescript_decl_wbtest.mbt
@@ -1157,9 +1157,16 @@ async test "bridge: emit TypeScript scaffold bundle keeps optional named params 
   assert_true(bundle.moon_pkg.contains("\"consume_callbacks\""))
   assert_true(bundle.moon_pkg.contains("\"nullValue\""))
   assert_true(bundle.moon_pkg.contains("\"undefinedValue\""))
-  assert_false(bundle.moon_pkg.contains("\"identity\""))
+  // Unconstrained generic free functions now export through a
+  // monomorphized `TsMbtGenericAny` glue wrapper.
+  assert_true(bundle.moon_pkg.contains("\"identity\""))
+  assert_true(
+    bundle.autolink_glue_mbt.contains(
+      "pub fn identity(arg0 : TsMbtGenericAny) -> TsMbtGenericAny {",
+    ),
+  )
   assert_false(bundle.moon_pkg.contains("\"make_secret\""))
-  assert_true(bundle.autolink_diagnostics_md.contains("- `identity`"))
+  assert_false(bundle.autolink_diagnostics_md.contains("- `identity`"))
   assert_true(bundle.autolink_diagnostics_md.contains("- `make_secret`"))
   let mut root_content = ""
   for file in bundle.files {
@@ -1167,7 +1174,7 @@ async test "bridge: emit TypeScript scaffold bundle keeps optional named params 
       root_content = file.content
     }
   }
-  assert_false(root_content.contains("export function identity<T>"))
+  assert_true(root_content.contains("export function identity<T>"))
   assert_false(root_content.contains("export function make_secret"))
   assert_true(
     bundle.autolink_glue_mbt.contains(
@@ -1537,4 +1544,57 @@ async test "bridge: emit TypeScript facade scaffold bundle omits generic root tr
   }
   assert_true(bundle.autolink_diagnostics_md.contains("- `eof`"))
   assert_false(bundle.autolink_glue_mbt.contains("pub fn[T"))
+}
+
+///|
+async test "bridge: unconstrained generic free fns export through monomorphized glue" {
+  let bundle = emit_typescript_scaffold_bundle_from_mbti_path(
+    "fixtures/mbti_typescript/generic_free_fn.pkg.generated.mbti",
+  ) catch {
+    MbtiTypescriptDeclError::ReadError(msg)
+    | MbtiTypescriptDeclError::ParseError(msg) =>
+      fail("MBTI scaffold bundle emit error: \{msg}")
+  }
+  // Eligible: unconstrained type params in passthrough positions.
+  assert_true(bundle.moon_pkg.contains("\"identity\""))
+  assert_true(bundle.moon_pkg.contains("\"first\""))
+  assert_true(
+    bundle.autolink_glue_mbt.contains(
+      "pub fn identity(arg0 : TsMbtGenericAny) -> TsMbtGenericAny {",
+    ),
+  )
+  // Bare `T?` returns unwrap to `value | undefined` at the boundary.
+  assert_true(
+    bundle.autolink_glue_mbt.contains(
+      "pub fn first(arg0 : Array[TsMbtGenericAny]) -> TsMbtGenericAny {",
+    ),
+  )
+  assert_true(bundle.autolink_glue_mbt.contains("tsmbt_generic_undefined()"))
+  assert_true(
+    bundle.autolink_glue_mbt.contains("#external\npub type TsMbtGenericAny"),
+  )
+  // Ineligible: trait bounds and tuple payloads stay omitted.
+  assert_false(bundle.moon_pkg.contains("\"describe\""))
+  assert_false(bundle.moon_pkg.contains("\"map_pair\""))
+  assert_true(bundle.autolink_diagnostics_md.contains("- `describe`"))
+  assert_true(bundle.autolink_diagnostics_md.contains("- `map_pair`"))
+  assert_false(bundle.autolink_diagnostics_md.contains("- `identity`"))
+  assert_false(bundle.autolink_diagnostics_md.contains("- `first`"))
+  // The public .d.ts keeps the generic signatures for glue-backed fns.
+  let mut root_content = ""
+  for file in bundle.files {
+    if file.relative_path == "index.d.ts" {
+      root_content = file.content
+    }
+  }
+  assert_true(
+    root_content.contains("export function identity<T>(value: T): T;"),
+  )
+  assert_true(
+    root_content.contains(
+      "export function first<T>(items: Array<T>): T | undefined;",
+    ),
+  )
+  assert_false(root_content.contains("export function describe"))
+  assert_false(root_content.contains("export function map_pair"))
 }

--- a/src/bridge/moonbit_decl.mbt
+++ b/src/bridge/moonbit_decl.mbt
@@ -5917,6 +5917,7 @@ fn append_lowered_interface_field(
   seen_field_names : Array[String],
   info : DeclModuleInfo,
   owner_name : String,
+  this_owner : @ast.TsType,
   field_name : String,
   field_type : @ast.TsType,
   is_readonly : Bool,
@@ -5927,14 +5928,21 @@ fn append_lowered_interface_field(
     return
   }
   seen_field_names.push(field_name)
+  // `this` in a member type always denotes the interface the struct is
+  // being generated for (the root of the extends expansion), applied to
+  // that struct's own type parameters — those are exactly the params in
+  // scope for the generated field / wrapper signatures.
   let lowered_type = decl_specialize_generated_interface_field_type(
     owner_name,
     field_name,
-    lower_react_utility_type(
-      info,
-      rewrite_type_refs(info, field_type, canonical_types),
-      modules,
-      canonical_types,
+    decl_replace_this_type(
+      lower_react_utility_type(
+        info,
+        rewrite_type_refs(info, field_type, canonical_types),
+        modules,
+        canonical_types,
+      ),
+      this_owner,
     ),
   )
   fields.push(
@@ -5954,6 +5962,7 @@ fn append_lowered_interface_field(
 ///|
 fn append_interface_origin_fields(
   origin : ResolvedInterfaceOrigin,
+  this_owner : @ast.TsType,
   modules : Map[String, DeclModuleInfo],
   canonical_types : Map[String, String],
   fields : Array[(String, @ast.TsType)],
@@ -5971,9 +5980,12 @@ fn append_interface_origin_fields(
       resolve_interface_origin(origin.info, base_name, modules, canonical_types) {
       Some(base_origin) =>
         if should_expand_interface_base(base_origin) {
+          // Base members merged into the derived struct keep the ROOT
+          // `this_owner`: `this` in an inherited member denotes the
+          // derived type, and only the root's type params are in scope.
           append_interface_origin_fields(
-            base_origin, modules, canonical_types, fields, readonly_fields, seen_field_names,
-            seen_origins,
+            base_origin, this_owner, modules, canonical_types, fields, readonly_fields,
+            seen_field_names, seen_origins,
           )
         }
       None => ()
@@ -5987,6 +5999,7 @@ fn append_interface_origin_fields(
       seen_field_names,
       origin.info,
       origin.export_name,
+      this_owner,
       field_name,
       field_type,
       origin.iface.readonly_fields.contains(field_name),
@@ -6007,7 +6020,13 @@ fn clone_resolved_interface_origin(
   let seen_field_names : Array[String] = []
   let seen_origins : Array[String] = []
   append_interface_origin_fields(
-    origin, modules, canonical_types, fields, readonly_fields, seen_field_names,
+    origin,
+    decl_this_owner_type(origin.export_name, origin.iface.type_params),
+    modules,
+    canonical_types,
+    fields,
+    readonly_fields,
+    seen_field_names,
     seen_origins,
   )
   {
@@ -6349,6 +6368,7 @@ fn clone_exported_interface(
   let seen_origins : Array[String] = []
   append_interface_origin_fields(
     { info, export_name: exported.export_name, iface: exported.iface },
+    decl_this_owner_type(exported.export_name, exported.iface.type_params),
     modules,
     canonical_types,
     fields,
@@ -7527,7 +7547,7 @@ fn decl_specialize_generated_class_method_return_type(
   // TypeScript `this` types in builder-style chains (`setIssuedAt(): this`)
   // are parsed as `Named("This")`. Replace them with the owning class so
   // chained calls keep type-checking.
-  let type_ = decl_replace_this_type(type_, class_name)
+  let type_ = decl_replace_this_type(type_, @ast.TsType::Named(class_name))
   if class_name == "Context" &&
     decl_is_hono_context_response_method(method_name) {
     return Named("Response")
@@ -7559,41 +7579,71 @@ fn decl_replace_this_in_function_return(
 ) -> @ast.TsType {
   match type_ {
     @ast.TsType::Func(params, return_type) =>
-      @ast.TsType::Func(params, decl_replace_this_type(return_type, owner_name))
+      @ast.TsType::Func(
+        params,
+        decl_replace_this_type(return_type, @ast.TsType::Named(owner_name)),
+      )
     _ => type_
+  }
+}
+
+///|
+/// The type that a member-level `this` denotes: the owning declaration
+/// applied to its own type parameters (`Box[A, B]`), or the bare name
+/// when the owner is not generic. Substituting the applied form keeps
+/// fluent chains typed instead of letting the bare generic reference
+/// fall into the `JSValue` arity filler.
+fn decl_this_owner_type(
+  owner_name : String,
+  type_params : Array[String],
+) -> @ast.TsType {
+  if type_params.length() == 0 {
+    @ast.TsType::Named(owner_name)
+  } else {
+    let args : Array[@ast.TsType] = []
+    for param in type_params {
+      args.push(@ast.TsType::Named(param))
+    }
+    @ast.TsType::Applied(owner_name, args)
   }
 }
 
 ///|
 fn decl_replace_this_type(
   type_ : @ast.TsType,
-  class_name : String,
+  owner : @ast.TsType,
 ) -> @ast.TsType {
   match type_ {
-    @ast.TsType::Named(n) if n == "this" || n == "This" =>
-      @ast.TsType::Named(class_name)
+    @ast.TsType::Named(n) if n == "this" || n == "This" => owner
     @ast.TsType::Array(inner) =>
-      @ast.TsType::Array(decl_replace_this_type(inner, class_name))
+      @ast.TsType::Array(decl_replace_this_type(inner, owner))
     @ast.TsType::Tuple(items) => {
       let next : Array[@ast.TsType] = []
       for item in items {
-        next.push(decl_replace_this_type(item, class_name))
+        next.push(decl_replace_this_type(item, owner))
       }
       @ast.TsType::Tuple(next)
     }
     @ast.TsType::Union(items) => {
       let next : Array[@ast.TsType] = []
       for item in items {
-        next.push(decl_replace_this_type(item, class_name))
+        next.push(decl_replace_this_type(item, owner))
       }
       @ast.TsType::Union(next)
     }
     @ast.TsType::Applied(name, args) => {
       let next_args : Array[@ast.TsType] = []
       for arg in args {
-        next_args.push(decl_replace_this_type(arg, class_name))
+        next_args.push(decl_replace_this_type(arg, owner))
       }
       @ast.TsType::Applied(name, next_args)
+    }
+    @ast.TsType::Func(params, return_type) => {
+      let next_params : Array[@ast.TsType] = []
+      for param in params {
+        next_params.push(decl_replace_this_type(param, owner))
+      }
+      @ast.TsType::Func(next_params, decl_replace_this_type(return_type, owner))
     }
     _ => type_
   }
@@ -8633,6 +8683,7 @@ fn clone_class_property_in_scope(
 fn clone_class_method_in_scope(
   class_method : @ast.TsClassMethodDecl,
   class_name : String,
+  this_owner : @ast.TsType,
   info : DeclModuleInfo,
   local_name_prefix : String,
   modules : Map[String, DeclModuleInfo],
@@ -8641,13 +8692,16 @@ fn clone_class_method_in_scope(
   let params : Array[(String, @ast.TsType)] = []
   for param_index, param in class_method.params {
     let (param_name, param_type) = param
-    let lowered_param_type = lower_react_utility_type(
-      info,
-      rewrite_type_refs_in_scope(
-        info, local_name_prefix, param_type, canonical_types,
+    let lowered_param_type = decl_replace_this_type(
+      lower_react_utility_type(
+        info,
+        rewrite_type_refs_in_scope(
+          info, local_name_prefix, param_type, canonical_types,
+        ),
+        modules,
+        canonical_types,
       ),
-      modules,
-      canonical_types,
+      this_owner,
     )
     params.push(
       (
@@ -8675,16 +8729,19 @@ fn clone_class_method_in_scope(
     return_type: decl_specialize_generated_class_method_return_type(
       class_name,
       class_method.name,
-      lower_react_utility_type(
-        info,
-        rewrite_type_refs_in_scope(
+      decl_replace_this_type(
+        lower_react_utility_type(
           info,
-          local_name_prefix,
-          class_method.return_type,
+          rewrite_type_refs_in_scope(
+            info,
+            local_name_prefix,
+            class_method.return_type,
+            canonical_types,
+          ),
+          modules,
           canonical_types,
         ),
-        modules,
-        canonical_types,
+        this_owner,
       ),
     ),
     is_static: class_method.is_static,
@@ -8701,6 +8758,7 @@ fn clone_class_method_in_scope(
 ///|
 fn callable_method_from_func_type(
   class_name : String,
+  this_owner : @ast.TsType,
   method_name : String,
   is_static : Bool,
   params : Array[@ast.TsType],
@@ -8713,13 +8771,16 @@ fn callable_method_from_func_type(
   let method_params : Array[(String, @ast.TsType)] = []
   for i, param_type in params {
     let param_name = "arg" + i.to_string()
-    let lowered_param_type = lower_react_utility_type(
-      info,
-      rewrite_type_refs_in_scope(
-        info, local_name_prefix, param_type, canonical_types,
+    let lowered_param_type = decl_replace_this_type(
+      lower_react_utility_type(
+        info,
+        rewrite_type_refs_in_scope(
+          info, local_name_prefix, param_type, canonical_types,
+        ),
+        modules,
+        canonical_types,
       ),
-      modules,
-      canonical_types,
+      this_owner,
     )
     method_params.push(
       (
@@ -8730,13 +8791,16 @@ fn callable_method_from_func_type(
       ),
     )
   }
-  let lowered_return_type = lower_react_utility_type(
-    info,
-    rewrite_type_refs_in_scope(
-      info, local_name_prefix, return_type, canonical_types,
+  let lowered_return_type = decl_replace_this_type(
+    lower_react_utility_type(
+      info,
+      rewrite_type_refs_in_scope(
+        info, local_name_prefix, return_type, canonical_types,
+      ),
+      modules,
+      canonical_types,
     ),
-    modules,
-    canonical_types,
+    this_owner,
   )
   {
     name: method_name,
@@ -8781,6 +8845,7 @@ fn preferred_callable_interface_field(iface : @ast.TsInterface) -> @ast.TsType? 
 ///|
 fn callable_method_from_property(
   class_name : String,
+  this_owner : @ast.TsType,
   class_property : @ast.TsClassPropertyDecl,
   info : DeclModuleInfo,
   local_name_prefix : String,
@@ -8792,6 +8857,7 @@ fn callable_method_from_property(
       Some(
         callable_method_from_func_type(
           class_name,
+          this_owner,
           class_property.name,
           class_property.is_static,
           params,
@@ -8811,6 +8877,7 @@ fn callable_method_from_property(
               Some(
                 callable_method_from_func_type(
                   class_name,
+                  this_owner,
                   class_property.name,
                   class_property.is_static,
                   params,
@@ -8870,6 +8937,7 @@ fn append_class_method_once(
 ///|
 fn append_class_origin_members(
   origin : ResolvedClassOrigin,
+  this_owner : @ast.TsType,
   graph : ModuleGraph,
   modules : Map[String, DeclModuleInfo],
   surface_cache : Map[String, Array[ResolvedExport]],
@@ -8896,8 +8964,8 @@ fn append_class_origin_members(
       ) {
       Some(base_origin) =>
         append_class_origin_members(
-          base_origin, graph, modules, surface_cache, canonical_types, properties,
-          methods, seen_property_keys, seen_method_keys, seen_origins,
+          base_origin, this_owner, graph, modules, surface_cache, canonical_types,
+          properties, methods, seen_property_keys, seen_method_keys, seen_origins,
         )
       None => ()
     }
@@ -8915,6 +8983,7 @@ fn append_class_origin_members(
     match
       callable_method_from_property(
         origin.class_.name,
+        this_owner,
         class_property,
         origin.info,
         origin.local_name_prefix,
@@ -8933,6 +9002,7 @@ fn append_class_origin_members(
       clone_class_method_in_scope(
         class_method,
         origin.class_.name,
+        this_owner,
         origin.info,
         origin.local_name_prefix,
         modules,
@@ -8962,6 +9032,7 @@ fn clone_exported_class(
       local_name_prefix: exported.local_name_prefix,
       class_: exported.class_,
     },
+    decl_this_owner_type(exported.export_name, exported.class_.type_params),
     graph,
     modules,
     surface_cache,

--- a/src/bridge/moonbit_js_ffi_wbtest.mbt
+++ b/src/bridge/moonbit_js_ffi_wbtest.mbt
@@ -5284,3 +5284,46 @@ test "ffi_classify_transparent_intersection: collapses uniform Number primitive"
     None => fail("expected Some(Number), got None")
   }
 }
+
+///|
+async test "bridge: polymorphic this lowers to the owner with its own type params" {
+  let bundle = emit_moonbit_js_ffi_bundle_from_entry_path(
+    "fixtures/resolver/project/types/generic-this-chain-entry.d.ts", "/runtime/mod.js",
+  ) catch {
+    e => {
+      match e {
+        ReadError(msg) | ParseError(msg) | ResolveError(msg) =>
+          fail("Emit error: \{msg}")
+      }
+      return
+    }
+  }
+  // Interface members: `this` keeps the fluent chain typed on Box[A, B]
+  // instead of falling into the JSValue arity filler.
+  assert_true(bundle.ffi_mbt.contains("check : (Array[String]) -> Box[A, B]"))
+  assert_true(bundle.ffi_mbt.contains("optional : () -> Wrap[Box[A, B]]"))
+  assert_true(bundle.ffi_mbt.contains("pair : (B) -> Box[A, B]"))
+  assert_true(
+    bundle.ffi_mbt.contains(
+      "pub fn[A, B] Box::check(self : Box[A, B], arg0 : Array[String]) -> Box[A, B]",
+    ),
+  )
+  // Class methods: `this` in returns and params maps to Chain[A, B].
+  assert_true(
+    bundle.ffi_mbt.contains(
+      "pub fn[A, B] Chain::push(self : Chain[A, B], item : A) -> Chain[A, B]",
+    ),
+  )
+  assert_true(
+    bundle.ffi_mbt.contains(
+      "pub fn[A, B] Chain::wrap(self : Chain[A, B]) -> Wrap[Chain[A, B]]",
+    ),
+  )
+  assert_true(
+    bundle.ffi_mbt.contains(
+      "pub fn[A, B] Chain::merge(self : Chain[A, B], other : Chain[A, B]) -> Chain[A, B]",
+    ),
+  )
+  assert_false(bundle.ffi_mbt.contains("Box[JSValue, JSValue]"))
+  assert_false(bundle.ffi_mbt.contains("Chain[JSValue, JSValue]"))
+}

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -15574,6 +15574,247 @@ fn check_explicit_type_args(
 }
 
 ///|
+/// TS7057 (noImplicitAny): in a generator lacking a return-type
+/// annotation, a `yield` whose RESULT is consumed with no contextual type
+/// implicitly gets `any`. Three syntactically decidable consumption
+/// shapes (generatorImplicitAny, generatorTypeCheck50,
+/// generatorReturnTypeInference g204):
+/// - `const x = yield ...` — Ident binding with no type annotation
+/// - `f(yield ...)` — `f` is a generic function whose matching parameter
+///   is a bare type parameter, with no explicit type arguments
+/// - `yield yield` — the inner yield feeds the outer yield's operand
+/// Everything else abstains: unused results (expression statements, comma
+/// operands, `void`, for-clauses), annotated bindings, destructuring
+/// targets (contextually typed by the pattern), and `f<T>(yield)` with
+/// explicit type arguments.
+fn check_generator_yield_implicit_any(
+  func : @ast.TsFunc,
+  ctx : CheckCtx,
+) -> Unit {
+  if !func.is_generator || !(func.return_type is Any) {
+    return
+  }
+  if !ctx.resolver.no_implicit_any {
+    return
+  }
+  for stmt in func.body.stmts {
+    generator_yield_any_walk_stmt(stmt, ctx)
+  }
+}
+
+///|
+const GENERATOR_YIELD_ANY_MSG : String = "`yield` expression implicitly results in an `any` type because its containing generator lacks a return-type annotation"
+
+///|
+fn generator_yield_any_walk_block(block : @ast.TsBlock, ctx : CheckCtx) -> Unit {
+  for stmt in block.stmts {
+    generator_yield_any_walk_stmt(stmt, ctx)
+  }
+}
+
+///|
+fn generator_yield_any_walk_stmt(stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
+  match stmt {
+    Var(binding, declared, init)
+    | Let(binding, declared, init)
+    | Const(binding, declared, init) =>
+      // `const x = yield ...` with an Ident binding and no annotation:
+      // nothing supplies a contextual type, so the yield result is any.
+      // Destructuring patterns abstain — the pattern (with defaults)
+      // contextually types the yield (generatorReturnTypeInference g310).
+      if binding is Ident(_) && declared is Any && init is Yield(_) {
+        record(ctx, "yield", GENERATOR_YIELD_ANY_MSG)
+      } else {
+        generator_yield_any_walk_expr(init, ctx)
+      }
+    Assign(_, e) | CompoundAssign(_, _, e) | Throw(e) | Expr(e) =>
+      generator_yield_any_walk_expr(e, ctx)
+    IndexAssign(a, i, v) => {
+      generator_yield_any_walk_expr(a, ctx)
+      generator_yield_any_walk_expr(i, ctx)
+      generator_yield_any_walk_expr(v, ctx)
+    }
+    PropAssign(o, _, v) => {
+      generator_yield_any_walk_expr(o, ctx)
+      generator_yield_any_walk_expr(v, ctx)
+    }
+    Return(Some(e)) => generator_yield_any_walk_expr(e, ctx)
+    Return(None) | Empty | Debugger => ()
+    Try(b, _, catch_block, finally_block) => {
+      generator_yield_any_walk_block(b, ctx)
+      match catch_block {
+        Some(cb) => generator_yield_any_walk_block(cb, ctx)
+        None => ()
+      }
+      match finally_block {
+        Some(fb) => generator_yield_any_walk_block(fb, ctx)
+        None => ()
+      }
+    }
+    If(cond, then_block, else_block) => {
+      generator_yield_any_walk_expr(cond, ctx)
+      generator_yield_any_walk_block(then_block, ctx)
+      match else_block {
+        Some(eb) => generator_yield_any_walk_block(eb, ctx)
+        None => ()
+      }
+    }
+    While(cond, body) | DoWhile(cond, body) => {
+      generator_yield_any_walk_expr(cond, ctx)
+      generator_yield_any_walk_block(body, ctx)
+    }
+    For(init, cond, update, body) => {
+      match init {
+        Some(s) => generator_yield_any_walk_stmt(s, ctx)
+        None => ()
+      }
+      match cond {
+        Some(e) => generator_yield_any_walk_expr(e, ctx)
+        None => ()
+      }
+      match update {
+        Some(s) => generator_yield_any_walk_stmt(s, ctx)
+        None => ()
+      }
+      generator_yield_any_walk_block(body, ctx)
+    }
+    ForOf(_, _, _, iter, body)
+    | ForAwaitOf(_, _, _, iter, body)
+    | ForIn(_, _, _, iter, body) => {
+      generator_yield_any_walk_expr(iter, ctx)
+      generator_yield_any_walk_block(body, ctx)
+    }
+    Switch(scrut, cases) => {
+      generator_yield_any_walk_expr(scrut, ctx)
+      for case in cases {
+        generator_yield_any_walk_block(case.body, ctx)
+      }
+    }
+    Label(_, inner) => generator_yield_any_walk_stmt(inner, ctx)
+    _ => ()
+  }
+}
+
+///|
+fn generator_yield_any_walk_expr(expr : @ast.TsExpr, ctx : CheckCtx) -> Unit {
+  match expr {
+    Yield(Some(operand)) => {
+      // `yield yield` — the inner yield's result feeds the outer operand
+      // with no contextual type (generatorTypeCheck50).
+      if operand is Yield(_) {
+        record(ctx, "yield", GENERATOR_YIELD_ANY_MSG)
+      }
+      generator_yield_any_walk_expr(operand, ctx)
+    }
+    Yield(None) => ()
+    YieldStar(operand) | Await(operand) =>
+      generator_yield_any_walk_expr(operand, ctx)
+    Call(name, args) => {
+      // `f(yield)` where `f`'s matching parameter is a bare type
+      // parameter: nothing constrains the yield, T infers as any
+      // (generatorImplicitAny g5, generatorReturnTypeInference g204).
+      // Function declarations register as `Func` in globals with their
+      // type-parameter list tracked separately in `func_type_params`.
+      match
+        (
+          ctx.resolver.globals.get(name),
+          ctx.resolver.func_type_params.get(name),
+        ) {
+        (Some(Func(params, _)), Some(tps)) if tps.length() > 0 =>
+          for i, a in args {
+            if a is Yield(_) && i < params.length() {
+              match params[i] {
+                Named(p) =>
+                  if tps.contains(p) {
+                    record(ctx, "yield", GENERATOR_YIELD_ANY_MSG)
+                    break
+                  }
+                _ => ()
+              }
+            }
+          }
+        _ => ()
+      }
+      for a in args {
+        generator_yield_any_walk_expr(a, ctx)
+      }
+    }
+    // Explicit type arguments contextually type the yield
+    // (`f<string>(yield)`, generatorImplicitAny g6): skip the generic-call
+    // pattern on the wrapped call, but keep scanning its arguments for
+    // nested shapes.
+    TypeArgs(_, Call(_, args)) =>
+      for a in args {
+        generator_yield_any_walk_expr(a, ctx)
+      }
+    TypeArgs(_, inner) | PureCall(inner) | Spread(inner) | UnaryOp(_, inner) =>
+      generator_yield_any_walk_expr(inner, ctx)
+    CallExpr(callee, args) => {
+      generator_yield_any_walk_expr(callee, ctx)
+      for a in args {
+        generator_yield_any_walk_expr(a, ctx)
+      }
+    }
+    MethodCall(recv, _, args) => {
+      generator_yield_any_walk_expr(recv, ctx)
+      for a in args {
+        generator_yield_any_walk_expr(a, ctx)
+      }
+    }
+    New(_, args) =>
+      for a in args {
+        generator_yield_any_walk_expr(a, ctx)
+      }
+    NewExpr(callee, args) => {
+      generator_yield_any_walk_expr(callee, ctx)
+      for a in args {
+        generator_yield_any_walk_expr(a, ctx)
+      }
+    }
+    BinOp(_, l, r) | Seq(l, r) | CompoundAssignExpr(l, _, r) => {
+      generator_yield_any_walk_expr(l, ctx)
+      generator_yield_any_walk_expr(r, ctx)
+    }
+    Cond(c, t, f) => {
+      generator_yield_any_walk_expr(c, ctx)
+      generator_yield_any_walk_expr(t, ctx)
+      generator_yield_any_walk_expr(f, ctx)
+    }
+    ArrayLit(items) =>
+      for item in items {
+        generator_yield_any_walk_expr(item, ctx)
+      }
+    ObjectLit(fields) =>
+      for field in fields {
+        let (_, v) = field
+        generator_yield_any_walk_expr(v, ctx)
+      }
+    ComputedProp(k, v) => {
+      generator_yield_any_walk_expr(k, ctx)
+      generator_yield_any_walk_expr(v, ctx)
+    }
+    IndexAccess(a, i) => {
+      generator_yield_any_walk_expr(a, ctx)
+      generator_yield_any_walk_expr(i, ctx)
+    }
+    PropAccess(o, _) => generator_yield_any_walk_expr(o, ctx)
+    AssignExpr(_, v) => generator_yield_any_walk_expr(v, ctx)
+    PropAssignExpr(o, _, v) => {
+      generator_yield_any_walk_expr(o, ctx)
+      generator_yield_any_walk_expr(v, ctx)
+    }
+    IndexAssignExpr(a, i, v) => {
+      generator_yield_any_walk_expr(a, ctx)
+      generator_yield_any_walk_expr(i, ctx)
+      generator_yield_any_walk_expr(v, ctx)
+    }
+    // Nested function scopes own their yields; do not descend.
+    ArrowFunc(_, _, _, _) | FuncExpr(_) | NativeClassExpr(_, _) => ()
+    _ => ()
+  }
+}
+
+///|
 fn check_call_args_in_expr(
   env : ExprEnv,
   expr : @ast.TsExpr,
@@ -15610,6 +15851,61 @@ fn check_call_args_in_expr(
             ctx, "call `BigInt`", "argument is not assignable to parameter of type `string | number | bigint | boolean`",
           )
         }
+      }
+      // TS2554 for the generic-rest-tuple pattern
+      // `call<TS extends unknown[]>(handler: (...args: TS) => R, ...args: TS)`
+      // (genericRestArity, genericRestArityStrict): TS infers to the
+      // handler's parameter tuple, so the call needs exactly
+      // 1 + <handler param count> arguments. The parser substitutes the
+      // tuple param with its declared array bound, so the recognizable
+      // shape is: a single-type-param declaration whose two params are
+      // `(...args: unknown[]/any[]) => R` and a rest of the same array
+      // bound. Restricted to a syntactic arrow / function-expression
+      // handler whose params are all required.
+      match
+        (
+          ctx.resolver.signatures.get(name),
+          ctx.resolver.func_type_params.get(name),
+        ) {
+        (Some(sig_params), Some(tps)) if tps.length() == 1 &&
+          sig_params.length() == 2 &&
+          args.length() >= 1 => {
+          let tuple_bound_shape = match
+            (sig_params[0].type_, sig_params[1].is_rest, sig_params[1].type_) {
+            (Func([Rest(Array(Unknown))], _), true, Array(Unknown)) => true
+            (Func([Rest(Array(Any))], _), true, Array(Any)) => true
+            _ => false
+          }
+          let handler_params = match args[0] {
+            ArrowFunc(ps, _, _, _) => Some(ps)
+            FuncExpr(f) => Some(f.params)
+            _ => None
+          }
+          match handler_params {
+            Some(ps) if tuple_bound_shape => {
+              let mut all_required = true
+              for p in ps {
+                if p.is_rest ||
+                  p.default is Some(_) ||
+                  classify_optional_like_union(p.type_) is Some((_, true)) {
+                  all_required = false
+                }
+              }
+              if all_required {
+                let expected = 1 + ps.length()
+                if args.length() != expected {
+                  record(
+                    ctx,
+                    "call `\{name}`",
+                    "expected \{expected} arguments, but got \{args.length()}",
+                  )
+                }
+              }
+            }
+            _ => ()
+          }
+        }
+        _ => ()
       }
       // TS2454: invoking an as-yet-unassigned variable (`var f: T; f()`)
       // reads it before assignment, same as a bare reference.
@@ -18229,6 +18525,7 @@ fn check_function_body_with(
   if func.body.stmts.length() == 0 {
     return issues
   }
+  check_generator_yield_implicit_any(func, ctx)
   for stmt in func.body.stmts {
     check_stmt(env, stmt, ctx)
   }

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -14599,3 +14599,79 @@ test "expr_check: buffer nominality, Array targs, primitive spreads, computed in
     0,
   )
 }
+
+///|
+test "expr_check: TS7057 generator yield implicit any + generic rest tuple arity (batch BQ)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  // TS7057: unannotated binding consumes the yield result
+  // (generatorImplicitAny g2).
+  assert_true(issues("function* g() {\n    const value = yield;\n}") > 0)
+  // Annotated bindings are contextually typed (g3).
+  @test.assert_eq(
+    issues("function* g() {\n    const value: string = yield;\n}"),
+    0,
+  )
+  // An annotated generator return type supplies TNext; no implicit any.
+  @test.assert_eq(
+    issues(
+      "function* g(): Generator<number, void, string> {\n    const value = yield 1;\n}",
+    ),
+    0,
+  )
+  // noImplicitAny off: no report.
+  @test.assert_eq(
+    issues("// @strict: false\nfunction* g() {\n    const value = yield;\n}"),
+    0,
+  )
+  // Unused results stay legal (g4).
+  @test.assert_eq(
+    issues(
+      "declare function noop(): void;\nfunction* g4() {\n    yield;\n    yield, noop();\n    (yield);\n    void (yield);\n    for(yield; false; yield);\n}",
+    ),
+    0,
+  )
+  // Destructuring targets are contextually typed by the pattern (g310).
+  @test.assert_eq(
+    issues("function* g() {\n    const [a = 1, b = 2] = yield;\n}"),
+    0,
+  )
+  // `yield yield` feeds the outer operand (generatorTypeCheck50).
+  assert_true(issues("function* g() {\n    yield yield;\n}") > 0)
+  // Generic call argument with no explicit type args (g5); explicit type
+  // arguments contextually type it (g6).
+  assert_true(
+    issues(
+      "declare function f<T>(value: T): void;\nfunction* g5() {\n    f(yield);\n}",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    issues(
+      "declare function f<T>(value: T): void;\nfunction* g6() {\n    f<string>(yield);\n}",
+    ),
+    0,
+  )
+  // TS2554: generic rest tuple arity — TS infers to the handler's param
+  // tuple (genericRestArity).
+  let rest_decl = "declare function call<TS extends unknown[]>(\n    handler: (...args: TS) => void,\n    ...args: TS): void;\n"
+  assert_true(issues(rest_decl + "call((x: number, y: number) => x + y);") > 0)
+  assert_true(
+    issues(
+      rest_decl + "call((x: number, y: number) => x + y, 1, 2, 3, 4, 5, 6, 7);",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    issues(rest_decl + "call((x: number, y: number) => x + y, 1, 2);"),
+    0,
+  )
+  // A non-generic unknown[]-rest signature accepts any arity.
+  @test.assert_eq(
+    issues(
+      "declare function call2(\n    handler: (...args: unknown[]) => void,\n    ...args: unknown[]): void;\ncall2((x: number, y: number) => x + y);",
+    ),
+    0,
+  )
+}

--- a/src/parser/lexer.mbt
+++ b/src/parser/lexer.mbt
@@ -2218,6 +2218,12 @@ fn token_can_end_expr(kind : TokenKind) -> Bool {
     | Null
     | RParen
     | RBracket
+    // `}` stays here even though a closing brace often ends a BLOCK
+    // (after which `/` starts a regex): JSX self-closing tags
+    // (`attr={x} />`) and object-literal division depend on the
+    // division reading. The statement-position regex case is recovered
+    // by the parser re-lexing from source (`Parser::parse_stmt`'s
+    // `Slash` arm — parser768531).
     | RBrace
     | PlusPlus
     | MinusMinus => true

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -2966,7 +2966,20 @@ fn Parser::parse_export_stmt(
       return
     }
     if self.check(Function) {
-      let func = self.parse_function_expr()
+      // A NAMED default function may be a bodiless overload signature
+      // (`export default function f();` — defaultExportWithOverloads01):
+      // route through the declaration parser, which tolerates missing
+      // bodies. Anonymous defaults keep the expression parser.
+      let is_named = match self.peek_at(1).kind {
+        Ident(_) => true
+        Star => self.peek_at(2).kind is Ident(_)
+        _ => false
+      }
+      let func = if is_named {
+        self.parse_function()
+      } else {
+        self.parse_function_expr()
+      }
       self.grammar_misuses.push("<export-default>fn:" + func.name)
       if func.name != "<anon>" {
         funcs.push(func)
@@ -3002,6 +3015,13 @@ fn Parser::parse_export_stmt(
     self.grammar_misuses.push("<export-default>expr:")
     self.consume_semicolon()
     return
+  }
+  // Decorators may sit between `export` and `class`
+  // (`export @dec class C {}` — decoratorOnClass3). Collect them into
+  // `pending_decorators`; the class parsers drain that list at their
+  // entry, exactly as for the `@dec export class` order.
+  while self.check(At) {
+    self.skip_decorator()
   }
   if self.check(Function) {
     let func = self.parse_function()

--- a/src/parser/parser_stmt.mbt
+++ b/src/parser/parser_stmt.mbt
@@ -43,6 +43,44 @@ fn Parser::is_namespace_decl_start(self : Parser) -> Bool {
 pub fn Parser::parse_stmt(self : Parser) -> @ast.TsStmt raise ParseError {
   let tok = self.peek()
   match tok.kind {
+    Slash => {
+      // A `/` in statement position starts a regex literal; the prelexer
+      // classified it as division because the previous token was a
+      // block's closing `}` (`{a: 3}` then `/x/` — parser768531). Re-lex
+      // the span from the source text with a fresh regex-allowing lexer,
+      // overwrite the last covered token slot with the regex token, and
+      // reparse so postfix expressions (`/x/.test(s)`) still work.
+      let start = tok.pos
+      let rest = self.src[start:self.src.length()].to_owned()
+      let relexer = Lexer::new(rest)
+      let relexed = relexer.next_token()
+      match relexed.kind {
+        Regex(_, flags) => {
+          // TS1499: only `d g i m s u v y` are regular-expression flags
+          // (`if (1) /regexp/a.foo()` —
+          // parserRegularExpressionDivideAmbiguity3).
+          for c in flags {
+            if !"dgimsuvy".contains_char(c) {
+              self.grammar_misuses.push("unknown regular expression flag")
+              break
+            }
+          }
+          let end_pos = start + relexer.pos
+          let mut k = self.pos
+          while k + 1 < self.tokens.length() && self.tokens[k + 1].pos < end_pos {
+            k += 1
+          }
+          self.tokens[k] = {
+            kind: relexed.kind,
+            pos: start,
+            has_newline_before: tok.has_newline_before,
+          }
+          self.pos = k
+          self.parse_stmt()
+        }
+        _ => raise ParseError("Unexpected token: Slash")
+      }
+    }
     At => {
       self.skip_decorator()
       // TS1206: at statement level a decorator can only precede a class

--- a/src/parser/parser_wbtest.mbt
+++ b/src/parser/parser_wbtest.mbt
@@ -7136,3 +7136,43 @@ test "parser: type alias in module block is collected" {
     msg="expected Callback",
   )
 }
+
+///|
+test "parser: legal shapes formerly in the PFLEGAL budget (batch BR)" {
+  // decoratorOnClass3: decorators between `export` and `class`.
+  let m1 = Parser::from_source(
+    (
+      #|declare function dec<T>(target: T): T;
+      #|
+      #|export
+      #|@dec
+      #|class C {
+      #|}
+    ),
+  ).parse_module()
+  @test.assert_eq(m1.classes.length(), 1)
+  assert_true(m1.classes[0].decorators.length() > 0)
+  // defaultExportWithOverloads01: bodiless overload signatures on a
+  // named default export function.
+  let m2 = Parser::from_source(
+    (
+      #|export default function f();
+      #|export default function f(x: string);
+      #|export default function f(...args: any[]) {
+      #|}
+    ),
+  ).parse_module()
+  @test.assert_eq(m2.funcs.length(), 3)
+  // parser768531: a `/x/` regex in statement position directly after a
+  // block's closing brace lexes as a regex, not division.
+  let m3 = Parser::from_source(
+    (
+      #|{a: 3}
+      #|/x/
+    ),
+  ).parse_module()
+  assert_true(m3.top_level_stmts.length() > 0)
+  // Division after a can-end-expression token still lexes as division.
+  let p4 = Parser::from_source("var y = (x) / 2;")
+  let _ = p4.parse_module()
+}


### PR DESCRIPTION
Four workstreams, in the priority order of the practical unsupported-surface review (①→④):

## ① TS→MoonBit: polymorphic `this` keeps fluent chains typed (`1961f38`)

zod-style fluent members (`check(): this`, `optional(): ZodOptional<this>`) were lowered by replacing `this` with the bare owner name, which the FFI arity filler then padded to `Owner[JSValue, ...]`. `this` now substitutes to the owner applied to its own type parameters (`Schema[Output, Input, Internals]`), root-scoped through extends expansion, and recurses through function params/returns (fixes the raw `This` opaque-type leak in callback params).

- zod: SCAFFOLD_DIAGNOSTICS JSValue fallback entries **748 → 648**; the whole fluent core stays typed end to end.
- New fixture + regression test (`generic-this-chain-entry.d.ts`).

## ② MoonBit→TS: unconstrained generic free functions export (`9a55c93`)

JS autolink cannot export generic functions, so every `pub fn[T] ...` was omitted. Unconstrained generics now export through a monomorphized glue wrapper: each type parameter instantiates at an opaque `#external pub type TsMbtGenericAny` (values cross the JS boundary unchanged — exactly parametric behavior), while the emitted `.d.ts` keeps the generic signature (`export function identity<T>(value: T): T`). Bare `T?` returns unwrap to `value | undefined`.

- Eligibility is centralized (`mbti_generic_glue_return_plan`) and shared by the glue emitter, runtime-inaccessible screening, and AUTOLINK_DIAGNOSTICS. Trait bounds, tuples, non-top-level Option, and optional params stay omitted with diagnostics.
- Verified with a node runtime smoke (identity/first round-trips incl. `undefined`) and a `tsc --strict` consumer typecheck.

## bridge-quality gate: budget pre-existing heterogeneous-union widenings (`cc6e961`)

`just bridge-quality` had been failing on five pre-existing "heterogeneous union member is not runtime-discriminable" diagnostics (hono `Child = string | number | JSX.Element`, react `ElementType`, vitest `CancelReason`/`TestArtifact`, drizzle `NeonAuthToken`) — verified present at the current main merge commit. They get an explicit budgeted class (5) per the documented fallback policy; drive-back-to-0 is recorded in TODO.md.

## ③ checker batch BQ: TP 2329 → 2335 (`557e8a9`)

- **TS7057**: in a generator lacking a return-type annotation (noImplicitAny), a `yield` whose result is consumed with no contextual type — `const x = yield`, `f(yield)` with a bare-type-param generic callee, `yield yield`. Annotated bindings, unused results, destructuring targets, and explicit type args abstain. Lands generatorImplicitAny, generatorTypeCheck50, generatorReturnTypeInference (+NonStrict).
- **TS2554** generic-rest-tuple arity (deferred since BP): `call<TS extends unknown[]>(handler: (...args: TS) => void, ...args: TS)` needs exactly 1 + handler-param-count args. Lands genericRestArity/Strict.

## ④ parser batch BR: legal-parse-failure budget emptied, PFLEGAL 3 → 0 (`16ebb40`)

- `export @dec class C {}` — decorators between `export` and `class`.
- `export default function f();` — named default overload signatures route through the declaration parser.
- `{a: 3}` then `/x/` — a statement-position `/` re-lexes from source as a regex (JSX self-closing tags and division stay untouched); invalid regex flags surface as TS1499-equivalent, keeping parserRegularExpressionDivideAmbiguity3's TP.
- The soundness gate now enforces `--max-legal-parsefail 0`.

## Validation

- Conformance sweep: **TP 2335 / FP 0 / PFLEGAL 0 / TN 1750 / MISS 399** (from TP 2329 / PFLEGAL 3), no lost TPs.
- Unit tests: **2,498 passing**.
- verify-scaffolds / verify-generated-fixtures / verify-mbti-dts / verify-examples / bridge-quality all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr)_