### PR TITLE
bridge: heterogeneous-union budget to 0, generic method facades, string|*Params subset

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,19 +348,22 @@ Supported surface:
   trait impl relationships.
 - Opt-in facade wrappers for local non-generic methods and constructors via
   `mbt2ts facade-scaffold`, including async constructors and methods.
-- Unconstrained generic free functions (`pub fn[T] identity(T) -> T`) export
-  through a monomorphized glue wrapper: each type parameter is instantiated
-  at an opaque `TsMbtGenericAny` boundary type (values cross the JS boundary
-  unchanged) while the emitted `.d.ts` keeps the full generic signature.
+- Unconstrained generic free functions (`pub fn[T] identity(T) -> T`) and
+  unconstrained generic METHODS on non-generic owners
+  (`pub fn[T] Counter::tap(Self, T) -> T`, via `mbt2ts facade-scaffold`)
+  export through a monomorphized glue wrapper: each type parameter is
+  instantiated at an opaque `TsMbtGenericAny` boundary type (values cross
+  the JS boundary unchanged) while the emitted `.d.ts` keeps the full
+  generic signature (`counter_tap<T>(self: Counter, arg1: T): T`).
   Bare `T?` returns unwrap to `value | undefined` at the boundary.
 
 Unsupported or limited surface:
 
-- Generic methods, generic constructors, trait methods, and generic
-  functions with trait bounds are not exported by JS autolink. Generic free
-  functions whose type parameters appear inside tuples or non-top-level
-  `Option` payloads also stay omitted (their runtime representation would
-  not match the declared TypeScript signature).
+- Generic constructors, trait methods, methods on GENERIC owners, and
+  generic functions with trait bounds are not exported by JS autolink.
+  Generic functions whose type parameters appear inside tuples or
+  non-top-level `Option` payloads also stay omitted (their runtime
+  representation would not match the declared TypeScript signature).
 - Public members omitted from the runtime export surface are listed in
   `AUTOLINK_DIAGNOSTICS.md`.
 - External MoonBit imports are left as bare TypeScript imports unless an

--- a/TODO.md
+++ b/TODO.md
@@ -889,16 +889,20 @@ valibot.
     all 24 corpus entries; per-package `JSValue` cause budgets, function
     counts, and unsupported-export budgets now reflect the actual
     generated output, including the new heterogeneous-union diagnostics.
-- [ ] Drive the `heterogeneous-union-widened` budget in
-  `scripts/bridge_quality_report.sh` back to 0 (currently 5, added
-  2026-07-15: hono `Child = string | number | JSX.Element`, react
-  `ElementType`, vitest `CancelReason` / `TestArtifact`, drizzle
-  `NeonAuthToken`). All five widen because a member has no
-  runtime-discriminable constructor name — qualified names like
-  `JSX.Element` don't resolve to a PascalCase constructor. The aliases
-  stay runtime-safe (widened to JSValue with diagnostics); the fix is
-  either resolving qualified member names to their canonical local
-  declarations before discriminability, or discriminating structurally.
+- [x] Drive the `heterogeneous-union-widened` budget back to 0 (done
+  2026-07-15, same day it was added). Four lowerings landed:
+  - qualified namespace refs resolve to their flattened export name
+    before classification (`JSX.Element` -> `JsxElement`, hono `Child`);
+  - function members discriminate via `typeof === "function"` and render
+    as arrow payloads (`FnValue(() -> String)` — drizzle `NeonAuthToken`,
+    react `ElementType`); inline `Auto_*` synthesis still excludes
+    function members (the useState wrapper glue can't produce the enum);
+  - branded-string intersections collapse to `string` and the
+    LiteralUnion pattern collapses to a plain String alias
+    (vitest `CancelReason = "a" | "b" | (string & Record<string, never>)`);
+  - indexed access over an EMPTY registry interface reduces to `never`
+    and drops from the union (vitest
+    `TestArtifact = A | B | C | Registry[keyof Registry]`).
 
 ### 2. Method-level generics preserved through bridge
 

--- a/TODO.md
+++ b/TODO.md
@@ -1074,6 +1074,28 @@ Previously every `pub fn[T] ...` free function was omitted from
 - Next increments: generic methods on non-generic owners (same
   monomorphization through the facade path), then generic owners.
 
+### 10. String-subset boundary for optional-message unions (done 2026-07-15)
+
+Pattern: zod's check surface passes `params?: string | $ZodCheckMinLengthParams`
+on nearly every validator (`min`, `max`, `length`, `regex`, ...). The
+`$`-prefixed name cannot become a tagged-union constructor (names must start
+`A-Z`), so the whole param degraded to `JSValue?`.
+
+- [x] `ffi_string_subset_union_text`: a two-member union pairing `string`
+  with a named `*Params` bag that is NOT a declared type on the bridge
+  surface now types the boundary as `String`. The common string form is
+  naturally typed; the structured object form stays reachable via
+  `unsafeCast`. Guards: exactly two members, `Params` suffix required,
+  abstains when the named type is declared / a generic param / a local type
+  param — so option-bag unions with reachable declarations keep their
+  tagged lowering and `string | URL` keeps the JSValue fallback.
+- zod: SCAFFOLD JSValue fallback entries 648 -> 565
+  (`min : (Double, String?) -> ZodMap[Key, Value]` etc.); the regenerated
+  zod3 package passes `moon check --target js`.
+- Note: per-package JSValue counts in the env-gated realworld METRICS
+  corpus may drift downward next time it is regenerated — the budget file
+  encodes upper bounds, so this is safe, but expect diffs there.
+
 ### Non-Goals (still)
 
 - [ ] Do not turn this list into a checklist for "all of TypeScript". Each item

--- a/fixtures/mbti_typescript/generic_method.pkg.generated.mbti
+++ b/fixtures/mbti_typescript/generic_method.pkg.generated.mbti
@@ -1,0 +1,20 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "demo/genmethod"
+
+// Values
+
+// Errors
+
+// Types and methods
+pub(all) struct Counter {
+  mut value : Int
+}
+pub fn[T : Show] Counter::describe(Self, T) -> String
+pub fn Counter::label(Self) -> String
+pub fn Counter::new() -> Self
+pub fn[T] Counter::pick(Self, Array[T]) -> T?
+pub fn[T] Counter::tap(Self, T) -> T
+
+// Type aliases
+
+// Traits

--- a/scripts/bridge_quality_report.sh
+++ b/scripts/bridge_quality_report.sh
@@ -13,12 +13,11 @@ ambiguous_unsupported_export_budget=1
 namespace_omitted_unsupported_export_budget=0
 namespace_widened_unsupported_export_budget=0
 # Heterogeneous unions whose members carry no runtime-discriminable
-# constructor name (e.g. hono `Child = string | number | JSX.Element`,
-# vitest `CancelReason` / `TestArtifact`, react `ElementType`, drizzle
-# `NeonAuthToken`). The alias widens to JSValue and stays runtime-safe;
-# driving this back to 0 is roadmap item "Heterogeneous union ->
-# auto-enum" in TODO.md.
-heterogeneous_union_unsupported_export_budget=5
+# constructor name. Function members, branded-string intersections,
+# empty-registry indexed accesses, and qualified namespace refs now
+# lower (2026-07-15), so the budget is 0: any new occurrence is a real
+# regression.
+heterogeneous_union_unsupported_export_budget=0
 
 rm -rf "$report_root"
 mkdir -p "$log_root"

--- a/scripts/verify_examples.sh
+++ b/scripts/verify_examples.sh
@@ -590,12 +590,18 @@ EOF
   grep_generated_mbt "$out" 'pub extern "js" fn get_assert() -> Chai_Assert'
   grep_generated_mbt "$out" 'pub extern "js" fn get_vi() -> VitestUtils'
   grep_generated_mbt "$out" 'pub extern "js" fn VitestUtils::isFakeTimers(self : VitestUtils) -> Bool'
-  # vitest's `CancelReason` (string-literal alias) and `TestArtifact`
-  # (object alias) are heterogeneous unions whose members aren't
-  # runtime-discriminable. They're correctly diagnosed and widened to
-  # `JSValue`; the rest of the public surface stays untouched.
-  grep -F 'CancelReason (heterogeneous union member is not runtime-discriminable' "$out/SCAFFOLD_DIAGNOSTICS.md" >/dev/null
-  grep -F 'TestArtifact (heterogeneous union member is not runtime-discriminable' "$out/SCAFFOLD_DIAGNOSTICS.md" >/dev/null
+  # vitest's `CancelReason` is the LiteralUnion pattern
+  # (`"a" | "b" | (string & Record<string, never>)`) and collapses to a
+  # plain String alias; `TestArtifact` drops its empty-registry indexed
+  # access (`TestArtifactRegistry[keyof TestArtifactRegistry]` -> never)
+  # and lowers to a tagged enum of the three artifact interfaces.
+  grep -F 'pub type CancelReason = String' "$out/bridge.mbti" >/dev/null
+  grep -F 'pub(all) enum TestArtifact {' "$out/bridge.mbti" >/dev/null
+  grep -F 'FailureScreenshotArtifactValue(FailureScreenshotArtifact)' "$out/bridge.mbti" >/dev/null
+  if grep -F 'heterogeneous union member is not runtime-discriminable' "$out/SCAFFOLD_DIAGNOSTICS.md" >/dev/null; then
+    echo "unexpected heterogeneous-union widening in vitest scaffold diagnostics" >&2
+    exit 1
+  fi
   moon -C "$out" check --target js
   moon -C "$out" test --target js
   run_typescript_to_moonbit_js_build_smoke "$out" "examples/typescript_to_moonbit_vitest" < \

--- a/src/bridge/mbti_typescript_decl.mbt
+++ b/src/bridge/mbti_typescript_decl.mbt
@@ -1989,10 +1989,41 @@ fn collect_mbti_autolink_glue_decls(
           Some(owner_name) if include_facades =>
             match local_type_params.get(owner_name) {
               Some(owner_type_params) => {
-                if owner_type_params.length() > 0 || fn_type_params.length() > 0 {
+                // Generic OWNERS stay out of scope (the facade would need
+                // a monomorphized receiver type).
+                if owner_type_params.length() > 0 {
                   continue
                 }
                 let owner_type_param_names = type_param_names(owner_type_params)
+                let raw_params = match
+                  parse_mbti_raw_facade_params(glue_params_src, owner_name) {
+                  Some(params) => params
+                  None => continue
+                }
+                // A generic METHOD on a non-generic owner monomorphizes
+                // through `TsMbtGenericAny` exactly like a generic free
+                // function; the facade TS declaration keeps the generic
+                // signature. Bounded / tuple / non-top-level-Option
+                // shapes stay omitted.
+                let is_generic = fn_type_params.length() > 0
+                let mut method_option_unwrap = false
+                if is_generic {
+                  match
+                    mbti_generic_glue_return_plan(
+                      fn_type_params, raw_params, return_src,
+                    ) {
+                    Some(MbtiGenericGlueReturnOptionUnwrap) =>
+                      method_option_unwrap = true
+                    Some(MbtiGenericGlueReturnDirect) => ()
+                    None => continue
+                  }
+                }
+                // NOTE: the type-param-names argument below parametrizes
+                // `Self` (`Self` -> `Owner<params>`), so method-level type
+                // params must NOT be passed there — the owner is
+                // non-generic and its `Self` renders bare. Method type
+                // params reach the TS declaration through the `<T>` suffix
+                // and render verbatim as unknown type refs.
                 let params = parse_mbti_params(
                   params_src,
                   imports,
@@ -2000,18 +2031,13 @@ fn collect_mbti_autolink_glue_decls(
                   Some(owner_name),
                   owner_type_param_names,
                 )
-                let raw_params = match
-                  parse_mbti_raw_facade_params(glue_params_src, owner_name) {
-                  Some(params) => params
-                  None => continue
-                }
                 if mbti_raw_facade_uses_private_types(
                     raw_params,
                     replace_mbti_self_refs(
                       glue_return_src_with_effect, owner_name,
                     ),
                     private_type_names,
-                    owner_type_param_names,
+                    fn_type_param_names,
                   ) {
                   continue
                 }
@@ -2040,35 +2066,78 @@ fn collect_mbti_autolink_glue_decls(
                   unique_export_name += "_facade"
                 }
                 let rendered_ts_params = render_ts_params(params)
-                let facade_ts_decl = "export function \{unique_export_name}(\{rendered_ts_params}): \{rendered_return_ty};"
+                let ts_type_param_suffix = if is_generic {
+                  "<" + fn_type_param_names.join(", ") + ">"
+                } else {
+                  ""
+                }
+                let facade_ts_decl = "export function \{unique_export_name}\{ts_type_param_suffix}(\{rendered_ts_params}): \{rendered_return_ty};"
                 let runtime_unique_export_name = runtime_export_prefix +
                   unique_export_name
                 let async_prefix = if is_async { "async " } else { "" }
+                // Monomorphize the MoonBit-side glue signature: every
+                // method type-parameter ref becomes the opaque boundary
+                // type.
+                let glue_raw_params = if is_generic {
+                  let substituted : Array[MbtiRawFacadeParam] = []
+                  for param in raw_params {
+                    substituted.push({
+                      name: param.name,
+                      ty_src: replace_mbti_type_param_refs(
+                        param.ty_src,
+                        fn_type_param_names,
+                        MBTI_GENERIC_ANY_TYPE_NAME,
+                      ),
+                      optional: param.optional,
+                    })
+                  }
+                  substituted
+                } else {
+                  raw_params
+                }
+                let glue_method_return_src = if is_generic {
+                  replace_mbti_type_param_refs(
+                    glue_return_src,
+                    fn_type_param_names,
+                    MBTI_GENERIC_ANY_TYPE_NAME,
+                  )
+                } else {
+                  glue_return_src
+                }
+                let glue_method_return_src_with_effect = if is_generic {
+                  replace_mbti_type_param_refs(
+                    glue_return_src_with_effect,
+                    fn_type_param_names,
+                    MBTI_GENERIC_ANY_TYPE_NAME,
+                  )
+                } else {
+                  glue_return_src_with_effect
+                }
                 let rendered_mbt_params = render_mbt_glue_params(
-                  raw_params,
+                  glue_raw_params,
                   local_type_names,
                   [],
                   source_alias,
                 )
                 let rendered_mbt_return = mbti_qualify_root_type_refs_for_glue(
-                  replace_mbti_self_refs(glue_return_src, owner_name),
+                  replace_mbti_self_refs(glue_method_return_src, owner_name),
                   local_type_names,
                   [],
                   source_alias,
                 )
                 let effect_suffix = mbti_qualified_effect_suffix_for_glue(
                   replace_mbti_self_refs(
-                    glue_return_src_with_effect, owner_name,
+                    glue_method_return_src_with_effect, owner_name,
                   ),
                   local_type_names,
                   [],
                   source_alias,
                 )
-                let call_args = render_mbt_glue_call_args(raw_params)
-                let body_expr = if raw_params.length() > 0 &&
-                  raw_params[0].name == "self" {
+                let call_args = render_mbt_glue_call_args(glue_raw_params)
+                let body_expr = if glue_raw_params.length() > 0 &&
+                  glue_raw_params[0].name == "self" {
                   let tail_args = render_mbt_glue_method_tail_call_args(
-                    raw_params,
+                    glue_raw_params,
                   )
                   if tail_args == "" {
                     "self_.\{fn_name}()"
@@ -2078,15 +2147,24 @@ fn collect_mbti_autolink_glue_decls(
                 } else {
                   "@\{source_alias}.\{owner_name}::\{fn_name}(\{call_args})"
                 }
-                let facade_mbt_decl = "pub \{async_prefix}fn \{runtime_unique_export_name}(\{rendered_mbt_params}) -> \{rendered_mbt_return}\{effect_suffix} {\n  \{body_expr}\n}"
+                let facade_mbt_decl = if method_option_unwrap {
+                  let unwrapped_return = if rendered_mbt_return.has_suffix("?") {
+                    rendered_mbt_return[:rendered_mbt_return.length() - 1].to_owned()
+                  } else {
+                    rendered_mbt_return
+                  }
+                  "pub \{async_prefix}fn \{runtime_unique_export_name}(\{rendered_mbt_params}) -> \{unwrapped_return}\{effect_suffix} {\n  match \{body_expr} {\n    Some(value) => value\n    None => tsmbt_generic_undefined()\n  }\n}"
+                } else {
+                  "pub \{async_prefix}fn \{runtime_unique_export_name}(\{rendered_mbt_params}) -> \{rendered_mbt_return}\{effect_suffix} {\n  \{body_expr}\n}"
+                }
                 decls.push({
                   package_name,
                   export_name: unique_export_name,
                   runtime_export_name: runtime_unique_export_name,
                   ts_decl: facade_ts_decl,
                   mbt_decl: facade_mbt_decl,
-                  uses_generic_any: false,
-                  uses_generic_undefined: false,
+                  uses_generic_any: is_generic,
+                  uses_generic_undefined: method_option_unwrap,
                 })
               }
               None => ()

--- a/src/bridge/mbti_typescript_decl_wbtest.mbt
+++ b/src/bridge/mbti_typescript_decl_wbtest.mbt
@@ -1598,3 +1598,44 @@ async test "bridge: unconstrained generic free fns export through monomorphized 
   assert_false(root_content.contains("export function describe"))
   assert_false(root_content.contains("export function map_pair"))
 }
+
+///|
+async test "bridge: generic methods on non-generic owners export via monomorphized facade" {
+  let bundle = emit_typescript_facade_scaffold_bundle_from_mbti_path(
+    "fixtures/mbti_typescript/generic_method.pkg.generated.mbti",
+  ) catch {
+    MbtiTypescriptDeclError::ReadError(msg)
+    | MbtiTypescriptDeclError::ParseError(msg) =>
+      fail("MBTI facade bundle emit error: \{msg}")
+  }
+  // Unconstrained generic methods monomorphize through TsMbtGenericAny.
+  assert_true(
+    bundle.autolink_glue_mbt.contains(
+      "pub fn counter_tap(self_ : @tsmbt_source.Counter, arg1 : TsMbtGenericAny) -> TsMbtGenericAny {",
+    ),
+  )
+  // Bare `T?` returns unwrap to `value | undefined`.
+  assert_true(bundle.autolink_glue_mbt.contains("pub fn counter_pick("))
+  assert_true(bundle.autolink_glue_mbt.contains("tsmbt_generic_undefined()"))
+  // The facade TS declaration keeps the generic signature with a BARE
+  // owner type (the method's params must not leak onto `self`).
+  let mut ts_decls = ""
+  for decl in bundle.files {
+    if decl.relative_path == "index.d.ts" {
+      ts_decls = decl.content
+    }
+  }
+  assert_true(
+    ts_decls.contains(
+      "export function counter_tap<T>(self: Counter, arg1: T): T;",
+    ),
+  )
+  assert_true(
+    ts_decls.contains(
+      "export function counter_pick<T>(self: Counter, items: Array<T>): T | undefined;",
+    ),
+  )
+  // Trait-bounded methods stay omitted.
+  assert_false(bundle.autolink_glue_mbt.contains("counter_describe"))
+  assert_false(bundle.moon_pkg.contains("counter_describe"))
+}

--- a/src/bridge/moonbit_decl.mbt
+++ b/src/bridge/moonbit_decl.mbt
@@ -1792,6 +1792,158 @@ fn resolve_decl_from_export_name(
 }
 
 ///|
+/// Resolve a QUALIFIED namespace type reference (`JSX.Element`) to its
+/// flattened export name (`JsxElement`) by walking the module's namespace
+/// declarations with the same prefixing scheme the exporter uses. Returns
+/// `None` when any segment doesn't resolve to a declared namespace /
+/// member.
+fn decl_qualified_namespace_type_name(
+  info : DeclModuleInfo,
+  name : String,
+) -> String? {
+  if !name.contains(".") {
+    return None
+  }
+  let segments : Array[String] = []
+  for seg in name.split(".") {
+    segments.push(seg.to_owned())
+  }
+  if segments.length() < 2 {
+    return None
+  }
+  let mut current : @ast.TsModule = info.module_
+  let mut prefix = ""
+  for i in 0..<(segments.length() - 1) {
+    let ns_name = segments[i]
+    let mut found : @ast.TsNamespaceDecl? = None
+    for ns in current.namespaces {
+      if ns.name == ns_name {
+        found = Some(ns)
+        break
+      }
+    }
+    match found {
+      Some(ns) => {
+        current = ns.module_
+        prefix = namespace_next_type_export_prefix(prefix, ns_name)
+      }
+      None => return None
+    }
+  }
+  let member = segments[segments.length() - 1]
+  let mut member_exists = false
+  for iface in current.interfaces {
+    if iface.name == member {
+      member_exists = true
+      break
+    }
+  }
+  if !member_exists {
+    for enum_ in current.enums {
+      if enum_.name == member {
+        member_exists = true
+        break
+      }
+    }
+  }
+  if !member_exists {
+    return None
+  }
+  Some(namespace_type_export_name(prefix, member))
+}
+
+///|
+/// Bridge-local normalizations applied to a type-alias body before the
+/// enum / tagged-union classification. Each rule keeps the alias
+/// classifiable instead of widening it to `JSValue`:
+/// - qualified namespace refs resolve to their flattened export name
+///   (`JSX.Element` -> `JsxElement`, hono `Child`);
+/// - branded-string intersections collapse to `string`
+///   (`string & Record<string, never>`, vitest `CancelReason`);
+/// - an indexed access over an EMPTY registry interface reduces to
+///   `never` (`TestArtifactRegistry[keyof TestArtifactRegistry]`, vitest
+///   `TestArtifact`), and `never` members drop out of unions;
+/// - a union of a plain `string` plus only string literals collapses to
+///   `string` (the LiteralUnion autocomplete pattern).
+fn decl_normalize_alias_union_body(
+  info : DeclModuleInfo,
+  type_ : @ast.TsType,
+) -> @ast.TsType {
+  match type_ {
+    Union(members) => {
+      let next : Array[@ast.TsType] = []
+      for m in members {
+        let normalized = decl_normalize_alias_union_body(info, m)
+        // `never` contributes no runtime values; drop it so the
+        // remaining members stay discriminable.
+        if normalized is Never {
+          continue
+        }
+        next.push(normalized)
+      }
+      if next.length() == 1 {
+        return next[0]
+      }
+      // LiteralUnion collapse: `"a" | "b" | string` is `string` for every
+      // runtime purpose (the literal split only preserves editor
+      // autocomplete).
+      let mut has_plain_string = false
+      let mut all_string_like = true
+      for m in next {
+        match m {
+          String_ => has_plain_string = true
+          Literal(_) => ()
+          _ => all_string_like = false
+        }
+      }
+      if has_plain_string && all_string_like {
+        return String_
+      }
+      Union(next)
+    }
+    Intersection(parts) => {
+      // Branded-string escape hatch: `string & Record<string, never>` /
+      // `string & {}` accept every plain string at runtime.
+      let mut has_string = false
+      let mut rest_is_empty_brand = true
+      for p in parts {
+        match p {
+          String_ => has_string = true
+          Applied("Record", [_, Never]) => ()
+          Object([]) => ()
+          _ => rest_is_empty_brand = false
+        }
+      }
+      if has_string && rest_is_empty_brand {
+        String_
+      } else {
+        type_
+      }
+    }
+    IndexedAccess(Named(reg), Keyof(Named(reg_keyof))) if reg == reg_keyof =>
+      // `Registry[keyof Registry]` over an EMPTY interface (the module
+      // augmentation registry pattern) has no keys: the member is
+      // `never`.
+      match find_interface_decl_recursive(info.module_, reg) {
+        Some(iface) if iface.fields.length() == 0 &&
+          iface.index_signatures.length() == 0 => Never
+        _ => type_
+      }
+    Named(name) =>
+      match decl_qualified_namespace_type_name(info, name) {
+        Some(flattened) => Named(flattened)
+        None => type_
+      }
+    Applied(name, args) =>
+      match decl_qualified_namespace_type_name(info, name) {
+        Some(flattened) => Applied(flattened, args)
+        None => type_
+      }
+    _ => type_
+  }
+}
+
+///|
 fn resolve_decl_from_local_name(
   export_name : String,
   source_path : String,
@@ -1830,9 +1982,13 @@ fn resolve_decl_from_local_name(
                   // pass an empty map so the lower path falls back to the
                   // raw alias names.
                   let canonical_types_for_lower : Map[String, String] = {}
+                  // Normalize BEFORE the utility lowering: the rules match
+                  // raw parse shapes (`Record<string, never>` inside a
+                  // brand intersection, `Registry[keyof Registry]`), which
+                  // the utility pass would otherwise rewrite first.
                   let lowered_alias_type = lower_react_utility_type(
                     info,
-                    type_alias.type_,
+                    decl_normalize_alias_union_body(info, type_alias.type_),
                     modules,
                     canonical_types_for_lower,
                   )

--- a/src/bridge/moonbit_js_ffi.mbt
+++ b/src/bridge/moonbit_js_ffi.mbt
@@ -982,10 +982,14 @@ fn ffi_type_name(state : MoonBitJsFfiState, type_ : @ast.TsType) -> String {
     Union(parts) =>
       match ffi_synthesize_inline_union(state, parts) {
         Some(synth_name) => synth_name
-        None => {
-          state.needs_js_any = true
-          "JSValue"
-        }
+        None =>
+          match ffi_string_subset_union_text(state, parts) {
+            Some(text) => text
+            None => {
+              state.needs_js_any = true
+              "JSValue"
+            }
+          }
       }
     _ => {
       state.needs_js_any = true
@@ -1105,6 +1109,39 @@ fn ffi_inline_union_synthesized_name(
   // parser-side helper so both paths produce the same synthetic alias name.
   names.sort()
   "Auto_" + names.join("_or_")
+}
+
+///|
+/// String-subset policy for the pervasive optional-message pattern
+/// (`params?: string | $ZodCheckMinLengthParams` across the zod check
+/// surface): when a two-member union pairs `string` with a named
+/// `...Params` bag that is NOT reachable as a declared type in this
+/// bridge surface, type the boundary as `String`. The common string form
+/// becomes naturally typed; the structured object form stays reachable
+/// via `unsafeCast`. Restricted to the `*Params` suffix so option-bag
+/// unions with reachable declarations keep their tagged lowering, and
+/// shapes like `string | URL` keep the JSValue fallback.
+fn ffi_string_subset_union_text(
+  state : MoonBitJsFfiState,
+  parts : Array[@ast.TsType],
+) -> String? {
+  if parts.length() != 2 {
+    return None
+  }
+  let named = match (parts[0], parts[1]) {
+    (String_, Named(n)) | (Named(n), String_) => n
+    _ => return None
+  }
+  if !named.has_suffix("Params") {
+    return None
+  }
+  let ident = ffi_type_identifier(named, "OpaqueType")
+  if state.declared_type_names.contains(ident) ||
+    state.generic_type_params_by_name.get(ident) is Some(_) ||
+    ffi_is_local_type_param(state, named) {
+    return None
+  }
+  Some("String")
 }
 
 ///|

--- a/src/bridge/moonbit_js_ffi.mbt
+++ b/src/bridge/moonbit_js_ffi.mbt
@@ -1122,6 +1122,17 @@ fn ffi_synthesize_inline_union(
   state : MoonBitJsFfiState,
   parts : Array[@ast.TsType],
 ) -> String? {
+  // Function members are accepted for EXPORTED alias lowering (their
+  // boundary stays passthrough), but inline synthesis would generate a
+  // wrapper whose conversion glue can't produce the enum from a raw
+  // value (`useState(initialState: S | (() => S))` — the JSValue
+  // argument has no path into `Auto_SValue_or_FnValue`). Keep such
+  // inline unions on the JSValue fallback.
+  for part in parts {
+    if part is Func(_, _) {
+      return None
+    }
+  }
   let cases = match tagged_union_cases(parts) {
     Some(c) => c
     None => return None
@@ -2485,13 +2496,29 @@ fn ffi_type_alias_constructors(
   if type_alias.type_params.length() > 0 {
     return []
   }
-  let items = match ffi_type_alias_union_items(type_alias.type_) {
-    Some(items) => items
-    None => return []
-  }
   let alias_type_name = ffi_type_identifier(type_alias.name, "OpaqueType")
   let alias_fn_prefix = ffi_to_snake_case(alias_type_name)
   let tagged_decl = state.tagged_union_decls_by_name.get(alias_type_name)
+  // When a tagged-union decl exists, its cases carry the NORMALIZED
+  // member types (qualified namespace refs resolved, `never` members
+  // dropped) in enum order — helpers built from the raw alias body would
+  // reference unresolved names (`JSX.Element` -> opaque `JSX_Element`)
+  // and mis-index `$tag` after a dropped member.
+  let items = match tagged_decl {
+    Some(decl) => {
+      let case_types : Array[@ast.TsType] = []
+      for entry in decl.cases {
+        let (_, inner) = entry
+        case_types.push(inner)
+      }
+      case_types
+    }
+    None =>
+      match ffi_type_alias_union_items(type_alias.type_) {
+        Some(items) => items
+        None => return []
+      }
+  }
   let ctors : Array[FfiAliasConstructor] = []
   let seen_names : Array[String] = []
   for index, item in items {
@@ -2967,6 +2994,10 @@ fn ffi_tagged_union_return_is_safe_to_wrap(
         let (_, inner) = entry
         match tagged_union_case_discriminator(inner) {
           Some(InstanceOfNamed(_)) => return false
+          // Function payloads stay on the raw passthrough: the generic
+          // wrapper would need closure conversion in both directions,
+          // which the auto-wrap doesn't model.
+          Some(TypeofFunction) => return false
           _ => ()
         }
       }

--- a/src/bridge/moonbit_js_ffi_wbtest.mbt
+++ b/src/bridge/moonbit_js_ffi_wbtest.mbt
@@ -5327,3 +5327,82 @@ async test "bridge: polymorphic this lowers to the owner with its own type param
   assert_false(bundle.ffi_mbt.contains("Box[JSValue, JSValue]"))
   assert_false(bundle.ffi_mbt.contains("Chain[JSValue, JSValue]"))
 }
+
+///|
+fn ffi_string_subset_test_state(declared : Array[String]) -> MoonBitJsFfiState {
+  MoonBitJsFfiState::{
+    declared_type_names: declared,
+    struct_type_names: [],
+    generic_type_params_by_name: {},
+    enums: [],
+    external_type_names: [],
+    local_type_param_names: [],
+    function_field_method_wrapper_limit: ffi_function_field_method_wrapper_limit,
+    tagged_union_decls_by_name: {},
+    synthesized_inline_unions: {},
+    needs_js_any: false,
+    needs_promise: false,
+  }
+}
+
+///|
+test "bridge: FFI type name subsets undeclared string-or-Params unions to String" {
+  // zod's optional-message pattern: `params?: string | $ZodCheckMinLengthParams`.
+  // The `$`-prefixed name rejects tagged-union synthesis (constructor names
+  // must start with A-Z), and the Params bag is not a declared type on this
+  // bridge surface — the boundary subsets to `String`.
+  let state = ffi_string_subset_test_state([])
+  let actual = ffi_type_name(
+    state,
+    @ast.TsType::Union([
+      @ast.TsType::String_,
+      @ast.TsType::Named("$ZodCheckMinLengthParams"),
+    ]),
+  )
+  assert_eq(actual, "String")
+  assert_false(state.needs_js_any)
+}
+
+///|
+test "bridge: FFI string-subset abstains when the Params type is declared" {
+  // `$ZodCheckMinLengthParams` sanitizes to `UnderscoreZodCheckMinLengthParams`;
+  // when that type is declared on the bridge surface the union keeps the
+  // JSValue fallback instead of silently dropping the reachable object form.
+  let state = ffi_string_subset_test_state(["UnderscoreZodCheckMinLengthParams"])
+  let actual = ffi_type_name(
+    state,
+    @ast.TsType::Union([
+      @ast.TsType::String_,
+      @ast.TsType::Named("$ZodCheckMinLengthParams"),
+    ]),
+  )
+  assert_eq(actual, "JSValue")
+  assert_true(state.needs_js_any)
+}
+
+///|
+test "bridge: FFI string-subset abstains without the Params suffix" {
+  // `string | $ZodURL`: not an option-bag shape — keep the JSValue fallback.
+  let state = ffi_string_subset_test_state([])
+  let actual = ffi_type_name(
+    state,
+    @ast.TsType::Union([@ast.TsType::String_, @ast.TsType::Named("$ZodURL")]),
+  )
+  assert_eq(actual, "JSValue")
+  assert_true(state.needs_js_any)
+}
+
+///|
+test "bridge: FFI string-subset abstains for three-member unions" {
+  let state = ffi_string_subset_test_state([])
+  let actual = ffi_type_name(
+    state,
+    @ast.TsType::Union([
+      @ast.TsType::String_,
+      @ast.TsType::Named("$ZodCheckMinLengthParams"),
+      @ast.TsType::Object([]),
+    ]),
+  )
+  assert_eq(actual, "JSValue")
+  assert_true(state.needs_js_any)
+}

--- a/src/bridge/pkg.generated.mbti
+++ b/src/bridge/pkg.generated.mbti
@@ -164,6 +164,7 @@ pub(all) enum TaggedUnionCaseDiscriminator {
   TypeofNumber
   TypeofBoolean
   TypeofBigInt
+  TypeofFunction
   IsArrayPredicate
   InstanceOfNamed(String)
   StrictEqualsString(String)

--- a/src/bridge/tagged_union_lowering.mbt
+++ b/src/bridge/tagged_union_lowering.mbt
@@ -67,6 +67,12 @@ pub fn tagged_union_member_constructor_name(t : @ast.TsType) -> String? {
   match t {
     @ast.TsType::Named(name) => tagged_union_named_constructor_name(name)
     @ast.TsType::Array(inner) => tagged_union_array_constructor_name(inner)
+    // A function-typed member discriminates via `typeof === "function"`
+    // (`NeonAuthToken = string | (() => ...)`,
+    // `ElementType = string | ((props) => ReactElement)`). At most one
+    // function member per union — a second one collides on the
+    // constructor name and rejects the alias.
+    @ast.TsType::Func(_, _) => Some("FnValue")
     @ast.TsType::Literal(_)
     | @ast.TsType::NumberLiteral(_)
     | @ast.TsType::BooleanLiteral(_)
@@ -386,6 +392,7 @@ pub(all) enum TaggedUnionCaseDiscriminator {
   TypeofNumber
   TypeofBoolean
   TypeofBigInt
+  TypeofFunction
   IsArrayPredicate
   InstanceOfNamed(String)
   StrictEqualsString(String)
@@ -405,6 +412,7 @@ pub fn tagged_union_case_discriminator(
     @ast.TsType::Boolean => Some(TypeofBoolean)
     @ast.TsType::BigInt => Some(TypeofBigInt)
     @ast.TsType::Array(_) => Some(IsArrayPredicate)
+    @ast.TsType::Func(_, _) => Some(TypeofFunction)
     @ast.TsType::Named(name) => Some(InstanceOfNamed(name))
     @ast.TsType::Literal(value) => Some(StrictEqualsString(value))
     @ast.TsType::NumberLiteral(value) => Some(StrictEqualsNumber(value))
@@ -424,6 +432,7 @@ fn tagged_union_case_predicate_text(
     TypeofNumber => "typeof " + expr + " === \"number\""
     TypeofBoolean => "typeof " + expr + " === \"boolean\""
     TypeofBigInt => "typeof " + expr + " === \"bigint\""
+    TypeofFunction => "typeof " + expr + " === \"function\""
     IsArrayPredicate => "Array.isArray(" + expr + ")"
     InstanceOfNamed(name) => expr + " instanceof " + name
     StrictEqualsString(value) =>
@@ -638,6 +647,35 @@ pub fn tagged_union_inner_moonbit_text_with_arity(
         Some(text) => Some("Array[" + text + "]")
         None => None
       }
+    // A function payload renders as a MoonBit arrow; positions whose type
+    // has no direct rendering widen to `JSValue` locally instead of
+    // failing the whole enum (`AuthToken = string | (() => string)`).
+    @ast.TsType::Func(params, ret) => {
+      let rendered_params : Array[String] = []
+      for p in params {
+        rendered_params.push(
+          match
+            tagged_union_inner_moonbit_text_with_arity(
+              p, generic_type_params_by_name,
+            ) {
+            Some(text) => text
+            None => "JSValue"
+          },
+        )
+      }
+      let rendered_ret = match ret {
+        @ast.TsType::Void => "Unit"
+        other =>
+          match
+            tagged_union_inner_moonbit_text_with_arity(
+              other, generic_type_params_by_name,
+            ) {
+            Some(text) => text
+            None => "JSValue"
+          }
+      }
+      Some("(" + rendered_params.join(", ") + ") -> " + rendered_ret)
+    }
     _ => None
   }
 }

--- a/src/bridge/tagged_union_lowering_wbtest.mbt
+++ b/src/bridge/tagged_union_lowering_wbtest.mbt
@@ -462,3 +462,35 @@ test "tagged union: from-JS snippet uses Array.isArray for arrays" {
     None => fail("Array.isArray should be a valid discriminator")
   }
 }
+
+///|
+test "tagged union: function member discriminates via typeof function" {
+  // `AuthToken = string | (() => string)` — drizzle NeonAuthToken shape.
+  let members : Array[@ast.TsType] = [String_, Func([], String_)]
+  match tagged_union_cases(members) {
+    Some(cases) => {
+      @test.assert_eq(cases.length(), 2)
+      @test.assert_eq(cases[1].0, "FnValue")
+    }
+    None => fail("expected function member union to be accepted")
+  }
+  match tagged_union_case_discriminator(Func([], String_)) {
+    Some(TypeofFunction) => ()
+    _ => fail("expected TypeofFunction discriminator")
+  }
+  // Two function members collide on the constructor name and reject.
+  let two_fns : Array[@ast.TsType] = [
+    Func([], String_),
+    Func([String_], String_),
+  ]
+  assert_true(tagged_union_cases(two_fns) is None)
+  // The enum section renders the arrow payload.
+  match
+    tagged_union_decl_to_moonbit_section({
+      name: "AuthToken",
+      cases: [("StringValue", String_), ("FnValue", Func([], String_))],
+    }) {
+    Some(section) => assert_true(section.contains("FnValue(() -> String)"))
+    None => fail("expected enum section for function payload")
+  }
+}


### PR DESCRIPTION
Three bridge improvements, continuing from #206.

## 1. Heterogeneous-union unsupported-export budget: 5 → 0 (`948c3a6`)

All five remaining real-world heterogeneous unions now lower instead of being dropped:

- **Qualified namespace refs** resolve to their flattened export names (`JSX.Element` → `JsxElement`) via `decl_qualified_namespace_type_name`, so hono's `Child` becomes a proper enum with a `JsxElementValue` case.
- **Function-typed members** discriminate via `typeof x === "function"` (new `TypeofFunction` discriminator, `FnValue` constructor): react's `ElementType`, drizzle's `NeonAuthToken`.
- **`string & {}` / `string & Record<string, never>`** members collapse to `string`, and indexed-access-over-empty-interface members reduce to `never` and drop: vitest's `CancelReason` becomes `pub type CancelReason = String`.
- **Literal-union collapse** (`string` + string literals → `string`) plus the above make vitest's `TestArtifact` a 3-case enum.

Union normalization runs on raw parse shapes before React utility-type lowering; FFI constructor helpers now read the normalized tagged decl cases so helper payloads and `$tag` indices stay aligned. Inline synthesis explicitly excludes function members (their conversion glue can't produce the enum from a raw value — react `useState` regression guard). `scripts/bridge_quality_report.sh` budget is now 0 and `verify_examples.sh` asserts the new lowerings.

## 2. Generic methods on non-generic owners export via monomorphized facades (`3c25b0f`)

`pub fn[T] Counter::tap(self, value: T) -> T` now exports through the same `TsMbtGenericAny` monomorphization used for generic free functions in #206: the glue wrapper is non-generic (type params instantiated at the opaque external type), the emitted `.d.ts` keeps the generic signature (`counter_tap<T>(self: Counter, arg1: T): T`), and bare `T?` returns unwrap to `value | undefined`. Eligibility is shared via `mbti_generic_glue_return_plan`; trait-bounded methods and generic owners stay omitted. Verified with a node smoke test and `tsc --strict`.

## 3. String-subset boundary for optional-message unions (`1278487`)

zod's check surface passes `params?: string | $ZodCheckMinLengthParams` on nearly every validator. The `$`-prefixed name can't become a tagged-union constructor (names must start A–Z), so the whole param degraded to `JSValue?`. A two-member `string | *Params` union whose Params bag is not a declared type on the bridge surface now types the boundary as `String` — the common string form is naturally typed, the structured form stays reachable via `unsafeCast`. Declared option bags keep their tagged lowering; `string | URL` keeps the JSValue fallback.

**zod SCAFFOLD JSValue fallback entries: 648 → 565** (e.g. `min : (Double, String?) -> ZodMap[Key, Value]`); the regenerated zod3 package passes `moon check --target js`.

## Verification

- `moon test --target native`: 2504 tests, 0 failures
- verify-scaffolds / verify-generated-fixtures / verify-examples / bridge-quality: all exit 0 (heterogeneous budget 0)
- Runtime smokes: hono/react/vitest/drizzle scaffold regeneration, generic-method node smoke, `tsc --strict` on emitted `.d.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr)_