### PR TITLE
bridge: zod full-feature — flattened bases, readable issues, shape builder, as_schema upcast

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1191,6 +1191,34 @@ returning the output handle.
   aliases stay opaque — the StringRecordOf* synthetics are equally
   unconstructible today).
 
+### 14. zod full-feature pillars 2-3: error issues + object shapes (done 2026-07-16)
+
+Runtime-verified continuations of #13 (pillar 1, generic-base
+flattening, landed separately):
+
+- [x] Pillar 2 — union aliases whose members cannot be
+  runtime-discriminated join to their nearest COMMON BASE interface
+  (`decl_join_union_alias_to_common_base`): zod's
+  `$ZodIssue = $ZodIssueInvalidType | ... (11 members)` — all
+  `$`-prefixed, so tagged lowering rejects every constructor name — all
+  extend `$ZodIssueBase`, and the reference now lands on
+  `pub(all) struct UnderscoreZodIssueBase { code : String?, input :
+  JSValue?, path : Array[PropertyKey], message : String }` instead of an
+  opaque handle. Nested union-alias members
+  (`$ZodIssueInvalidUnion = NoMatch | MultipleMatch`) recurse; tagged- /
+  enum-lowerable unions never reach the join. Runtime:
+  `issues[0].message` / `.code == "invalid_type"` read directly.
+- [x] Pillar 3 — `loose_shape_from_pairs(keys, values) ->
+  Core__ZodLooseShape` (zod module hook, same pattern as react-router's
+  `params_from_pairs`): `object()` shapes are built from MoonBit without
+  hand-written externs. Runtime: object schema accepts a matching user
+  object and rejects a non-object.
+- Remaining ergonomic gap: GENERIC owners (ZodObject, ZodError) stay
+  opaque — `object(...)` still casts to `Schema[...]` for the parse
+  surface, and `error.issues` reads through a one-line extern accessor.
+  Follow-up: per-generic-owner facade wrappers (same monomorphization as
+  the mbt2ts generic-method glue).
+
 ### Non-Goals (still)
 
 - [ ] Do not turn this list into a checklist for "all of TypeScript". Each item

--- a/TODO.md
+++ b/TODO.md
@@ -1213,11 +1213,12 @@ flattening, landed separately):
   `params_from_pairs`): `object()` shapes are built from MoonBit without
   hand-written externs. Runtime: object schema accepts a matching user
   object and rejects a non-object.
-- Remaining ergonomic gap: GENERIC owners (ZodObject, ZodError) stay
-  opaque — `object(...)` still casts to `Schema[...]` for the parse
-  surface, and `error.issues` reads through a one-line extern accessor.
-  Follow-up: per-generic-owner facade wrappers (same monomorphization as
-  the mbt2ts generic-method glue).
+- [x] GENERIC owners reach the parse surface via the `as_schema` identity
+  upcast (zod module hook): `as_schema(object(Some(shape), None))
+  .safeParse(...)` — runtime-verified. MoonBit's nominal structs cannot
+  express the extends relation, so the upcast makes it callable; a
+  full per-generic-owner facade (monomorphized method wrappers like the
+  mbt2ts generic-method glue) remains the eventual principled shape.
 
 ### Non-Goals (still)
 

--- a/fixtures/resolver/project/types/generic-base-expansion-entry.d.ts
+++ b/fixtures/resolver/project/types/generic-base-expansion-entry.d.ts
@@ -1,0 +1,8 @@
+export interface Base<T> {
+    parse(value: unknown): T;
+    label: T;
+}
+export interface StrSchema extends Base<string> {
+    kind: string;
+}
+export declare function make(): StrSchema;

--- a/fixtures/resolver/project/types/union-common-base-entry.d.ts
+++ b/fixtures/resolver/project/types/union-common-base-entry.d.ts
@@ -1,0 +1,22 @@
+export interface $IssueBase {
+    readonly path: string[];
+    readonly message: string;
+}
+export interface $IssueTooBig extends $IssueBase {
+    readonly code: "too_big";
+}
+export interface $IssueTooSmall extends $IssueBase {
+    readonly code: "too_small";
+}
+interface $IssueNoMatch extends $IssueBase {
+    readonly code: "no_match";
+}
+interface $IssueMultiMatch extends $IssueBase {
+    readonly code: "multi_match";
+}
+export type $IssueUnionKind = $IssueNoMatch | $IssueMultiMatch;
+export type $Issue = $IssueTooBig | $IssueTooSmall | $IssueUnionKind;
+export interface Report {
+    issues: $Issue[];
+}
+export declare function report(): Report;

--- a/scripts/verify_realworld_typescript.sh
+++ b/scripts/verify_realworld_typescript.sh
@@ -743,23 +743,30 @@ EOF
 test "real-world zod bridge smoke" {
   let _ = number(None)
   let _ = boolean(None)
-  let schema : Schema[JSValue, JSValue, JSValue] = unsafeCast(string(None))
-  let ok = schema.safeParse(unsafeCast("hello"), None)
-  if !ok.success {
+  // Concrete schemas expose the flattened ZodType surface directly.
+  let s = string(None)
+  if !s.safeParse(unsafeCast("hello"), None).success {
     abort("expected zod safeParse success")
   }
-  let bad = schema.safeParse(unsafeCast(42), None)
-  if bad.success {
+  if s.safeParse(unsafeCast(42), None).success {
     abort("expected zod safeParse failure")
   }
-  let email : Schema[JSValue, JSValue, JSValue] = unsafeCast(
-    string(None).email(None),
-  )
+  let email = string(None).email(None)
   if !email.safeParse(unsafeCast("a@b.co"), None).success {
     abort("expected zod email success")
   }
   if email.safeParse(unsafeCast("nope"), None).success {
     abort("expected zod email failure")
+  }
+  // Generic owners (ZodObject) reach the surface via the as_schema upcast;
+  // the shape is built with the loose_shape_from_pairs module hook.
+  let shape = loose_shape_from_pairs(
+    ["name"],
+    [unsafeCast(string(None))],
+  )
+  let obj = as_schema(object(Some(shape), None))
+  if obj.safeParse(unsafeCast("not an object"), None).success {
+    abort("expected zod object failure")
   }
 }
 EOF
@@ -1279,14 +1286,16 @@ EOF
 fn main {
   let _ = @sut.number(None)
   let _ = @sut.boolean(None)
-  let schema : @sut.Schema[@sut.JSValue, @sut.JSValue, @sut.JSValue] = @sut.unsafeCast(
-    @sut.string(None),
-  )
-  if !schema.safeParse(@sut.unsafeCast("hello"), None).success {
+  let s = @sut.string(None)
+  if !s.safeParse(@sut.unsafeCast("hello"), None).success {
     abort("expected zod safeParse success")
   }
-  if schema.safeParse(@sut.unsafeCast(42), None).success {
+  if s.safeParse(@sut.unsafeCast(42), None).success {
     abort("expected zod safeParse failure")
+  }
+  let obj = @sut.as_schema(@sut.object(None, None))
+  if obj.safeParse(@sut.unsafeCast("nope"), None).success {
+    abort("expected zod object failure")
   }
 }
 EOF

--- a/src/bridge/moonbit_decl.mbt
+++ b/src/bridge/moonbit_decl.mbt
@@ -6525,6 +6525,8 @@ fn append_interface_origin_fields(
   seen_origins : Array[String],
   internal_members : Array[String],
   deprecated_members : Array[String],
+  subst : Array[(String, @ast.TsType)],
+  root_is_concrete : Bool,
 ) -> Unit {
   let origin_key = decl_key(origin.info.record.path, origin.iface.name)
   if seen_origins.contains(origin_key) {
@@ -6544,22 +6546,9 @@ fn append_interface_origin_fields(
       deprecated_members.push(name)
     }
   }
-  for base_name in origin.iface.extends_names {
-    match
-      resolve_interface_origin(origin.info, base_name, modules, canonical_types) {
-      Some(base_origin) =>
-        if should_expand_interface_base(base_origin) {
-          // Base members merged into the derived struct keep the ROOT
-          // `this_owner`: `this` in an inherited member denotes the
-          // derived type, and only the root's type params are in scope.
-          append_interface_origin_fields(
-            base_origin, this_owner, modules, canonical_types, fields, readonly_fields,
-            seen_field_names, seen_origins, internal_members, deprecated_members,
-          )
-        }
-      None => ()
-    }
-  }
+  // OWN fields first, bases after: a derived redeclaration narrows its
+  // base member (`ZodString`'s `_zod` vs the raw `_ZodType` one) and the
+  // seen-set gives the first pusher precedence.
   for field in origin.iface.fields {
     let (field_name, field_type) = field
     // A generic METHOD's constrained type parameters are substituted with
@@ -6575,7 +6564,7 @@ fn append_interface_origin_fields(
       decl_substitute_method_type_param_bounds(
         origin.iface,
         field_name,
-        field_type,
+        decl_apply_subst(field_type, subst),
       ),
       0,
     )
@@ -6593,6 +6582,69 @@ fn append_interface_origin_fields(
       canonical_types,
     )
   }
+  for base_index, base_name in origin.iface.extends_names {
+    match
+      resolve_interface_origin(origin.info, base_name, modules, canonical_types) {
+      Some(base_origin) => {
+        // Generic bases expand when the derived interface supplied a
+        // full argument list (`_ZodString<T> extends _ZodType<T>`,
+        // `_ZodType<Internals> extends ZodType<any, any, Internals>`):
+        // the arguments — rewritten through the CURRENT substitution —
+        // become the base's parameter bindings, so `ZodString` inherits
+        // `parse` with `Internals := $ZodStringInternals<string>`.
+        // Non-generic bases expand as before with an empty env; a
+        // generic base referenced BARE (no arguments) keeps the old
+        // no-expansion behavior.
+        let base_params = base_origin.iface.type_params
+        let raw_args = if base_index < origin.iface.extends_args.length() {
+          origin.iface.extends_args[base_index]
+        } else {
+          []
+        }
+        // Only CONCRETE roots (no type parameters of their own — zod's
+        // ZodString / ZodEmail / ZodNumber...) flatten their generic
+        // bases: expanding generic roots multiplies every base member
+        // across every instantiation context and measurably explodes
+        // the widened surface.
+        let expandable = should_expand_interface_base(base_origin) ||
+          (root_is_concrete && base_params.length() == raw_args.length())
+        if expandable {
+          let base_subst : Array[(String, @ast.TsType)] = []
+          if base_params.length() == raw_args.length() {
+            for i, param in base_params {
+              base_subst.push((param, decl_apply_subst(raw_args[i], subst)))
+            }
+          }
+          // Base members merged into the derived struct keep the ROOT
+          // `this_owner`: `this` in an inherited member denotes the
+          // derived type, and only the root's type params are in scope.
+          append_interface_origin_fields(
+            base_origin, this_owner, modules, canonical_types, fields, readonly_fields,
+            seen_field_names, seen_origins, internal_members, deprecated_members,
+            base_subst, root_is_concrete,
+          )
+        }
+      }
+      None => ()
+    }
+  }
+}
+
+///|
+fn decl_apply_subst(
+  t : @ast.TsType,
+  subst : Array[(String, @ast.TsType)],
+) -> @ast.TsType {
+  if subst.length() == 0 {
+    return t
+  }
+  let params : Array[String] = []
+  let args : Array[@ast.TsType] = []
+  for pair in subst {
+    params.push(pair.0)
+    args.push(pair.1)
+  }
+  substitute_type_alias_params(t, params, args)
 }
 
 ///|
@@ -7034,6 +7086,8 @@ fn clone_resolved_interface_origin(
     seen_origins,
     internal_members,
     deprecated_members,
+    [],
+    origin.iface.type_params.length() == 0,
   )
   {
     name: origin.export_name,
@@ -7388,6 +7442,8 @@ fn clone_exported_interface(
     seen_origins,
     internal_members,
     deprecated_members,
+    [],
+    exported.iface.type_params.length() == 0,
   )
   {
     name: exported.export_name,

--- a/src/bridge/moonbit_decl.mbt
+++ b/src/bridge/moonbit_decl.mbt
@@ -4847,6 +4847,173 @@ fn decl_exclusive_union_alias_interface_spec(
 }
 
 ///|
+/// Join a union ALIAS whose members cannot be runtime-discriminated to
+/// their nearest common base interface: zod's
+/// `$ZodIssue = $ZodIssueInvalidType | $ZodIssueTooBig | ...` (eleven
+/// `$`-prefixed interfaces, so tagged lowering rejects every constructor
+/// name) all extend `$ZodIssueBase { code?, input?, path, message }` —
+/// referencing the BASE is a sound upper approximation and turns the
+/// previously opaque handle into a readable struct. Members that CAN
+/// tag-lower keep the existing enum path (the alias never reaches here).
+fn decl_join_union_alias_to_common_base(
+  info : DeclModuleInfo,
+  modules : Map[String, DeclModuleInfo],
+  canonical_types : Map[String, String],
+  name : String,
+) -> @ast.TsType? {
+  let (ta, ta_info) = match decl_find_type_alias_deep(info, modules, name, []) {
+    Some(found) => found
+    None => return None
+  }
+  if ta.type_params.length() != 0 {
+    return None
+  }
+  let members = match ta.type_ {
+    Union(items) => items
+    _ => return None
+  }
+  if members.length() < 2 || members.length() > 32 {
+    return None
+  }
+  // A tag-lowerable union keeps the enum path.
+  match tagged_union_cases(members) {
+    Some(_) => return None
+    None => ()
+  }
+  let mut common : Array[String]? = None
+  for member in members {
+    let ancestors : Array[String] = []
+    if !decl_member_ancestor_names(
+        ta_info, modules, canonical_types, member, ancestors, 0,
+      ) {
+      return None
+    }
+    if ancestors.length() == 0 {
+      return None
+    }
+    common = match common {
+      None => Some(ancestors)
+      Some(existing) => {
+        let kept : Array[String] = []
+        for a in existing {
+          if ancestors.contains(a) {
+            kept.push(a)
+          }
+        }
+        Some(kept)
+      }
+    }
+  }
+  match common {
+    Some(shared) if shared.length() > 0 => {
+      let base_name = shared[0]
+      match
+        resolve_interface_origin(ta_info, base_name, modules, canonical_types) {
+        Some(base_origin) => Some(Named(base_origin.export_name))
+        None => Some(Named(base_name))
+      }
+    }
+    _ => None
+  }
+}
+
+///|
+/// Ancestor names for one union member: an interface contributes its
+/// extends chain; a member that is itself a (non-generic) union ALIAS —
+/// zod's `$ZodIssueInvalidUnion = ...NoMatch | ...MultipleMatch` —
+/// recurses into its members, requiring EVERY leaf to contribute.
+/// Returns false when any leaf is unresolvable.
+fn decl_member_ancestor_names(
+  info : DeclModuleInfo,
+  modules : Map[String, DeclModuleInfo],
+  canonical_types : Map[String, String],
+  member : @ast.TsType,
+  out : Array[String],
+  depth : Int,
+) -> Bool {
+  if depth > 4 {
+    return false
+  }
+  let member_name = match member {
+    Named(n) => n
+    Applied(n, _) => n
+    _ => return false
+  }
+  match resolve_interface_origin(info, member_name, modules, canonical_types) {
+    Some(origin) => {
+      decl_collect_ancestor_names(origin, modules, canonical_types, out, 0)
+      return true
+    }
+    None => ()
+  }
+  match decl_find_type_alias_deep(info, modules, member_name, []) {
+    Some((ta, ta_info)) if ta.type_params.length() == 0 =>
+      match ta.type_ {
+        Union(items) => {
+          for item in items {
+            if !decl_member_ancestor_names(
+                ta_info,
+                modules,
+                canonical_types,
+                item,
+                out,
+                depth + 1,
+              ) {
+              return false
+            }
+          }
+          true
+        }
+        Named(_) | Applied(_, _) =>
+          decl_member_ancestor_names(
+            ta_info,
+            modules,
+            canonical_types,
+            ta.type_,
+            out,
+            depth + 1,
+          )
+        _ => false
+      }
+    _ => false
+  }
+}
+
+///|
+fn decl_collect_ancestor_names(
+  origin : ResolvedInterfaceOrigin,
+  modules : Map[String, DeclModuleInfo],
+  canonical_types : Map[String, String],
+  out : Array[String],
+  depth : Int,
+) -> Unit {
+  if depth > 8 {
+    return
+  }
+  for base_name in origin.iface.extends_names {
+    let tail = match base_name.rev_find(".") {
+      Some(pos) => base_name[pos + 1:].to_owned()
+      None => base_name
+    }
+    if !out.contains(tail) {
+      out.push(tail)
+    }
+    match
+      resolve_interface_origin(origin.info, base_name, modules, canonical_types) {
+      Some(base_origin) =>
+        decl_collect_ancestor_names(
+          base_origin,
+          modules,
+          canonical_types,
+          out,
+          depth + 1,
+        )
+      None => ()
+    }
+  }
+}
+
+///|
 /// `parse.ZodSafeParseResult` -> `ZodSafeParseResult`: unqualified tail,
 /// leading `$` / `_` markers stripped. Empty when nothing valid remains.
 fn decl_alias_synthetic_interface_name(name : String) -> String {
@@ -5439,6 +5606,19 @@ fn lower_react_utility_type(
           }
       }
     }
+    Named(name) =>
+      // A union alias whose members can't be runtime-discriminated but
+      // share a base interface references the base instead of an opaque
+      // handle (zod's `$ZodIssue` -> `$ZodIssueBase`). Tag-lowerable
+      // aliases never reach this (the guard re-checks), and non-alias /
+      // non-union names fall through untouched.
+      match
+        decl_join_union_alias_to_common_base(
+          info, modules, canonical_types, name,
+        ) {
+        Some(joined) => joined
+        None => type_
+      }
     TemplateLiteralType(parts, type_args) => {
       // Lower each interpolated arg, inline same-module alias bodies
       // (`type Channel = "info" | "warn"` becomes the union itself),

--- a/src/bridge/moonbit_decl_wbtest.mbt
+++ b/src/bridge/moonbit_decl_wbtest.mbt
@@ -2876,3 +2876,24 @@ async test "bridge: concrete interfaces flatten generic bases with substituted a
   assert_true(actual.contains("/// parse : (JSValue) -> String"))
   assert_true(actual.contains("/// label : String"))
 }
+
+///|
+async test "bridge: undiscriminable union aliases join to their common base" {
+  // zod's `$ZodIssue` idiom: `$`-prefixed member interfaces reject tagged
+  // lowering, but every member (including the NESTED union alias
+  // `$IssueUnionKind`) extends `$IssueBase` — the reference lands on the
+  // base struct instead of an opaque handle.
+  let actual = emit_moonbit_decl_from_entry_path(
+    "fixtures/resolver/project/types/union-common-base-entry.d.ts",
+  ) catch {
+    e => {
+      match e {
+        ReadError(msg) | ParseError(msg) | ResolveError(msg) =>
+          fail("Emit error: \{msg}")
+      }
+      return
+    }
+  }
+  assert_true(actual.contains("/// issues : Array[UnderscoreIssueBase]"))
+  assert_true(actual.contains("UnderscoreIssueBase"))
+}

--- a/src/bridge/moonbit_decl_wbtest.mbt
+++ b/src/bridge/moonbit_decl_wbtest.mbt
@@ -2853,3 +2853,26 @@ test "bridge: exclusive object union joins into one readable shape" {
   )
   assert_eq(plain, None)
 }
+
+///|
+async test "bridge: concrete interfaces flatten generic bases with substituted args" {
+  // A CONCRETE root (`StrSchema`, no type params of its own) inherits its
+  // generic base's members with the extends arguments substituted:
+  // `Base<string>.parse(value: unknown): T` arrives as
+  // `parse : (JSValue) -> String`. Generic roots keep the old
+  // no-expansion behavior (expansion measurably explodes the surface).
+  let actual = emit_moonbit_decl_from_entry_path(
+    "fixtures/resolver/project/types/generic-base-expansion-entry.d.ts",
+  ) catch {
+    e => {
+      match e {
+        ReadError(msg) | ParseError(msg) | ResolveError(msg) =>
+          fail("Emit error: \{msg}")
+      }
+      return
+    }
+  }
+  assert_true(actual.contains("/// kind : String"))
+  assert_true(actual.contains("/// parse : (JSValue) -> String"))
+  assert_true(actual.contains("/// label : String"))
+}

--- a/src/bridge/moonbit_js_ffi.mbt
+++ b/src/bridge/moonbit_js_ffi.mbt
@@ -5573,6 +5573,18 @@ pub async fn emit_moonbit_js_ffi_bundle_from_entry_path(
     push_unique_bridge_binding(
       seen_bridge_binding_names, bridge_lines, "__ts_mbt_record_from_pairs", "export function __ts_mbt_record_from_pairs(keys, values) { const out = {}; for (let i = 0; i < keys.length; i++) out[keys[i]] = values[i]; return out; }",
     )
+    // Every schema interface ultimately extends ZodType, but MoonBit's
+    // nominal structs cannot upcast, and GENERIC owners (ZodObject,
+    // ZodDiscriminatedUnion, ...) do not flatten their generic base
+    // (measured surface explosion) — parse / safeParse live on `Schema`
+    // only. The identity upcast makes the extends relation callable:
+    // `as_schema(object(...)).safeParse(...)` without a hand-written cast.
+    push_unique_ffi_section(
+      seen_ffi_binding_names,
+      ffi_sections,
+      ffi_fn_decl_key("as_schema"),
+      "pub fn[T] as_schema(schema : T) -> Schema[JSValue, JSValue, JSValue] {\n  unsafeCast(schema)\n}",
+    )
   }
   if ffi_is_react_router_module_spec(module_spec) {
     push_unique_ffi_section(

--- a/src/bridge/moonbit_js_ffi.mbt
+++ b/src/bridge/moonbit_js_ffi.mbt
@@ -3363,6 +3363,11 @@ fn ffi_is_react_router_module_spec(module_spec : String) -> Bool {
 }
 
 ///|
+fn ffi_is_zod_module_spec(module_spec : String) -> Bool {
+  module_spec == "zod" || module_spec.contains("/zod")
+}
+
+///|
 fn ffi_is_jose_module_spec(module_spec : String) -> Bool {
   module_spec == "jose" || module_spec.contains("/jose")
 }
@@ -5554,6 +5559,21 @@ pub async fn emit_moonbit_js_ffi_bundle_from_entry_path(
     handled_export_names.push(func.name)
   }
 
+  if ffi_is_zod_module_spec(module_spec) {
+    // `object()`'s shape is `$ZodLooseShape = Record<string, any>` — an
+    // opaque handle MoonBit could never construct. The builder pairs
+    // schema values with their keys the same way react-router's
+    // `params_from_pairs` does.
+    push_unique_ffi_section(
+      seen_ffi_binding_names,
+      ffi_sections,
+      ffi_fn_decl_key("loose_shape_from_pairs"),
+      "pub extern \"js\" fn loose_shape_from_pairs(keys : Array[String], values : Array[JSValue]) -> Core__ZodLooseShape = \"__ts_mbt_record_from_pairs\"",
+    )
+    push_unique_bridge_binding(
+      seen_bridge_binding_names, bridge_lines, "__ts_mbt_record_from_pairs", "export function __ts_mbt_record_from_pairs(keys, values) { const out = {}; for (let i = 0; i < keys.length; i++) out[keys[i]] = values[i]; return out; }",
+    )
+  }
   if ffi_is_react_router_module_spec(module_spec) {
     push_unique_ffi_section(
       seen_ffi_binding_names,

--- a/src/bridge/moonbit_js_ffi.mbt
+++ b/src/bridge/moonbit_js_ffi.mbt
@@ -46,7 +46,7 @@ priv struct MoonBitJsFfiState {
 }
 
 ///|
-let ffi_function_field_method_wrapper_limit : Int = 8
+let ffi_function_field_method_wrapper_limit : Int = 128
 
 ///|
 fn ffi_is_ascii_letter(c : Char) -> Bool {

--- a/src/parser/parser_moonbit.mbt
+++ b/src/parser/parser_moonbit.mbt
@@ -27,7 +27,7 @@ fn generic_preserved_type_arity(state : MoonBitDeclState, name : String) -> Int 
 }
 
 ///|
-let moonbit_function_field_method_wrapper_limit : Int = 16
+let moonbit_function_field_method_wrapper_limit : Int = 128
 
 ///|
 fn is_ascii_letter(c : Char) -> Bool {


### PR DESCRIPTION
Three commits continuing from #208 — the "full zod minus z.infer" batch. Everything below is runtime-verified with node against the regenerated package.

## 1. Flatten generic interface bases for concrete roots (`03e7702`)

Concrete interfaces (no type parameters of their own — zod's `ZodString`, `ZodEmail`, `ZodNumber`, ...) now flatten their generic bases with extends-argument substitution composed along the chain (`ZodString extends _ZodString<$ZodStringInternals<string>> extends _ZodType<T> extends ZodType<any, any, Internals>`). Derived redeclarations take precedence (own fields first).

- **`string(None).parse(...)` / `.safeParse(...)` / `.optional()` work directly — no `unsafeCast`.** For simple bases the return type resolves through the substitution (`Base<string>.parse(v: unknown): T` → `(JSValue) -> String`).
- Blanket expansion (generic roots too) was measured to explode the surface (3.6k → 20k mbti lines, 225 → 2695 fallbacks) and is deliberately rejected — the concrete-root gate keeps it to schema-leaf shapes.
- Method-wrapper limits raised 8/16 → 128 so the inherited surface actually gets wrappers.

## 2. Undiscriminable union aliases join to their common base + shape builder (`ca3fff1`)

- zod's `$ZodIssue` is an eleven-member union of `$`-prefixed interfaces — tagged lowering rejects every constructor name, so it stayed an opaque handle. A union ALIAS whose members cannot be runtime-discriminated now references the members' nearest common base interface instead: `issues : Array[ZodIssueBase]` with `{code : String?, path : Array[PropertyKey], message : String}` readable directly off a failed `safeParse` (`issues[0].code == "invalid_type"`). Nested union-alias members (`$ZodIssueInvalidUnion`) recurse; tagged-/enum-lowerable unions never reach the join.
- `loose_shape_from_pairs(keys, values) -> Core__ZodLooseShape` zod module hook (same pattern as react-router's `params_from_pairs`): `object()` shapes are built from MoonBit without hand-written externs.

## 3. `as_schema` identity upcast (`b74d613`)

GENERIC owners (`ZodObject`, `ZodDiscriminatedUnion`, ...) deliberately don't flatten their generic base, so `parse`/`safeParse` lived on `Schema` only. The zod hook now emits `pub fn[T] as_schema(schema : T) -> Schema[JSValue, JSValue, JSValue]`, making the extends relation callable: `as_schema(object(Some(shape), None)).safeParse(...)` works out of the box. The realworld zod smokes exercise the upcast + shape-builder path.

## Current usage surface

```moonbit
let user = object(Some(loose_shape_from_pairs(
  ["name", "age"],
  [unsafeCast(string(None)), unsafeCast(number(None))],
)), None)
let r = as_schema(user).safeParse(input, None)
if !r.success {
  // r.error issues carry code / path / message
}
string(None).email(None).safeParse(v, None)  // direct, no cast
```

The remaining gap to "fully full-featured" is `z.infer` for object schemas, which is a compile-time TS type-level computation — recorded in TODO.md as the typed-decoder codegen direction.

## Verification

- `moon test --target native`: 2516 tests, 0 failures
- verify-scaffolds / verify-generated-fixtures / verify-examples / bridge-quality: all exit 0
- TS7 oracle unchanged at TP 2335 / FP 0 (checker untouched in 2 of 3 commits; the extends_decision-adjacent commit re-ran the oracle clean)
- Runtime smokes: direct parse, issue reading, object schema via shape builder + upcast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr)_