### PR TITLE
ts2mbt: hono async handlers + middleware hooks; fetch roundtrip verified

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1220,6 +1220,35 @@ flattening, landed separately):
   full per-generic-owner facade (monomorphized method wrappers like the
   mbt2ts generic-method glue) remains the eventual principled shape.
 
+### 15. hono runs end-to-end: async handlers + middleware (done 2026-07-16)
+
+Runtime-verified (node, `app.fetch(new Request(...))` round-trips through
+MoonBit handlers): sync route via the existing `Context::text` wrapper
+(`c.text("...", None, None)` — the generic-owner method glue was ALREADY
+emitted for Context's callable-interface properties; the earlier "mbti
+declares it but it doesn't exist" reading was wrong, the decl is the
+method form), an async route returning `Promise[Response]`, a middleware
+that `c.set`s a variable before `next()` with the handler reading it via
+`c.get`, and 404 fallback.
+
+- [x] hono module hooks (same pattern as zod's `as_schema`):
+  `Hono::get_async / post_async / put_async / delete_async(path,
+  (Context) -> Promise[Response])` — the HandlerInterface overload the
+  generator picks is sync-only, but hono awaits whatever the handler
+  returns and MoonBit closures ARE JS functions on the js backend, so the
+  hooks register the closure raw with a typed surface.
+- [x] `Hono::use_middleware(path?, (Context, () -> Promise[Unit]) ->
+  Promise[Unit])`: pre-processing middleware calls `next()` and returns
+  its promise. Post-processing (sequencing AFTER next resolves) needs
+  Promise combinators on the MoonBit side and stays raw-JS territory.
+- [x] realworld hono smoke upgraded from register-only to the full
+  fetch round-trip (sync + async + middleware + 404).
+- Remaining hono gaps (documented, not blocking): `app.fetch` returns
+  `JSValue` (Response | Promise union), route methods return `HonoBase`
+  (chain loses generics), path-param TYPE inference (`/users/:id` ->
+  `{id: string}`) is TS type-level computation — same fundamental limit
+  as zod's `z.infer`.
+
 ### Non-Goals (still)
 
 - [ ] Do not turn this list into a checklist for "all of TypeScript". Each item

--- a/scripts/verify_realworld_typescript.sh
+++ b/scripts/verify_realworld_typescript.sh
@@ -724,17 +724,70 @@ EOF
 extern "js" fn realworld_hono_options() -> HonoOptions[Env] =
   #| () => ({ strict: true })
 
+extern "js" fn realworld_hono_resolve(r : Response) -> Promise[Response] =
+  #| (r) => Promise.resolve(r)
+
+extern "js" fn realworld_hono_key(s : String) -> Key =
+  #| (s) => s
+
+extern "js" fn realworld_hono_str(v : JSValue) -> String =
+  #| (v) => String(v)
+
+extern "js" fn realworld_hono_roundtrip(app : Hono[JSValue, JSValue, JSValue]) -> Unit =
+  #| (app) => {
+  #|   globalThis.__tsmbt_pending = (async () => {
+  #|     const ok = await app.fetch(new Request("http://localhost/"));
+  #|     if (ok.status !== 200 || (await ok.text()) !== "hello from moonbit") {
+  #|       console.error("hono sync route failed"); process.exit(1);
+  #|     }
+  #|     const a = await app.fetch(new Request("http://localhost/async"));
+  #|     if (a.status !== 200 || (await a.text()) !== "async moonbit") {
+  #|       console.error("hono async route failed"); process.exit(1);
+  #|     }
+  #|     const m = await app.fetch(new Request("http://localhost/mw"));
+  #|     if (m.status !== 200 || (await m.text()) !== "from middleware") {
+  #|       console.error("hono middleware failed"); process.exit(1);
+  #|     }
+  #|     const missing = await app.fetch(new Request("http://localhost/nope"));
+  #|     if (missing.status !== 404) { console.error("hono 404 failed"); process.exit(1); }
+  #|   })();
+  #| }
+
 fn realworld_hono_handler(
   c : Context[JSValue, JSValue, JSValue],
 ) -> Response {
   c.text("hello from moonbit", None, None)
 }
 
+fn realworld_hono_async_handler(
+  c : Context[JSValue, JSValue, JSValue],
+) -> Promise[Response] {
+  realworld_hono_resolve(c.text("async moonbit", None, None))
+}
+
+fn realworld_hono_mw(
+  c : Context[JSValue, JSValue, JSValue],
+  next : () -> Promise[Unit],
+) -> Promise[Unit] {
+  c.set(realworld_hono_key("who"), unsafeCast("from middleware"))
+  next()
+}
+
+fn realworld_hono_mw_handler(
+  c : Context[JSValue, JSValue, JSValue],
+) -> Response {
+  c.text(realworld_hono_str(c.get(realworld_hono_key("who"))), None, None)
+}
+
 test "real-world hono bridge smoke" {
   let app : Hono[JSValue, JSValue, JSValue] = new_hono(
     Some(realworld_hono_options()),
   )
+  app.use_middleware(None, realworld_hono_mw)
   let _ = app.get("/", realworld_hono_handler)
+  app.get_async("/async", realworld_hono_async_handler)
+  let _ = app.get("/mw", realworld_hono_mw_handler)
+  realworld_hono_roundtrip(app)
 }
 EOF
       ;;

--- a/src/bridge/moonbit_js_ffi.mbt
+++ b/src/bridge/moonbit_js_ffi.mbt
@@ -3368,6 +3368,17 @@ fn ffi_is_zod_module_spec(module_spec : String) -> Bool {
 }
 
 ///|
+/// Exact-package match only: a bare `contains("/hono")` also matches
+/// fixture paths like `.../hono-options-entry.d.ts`, injecting the hono
+/// hooks into minimal surfaces that lack Context / Response / the full
+/// Hono arity and breaking their compile.
+fn ffi_is_hono_module_spec(module_spec : String) -> Bool {
+  module_spec == "hono" ||
+  module_spec.has_suffix("/hono") ||
+  module_spec.contains("/hono/")
+}
+
+///|
 fn ffi_is_jose_module_spec(module_spec : String) -> Bool {
   module_spec == "jose" || module_spec.contains("/jose")
 }
@@ -5584,6 +5595,29 @@ pub async fn emit_moonbit_js_ffi_bundle_from_entry_path(
       ffi_sections,
       ffi_fn_decl_key("as_schema"),
       "pub fn[T] as_schema(schema : T) -> Schema[JSValue, JSValue, JSValue] {\n  unsafeCast(schema)\n}",
+    )
+  }
+  if ffi_is_hono_module_spec(module_spec) {
+    // Real-world handlers are async (`(c) => Promise<Response>`), but the
+    // HandlerInterface overload the generator picks is the sync one. The
+    // async registration hooks pass the MoonBit closure through raw —
+    // closures ARE JS functions on the js backend, and hono awaits
+    // whatever the handler returns.
+    push_unique_ffi_section(
+      seen_ffi_binding_names,
+      ffi_sections,
+      ffi_fn_decl_key("hono_get_async"),
+      "extern \"js\" fn _hono_route_async_extern_js(app : JSValue, method_name : String, path : String, handler : JSValue) -> Unit =\n  #| (app, method, path, handler) => { app[method](path, handler) }\n\npub fn[E, S, BasePath] Hono::get_async(self : Hono[E, S, BasePath], path : String, handler : (Context[JSValue, JSValue, JSValue]) -> Promise[Response]) -> Unit {\n  _hono_route_async_extern_js(unsafeCast(self), \"get\", path, unsafeCast(handler))\n}\n\npub fn[E, S, BasePath] Hono::post_async(self : Hono[E, S, BasePath], path : String, handler : (Context[JSValue, JSValue, JSValue]) -> Promise[Response]) -> Unit {\n  _hono_route_async_extern_js(unsafeCast(self), \"post\", path, unsafeCast(handler))\n}\n\npub fn[E, S, BasePath] Hono::put_async(self : Hono[E, S, BasePath], path : String, handler : (Context[JSValue, JSValue, JSValue]) -> Promise[Response]) -> Unit {\n  _hono_route_async_extern_js(unsafeCast(self), \"put\", path, unsafeCast(handler))\n}\n\npub fn[E, S, BasePath] Hono::delete_async(self : Hono[E, S, BasePath], path : String, handler : (Context[JSValue, JSValue, JSValue]) -> Promise[Response]) -> Unit {\n  _hono_route_async_extern_js(unsafeCast(self), \"delete\", path, unsafeCast(handler))\n}",
+    )
+    // Middleware: `(c, next) => Promise<void>` with `next : () =>
+    // Promise<void>`. Pre-processing middleware calls next() and returns
+    // its promise; post-processing (after-next sequencing) needs Promise
+    // combinators and stays raw-JS territory for now.
+    push_unique_ffi_section(
+      seen_ffi_binding_names,
+      ffi_sections,
+      ffi_fn_decl_key("hono_use_middleware"),
+      "extern \"js\" fn _hono_use_middleware_extern_js(app : JSValue, path : JSValue, mw : JSValue) -> Unit =\n  #| (app, path, mw) => { const u = (path == null ? undefined : (typeof path === \"object\" && \"$tag\" in path ? (path.$tag === 1 ? path._0 : undefined) : path)); if (u === undefined) { app.use(mw) } else { app.use(u, mw) } }\n\npub fn[E, S, BasePath] Hono::use_middleware(self : Hono[E, S, BasePath], path : String?, mw : (Context[JSValue, JSValue, JSValue], () -> Promise[Unit]) -> Promise[Unit]) -> Unit {\n  _hono_use_middleware_extern_js(unsafeCast(self), unsafeCast(path), unsafeCast(mw))\n}",
     )
   }
   if ffi_is_react_router_module_spec(module_spec) {


### PR DESCRIPTION
hono full-feature batch, continuing the zod work in #209. Everything runtime-verified with node: `app.fetch(new Request(...))` round-trips through MoonBit handlers.

## What was already there (correction to the initial assessment)

The generic-owner method glue for `Context` **already existed** — callable-interface properties (`text` / `json` / `html`) get extern+wrapper method glue, so `c.text("...", None, None)` works directly. The earlier reading of an mbti/ffi mismatch was wrong: the mbti's `context_text(self, ...)` line is the method decl form.

## What this PR adds

**Async handlers** — hono module hooks (same pattern as zod's `as_schema`):

```moonbit
Hono::get_async / post_async / put_async / delete_async(
  path : String, handler : (Context[JSValue, JSValue, JSValue]) -> Promise[Response])
```

The `HandlerInterface` overload the generator picks is sync-only, but hono awaits whatever the handler returns and MoonBit closures ARE JS functions on the js backend — the hooks register the closure raw behind a typed surface.

**Middleware**:

```moonbit
Hono::use_middleware(path : String?, mw : (Context[...], () -> Promise[Unit]) -> Promise[Unit])
```

Pre-processing middleware calls `next()` and returns its promise (`c.set` before `next`, handler reads via `c.get` — verified). Post-next sequencing needs Promise combinators on the MoonBit side and stays raw-JS territory for now.

**Predicate fix** — the hono module-spec predicate matches the exact package only: `contains("/hono")` also matched fixture paths like `hono-options-entry.d.ts`, injecting the hooks into minimal surfaces lacking `Context`/`Response` and breaking their compile.

## Current usage surface

```moonbit
let app : Hono[JSValue, JSValue, JSValue] = new_hono(None)
app.use_middleware(None, mw)
let _ = app.get("/", fn(c) { c.text("hi", None, None) })
app.get_async("/db", async_handler)   // (Context) -> Promise[Response]
```

The realworld hono smoke upgraded from register-only to the full fetch round-trip (sync route, async route, middleware `c.set` → `next()` → handler `c.get`, 404 fallback).

Remaining hono gap is path-param type inference (`/users/:id` → `{id: string}`) — TS type-level computation, same fundamental limit as zod's `z.infer`, recorded in TODO.md.

## Verification

- `moon test --target native`: 2516 tests, 0 failures
- verify-scaffolds / verify-generated-fixtures / verify-examples / bridge-quality: all exit 0
- Runtime smoke: hono full roundtrip ok (sync + async + middleware + 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr)_