### PR TITLE
Performance tuning round 1: parser/checker hotspots -48% parse, -14% check, all behavior-preserving

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1425,6 +1425,49 @@ both the name and the type diverged. Fixed from both sides:
 - [ ] Do not pursue `any` / `unknown` AST distinction unless a downstream
   consumer needs it; the JSValue count is unaffected.
 
+## Performance Tuning Round 1 (2026-07-19)
+
+Profiled with `moon bench --target native` + callgrind over the release
+`tscheck` binary (`--parse` / full, `--iters N`). Three landed batches,
+all behavior-preserving (full suite 2523 green, oracle byte-identical
+TP 2338 / FP 0 / TN 1750 / MISS 396, every gate green):
+
+1. Parser whole-source rescans (`20ff7e7`): `from_source_with_jsx`
+   lowered the FULL source 3x per parse (`@noImplicitThis` x2,
+   `@filename:`); all whole-source markers now come from one
+   `scan_source_directive_flags` pass over `@` positions. The ~10
+   conformance-header detectors each sliced+lowered their own 1KB head
+   -- multiplied by JSX speculation re-entering `from_source_with_jsx`
+   on sub-sources (2k+ nested parses on parserharness.ts); the head is
+   now computed once per parse and threaded through. `parse_jsdoc_block`
+   rewritten single-pass over StringViews (was 3+ owned strings per
+   comment line); the lexer passes the comment span without copying.
+2. Checker structural scans (`58527b4`): `iface_extends_reaches` was
+   O(ifaces^2 x chain) via per-step rescans of every interface decl
+   (~7.5% of a dom.generated.d.ts run) -- now a prebuilt name->extends
+   adjacency map + hash-set DFS. `is_lib_global_value`/`_type` (generated
+   1k/2.2k-arm string matches, probed once per reference; 9.6% of a
+   generic-heavy run) now memoize per name via gen_lib_globals.sh.
+3. Bench coverage: `moon bench` gains JSDoc-heavy (300 documented
+   decls) and old-style-cast-heavy (200 funcs, JSX speculation) parser
+   fixtures so both optimized paths regress visibly.
+
+Measured (release tscheck, per iteration):
+- es5.d.ts parse 11.7ms -> 6.1ms (~19 -> ~36 MB/s); full check 15 -> 9.7ms
+- dom.generated.d.ts parse 115 -> 60ms; full 170 -> ~100ms
+- parserharness.ts parse 44 -> 30ms; full 60 -> 49ms
+- generic-heavy check phase 26 -> 19ms
+- moon bench parser fixtures -17%..-38%
+
+Remaining known sinks (next round candidates): JSX speculative
+sub-parsing re-lexes substrings per `<` attempt (structural; a
+file-extension-driven `allow_jsx` would eliminate it for `.ts` but
+changes oracle-visible parse behavior for @filename .tsx embeds --
+needs oracle-gated validation); refcount+alloc runtime overhead is
+~25-30% of remaining profiles (only fixable by allocating less, e.g.
+token payload interning); `TokenKind::equal`/`Parser::peek/check` are
+~8% of body-heavy parses (derived Eq on payload enum).
+
 ## TS Checker Conformance (current state, 2026-07-17 — TypeScript 7)
 
 react joined the real-world gate as the 21st package (2026-07-18):

--- a/TODO.md
+++ b/TODO.md
@@ -1428,9 +1428,11 @@ both the name and the type diverged. Fixed from both sides:
 ## Performance Tuning Round 1 (2026-07-19)
 
 Profiled with `moon bench --target native` + callgrind over the release
-`tscheck` binary (`--parse` / full, `--iters N`). Four landed batches,
-all behavior-preserving (full suite 2523 green, oracle byte-identical
-TP 2338 / FP 0 / TN 1750 / MISS 396, every gate green):
+`tscheck` binary (`--parse` / full, `--iters N`; use
+`--toggle-collect=<mangled check entry>` to isolate the check phase from
+the parse). Five landed batches, all behavior-preserving (full suite
+2523 green, oracle byte-identical TP 2338 / FP 0 / TN 1750 / MISS 396,
+every gate green):
 
 1. Parser whole-source rescans (`20ff7e7`): `from_source_with_jsx`
    lowered the FULL source 3x per parse (`@noImplicitThis` x2,
@@ -1472,14 +1474,29 @@ Measured (release tscheck, per iteration):
    results. `moon bench` cast fixture split into `.tsx`-mode (4.96ms,
    speculation still exercised) and `.ts`-mode (3.51ms) variants.
 
+5. Module-pass allocation hoists (batch 5, check-phase Ir on
+   dom.generated.d.ts 552M -> 473M, -14%): `check_structural_duplicates`
+   and `walk_module_undeclared_tps` interpolated their diagnostic path
+   string (`"interface \{name}"` etc.) once per FIELD/PARAM instead of
+   per declaration — hoisted; `walk_module_undeclared_tps` also did a
+   linear scan of `method_type_params` per field (quadratic on lib.dom
+   interfaces) — now grouped once per interface;
+   `check_interface_extends_compat` rebuilt the base interface's
+   field/overload-count maps once per (derived, base) EDGE — popular DOM
+   bases like `Event` are extended by hundreds of interfaces — now
+   cached per base name, and the derived counts hoisted out of the
+   bases loop.
+
 Remaining known sinks (next round candidates): `.tsx`-mode JSX
 speculation still re-lexes substrings per `<` attempt (only matters
 for real `.tsx` sources now); refcount+alloc runtime overhead is
-~25-30% of remaining profiles (only fixable by allocating less, e.g.
-token payload interning); `Parser::peek/check` + `TokenKind::equal`
-are ~30% of body-heavy `.ts` parses (each peek copies a Token and
-refcounts its payload; a tag-int fast path would need parser-wide
-changes).
+~29% of the remaining check-phase profile and ~25-30% of parse (only
+fixable by allocating less); String-keyed Map probes are ~8% of the
+check phase spread across all passes (an interned-name or ID-keyed
+resolver would be a deep refactor); `Parser::peek/check` +
+`TokenKind::equal` are ~30% of body-heavy `.ts` parses (each peek
+copies a Token and refcounts its payload; a tag-int fast path would
+need parser-wide changes).
 
 ## TS Checker Conformance (current state, 2026-07-17 — TypeScript 7)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1428,7 +1428,7 @@ both the name and the type diverged. Fixed from both sides:
 ## Performance Tuning Round 1 (2026-07-19)
 
 Profiled with `moon bench --target native` + callgrind over the release
-`tscheck` binary (`--parse` / full, `--iters N`). Three landed batches,
+`tscheck` binary (`--parse` / full, `--iters N`). Four landed batches,
 all behavior-preserving (full suite 2523 green, oracle byte-identical
 TP 2338 / FP 0 / TN 1750 / MISS 396, every gate green):
 
@@ -1459,14 +1459,27 @@ Measured (release tscheck, per iteration):
 - generic-heavy check phase 26 -> 19ms
 - moon bench parser fixtures -17%..-38%
 
-Remaining known sinks (next round candidates): JSX speculative
-sub-parsing re-lexes substrings per `<` attempt (structural; a
-file-extension-driven `allow_jsx` would eliminate it for `.ts` but
-changes oracle-visible parse behavior for @filename .tsx embeds --
-needs oracle-gated validation); refcount+alloc runtime overhead is
+4. Paren-JSX speculation gated on `allow_jsx` (batch 4): tscheck was
+   already extension-driven (`.tsx` only), but THREE paren-path JSX
+   attempts (`try_parse_parenthesized_jsx_expr` + the two
+   `peek_at(1)==Lt` temp parses in `parse_parenthesized_expr` /
+   `parse_primary`) ignored the flag, so every `(<any>x)` cast in a
+   `.ts` file ran the full JSX source scan + nested embed sub-parses
+   and threw the work away. All three now early-out in `.ts` mode --
+   tsc-aligned (`(<T>x)` is a parenthesized type assertion there).
+   parserharness.ts parse 30 -> 11ms (44ms pre-round; -75% total),
+   full check 49 -> 35ms, byte-identical diagnostics and oracle
+   results. `moon bench` cast fixture split into `.tsx`-mode (4.96ms,
+   speculation still exercised) and `.ts`-mode (3.51ms) variants.
+
+Remaining known sinks (next round candidates): `.tsx`-mode JSX
+speculation still re-lexes substrings per `<` attempt (only matters
+for real `.tsx` sources now); refcount+alloc runtime overhead is
 ~25-30% of remaining profiles (only fixable by allocating less, e.g.
-token payload interning); `TokenKind::equal`/`Parser::peek/check` are
-~8% of body-heavy parses (derived Eq on payload enum).
+token payload interning); `Parser::peek/check` + `TokenKind::equal`
+are ~30% of body-heavy `.ts` parses (each peek copies a Token and
+refcounts its payload; a tag-int fast path would need parser-wide
+changes).
 
 ## TS Checker Conformance (current state, 2026-07-17 — TypeScript 7)
 

--- a/scripts/gen_lib_globals.sh
+++ b/scripts/gen_lib_globals.sh
@@ -38,11 +38,29 @@ grep -hoP '^\s*(?:interface|type|declare\s+(?:class|abstract class|namespace|enu
   | sort -u > /tmp/lib_type_names.txt
 
 emit_match() {
-  # $1 = fn name, $2 = names file. Emits a single match arm of the form
+  # $1 = fn name, $2 = names file. Emits a memoized predicate: the raw
+  # match spans thousands of arms and callers probe the same module-local
+  # names once per *reference*, so the wrapper caches per distinct name.
+  # The `_uncached` match emits arms of the form
   #   "a" | "b" | ... => true
   # wrapped across lines; continuation lines start with "| " so adjacent
   # lines join into one alternation without producing an empty alternative.
+  echo "let $1_memo : Map[String, Bool] = {}"
+  echo ""
+  echo "///|"
   echo "fn $1(name : String) -> Bool {"
+  echo "  match $1_memo.get(name) {"
+  echo "    Some(v) => v"
+  echo "    None => {"
+  echo "      let v = $1_uncached(name)"
+  echo "      $1_memo[name] = v"
+  echo "      v"
+  echo "    }"
+  echo "  }"
+  echo "}"
+  echo ""
+  echo "///|"
+  echo "fn $1_uncached(name : String) -> Bool {"
   echo "  match name {"
   awk '{ printf "\"%s\"", $0; if (NR % 6 == 0) printf "\n" ; else printf " " }
        END { if (NR % 6 != 0) printf "\n" }' "$2" \

--- a/src/bridge/moonbit_decl.mbt
+++ b/src/bridge/moonbit_decl.mbt
@@ -9844,32 +9844,6 @@ fn decl_func_wider_same_param_overload(
 }
 
 ///|
-fn decl_import_wider_than_any_same_param_preferred(
-  candidate : @ast.TsImport,
-  preferred : Array[@ast.TsImport],
-) -> Bool {
-  for item in preferred {
-    if decl_import_wider_same_param_overload(candidate, item) {
-      return true
-    }
-  }
-  false
-}
-
-///|
-fn decl_func_wider_than_any_same_param_preferred(
-  candidate : @ast.TsFunc,
-  preferred : Array[@ast.TsFunc],
-) -> Bool {
-  for item in preferred {
-    if decl_func_wider_same_param_overload(candidate, item) {
-      return true
-    }
-  }
-  false
-}
-
-///|
 fn decl_type_is_string_nonshared_buffer_union(type_ : @ast.TsType) -> Bool {
   match type_ {
     Union(items) => {

--- a/src/checker/check_module.mbt
+++ b/src/checker/check_module.mbt
@@ -121,9 +121,27 @@ pub fn check_module(module_ : @ast.TsModule) -> TypeCheckReport {
 
   // 3b. Interface extends-chain cycles: `interface A extends B {}` followed
   //     by `interface B extends A {}` — TypeScript rejects, synthesized
-  //     output must not produce.
+  //     output must not produce. Adjacency is built once (merged across
+  //     same-name declarations) so each interface's check is a plain DFS
+  //     instead of rescanning every declaration at every step.
+  let iface_edges : Map[String, Array[String]] = {}
   for iface in module_.interfaces {
-    if iface_extends_reaches(module_, iface.name, iface.extends_names, []) {
+    match iface_edges.get(iface.name) {
+      Some(edges) =>
+        for n in iface.extends_names {
+          edges.push(n)
+        }
+      None => iface_edges[iface.name] = iface.extends_names.copy()
+    }
+  }
+  for iface in module_.interfaces {
+    let visited : Map[String, Unit] = {}
+    if iface_extends_reaches(
+        iface_edges,
+        iface.name,
+        iface.extends_names,
+        visited,
+      ) {
       issues.push({
         kind: InterfaceExtendsCycle,
         name: iface.name,
@@ -785,11 +803,17 @@ fn scope_with_iface_params(iface : @ast.TsInterface) -> Array[String] {
 }
 
 ///|
+/// Whether `target` is reachable from `extends_names` over the interface
+/// extends graph (`edges` maps an interface name to the union of its
+/// declarations' extends lists). `visited` persists across branches — for
+/// fixed-target reachability a globally-marked DFS gives the same answer
+/// as the backtracking walk this replaced, without re-exploring shared
+/// ancestors from every path.
 fn iface_extends_reaches(
-  module_ : @ast.TsModule,
+  edges : Map[String, Array[String]],
   target : String,
   extends_names : Array[String],
-  visited : Array[String],
+  visited : Map[String, Unit],
 ) -> Bool {
   for name in extends_names {
     if name == target {
@@ -798,20 +822,14 @@ fn iface_extends_reaches(
     if visited.contains(name) {
       continue
     }
-    for iface in module_.interfaces {
-      if iface.name == name {
-        visited.push(name)
-        let reached = iface_extends_reaches(
-          module_,
-          target,
-          iface.extends_names,
-          visited,
-        )
-        let _ = visited.pop()
-        if reached {
+    match edges.get(name) {
+      Some(next) => {
+        visited[name] = ()
+        if iface_extends_reaches(edges, target, next, visited) {
           return true
         }
       }
+      None => ()
     }
   }
   false

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -23704,15 +23704,13 @@ fn check_structural_duplicates(module_ : @ast.TsModule) -> Array[ExprIssue] {
   // synthesized into an interface by the parser, so the interface loop
   // below already covers it -- no separate type-alias pass is needed.
   for iface in module_.interfaces {
+    let ipath = "interface \{iface.name}"
     for name in member_name_duplicates(iface.fields) {
-      issues.push({
-        path: "interface \{iface.name}",
-        message: "duplicate identifier `\{name}`",
-      })
+      issues.push({ path: ipath, message: "duplicate identifier `\{name}`" })
     }
     // Nested object type-literals inside field types.
     for f in iface.fields {
-      collect_type_dup_issues(f.1, "interface \{iface.name}", issues)
+      collect_type_dup_issues(f.1, ipath, issues)
     }
   }
   // Object type-literals in other declaration positions: alias bodies,
@@ -23726,16 +23724,18 @@ fn check_structural_duplicates(module_ : @ast.TsModule) -> Array[ExprIssue] {
     }
   }
   for f in module_.funcs {
+    let fpath = "function \{f.name}"
     for p in f.params {
-      collect_type_dup_issues(p.type_, "function \{f.name}", issues)
+      collect_type_dup_issues(p.type_, fpath, issues)
     }
-    collect_type_dup_issues(f.return_type, "function \{f.name}", issues)
+    collect_type_dup_issues(f.return_type, fpath, issues)
   }
   for imp in module_.imports {
+    let ipath = "function \{imp.name}"
     for p in imp.params {
-      collect_type_dup_issues(p.1, "function \{imp.name}", issues)
+      collect_type_dup_issues(p.1, ipath, issues)
     }
-    collect_type_dup_issues(imp.return_type, "function \{imp.name}", issues)
+    collect_type_dup_issues(imp.return_type, ipath, issues)
   }
   for v in module_.values {
     collect_type_dup_issues(v.type_, "value \{v.name}", issues)
@@ -24429,44 +24429,40 @@ fn walk_module_undeclared_tps(
 ) -> Unit {
   for f in module_.funcs {
     let scope = scope_extend(tp_scope, f.type_params)
+    let fpath = "function \{f.name}"
     for p in f.params {
-      check_type_undeclared_tps(
-        p.type_,
-        scope,
-        declared,
-        issues,
-        "function \{f.name}",
-      )
+      check_type_undeclared_tps(p.type_, scope, declared, issues, fpath)
     }
-    check_type_undeclared_tps(
-      f.return_type,
-      scope,
-      declared,
-      issues,
-      "function \{f.name}",
-    )
+    check_type_undeclared_tps(f.return_type, scope, declared, issues, fpath)
   }
   for imp in module_.imports {
     let scope = scope_extend(tp_scope, imp.type_params)
+    let ipath = "function \{imp.name}"
     for p in imp.params {
-      check_type_undeclared_tps(
-        p.1,
-        scope,
-        declared,
-        issues,
-        "function \{imp.name}",
-      )
+      check_type_undeclared_tps(p.1, scope, declared, issues, ipath)
     }
-    check_type_undeclared_tps(
-      imp.return_type,
-      scope,
-      declared,
-      issues,
-      "function \{imp.name}",
-    )
+    check_type_undeclared_tps(imp.return_type, scope, declared, issues, ipath)
   }
   for iface in module_.interfaces {
     let iscope = scope_extend(tp_scope, iface.type_params)
+    let ipath = "interface \{iface.name}"
+    // A generic method field carries its own fresh type parameters.
+    // Accumulate across ALL same-name entries: an overloaded method has
+    // one entry per overload (lib.dom's `querySelector<K>` /
+    // `querySelector<E>` set), and the fields are keyed by name only,
+    // so each field must see the union of the overloads' binders.
+    // Group once per interface — the per-field linear scan over
+    // `method_type_params` was quadratic on lib.dom-sized interfaces.
+    let method_tps_by_name : Map[String, Array[String]] = {}
+    for entry in iface.method_type_params {
+      match method_tps_by_name.get(entry.0) {
+        Some(acc) =>
+          for tp in entry.1 {
+            acc.push(tp)
+          }
+        None => method_tps_by_name[entry.0] = entry.1.copy()
+      }
+    }
     for field in iface.fields {
       // Call / construct / index signatures (`<T>(x: T): T`) declare their own
       // generic parameters under a sentinel field name that doesn't key into
@@ -24475,55 +24471,25 @@ fn walk_module_undeclared_tps(
       if is_signature_sentinel(field.0) {
         continue
       }
-      // A generic method field carries its own fresh type parameters.
-      // Accumulate across ALL same-name entries: an overloaded method has
-      // one entry per overload (lib.dom's `querySelector<K>` /
-      // `querySelector<E>` set), and the fields are keyed by name only,
-      // so each field must see the union of the overloads' binders.
-      let mut mscope = iscope
-      for entry in iface.method_type_params {
-        if entry.0 == field.0 {
-          mscope = scope_extend(mscope, entry.1)
-        }
+      let mscope = match method_tps_by_name.get(field.0) {
+        Some(tps) => scope_extend(iscope, tps)
+        None => iscope
       }
-      check_type_undeclared_tps(
-        field.1,
-        mscope,
-        declared,
-        issues,
-        "interface \{iface.name}",
-      )
+      check_type_undeclared_tps(field.1, mscope, declared, issues, ipath)
     }
   }
   for c in module_.classes {
     let cscope = scope_extend(tp_scope, c.type_params)
+    let cpath = "class \{c.name}"
     for prop in c.properties {
-      check_type_undeclared_tps(
-        prop.type_,
-        cscope,
-        declared,
-        issues,
-        "class \{c.name}",
-      )
+      check_type_undeclared_tps(prop.type_, cscope, declared, issues, cpath)
     }
     for m in c.methods {
       let mscope = scope_extend(cscope, m.type_params)
       for p in m.params {
-        check_type_undeclared_tps(
-          p.1,
-          mscope,
-          declared,
-          issues,
-          "class \{c.name}",
-        )
+        check_type_undeclared_tps(p.1, mscope, declared, issues, cpath)
       }
-      check_type_undeclared_tps(
-        m.return_type,
-        mscope,
-        declared,
-        issues,
-        "class \{c.name}",
-      )
+      check_type_undeclared_tps(m.return_type, mscope, declared, issues, cpath)
     }
   }
   for v in module_.values {
@@ -28482,12 +28448,56 @@ fn check_interface_extends_compat(
       _ => false
     }
   }
+  // Field map + overload counts per BASE interface, built once per name
+  // instead of once per (derived, base) edge — popular DOM bases like
+  // `Event` / `Node` are extended by hundreds of interfaces. Keyed by
+  // name, which is exactly how bases resolve (`iface_by_name`).
+  let base_fields_cache : Map[
+    String,
+    (Map[String, @ast.TsType], Map[String, Int]),
+  ] = {}
+  fn base_field_maps(
+    name : String,
+    base : @ast.TsInterface,
+  ) -> (Map[String, @ast.TsType], Map[String, Int]) {
+    match base_fields_cache.get(name) {
+      Some(v) => v
+      None => {
+        let fields : Map[String, @ast.TsType] = {}
+        let counts : Map[String, Int] = {}
+        for f in base.fields {
+          fields[f.0] = f.1
+          counts[f.0] = match counts.get(f.0) {
+            Some(n) => n + 1
+            None => 1
+          }
+        }
+        let v = (fields, counts)
+        base_fields_cache[name] = v
+        v
+      }
+    }
+  }
+
   for iface in module_.interfaces {
     if iface.type_params.length() > 0 {
       continue
     }
     if iface.extends_names.length() == 0 {
       continue
+    }
+    // Overload sets: when either side declares the member more than
+    // once, tsc compares the WHOLE set (any-overload satisfies), so a
+    // pairwise entry comparison is wrong — lib.dom's specialized
+    // `addEventListener<K extends keyof ...>` + string-overload pattern
+    // misfired 464 times. Count once per derived declaration (NOT per
+    // base edge) and skip those members below.
+    let derived_counts : Map[String, Int] = {}
+    for df in iface.fields {
+      derived_counts[df.0] = match derived_counts.get(df.0) {
+        Some(n) => n + 1
+        None => 1
+      }
     }
     for bi, base_name in iface.extends_names {
       // Skip bases supplied with type arguments (`extends Foo<X>`).
@@ -28498,30 +28508,8 @@ fn check_interface_extends_compat(
         Some(b) => b
         None => continue
       }
-      // Base field name -> (type, accepts-undefined).
-      let base_fields : Map[String, @ast.TsType] = {}
-      for f in base.fields {
-        base_fields[f.0] = f.1
-      }
-      // Overload sets: when either side declares the member more than
-      // once, tsc compares the WHOLE set (any-overload satisfies), so a
-      // pairwise entry comparison is wrong — lib.dom's specialized
-      // `addEventListener<K extends keyof ...>` + string-overload pattern
-      // misfired 464 times. Count and skip those members below.
-      let derived_counts : Map[String, Int] = {}
-      for df in iface.fields {
-        derived_counts[df.0] = match derived_counts.get(df.0) {
-          Some(n) => n + 1
-          None => 1
-        }
-      }
-      let base_counts : Map[String, Int] = {}
-      for f in base.fields {
-        base_counts[f.0] = match base_counts.get(f.0) {
-          Some(n) => n + 1
-          None => 1
-        }
-      }
+      // Base field name -> (type, overload count).
+      let (base_fields, base_counts) = base_field_maps(base_name, base)
       fn member_is_overloaded(name : String) -> Bool {
         (match derived_counts.get(name) {
           Some(n) => n > 1

--- a/src/checker/lib_globals.mbt
+++ b/src/checker/lib_globals.mbt
@@ -6,7 +6,22 @@
 ///|
 /// True when `name` is a standard-library ambient global *value*
 /// (`console`, `Math`, `Promise`, `document`, `Symbol`, …).
+let is_lib_global_value_memo : Map[String, Bool] = {}
+
+///|
 fn is_lib_global_value(name : String) -> Bool {
+  match is_lib_global_value_memo.get(name) {
+    Some(v) => v
+    None => {
+      let v = is_lib_global_value_uncached(name)
+      is_lib_global_value_memo[name] = v
+      v
+    }
+  }
+}
+
+///|
+fn is_lib_global_value_uncached(name : String) -> Bool {
   match name {
     "AbortController"
     | "AbortSignal"
@@ -1050,7 +1065,22 @@ fn is_lib_global_value(name : String) -> Bool {
 /// (`PropertyDescriptor`, `PromiseLike`, `HTMLElement`,
 /// `IteratorResult`, …). Interfaces, type aliases, declared classes,
 /// namespaces, and enums across every lib target.
+let is_lib_global_type_memo : Map[String, Bool] = {}
+
+///|
 fn is_lib_global_type(name : String) -> Bool {
+  match is_lib_global_type_memo.get(name) {
+    Some(v) => v
+    None => {
+      let v = is_lib_global_type_uncached(name)
+      is_lib_global_type_memo[name] = v
+      v
+    }
+  }
+}
+
+///|
+fn is_lib_global_type_uncached(name : String) -> Bool {
   match name {
     "ANGLE_instanced_arrays"
     | "ARIAMixin"

--- a/src/parser/jsdoc.mbt
+++ b/src/parser/jsdoc.mbt
@@ -60,76 +60,90 @@ pub fn JsdocBlock::is_empty(self : JsdocBlock) -> Bool {
 /// comment isn't a JSDoc block (`/* … */` without the double
 /// asterisk) or is empty.
 pub fn parse_jsdoc_block(text : String) -> JsdocBlock? {
-  // Must start with `/**` and end with `*/`. Single-asterisk
-  // `/* … */` comments aren't JSDoc; we still scan them for
-  // inline `@__PURE__` markers separately.
+  parse_jsdoc_block_view(text[:])
+}
+
+///|
+/// View-based implementation of `parse_jsdoc_block`. Runs once per
+/// `/**` comment during lexing, so it stays single-pass and slices the
+/// comment span in place — building per-line owned strings here used to
+/// dominate whole-file parse profiles on comment-heavy inputs like
+/// es5.d.ts.
+fn parse_jsdoc_block_view(text : StringView) -> JsdocBlock? {
   if !text.has_prefix("/**") {
     return None
   }
-  let body_start = 3
   let body_end = if text.has_suffix("*/") {
     text.length() - 2
   } else {
     text.length()
   }
-  if body_end <= body_start {
+  if body_end <= 3 {
     return None
   }
-  let raw = text[body_start:body_end].to_owned()
-  // Strip the leading `*` (with optional space) on each line —
-  // standard JSDoc convention puts a `*` at column 0 of every
-  // continuation line. Without this we'd leak `*` chars into
-  // descriptions.
-  let cleaned = strip_jsdoc_line_prefixes(raw)
-  // Split into description + tags. The first `@tag` at the start
-  // of a line marks the boundary. Lines before the first tag
-  // form the description.
-  let mut description = ""
+  let body = text[3:body_end]
+  // Accumulators. The description and each tag's content are built by
+  // appending cleaned line views separated by '\n', matching the old
+  // join("\n") shape exactly.
+  let description = StringBuilder::new()
+  let mut description_started = false
   let tags : Array[JsdocTag] = []
   let mut current_tag_name = ""
-  let mut current_tag_content : Array[String] = []
+  let tag_content = StringBuilder::new()
   let mut in_description = true
-  for line_view in cleaned.split("\n") {
-    let line = line_view.to_owned()
-    let trimmed = line.trim_start()
+  fn flush_tag() {
+    tags.push(
+      interpret_tag(
+        current_tag_name,
+        tag_content.to_string().trim_end().to_owned(),
+      ),
+    )
+  }
+
+  for line in body.split("\n") {
+    // Strip the leading `*` (with optional space) that the JSDoc
+    // convention puts on every continuation line; lines without the
+    // marker keep their original indentation.
+    let star_trimmed = line.trim_start()
+    let cleaned = if star_trimmed.has_prefix("* ") {
+      star_trimmed[2:]
+    } else if star_trimmed.has_prefix("*") {
+      star_trimmed[1:]
+    } else {
+      line
+    }
+    let trimmed = cleaned.trim_start()
     if trimmed.has_prefix("@") {
       // Flush whatever we were collecting.
       if !in_description {
-        tags.push(
-          interpret_tag(
-            current_tag_name,
-            current_tag_content.join("\n").trim_end().to_owned(),
-          ),
-        )
-      } else if description != "" {
-        description = description.trim_end().to_owned()
+        flush_tag()
+        tag_content.reset()
       }
       in_description = false
-      // Split into tag name + rest. Tag name is `[a-zA-Z_]+` or
+      // Split into tag name + rest. Tag name is `[a-zA-Z0-9_]+` or
       // the special `__PURE__` / `__NO_SIDE_EFFECTS__` marker.
-      let rest = trimmed[1:].to_owned()
-      let (name, body) = split_tag_head(rest)
+      let (name, body_view) = split_tag_head(trimmed[1:])
       current_tag_name = name
-      current_tag_content = [body]
+      tag_content.write_view(body_view)
     } else if in_description {
-      if description != "" {
-        description = description + "\n"
+      if description_started {
+        description.write_char('\n')
       }
-      description = description + line
+      description.write_view(cleaned)
+      description_started = description_started || cleaned.length() > 0
     } else {
-      current_tag_content.push(line)
+      tag_content.write_char('\n')
+      tag_content.write_view(cleaned)
     }
   }
   // Flush the trailing tag.
   if !in_description {
-    tags.push(
-      interpret_tag(
-        current_tag_name,
-        current_tag_content.join("\n").trim_end().to_owned(),
-      ),
-    )
+    flush_tag()
   }
-  let block : JsdocBlock = { description: description.trim().to_owned(), tags }
+  let block : JsdocBlock = {
+    description: description.to_string().trim().to_owned(),
+    tags,
+  }
   if block.is_empty() {
     None
   } else {
@@ -138,27 +152,9 @@ pub fn parse_jsdoc_block(text : String) -> JsdocBlock? {
 }
 
 ///|
-fn strip_jsdoc_line_prefixes(s : String) -> String {
-  let out : Array[String] = []
-  for line_view in s.split("\n") {
-    let line = line_view.to_owned()
-    let trimmed = line.trim_start().to_owned()
-    let cleaned = if trimmed.has_prefix("* ") {
-      trimmed[2:].to_owned()
-    } else if trimmed.has_prefix("*") {
-      trimmed[1:].to_owned()
-    } else {
-      line
-    }
-    out.push(cleaned)
-  }
-  out.join("\n")
-}
-
-///|
 /// Split a tag line (post-`@`) into `(tag_name, rest)`.
 /// `paramName description` → `("paramName", "description")`.
-fn split_tag_head(s : String) -> (String, String) {
+fn split_tag_head(s : StringView) -> (String, StringView) {
   let mut i = 0
   while i < s.length() {
     let c = s[i]
@@ -175,7 +171,7 @@ fn split_tag_head(s : String) -> (String, String) {
     return ("", s)
   }
   let name = s[0:i].to_owned()
-  let rest = s[i:].to_owned().trim_start().to_owned()
+  let rest = s[i:].trim_start()
   (name, rest)
 }
 

--- a/src/parser/lexer.mbt
+++ b/src/parser/lexer.mbt
@@ -418,7 +418,7 @@ fn Lexer::skip_whitespace(self : Lexer) -> Unit {
             // inline `@__PURE__` marker); JSDoc `/** … */` goes
             // through the structured parser so individual tags
             // are queryable downstream.
-            let comment_text = self.src[comment_start:self.pos].to_owned()
+            let comment_text = self.src[comment_start:self.pos]
             // Quick-and-cheap markers — these still drive the
             // existing `pure_marker_positions` /
             // `internal_marker_positions` tables for callers that
@@ -433,7 +433,7 @@ fn Lexer::skip_whitespace(self : Lexer) -> Unit {
             // last block wins when multiple stack up before one
             // declaration.
             if comment_text.has_prefix("/**") {
-              match parse_jsdoc_block(comment_text) {
+              match parse_jsdoc_block_view(comment_text) {
                 Some(jb) => self.pending_jsdoc = Some(jb)
                 None => ()
               }

--- a/src/parser/parser_bench_wbtest.mbt
+++ b/src/parser/parser_bench_wbtest.mbt
@@ -259,11 +259,29 @@ test "bench parser: JSDoc-heavy (300 documented decls)" (it : @bench.T) {
 }
 
 ///|
-test "bench parser: old-style cast heavy (200 funcs, JSX speculation)" (
+/// `.tsx` mode: `<T>expr` in expression position triggers the JSX
+/// speculation scan (tsc would reject old-style casts here, but the
+/// parser still has to disambiguate — this tracks that path's cost).
+test "bench parser: old-style cast heavy (200 funcs, .tsx JSX speculation)" (
   it : @bench.T,
 ) {
   it.bench(fn() {
     let module_ = Parser::from_source(cast_heavy_200).parse_module() catch {
+      _ => return
+    }
+    it.keep(module_.funcs.length())
+  })
+}
+
+///|
+/// `.ts` mode (`allow_jsx` off): the same casts parse as type
+/// assertions with no JSX speculation — the mode tscheck uses for every
+/// non-`.tsx` file.
+test "bench parser: old-style cast heavy (200 funcs, .ts assertion mode)" (
+  it : @bench.T,
+) {
+  it.bench(fn() {
+    let module_ = Parser::from_source_with_jsx(cast_heavy_200, false).parse_module() catch {
       _ => return
     }
     it.keep(module_.funcs.length())

--- a/src/parser/parser_bench_wbtest.mbt
+++ b/src/parser/parser_bench_wbtest.mbt
@@ -137,6 +137,64 @@ let wide_500 : String = build_wide_interface(500)
 let wide_2000 : String = build_wide_interface(2000)
 
 ///|
+/// JSDoc-heavy fixture: every declaration carries a multi-line doc
+/// comment with tags, mirroring real `.d.ts` inputs (es5.d.ts is ~60%
+/// comments by volume). Tracks the lexer's comment scan +
+/// `parse_jsdoc_block` path, which dominated whole-file profiles before
+/// the view-based rewrite.
+fn build_jsdoc_heavy(decl_count : Int) -> String {
+  let buf = StringBuilder::new()
+  for i in 0..<decl_count {
+    let n = i.to_string()
+    buf.write_string("/**\n")
+    buf.write_string(
+      " * Reads the value of entry " + n + " from the backing store.\n",
+    )
+    buf.write_string(" * Second description line with more prose text.\n")
+    buf.write_string(" * @param key" + n + " - the lookup key\n")
+    buf.write_string(" * @param options optional retrieval options\n")
+    buf.write_string(" * @returns {Entry" + n + "} the resolved entry\n")
+    buf.write_string(" * @deprecated use readEntryV2 instead\n")
+    buf.write_string(" */\n")
+    buf.write_string(
+      "declare function readEntry" +
+      n +
+      "(key" +
+      n +
+      ": string, options?: object): Entry" +
+      n +
+      ";\n",
+    )
+    buf.write_string("interface Entry" + n + " { value: string }\n")
+  }
+  buf.to_string()
+}
+
+///|
+let jsdoc_heavy_300 : String = build_jsdoc_heavy(300)
+
+///|
+/// Old-style-cast-heavy fixture: `<Type>expr` casts in expression
+/// position trigger the JSX speculation path (scan + nested sub-parse)
+/// when `allow_jsx` is on, the dominant cost on legacy TS sources like
+/// parserharness.ts. Tracks the speculative re-parse overhead.
+fn build_cast_heavy(func_count : Int) -> String {
+  let buf = StringBuilder::new()
+  for i in 0..<func_count {
+    let n = i.to_string()
+    buf.write_string("function conv" + n + "(x: unknown): number {\n")
+    buf.write_string("  const a = <any>x;\n")
+    buf.write_string("  const b = <number>(<any>a);\n")
+    buf.write_string("  return <number>b + " + n + ";\n")
+    buf.write_string("}\n")
+  }
+  buf.to_string()
+}
+
+///|
+let cast_heavy_200 : String = build_cast_heavy(200)
+
+///|
 test "bench parser: small mixed declarations (~9 decls)" (it : @bench.T) {
   it.bench(fn() {
     let module_ = Parser::from_source(small_source).parse_module() catch {
@@ -187,6 +245,28 @@ test "bench parser: wide interface (2000 fields)" (it : @bench.T) {
       _ => return
     }
     it.keep(module_.interfaces.length())
+  })
+}
+
+///|
+test "bench parser: JSDoc-heavy (300 documented decls)" (it : @bench.T) {
+  it.bench(fn() {
+    let module_ = Parser::from_source(jsdoc_heavy_300).parse_module() catch {
+      _ => return
+    }
+    it.keep(module_.funcs.length())
+  })
+}
+
+///|
+test "bench parser: old-style cast heavy (200 funcs, JSX speculation)" (
+  it : @bench.T,
+) {
+  it.bench(fn() {
+    let module_ = Parser::from_source(cast_heavy_200).parse_module() catch {
+      _ => return
+    }
+    it.keep(module_.funcs.length())
   })
 }
 

--- a/src/parser/parser_core.mbt
+++ b/src/parser/parser_core.mbt
@@ -326,6 +326,12 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
   let lexer = Lexer::new(src)
   let tokens = lexer.tokenize()
   let in_strict = detect_use_strict_prologue(src)
+  // The conformance-header detectors below all scan the same leading
+  // window. Slice + lowercase it once — JSX speculation re-enters
+  // `from_source_with_jsx` on sub-sources, so per-detector copies used to
+  // multiply across every speculative parse.
+  let head = source_head(src)
+  let head_lower = head.to_lower()
   let grammar_misuses : Array[String] = []
   if lexer.invalid_char_count > 0 {
     grammar_misuses.push("invalid character in source")
@@ -333,17 +339,21 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
   if lexer.unterminated_template {
     grammar_misuses.push("unterminated template literal")
   }
+  // Whole-source directive markers, collected in one pass (each used to
+  // be its own full-source scan — two of them via lowered copies).
+  let (has_ts_suppression, noimplicitthis_off, has_filename_directive) = scan_source_directive_flags(
+    src,
+  )
   // Marker: the file uses `@ts-ignore` / `@ts-expect-error` suppression
   // comments somewhere. Our issues carry no line positions, so rules
   // whose corpus counter-examples are suppressed lines (the computed-key
   // TS2465/TS1166 family) abstain for the whole file when set.
-  if src.contains("@ts-ignore") || src.contains("@ts-expect-error") {
+  if has_ts_suppression {
     grammar_misuses.push("<ts-suppression-present>")
   }
   // TS2683 opt-out: `@noImplicitThis: false` disables the implicit-any
   // `this` diagnostics for the file.
-  if src.to_lower().contains("@noimplicitthis: false") ||
-    src.to_lower().contains("@noimplicitthis:false") {
+  if noimplicitthis_off {
     grammar_misuses.push("<noimplicitthis-off>")
   }
   for _i in 0..<lexer.invalid_radix_digit_count {
@@ -362,7 +372,7 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
   }
   // Module-scoped flag marker for the override checks (TS4114 fires only
   // under `@noImplicitOverride: true`); TS4112/TS4113 are unconditional.
-  if detect_no_implicit_override(src) {
+  if detect_no_implicit_override(head) {
     grammar_misuses.push("<noimplicitoverride-on>")
   }
   // TS2318 evidence: lib-set directives that provably remove global types
@@ -372,10 +382,10 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
   // lacks `IterableIterator` (needed by generators —
   // generatorReturnTypeFallback.2), and one without `esnext` lacks
   // `Disposable` (needed by `using` — usingDeclarations.9).
-  if detect_nolib(src) {
+  if detect_nolib(head_lower) {
     grammar_misuses.push("<nolib>")
   }
-  match detect_lib_list(src) {
+  match detect_lib_list(head_lower) {
     Some(libs) => {
       if !lib_list_grants_iterable(libs) {
         grammar_misuses.push("<lib-lacks-iterable>")
@@ -394,7 +404,7 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
       // No explicit `@lib:` — the default lib follows the target, so an
       // explicit `@target:` list capped below es2017 also lacks the
       // es2017 surface (useObjectValuesAndEntries3's `@target: es6`).
-      match detect_target_list(src) {
+      match detect_target_list(head_lower) {
         Some(targets) =>
           if !target_list_reaches_es2017(targets) {
             grammar_misuses.push("<lib-lacks-es2017>")
@@ -404,7 +414,7 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
   }
   // TS2854 evidence: a top-level `await using` needs target >= es2017;
   // conformance files list their variant targets in one directive.
-  match detect_target_list(src) {
+  match detect_target_list(head_lower) {
     Some(targets) =>
       if target_list_has_below_es2017(targets) {
         grammar_misuses.push("<target-below-es2017>")
@@ -413,12 +423,13 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
   }
   // Decorator-mode marker so checker-side decorator signature rules can
   // pick the runtime invocation arity (legacy = 1 arg, standard = 2).
-  if detect_experimental_decorators(src) {
+  let experimental_decorators = detect_experimental_decorators(head_lower)
+  if experimental_decorators {
     grammar_misuses.push("<experimental-decorators>")
   }
   // Marker for the TS2695 comma-operator check, which tsc disables under
   // `@allowUnreachableCode: true`.
-  if detect_allow_unreachable_code(src) {
+  if detect_allow_unreachable_code(head) {
     grammar_misuses.push("<allowunreachable-on>")
   }
   {
@@ -455,18 +466,18 @@ pub fn Parser::from_source_with_jsx(src : String, allow_jsx : Bool) -> Parser {
     grammar_misuses,
     imported_binding_names: [],
     import_module_specs: [],
-    multi_file_source: detect_filename_directives(src),
+    multi_file_source: has_filename_directive,
     class_base_type_args: [],
     no_bound_inline: false,
-    target_es6_plus: detect_target_es6_plus(src),
-    no_implicit_any: detect_no_implicit_any(src),
-    experimental_decorators: detect_experimental_decorators(src),
+    target_es6_plus: detect_target_es6_plus(head_lower),
+    no_implicit_any: detect_no_implicit_any(head),
+    experimental_decorators,
     template_invalid_escape_positions: lexer.template_invalid_escape_positions,
     record_implicit_any_params: false,
     class_decl_no_heritage: false,
     in_class_expr_body: false,
     written_any_params: {},
-    directive_strict: detect_directive_strict(src),
+    directive_strict: detect_directive_strict(head),
     param_optional_initializer_misuses: [],
     interface_member_modifier_misuses: [],
     collected_class_dups: [],
@@ -723,9 +734,7 @@ fn detect_use_strict_prologue(src : String) -> Bool {
 /// list contains `true`. Multi-variant directives (`@alwaysStrict: true,
 /// false`) count -- at least one tsc variant runs strict, so a strict-mode
 /// grammar misuse is an error in that variant's baseline.
-fn detect_directive_strict(src : String) -> Bool {
-  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
-  let head = src[:head_len].to_owned()
+fn detect_directive_strict(head : String) -> Bool {
   for directive in ["@alwaysStrict:", "@strict:"] {
     match head.find(directive) {
       Some(i) => {
@@ -777,12 +786,102 @@ fn Parser::rollback_recordings(
 }
 
 ///|
+/// Exact match of `needle` against `src` starting at position `i`.
+fn matches_at(src : String, i : Int, needle : String) -> Bool {
+  let n = needle.length()
+  if i + n > src.length() {
+    return false
+  }
+  for j in 0..<n {
+    if src[i + j] != needle[j] {
+      return false
+    }
+  }
+  true
+}
+
+///|
+/// ASCII-case-insensitive match of lowercase-ASCII `needle` against
+/// `src` starting at position `i` (code-unit compare, A-Z folded).
+fn matches_ascii_ci_at(src : String, i : Int, needle : String) -> Bool {
+  let n = needle.length()
+  if i + n > src.length() {
+    return false
+  }
+  for j in 0..<n {
+    let mut c = src[i + j].to_int()
+    if c >= 65 && c <= 90 {
+      c = c + 32
+    }
+    if c != needle[j].to_int() {
+      return false
+    }
+  }
+  true
+}
+
+///|
+/// One pass over the whole source collecting every marker that
+/// `from_source_with_jsx` needs from arbitrary positions:
+///
+///   .0  `@ts-ignore` / `@ts-expect-error` (case-sensitive)
+///   .1  `@noImplicitThis:` + optional single space + `false`
+///       (case-insensitive)
+///   .2  `@filename:` (case-insensitive)
+///
+/// All markers start with `@`, so the scan only inspects positions whose
+/// code unit is `@`. Replaces five separate full-source scans, two of
+/// which lowered a full mutable copy of the source per call.
+fn scan_source_directive_flags(src : String) -> (Bool, Bool, Bool) {
+  let mut suppression = false
+  let mut noimplicitthis_off = false
+  let mut filename = false
+  let at_code = '@'.to_int()
+  let m = src.length()
+  for i in 0..<m {
+    if src[i].to_int() != at_code {
+      continue
+    }
+    if !suppression &&
+      (
+        matches_at(src, i, "@ts-ignore") ||
+        matches_at(src, i, "@ts-expect-error")
+      ) {
+      suppression = true
+    }
+    if !noimplicitthis_off && matches_ascii_ci_at(src, i, "@noimplicitthis:") {
+      let mut j = i + "@noimplicitthis:".length()
+      if j < m && src[j].to_int() == ' '.to_int() {
+        j += 1
+      }
+      if matches_ascii_ci_at(src, j, "false") {
+        noimplicitthis_off = true
+      }
+    }
+    if !filename && matches_ascii_ci_at(src, i, "@filename:") {
+      filename = true
+    }
+    if suppression && noimplicitthis_off && filename {
+      break
+    }
+  }
+  (suppression, noimplicitthis_off, filename)
+}
+
+///|
+/// The leading window the conformance-header detectors scan: the first
+/// 1024 UTF-16 code units of the source, as an owned string. Computed
+/// once per `from_source_with_jsx` and threaded through every detector.
+fn source_head(src : String) -> String {
+  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
+  src[:head_len].to_owned()
+}
+
+///|
 /// True when the conformance header names an ES2015+ target
 /// (`@target: es6` / `es2015` .. `esnext`), in any position of the
-/// comma list.
-fn detect_target_es6_plus(src : String) -> Bool {
-  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
-  let head = src[:head_len].to_owned().to_lower()
+/// comma list. `head` is the pre-lowered leading window.
+fn detect_target_es6_plus(head : String) -> Bool {
   match head.find("@target:") {
     Some(i) => {
       let rest = head[i + "@target:".length():].to_owned()
@@ -806,10 +905,8 @@ fn detect_target_es6_plus(src : String) -> Bool {
 /// noImplicitAny from the conformance header. Default `true` (matching the
 /// baselines for directive-less files); `@strict: false` /
 /// `@noImplicitAny: false` opt out, explicit `@noImplicitAny: true` wins
-/// over `@strict: false`.
-fn detect_no_implicit_any(src : String) -> Bool {
-  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
-  let head = src[:head_len].to_owned()
+/// over `@strict: false`. `head` is the (case-preserved) leading window.
+fn detect_no_implicit_any(head : String) -> Bool {
   if head.contains("@noImplicitAny: true") ||
     head.contains("@noImplicitAny:true") {
     return true
@@ -827,10 +924,8 @@ fn detect_no_implicit_any(src : String) -> Bool {
 ///|
 /// True when the conformance header enables `@noImplicitOverride`.
 /// Default OFF (unlike noImplicitAny): tsc only checks missing `override`
-/// modifiers under the explicit flag.
-fn detect_no_implicit_override(src : String) -> Bool {
-  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
-  let head = src[:head_len].to_owned()
+/// modifiers under the explicit flag. `head` is the case-preserved window.
+fn detect_no_implicit_override(head : String) -> Bool {
   head.contains("@noImplicitOverride: true") ||
   head.contains("@noImplicitOverride:true")
 }
@@ -838,27 +933,16 @@ fn detect_no_implicit_override(src : String) -> Bool {
 ///|
 /// True when the conformance header enables `@allowUnreachableCode`.
 /// tsc gates the TS2695 comma-operator check on this flag being off.
-fn detect_allow_unreachable_code(src : String) -> Bool {
-  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
-  let head = src[:head_len].to_owned()
+/// `head` is the case-preserved leading window.
+fn detect_allow_unreachable_code(head : String) -> Bool {
   head.contains("@allowUnreachableCode: true") ||
   head.contains("@allowUnreachableCode:true")
 }
 
 ///|
-/// True when the source embeds `@filename:` conformance directives (any
-/// case variant) -- i.e. a multi-file test concatenated into one parse.
-fn detect_filename_directives(src : String) -> Bool {
-  src.to_lower().contains("@filename:")
-}
-
-///|
-/// True when the leading test-header directives enable legacy decorators
-/// (`// @experimentaldecorators: true`). Parameter decorators are legal
-/// only in that mode.
-fn detect_nolib(src : String) -> Bool {
-  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
-  let head = src[:head_len].to_owned().to_lower()
+/// True when the leading test-header directives set `@noLib: true`.
+/// `head` is the pre-lowered leading window.
+fn detect_nolib(head : String) -> Bool {
   match head.find("@nolib:") {
     Some(idx) => {
       let after = head[idx + "@nolib:".length():].to_owned()
@@ -874,10 +958,8 @@ fn detect_nolib(src : String) -> Bool {
 
 ///|
 /// The raw (lower-cased, comma-separated) `@lib:` directive value from the
-/// test-header comment block, if present.
-fn detect_lib_list(src : String) -> String? {
-  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
-  let head = src[:head_len].to_owned().to_lower()
+/// test-header comment block, if present. `head` is the pre-lowered window.
+fn detect_lib_list(head : String) -> String? {
   match head.find("@lib:") {
     Some(idx) => {
       let after = head[idx + "@lib:".length():].to_owned()
@@ -912,10 +994,8 @@ fn lib_list_grants_iterable(libs : String) -> Bool {
 
 ///|
 /// The raw (lower-cased, comma-separated) `@target:` directive value, if
-/// present.
-fn detect_target_list(src : String) -> String? {
-  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
-  let head = src[:head_len].to_owned().to_lower()
+/// present. `head` is the pre-lowered leading window.
+fn detect_target_list(head : String) -> String? {
   match head.find("@target:") {
     Some(idx) => {
       let after = head[idx + "@target:".length():].to_owned()
@@ -995,9 +1075,8 @@ fn target_list_has_below_es2017(targets : String) -> Bool {
 }
 
 ///|
-fn detect_experimental_decorators(src : String) -> Bool {
-  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
-  let head = src[:head_len].to_owned().to_lower()
+/// `@experimentalDecorators: true` from the pre-lowered leading window.
+fn detect_experimental_decorators(head : String) -> Bool {
   match head.find("@experimentaldecorators:") {
     Some(idx) => {
       let after = head[idx + "@experimentaldecorators:".length():].to_owned()

--- a/src/parser/parser_expr.mbt
+++ b/src/parser/parser_expr.mbt
@@ -1176,7 +1176,7 @@ fn Parser::try_skip_call_type_args(self : Parser, expr : @ast.TsExpr) -> Bool {
 fn Parser::parse_parenthesized_expr(
   self : Parser,
 ) -> @ast.TsExpr raise ParseError {
-  if self.peek_at(1).kind == Lt {
+  if self.allow_jsx && self.peek_at(1).kind == Lt {
     let temp = { ..self, pos: self.pos + 1 }
     if temp.is_jsx_element_start() {
       let jsx_expr = temp.parse_jsx_element_expr()
@@ -1832,6 +1832,12 @@ fn Parser::scan_jsx_source_end_with_embeds(
 fn Parser::try_parse_parenthesized_jsx_expr(
   self : Parser,
 ) -> (Bool, Array[@ast.TsExpr]) {
+  // `.ts` mode (`allow_jsx` off) never parses JSX — `(<T>x)` is a
+  // parenthesized type assertion there, and the speculative source scan
+  // below is expensive on cast-heavy legacy sources.
+  if !self.allow_jsx {
+    return (false, [])
+  }
   if self.src.length() == 0 || !self.check(LParen) {
     return (false, [])
   }
@@ -2980,7 +2986,7 @@ fn Parser::parse_primary(self : Parser) -> @ast.TsExpr raise ParseError {
         // checker still recurses into the embedded sub-expressions.
         @ast.TsExpr::JsxElement("", [], paren_embeds)
         // functioncheck
-      } else if self.peek_at(1).kind == Lt {
+      } else if self.allow_jsx && self.peek_at(1).kind == Lt {
         let temp = { ..self, pos: self.pos + 1 }
         if temp.is_jsx_element_start() {
           let jsx_expr = temp.parse_jsx_element_expr()

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -3596,6 +3596,9 @@ fn Parser::parse_module_with_seeded_const_values_internal(
       }
     }
   }
+  // Shared leading window for the directive detectors below (one slice
+  // instead of one per detector).
+  let module_head = source_head(self.src)
   {
     funcs,
     interfaces,
@@ -3608,12 +3611,16 @@ fn Parser::parse_module_with_seeded_const_values_internal(
     module_augmentations,
     top_level_stmts,
     strict_property_initialization: detect_strict_property_initialization(
-      self.src,
+      module_head,
     ),
-    no_implicit_any: detect_no_implicit_any(self.src),
-    strict_null_checks: detect_strict_null_checks(self.src),
-    use_define_for_class_fields: detect_use_define_for_class_fields(self.src),
-    deprecated_compiler_options: detect_deprecated_compiler_options(self.src),
+    no_implicit_any: detect_no_implicit_any(module_head),
+    strict_null_checks: detect_strict_null_checks(module_head),
+    use_define_for_class_fields: detect_use_define_for_class_fields(
+      module_head,
+    ),
+    deprecated_compiler_options: detect_deprecated_compiler_options(
+      module_head,
+    ),
     parameter_property_misuses: self.param_property_misuses,
     strict_mode_misuses: self.strict_mode_misuses,
     invalid_decorator_uses: self.invalid_decorator_uses,
@@ -3642,10 +3649,8 @@ fn Parser::parse_module_with_seeded_const_values_internal(
 /// `.d.ts` / `.ts` bridge inputs never carry them, so this stays empty for
 /// them. Returns one canonical option string per detected deprecation, in a
 /// stable order.
-fn detect_deprecated_compiler_options(src : String) -> Array[String] {
+fn detect_deprecated_compiler_options(head : String) -> Array[String] {
   let out : Array[String] = []
-  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
-  let head = src[:head_len].to_owned()
   let head_lower = head.to_lower()
   // Value-specific: the `@target:` directive's comma list.
   match head.find("@target:") {
@@ -3729,10 +3734,7 @@ fn detect_deprecated_compiler_options(src : String) -> Array[String] {
 /// files in or out of strict mode. Default is `true`: the tsc-
 /// generated baselines for files *without* a directive include
 /// TS2564, so emitting matches the baseline.
-fn detect_strict_property_initialization(src : String) -> Bool {
-  // Only scan the first ~1 KB; directives always live at the top.
-  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
-  let head = src[:head_len].to_owned()
+fn detect_strict_property_initialization(head : String) -> Bool {
   // Explicit opt-outs.
   if head.contains("@strict: false") || head.contains("@strict:false") {
     return false
@@ -3752,9 +3754,7 @@ fn detect_strict_property_initialization(src : String) -> Bool {
 /// `detect_strict_property_initialization`, but ignores
 /// `@strictPropertyInitialization: false` and honours an explicit
 /// `@strictNullChecks: false` opt-out instead.
-fn detect_strict_null_checks(src : String) -> Bool {
-  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
-  let head = src[:head_len].to_owned()
+fn detect_strict_null_checks(head : String) -> Bool {
   if head.contains("@strict: false") || head.contains("@strict:false") {
     return false
   }
@@ -3773,9 +3773,7 @@ fn detect_strict_null_checks(src : String) -> Bool {
 /// Fires on explicit `// @useDefineForClassFields: true` directives,
 /// otherwise falls back to the TS default for the target (es2022+ /
 /// esnext default to true).
-fn detect_use_define_for_class_fields(src : String) -> Bool {
-  let head_len = if src.length() < 1024 { src.length() } else { 1024 }
-  let head = src[:head_len].to_owned()
+fn detect_use_define_for_class_fields(head : String) -> Bool {
   if head.contains("@useDefineForClassFields: true") ||
     head.contains("@useDefineForClassFields:true") {
     return true

--- a/src/parser/parser_module.mbt
+++ b/src/parser/parser_module.mbt
@@ -3615,12 +3615,8 @@ fn Parser::parse_module_with_seeded_const_values_internal(
     ),
     no_implicit_any: detect_no_implicit_any(module_head),
     strict_null_checks: detect_strict_null_checks(module_head),
-    use_define_for_class_fields: detect_use_define_for_class_fields(
-      module_head,
-    ),
-    deprecated_compiler_options: detect_deprecated_compiler_options(
-      module_head,
-    ),
+    use_define_for_class_fields: detect_use_define_for_class_fields(module_head),
+    deprecated_compiler_options: detect_deprecated_compiler_options(module_head),
     parameter_property_misuses: self.param_property_misuses,
     strict_mode_misuses: self.strict_mode_misuses,
     invalid_decorator_uses: self.invalid_decorator_uses,


### PR DESCRIPTION
## Summary

Profiling round over the parse + check pipeline (`moon bench --target native` + callgrind on the release `tscheck` binary, `--toggle-collect` to isolate the check phase). Five batches, every one behavior-preserving: the full suite (2523 tests), the TS7 oracle (byte-identical per file: TP 2338 / FP 0 / TN 1750 / MISS 396), and all scaffold / fixtures / examples / quality / realworld (42 packages) gates stay green after each batch.

### Parser

- **Whole-source rescans** (`20ff7e7`): `from_source_with_jsx` lowered the FULL source three times per parse (`@noImplicitThis` ×2, `@filename:`); all whole-source markers now come from one `scan_source_directive_flags` pass over `@` positions. The ~10 conformance-header detectors each sliced + lowercased their own 1KB head — multiplied by JSX speculation re-entering `from_source_with_jsx` on sub-sources — now sliced/lowered once per parse and threaded through.
- **JSDoc** (`20ff7e7`): `parse_jsdoc_block` built 3+ owned strings per comment line; rewritten as a single pass over `StringView`s, with the lexer handing over the comment span without an owned copy.
- **Paren-JSX speculation** (`46feb28`): tscheck was already extension-driven (`.tsx` only), but three paren-path JSX attempts ignored `allow_jsx`, so every `(<any>x)` cast in a `.ts` file ran the full JSX source scan + nested embed sub-parses and discarded the work. All three now early-out in `.ts` mode — tsc-aligned (`(<T>x)` is a parenthesized type assertion there).

### Checker

- **Structural scans** (`58527b4`): `iface_extends_reaches` was O(ifaces² × chain) via per-step rescans of every interface declaration — now a prebuilt name→extends adjacency map + hash-set DFS. `is_lib_global_value`/`_type` (generated 1k/2.2k-arm string matches, probed once per reference) now memoize per name via `gen_lib_globals.sh`.
- **Module-pass allocation hoists** (`8ffa452`): diagnostic path strings were interpolated per field/param instead of per declaration; `walk_module_undeclared_tps` scanned `method_type_params` linearly per field (quadratic on lib.dom interfaces); `check_interface_extends_compat` rebuilt base-interface field maps once per (derived, base) edge — DOM bases like `Event` are extended by hundreds of interfaces. Check-phase Ir on dom.generated.d.ts: 552M → 473M (−14%).

### Bench coverage (`aa6694f`)

`moon bench` gains JSDoc-heavy (300 documented decls) and old-style-cast-heavy fixtures (`.tsx` speculation mode + `.ts` assertion mode) so the optimized paths regress visibly.

## Measured (release tscheck, per iteration)

| input | before | after |
|---|---|---|
| es5.d.ts (222KB) parse | 11.7ms | 6.1ms (−48%, ~36MB/s) |
| dom.generated.d.ts (2.3MB) parse | 115ms | 60ms (−48%) |
| dom.generated.d.ts check phase (Ir) | 552M | 473M (−14%) |
| parserharness.ts (84KB legacy code) parse | 44ms | 11ms (−75%) |
| generic-heavy check phase | 26ms | 19ms (−27%) |
| moon bench parser fixtures | — | −17%..−38% |

## Test plan

- [x] `moon test --target native` — 2523 tests green after every batch
- [x] TS7 oracle — per-file diff empty vs. pre-round baseline (TP 2338 / **FP 0** / TN 1750 / MISS 396)
- [x] verify_scaffolds / verify_generated_fixtures / verify_examples / bridge_quality_report — exit 0
- [x] verify_realworld_typescript (42 packages + 10 node builtins) — exit 0
- [x] parserharness diagnostics byte-identical (1310 issues before and after the JSX gating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptb4njHNfwHQXJQsQnrNLr)_