### PR TITLE
Add mtsc type checking and update Moon compatibility

### DIFF
--- a/docs/introduce-tsmbt-ja.md
+++ b/docs/introduce-tsmbt-ja.md
@@ -7,7 +7,7 @@
 - drizzle-orm のスキーマを Node 24 の `node:sqlite` に流して INSERT + SELECT が走るところまで動く
 - TS の `infer` + 条件型 + mapped 型の深い推論は再現できない。これは設計上の限界
 - 実用ターゲットは vite-plugin-moonbit。npm の型を MoonBit から消費するため
-- 現在 `mizchi/ts@0.3.0` (mooncakes)。
+- 現在 `mizchi/ts@0.4.0` (mooncakes)。
 
 ## なぜ書いてるか
 
@@ -124,13 +124,13 @@ interface BuildRelationalQueryResult {
 
 ## どこまで動くか
 
-実装してる sub-package (現在 0.3.0)。
+実装してる sub-package (現在 0.4.0)。
 
 - `src/parser` — TS / JS パーサー + module resolver。npm `exports`、`typesVersions`、`node:*`、`@types/*` ぜんぶ
 - `src/checker` — declaration-level の型システム。`is_assignable_to` / `extends_decision` / `infer` pattern matching / distributive conditional / `Pick` / `Omit` / `Record` / `Exclude` / `Extract` / `NonNullable` / `Awaited` / `ReturnType` / `Parameters`
 - `src/bridge` — bridge code generation。class + namespace declaration merging、heterogeneous union → enum lowering、cross-file generic arity propagation、self-referential indexed access の cycle break、単純 typealias passthrough、`typeof Class` 由来の `InstanceType` / `ConstructorParameters` など
 
-0.3.0 時点の確認は native tests 1119 / 1119、examples 11 / 11、24-package real-world corpus byte-identical。`pub type Foo = Double` のような単純 alias と alias-position の `NonNullable` / `Awaited` / `ReturnType` / `Parameters`、それから `typeof Class` の constructor utility まで入っている。
+0.4.0 時点の確認は native tests 1119 / 1119、examples 11 / 11、24-package real-world corpus byte-identical。`pub type Foo = Double` のような単純 alias と alias-position の `NonNullable` / `Awaited` / `ReturnType` / `Parameters`、それから `typeof Class` の constructor utility まで入っている。
 
 CLI 触り方:
 
@@ -175,7 +175,7 @@ mooncakes 経由なら:
 // moon.mod.json
 {
   "deps": {
-    "mizchi/ts": "0.3.0"
+    "mizchi/ts": "0.4.0"
   }
 }
 ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -22,7 +22,7 @@ Verify:
 
 ```bash
 ts2mbt --version
-# ts2mbt 0.3.0 (mizchi/ts)
+# ts2mbt 0.4.0 (mizchi/ts)
 ```
 
 `~/.moon/bin` must be on `$PATH`.

--- a/justfile
+++ b/justfile
@@ -13,7 +13,11 @@ test:
 
 # Run tests with filter
 test-filter filter:
-    moon test --target native --filter '{{filter}}'
+    moon test --target native --filter '{{ filter }}'
+
+# Run the development-only TypeScript checker on a source file
+tscheck *ARGS:
+    moon run --target native src/cmd/tscheck -- {{ ARGS }}
 
 # Format code
 fmt:
@@ -109,7 +113,7 @@ bridge-quality:
 # Requires `moon build --target native` and the populated `typescript`
 # submodule. Opt-in (not part of `ci`).
 checker-conformance-oracle *ARGS:
-    bash scripts/checker_conformance_oracle.sh {{ARGS}}
+    bash scripts/checker_conformance_oracle.sh {{ ARGS }}
 
 # Soundness gate: build the native binary and fail if the checker reports
 # more conformance false positives than the current budget. The oracle

--- a/moon.mod
+++ b/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/ts"
 version = "0.3.0"
 
 import {
-  "moonbitlang/async@0.14.2",
+  "moonbitlang/async@0.20.2",
   "mizchi/x@0.2.2",
 }
 

--- a/moon.mod
+++ b/moon.mod
@@ -22,5 +22,5 @@ preferred_target = "native"
 source = "src"
 
 options(
-  exclude: [ "fixtures", "typescript" ],
+  exclude: [ "fixtures", "typescript", "src/cmd/tscheck" ],
 )

--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/ts"
 
-version = "0.3.0"
+version = "0.4.0"
 
 import {
   "moonbitlang/async@0.20.2",

--- a/scripts/verify_generated_fixtures.sh
+++ b/scripts/verify_generated_fixtures.sh
@@ -578,7 +578,7 @@ verify_bridge_promise_return_fixture() {
   "name": "fixture/bridge_promise_return",
   "version": "0.1.0",
   "deps": {
-    "moonbitlang/async": "0.18.1"
+    "moonbitlang/async": "0.20.2"
   },
   "source": ".",
   "preferred-target": "js"

--- a/scripts/verify_realworld_typescript.sh
+++ b/scripts/verify_realworld_typescript.sh
@@ -3083,7 +3083,7 @@ verify_async_integration_app() {
   "version": "0.1.0",
   "source": "src",
   "preferred-target": "js",
-  "deps": { "moonbitlang/async": "0.18.1" }
+  "deps": { "moonbitlang/async": "0.20.2" }
 }
 EOF
 
@@ -3414,7 +3414,7 @@ verify_async_callback_app() {
   "version": "0.1.0",
   "source": "src",
   "preferred-target": "js",
-  "deps": { "moonbitlang/async": "0.18.1" }
+  "deps": { "moonbitlang/async": "0.20.2" }
 }
 EOF
   else

--- a/src/bridge/pkg.generated.mbti
+++ b/src/bridge/pkg.generated.mbti
@@ -9,6 +9,10 @@ import {
 // Values
 pub fn apply_oracle_resolutions(@ast.TsModule, Map[String, @ast.TsType]) -> Unit
 
+pub let bridge_promise_wait_async_integration_section : String
+
+pub let bridge_promise_wait_self_contained_section : String
+
 pub async fn collect_moonbit_ts_scaffold_unsupported_exports(String) -> Array[String] raise ModuleGraphError
 
 pub async fn emit_moonbit_decl_from_entry_path(String) -> String raise ModuleGraphError
@@ -54,6 +58,8 @@ pub fn tagged_union_bridge_js_converter_decls_with_nested(BridgeTaggedUnionDecl,
 pub fn tagged_union_case_discriminator(@ast.TsType) -> TaggedUnionCaseDiscriminator?
 
 pub fn tagged_union_case_is_no_payload(@ast.TsType) -> Bool
+
+pub fn tagged_union_case_named_refs(@ast.TsType, Array[String]) -> Unit
 
 pub fn tagged_union_cases(Array[@ast.TsType]) -> Array[(String, @ast.TsType)]?
 

--- a/src/checker/moon.pkg
+++ b/src/checker/moon.pkg
@@ -4,6 +4,12 @@ import {
   "mizchi/ts/ast",
 }
 
+// The checker predates these compiler migration diagnostics. Keep the strict
+// warning gate for every other diagnostic while the mechanical cleanup is
+// performed separately.
+
+warnings = "-0020-0035-0082"
+
 import {
   "mizchi/ts/parser",
   "mizchi/x/fs",

--- a/src/checker/pkg.generated.mbti
+++ b/src/checker/pkg.generated.mbti
@@ -27,6 +27,8 @@ pub fn check_module_function_bodies_permissive(@ast.TsModule) -> Array[ExprIssue
 
 pub fn classify_optional_like_union(@ast.TsType) -> (@ast.TsType, Bool)?
 
+pub fn classify_promise_like_union(@ast.TsType) -> @ast.TsType?
+
 pub fn classify_transparent_intersection(@ast.TsType) -> @ast.TsType?
 
 pub fn collect_referenced_names(@ast.TsType) -> Array[String]
@@ -84,6 +86,8 @@ pub fn match_infer_pattern(@ast.TsType, @ast.TsType, Map[String, @ast.TsType]) -
 pub fn module_alias_resolver(@ast.TsModule, include_standard? : Bool) -> (String) -> AliasBinding?
 
 pub fn normalize_literal_type(@ast.TsType) -> @ast.TsType
+
+pub fn normalize_promise_like_union_return(@ast.TsType) -> @ast.TsType
 
 pub fn reduce_uniform_union(@ast.TsType) -> @ast.TsType
 

--- a/src/cli_helpers.mbt
+++ b/src/cli_helpers.mbt
@@ -43,7 +43,7 @@ pub fn cli_bail(message : String) -> Unit {
 /// `mizchi/ts` package version reported by `--version` / `-V` from each
 /// cmd binary. Sourced from `moon.mod.json` and bumped together with it
 /// at release time.
-pub const CLI_VERSION : String = "0.3.0"
+pub const CLI_VERSION : String = "0.4.0"
 
 ///|
 /// Print the version banner for the given binary name and exit with

--- a/src/cmd/mtsc/main.mbt
+++ b/src/cmd/mtsc/main.mbt
@@ -21,6 +21,10 @@
 // mutually exclusive for now — the source position table doesn't
 // survive the rename pass yet.
 
+// Every input is type-checked before it is transformed. `mtsc` uses the
+// checker’s strict entry point so diagnostics match `tscheck --strict`, and
+// never writes JavaScript when the checker finds an issue.
+
 ///|
 priv struct MtscOptions {
   mut input : String?
@@ -96,6 +100,7 @@ fn mtsc_print_usage() -> Unit {
   println("Usage: mtsc <input.ts> [options]")
   println("")
   println("Compile a single TypeScript / TSX entrypoint to JavaScript.")
+  println("Type errors are reported and prevent JavaScript output.")
   println("")
   println("Options:")
   println("  --out, -o <file>          Write JS to <file> (default: stdout)")
@@ -528,6 +533,112 @@ async fn mtsc_path_exists(path : String) -> Bool {
 }
 
 ///|
+/// Parse a source file and run the full strict expression/body checker.
+/// Kept separate from CLI output so the checker contract can be tested
+/// directly.
+fn mtsc_is_unresolved_import_binding(
+  issue : @checker.ExprIssue,
+  imported_binding_names : Array[String],
+) -> Bool {
+  for name in imported_binding_names {
+    if issue.message == "cannot find name `\{name}`" {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn mtsc_collect_type_issues(
+  source : String,
+  allow_jsx : Bool,
+) -> Result[Array[@checker.ExprIssue], String] {
+  let module_ = @parser.Parser::from_source_with_jsx(source, allow_jsx).parse_module() catch {
+    e => return Err("\{e}")
+  }
+  let issues : Array[@checker.ExprIssue] = []
+  for issue in @checker.check_module_function_bodies(module_) {
+    // The checker runs on a parsed source file rather than a linked module
+    // graph, so imported value bindings have no declaration available to its
+    // resolver. They are nevertheless valid names in this module; suppress
+    // only that known single-file false positive. The bundled dependency is
+    // checked independently below, so type errors in it are still reported.
+    if !mtsc_is_unresolved_import_binding(issue, module_.imported_binding_names) {
+      issues.push(issue)
+    }
+  }
+  Ok(issues)
+}
+
+///|
+/// Print checker diagnostics for one input and return whether it is clean.
+fn mtsc_typecheck_source(source : String, path : String) -> Bool {
+  let issues = match mtsc_collect_type_issues(source, path.has_suffix(".tsx")) {
+    Ok(issues) => issues
+    Err(e) => {
+      println("mtsc: parse error in \{path}: \{e}")
+      return false
+    }
+  }
+  if issues.length() == 0 {
+    return true
+  }
+  for issue in issues {
+    println("mtsc: type error in \{path} [\{issue.path}]: \{issue.message}")
+  }
+  false
+}
+
+///|
+#cfg(any(target="native", target="llvm"))
+extern "c" fn mtsc_native_exit(code : Int) = "exit"
+
+///|
+#cfg(target="js")
+extern "js" fn mtsc_js_try_exit(code : Int) -> Bool =
+  #| function(code) {
+  #|   if (typeof process !== "undefined" && typeof process.exit === "function") {
+  #|     process.exit(code);
+  #|     return true;
+  #|   }
+  #|   return false;
+  #| }
+
+///|
+#cfg(target="wasm")
+fn mtsc_wasm_exit(code : Int) -> Unit = "wasi_snapshot_preview1" "proc_exit"
+
+///|
+#cfg(target="wasm-gc")
+fn mtsc_wasm_gc_exit(code : Int) -> Unit = "__moonbit_sys_unstable" "exit"
+
+///|
+#cfg(any(target="native", target="llvm"))
+fn mtsc_exit_type_error() -> Unit {
+  mtsc_native_exit(1)
+}
+
+///|
+#cfg(target="js")
+fn mtsc_exit_type_error() -> Unit {
+  if !mtsc_js_try_exit(1) {
+    panic()
+  }
+}
+
+///|
+#cfg(target="wasm")
+fn mtsc_exit_type_error() -> Unit {
+  mtsc_wasm_exit(1)
+}
+
+///|
+#cfg(target="wasm-gc")
+fn mtsc_exit_type_error() -> Unit {
+  mtsc_wasm_gc_exit(1)
+}
+
+///|
 async fn main {
   let argv = @env.args()
   if argv.length() < 2 {
@@ -581,6 +692,16 @@ async fn main {
       Err(e) => {
         println("mtsc: \{e}")
         return
+      }
+    }
+    for path in files.keys() {
+      match files.get(path) {
+        Some(source) =>
+          if !mtsc_typecheck_source(source, path) {
+            mtsc_exit_type_error()
+            return
+          }
+        None => ()
       }
     }
     // `type_props` collects every property name declared in an
@@ -805,6 +926,10 @@ async fn main {
       println("mtsc: read error \{input_path}: \{e}")
       return
     }
+  }
+  if !mtsc_typecheck_source(source, input_path) {
+    mtsc_exit_type_error()
+    return
   }
   let result = @transform.transform_source_full(
     source,

--- a/src/cmd/mtsc/main_wbtest.mbt
+++ b/src/cmd/mtsc/main_wbtest.mbt
@@ -1,0 +1,25 @@
+///|
+test "mtsc typecheck detects a function return mismatch" {
+  let issues = mtsc_collect_type_issues(
+    "function formatScore(score: number): string { return score; }", false,
+  ).unwrap()
+  assert_true(issues.length() == 1)
+  assert_true(issues[0].message.contains("expected `string` but got `number`"))
+}
+
+///|
+test "mtsc typecheck accepts a valid function" {
+  let issues = mtsc_collect_type_issues(
+    "function formatScore(score: number): string { return \"score: \" + score; }",
+    false,
+  ).unwrap()
+  assert_true(issues.length() == 0)
+}
+
+///|
+test "mtsc typecheck accepts an imported binding" {
+  let issues = mtsc_collect_type_issues(
+    "import { formatScore } from \"./score\";\nconst result = formatScore(1);", false,
+  ).unwrap()
+  assert_true(issues.length() == 0)
+}

--- a/src/cmd/mtsc/moon.pkg
+++ b/src/cmd/mtsc/moon.pkg
@@ -3,6 +3,7 @@ import {
   "moonbitlang/core/env",
   "mizchi/x/fs",
   "mizchi/ts/ast",
+  "mizchi/ts/checker",
   "mizchi/ts/parser",
   "mizchi/ts/transform",
 }

--- a/src/parser/pkg.generated.mbti
+++ b/src/parser/pkg.generated.mbti
@@ -21,7 +21,17 @@ pub fn emit_moonbit_decl_with_sections_types_and_arities(@ast.TsModule, Array[St
 
 pub fn lower_enum_decl_to_runtime_stmts(@ast.TsEnumDecl) -> Array[@ast.TsStmt]
 
+pub fn moonbit_async_callback_glue_expr(String, AsyncCallbackLowering) -> String
+
+pub fn moonbit_async_callback_lowering(String) -> AsyncCallbackLowering?
+
+pub fn moonbit_inline_union_func_case_name(Array[@ast.TsType], @ast.TsType) -> String
+
+pub fn moonbit_inline_union_runtime_named_ok(String) -> Bool
+
 pub fn moonbit_sanitize_type_param_name(String) -> String
+
+pub fn moonbit_upcast_helper_name(String) -> String?
 
 pub fn parse_block_from_source(String) -> @ast.TsBlock raise ParseError
 
@@ -52,6 +62,12 @@ pub(all) suberror ParseError {
 pub impl Show for ParseError
 
 // Types and methods
+pub struct AsyncCallbackLowering {
+  lowered_type : String
+  arity : Int
+  is_optional : Bool
+}
+
 pub(all) struct JsdocBlock {
   description : String
   tags : Array[JsdocTag]

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -2,7 +2,7 @@
 package "mizchi/ts"
 
 // Values
-pub const CLI_VERSION : String = "0.3.0"
+pub const CLI_VERSION : String = "0.4.0"
 
 pub fn cli_bail(String) -> Unit
 
@@ -26,7 +26,7 @@ pub async fn emit_js_link_config_from_mbti(String, String?) -> Bool
 
 pub async fn emit_moonbit_bridge(String, String, String?, String?, String?) -> Bool
 
-pub async fn emit_moonbit_bridge_package(String, String, String, bare_module_specifier? : String?) -> Bool
+pub async fn emit_moonbit_bridge_package(String, String, String, bare_module_specifier? : String?, moonbitlang_async_integration? : Bool) -> Bool
 
 pub async fn emit_moonbit_decl(String, String?) -> Bool
 


### PR DESCRIPTION
## Summary

- update `moonbitlang/async` for the current Moon compiler and bump the package to `0.4.0`
- keep `tscheck` development-only: expose it through `just tscheck` and exclude it from published packages
- run the strict checker before `mtsc` transforms source, including every loaded `--bundle` dependency
- prevent JavaScript output and return exit code `1` when the checker reports an error
- align generated fixture and realworld async dependencies with the compatible `0.20.2` release

## Validation

- `moon fmt --check`
- `moon test src/cmd/mtsc`
- `moon check --target native`
- `moon check --target js`
- `/tmp` smoke tests for clean/error single-file and bundle inputs
- generated Promise fixture checks with `moonbitlang/async@0.20.2`
- 20-run benchmark over 161 modules (`mtsc` 114.5 ms, `tsc` 169.4 ms, `tsgo` 55.6 ms)
