### PR TITLE
feat: finalize MoonBit TypeScript bridge APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,33 @@ Shared `--input` flow flags:
 - `--no-facade` (`mbt2ts` only) — skip facade-wrapper generation and emit
   only top-level free-function glue.
 
+## Public integration contract
+
+The following are the supported integration APIs for the current `0.4.x`
+series. Treat generated files as outputs: consume their documented package
+surface, rather than importing temporary MoonBit glue or build artifacts.
+
+- **MoonBit → TypeScript CLI:** `mbt2ts --input <pkg-or-mbti> --out <dir>` is
+  the canonical package-generation command. It generates facade wrappers by
+  default; `--no-facade`, `--strict`, `--diagnostics`, and
+  `--import-rewrites` are its supported controls. The named subcommands remain
+  lower-level stage APIs for tooling.
+- **Vite integration:** use `moonbit({ tsBridge: { generatorRoot, entries } })`
+  to check a TypeScript module graph before generating a MoonBit bridge, and
+  `moonbit({ npmPackage: { entry, outDir } })` to generate a publishable npm
+  package. `generatorRoot` and `command` are shared when `npmPackage` is used
+  with `tsBridge`; `facade` and `bundle` default to `true`, and
+  `runtimeValidation` defaults to `false`.
+- **Generated npm package:** `index.js`, `index.d.ts`, `package.json`, and
+  `AUTOLINK_DIAGNOSTICS.md` are its public artifacts. Structs are plain
+  objects, enum values use `$tag`, and opaque declaration brands prevent a
+  TypeScript lookalike from being passed back as a MoonBit value. Trait methods
+  and temporary glue files are not part of that API.
+- **`mtsc` checker:** Vite builds and imports the MoonBit JS module directly;
+  its sole JS ABI is `checkModuleGraph`. `checkSource`,
+  `checkModuleSources`, and the command-line checker are implementation and
+  development APIs, not consumer-facing interfaces.
+
 ## Generate / vendor (TypeScript -> MoonBit)
 
 When you're consuming a MoonBit package and want bridges for the
@@ -317,17 +344,24 @@ Current export model:
   to the temporary glue package, then exposes those wrappers from the built
   JS and the matching package `.d.ts`. Async wrappers are exposed as
   Promise-returning JavaScript functions.
-- Public MoonBit traits are declaration-only structural TypeScript interfaces.
-  `pub impl Trait for Type` is represented by `extends Trait` / type
-  intersections in `.d.ts` output, but trait methods are not generated as
-  runtime bridge exports.
+- Scaffold runtime wrappers normalize public MoonBit structs and enums into
+  ordinary JavaScript objects; enum cases use a `$tag` discriminant. Their
+  `.d.ts` values carry an internal opaque brand, so a returned value can be
+  passed back to MoonBit but a plain TypeScript lookalike cannot.
+- MoonBit trait methods are not part of this plain-object npm boundary.
+  `mbt2ts decl` continues to describe traits, while scaffold declarations
+  remove trait intersections from runtime-normalized structs and enums.
 - Generated glue declarations, runtime export lists, package `exports`, and
   child-package re-export files are sorted deterministically to keep scaffold
   diffs reviewable.
 - The temporary `moon.pkg` and wrapper `.mbt` files are build inputs
   only; they are not written to the final TypeScript package.
-- Recursive `.mbti` resolution only rewrites imports that stay under the same
-  root package prefix. External imports remain bare specifiers.
+- Recursive `.mbti` resolution rewrites imports that stay under the same root
+  package prefix. Unmapped external MoonBit values in public function
+  parameters/results are omitted from the npm surface and listed in
+  `AUTOLINK_DIAGNOSTICS.md`; nested external slots become `unknown` so the
+  declaration remains standalone. An explicit import rewrite opts into the
+  mapped TypeScript package instead.
 - `mbt2ts package` and `mbt2ts scaffold`
   accept an optional JSON object for external import rewrites, for example
   `{ "moonbitlang/core/debug": "demo-debug" }`.
@@ -385,6 +419,10 @@ Lower-level commands are also available:
 # full bridge package
 ts2mbt package path/to/entry.d.ts /runtime/module.js out/moonbit-pkg
 
+# opt in to public validate<Type>(JSValue) -> Type? boundary functions for
+# generated structural types; normal bridge calls stay unchecked
+ts2mbt package-validated path/to/entry.d.ts /runtime/module.js out/moonbit-pkg
+
 # inspect generated decl/ffi/bridge snippets without writing a package
 ts2mbt bridge path/to/entry.d.ts /runtime/module.js
 ts2mbt ffi path/to/entry.d.ts /runtime/module.js
@@ -405,7 +443,13 @@ module state.
   to `String` / `Bool` instead of being widened to `JSValue`.
 - Generated bridge packages preserve camelCase top-level export names in
   their public MoonBit API, even when the internal JS extern binding is
-  lowered to snake_case.
+  lowered to snake_case. Value exports use the explicit public
+  `get_<snake_case>()` convention. Internal conversion and identity-cast
+  helpers are private implementation details and never appear in `bridge.mbti`.
+- `package-validated` is an opt-in boundary-safety mode: generated structural
+  types get public `validate<Type>(value : JSValue) -> Type?` functions. It
+  checks supported primitive fields at runtime and returns `None` for invalid
+  values without changing the default bridge API or adding per-call checks.
 
 Supported surface:
 

--- a/examples/typescript-to-moonbit/drizzle/smoke/main.mbt
+++ b/examples/typescript-to-moonbit/drizzle/smoke/main.mbt
@@ -76,6 +76,8 @@ extern "js" fn row_str(rows : @sut.JSValue, i : Int, k : String) -> String =
 extern "js" fn smoke_print_ok() -> Unit =
   #| () => console.log("ok")
 
+fn[A, B] test_unsafe_cast(value : A) -> B = "%identity"
+
 fn main {
   // Build a `users` schema using drizzle's runtime sqliteTable + column
   // builders. The result is structurally a drizzle Table at JS level;
@@ -87,7 +89,7 @@ fn main {
   let age_col = sqlite_integer_js("age")
   let columns = make_columns_object_js(id_col, name_col, email_col, age_col)
   let users = sqlite_table_js("users", columns)
-  let typed_users : @sut.Table[@sut.JSValue] = @sut.unsafeCast(users)
+  let typed_users : @sut.Table[@sut.JSValue] = test_unsafe_cast(users)
   let _ = typed_users
 
   // Run an INSERT + SELECT round-trip against Node 24's built-in

--- a/examples/typescript-to-moonbit/hono-real/smoke/main.mbt
+++ b/examples/typescript-to-moonbit/hono-real/smoke/main.mbt
@@ -16,6 +16,8 @@ extern "js" fn test_hono_route_response(
   #|   return `${res.status}:${route.method}:${route.path}:${res.headers.get("content-type")}`;
   #| }
 
+fn[A, B] test_unsafe_cast(value : A) -> B = "%identity"
+
 fn main {
   let app : @sut.Hono[@sut.JSValue, @sut.JSValue, @sut.JSValue] = @sut.new_hono(
     None,
@@ -23,10 +25,10 @@ fn main {
   let _ = app.get("/hello", test_hono_handler)
   let undefined_ = test_undefined()
   let res = app.request(
-    @sut.unsafeCast("/hello"),
-    @sut.unsafeCast(undefined_),
-    @sut.unsafeCast(undefined_),
-    @sut.unsafeCast(undefined_),
+    test_unsafe_cast("/hello"),
+    test_unsafe_cast(undefined_),
+    test_unsafe_cast(undefined_),
+    test_unsafe_cast(undefined_),
   )
   if test_hono_route_response(app, res) != "200:GET:/hello:text/plain;charset=UTF-8" {
     abort("unexpected Hono route response")

--- a/examples/typescript-to-moonbit/react-types/smoke/main.mbt
+++ b/examples/typescript-to-moonbit/react-types/smoke/main.mbt
@@ -13,10 +13,12 @@ extern "js" fn test_forward_ref_render() -> @sut.ForwardRefRenderFunction =
 extern "js" fn test_transition_scope() -> @sut.TransitionFunction =
   #| () => () => undefined
 
+fn[A, B] test_unsafe_cast(value : A) -> B = "%identity"
+
 fn main {
   let element = @sut.createElement("div", Some(test_props()), test_children())
   let _ = @sut.cloneElement(element, None, test_children())
-  if !@sut.isValidElement(@sut.unsafeCast(element)) {
+  if !@sut.isValidElement(test_unsafe_cast(element)) {
     abort("expected generated React element to be valid")
   }
   let _ = @sut.memo(test_function_component(), None)

--- a/examples/typescript-to-moonbit/typescript-ast/smoke/main.mbt
+++ b/examples/typescript-to-moonbit/typescript-ast/smoke/main.mbt
@@ -2,12 +2,14 @@ fn script_target() -> @sut.ScriptTarget {
   @sut.ScriptTarget::ES2024
 }
 
+fn[A, B] test_unsafe_cast(value : A) -> B = "%identity"
+
 fn rename_identifier(identifier : @sut.Identifier) -> @sut.Node {
-  let text : String = @sut.unsafeCast(identifier.escapedText)
+  let text : String = test_unsafe_cast(identifier.escapedText)
   if text == "value" {
-    @sut.unsafeCast(@sut.get_factory().createIdentifier("renamed"))
+    test_unsafe_cast(@sut.get_factory().createIdentifier("renamed"))
   } else {
-    @sut.unsafeCast(identifier)
+    test_unsafe_cast(identifier)
   }
 }
 
@@ -27,7 +29,7 @@ fn transformer_factory(
   context : @sut.TransformationContext
 ) -> (@sut.SourceFile) -> @sut.SourceFile {
   fn(source_file) {
-    match visit_node(@sut.unsafeCast(source_file), context).asSourceFile() {
+    match visit_node(test_unsafe_cast(source_file), context).asSourceFile() {
       Some(source_file) => source_file
       None => abort("expected transformer result to remain a SourceFile")
     }

--- a/examples/typescript-to-moonbit/vitest/smoke/main.mbt
+++ b/examples/typescript-to-moonbit/vitest/smoke/main.mbt
@@ -11,13 +11,15 @@ extern "js" fn test_vitest_vi(vi : @sut.VitestUtils) -> Unit =
   #|   if (!vi.isMockFunction(fn)) throw new Error("expected vi.fn mock");
   #| }
 
+fn[A, B] test_unsafe_cast(value : A) -> B = "%identity"
+
 fn main {
   let expect = @sut.get_expect()
   // Build assertions to ensure the generic-preserved chain compiles. The
   // generic-preserved `Assertion[T]` falls through to a pure-MoonBit
   // wrapper whose `(self.toBe)(arg)` form loses chai's `this`-bound
   // method receiver, so don't actually invoke `.toBe` here.
-  let _ = expect._call_(@sut.unsafeCast(test_number()), None)
-  let _ = expect._call_(@sut.unsafeCast(test_object()), None)
+  let _ = expect._call_(test_unsafe_cast(test_number()), None)
+  let _ = expect._call_(test_unsafe_cast(test_object()), None)
   test_vitest_vi(@sut.get_vi())
 }

--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/ts"
 
-version = "0.4.0"
+version = "0.4.1"
 
 import {
   "moonbitlang/async@0.20.2",

--- a/scripts/verify_examples.sh
+++ b/scripts/verify_examples.sh
@@ -907,7 +907,9 @@ EOF
   grep_generated_mbt "$out" 'pub extern "js" fn transform(source : SourceFile, transformers : Array[(TransformationContext) -> (SourceFile) -> SourceFile], compilerOptions : CompilerOptions?) -> TransformationResult[Node]'
   grep_generated_mbt "$out" 'pub fn visitEachChild(node : Node, visitor : (Node) -> Node, context : TransformationContext?) -> Node'
   grep_generated_mbt "$out" 'pub fn isIdentifier(node : Node) -> Bool'
-  grep_generated_mbt "$out" 'pub fn[A, B] unsafeCast(value : A) -> B = "%identity"'
+  # `unsafeCast` is an implementation helper; keeping it private ensures the
+  # generated package does not expose an unchecked escape hatch to consumers.
+  grep_generated_mbt "$out" 'fn[A, B] unsafeCast(value : A) -> B = "%identity"'
   grep_generated_mbt "$out" 'pub fn Node::asIdentifier(self : Node) -> Identifier?'
   grep_generated_mbt "$out" '  createIdentifier : (String) -> Identifier'
   grep_generated_mbt "$out" 'pub extern "js" fn NodeFactory::createIdentifier(self : NodeFactory, arg0 : String) -> Identifier'

--- a/scripts/verify_examples.sh
+++ b/scripts/verify_examples.sh
@@ -1099,7 +1099,16 @@ EOF
   # removed `--experimental-sqlite` flag. Bypass the script's `node()`
   # wrapper and suppress stderr so the captured stdout remains exactly
   # "ok" across both releases.
-  output="$(command node "$built_js" 2>/dev/null)"
+  local drizzle_node_stderr
+  drizzle_node_stderr="$(mktemp)"
+  if output="$(command node "$built_js" 2>"$drizzle_node_stderr")"; then
+    :
+  else
+    local drizzle_node_status=$?
+    echo "drizzle smoke process failed:" >&2
+    sed -n '1,200p' "$drizzle_node_stderr" >&2
+    return "$drizzle_node_status"
+  fi
   if [ "$output" != "ok" ]; then
     echo "expected drizzle smoke to print 'ok', got: $output" >&2
     exit 1

--- a/scripts/verify_examples.sh
+++ b/scripts/verify_examples.sh
@@ -893,11 +893,13 @@ verify_typescript_to_moonbit_typescript_ast_example() {
 }
 EOF
 
-  [ -f "$out/moon.pkg" ]
-  [ -f "$out/bridge.mbti" ]
-  [ -f "$out/bridge.mbt" ]
-  [ -f "$out/bridge.js" ]
-  [ -f "$out/SCAFFOLD_DIAGNOSTICS.md" ]
+  for generated_file in moon.pkg bridge.mbti bridge.mbt bridge.js SCAFFOLD_DIAGNOSTICS.md; do
+    if [ ! -f "$out/$generated_file" ]; then
+      echo "TypeScript AST bridge is missing $generated_file" >&2
+      find "$out" -maxdepth 1 -type f -exec basename {} \; | sort >&2
+      exit 1
+    fi
+  done
   grep_generated_mbt "$out" 'pub fn createSourceFile(fileName : String, sourceText : String, languageVersionOrOptions : ScriptTarget, setParentNodes : Bool?, scriptKind : ScriptKind?) -> SourceFile'
   grep_generated_mbt "$out" 'pub extern "js" fn transform(source : SourceFile, transformers : Array[(TransformationContext) -> (SourceFile) -> SourceFile], compilerOptions : CompilerOptions?) -> TransformationResult[Node]'
   grep_generated_mbt "$out" 'pub fn visitEachChild(node : Node, visitor : (Node) -> Node, context : TransformationContext?) -> Node'
@@ -951,7 +953,7 @@ EOF
 }
 EOF
 
-  echo "Generating Drizzle bridge"
+  echo "Generating Hono server bridges"
   moon run src/cmd/ts2mbt -- \
     generate --package-json "$root/package.json" \
     --out "$root/internal/generated"

--- a/scripts/verify_examples.sh
+++ b/scripts/verify_examples.sh
@@ -879,8 +879,10 @@ verify_typescript_to_moonbit_typescript_ast_example() {
     --out "$out" \
     --module-spec typescript
 
+  echo "Writing TypeScript AST JS stubs"
   write_js_any_stub "$out"
 
+  echo "Writing TypeScript AST MoonBit manifest"
   cat > "$out/moon.mod.json" <<'EOF'
 {
   "name": "examples/typescript_to_moonbit_typescript_ast",
@@ -893,6 +895,7 @@ verify_typescript_to_moonbit_typescript_ast_example() {
 }
 EOF
 
+  echo "Checking TypeScript AST bridge artifacts"
   for generated_file in moon.pkg bridge.mbti bridge.mbt bridge.js SCAFFOLD_DIAGNOSTICS.md; do
     if [ ! -f "$out/$generated_file" ]; then
       echo "TypeScript AST bridge is missing $generated_file" >&2

--- a/scripts/verify_examples.sh
+++ b/scripts/verify_examples.sh
@@ -1094,11 +1094,12 @@ EOF
 EOF
 
   local output
-  # `node:sqlite` is built-in on Node 24+ and emits an experimental
-  # warning. Bypass the script's `node()` wrapper (which treats
-  # warnings as fatal) with `command node`, and route stderr to
-  # /dev/null so the captured stdout stays equal to "ok".
-  output="$(command node --experimental-sqlite "$built_js" 2>/dev/null)"
+  # `node:sqlite` is built-in on Node 24+. It emitted an experimental
+  # warning in older Node 24 releases, while current Node 24 rejects the
+  # removed `--experimental-sqlite` flag. Bypass the script's `node()`
+  # wrapper and suppress stderr so the captured stdout remains exactly
+  # "ok" across both releases.
+  output="$(command node "$built_js" 2>/dev/null)"
   if [ "$output" != "ok" ]; then
     echo "expected drizzle smoke to print 'ok', got: $output" >&2
     exit 1

--- a/scripts/verify_examples.sh
+++ b/scripts/verify_examples.sh
@@ -873,10 +873,11 @@ verify_typescript_to_moonbit_typescript_ast_example() {
   rm -rf "$root"
   mkdir -p "$root"
 
+  echo "Generating TypeScript AST bridge"
   moon run src/cmd/ts2mbt -- \
     --input node_modules/typescript/lib/typescript.d.ts \
     --out "$out" \
-    --module-spec typescript >/dev/null
+    --module-spec typescript
 
   write_js_any_stub "$out"
 
@@ -911,6 +912,7 @@ EOF
   grep_generated_mbt "$out" 'pub fn[T] TransformationResult::dispose(self : TransformationResult[T]) -> Unit'
   grep -F 'No structural unsupported exports were detected' "$out/SCAFFOLD_DIAGNOSTICS.md" >/dev/null
   moon -C "$out" check --target js
+  echo "Running TypeScript AST bridge runtime smoke"
   run_typescript_ast_build_smoke "$out" "examples/typescript_to_moonbit_typescript_ast"
 }
 
@@ -949,9 +951,10 @@ EOF
 }
 EOF
 
+  echo "Generating Drizzle bridge"
   moon run src/cmd/ts2mbt -- \
     generate --package-json "$root/package.json" \
-    --out "$root/internal/generated" >/dev/null
+    --out "$root/internal/generated"
 
   cat > "$root/cmd/main/moon.pkg" <<'EOF'
 import {

--- a/scripts/verify_examples.sh
+++ b/scripts/verify_examples.sh
@@ -227,7 +227,10 @@ EOF
   fi
 
   printf '{ "type": "module" }\n' > "$(dirname "$built_js")/package.json"
-  node --input-type=module - <<EOF
+  # This is a runtime smoke, so bypass warning_guard.sh's `node()` wrapper.
+  # The wrapper is useful for compile commands, but it can turn a runtime
+  # warning emitted by the current Node release into an opaque test failure.
+  command node --input-type=module - <<EOF
 await import("./$built_js");
 EOF
 }
@@ -1097,18 +1100,9 @@ EOF
   # `node:sqlite` is built-in on Node 24+. It emitted an experimental
   # warning in older Node 24 releases, while current Node 24 rejects the
   # removed `--experimental-sqlite` flag. Bypass the script's `node()`
-  # wrapper and suppress stderr so the captured stdout remains exactly
-  # "ok" across both releases.
-  local drizzle_node_stderr
-  drizzle_node_stderr="$(mktemp)"
-  if output="$(command node "$built_js" 2>"$drizzle_node_stderr")"; then
-    :
-  else
-    local drizzle_node_status=$?
-    echo "drizzle smoke process failed:" >&2
-    sed -n '1,200p' "$drizzle_node_stderr" >&2
-    return "$drizzle_node_status"
-  fi
+  # wrapper. Keep stderr visible if the runtime fails, while only stdout
+  # participates in the expected `ok` assertion.
+  output="$(command node "$built_js")"
   if [ "$output" != "ok" ]; then
     echo "expected drizzle smoke to print 'ok', got: $output" >&2
     exit 1

--- a/scripts/verify_examples.sh
+++ b/scripts/verify_examples.sh
@@ -333,15 +333,17 @@ extern "js" fn test_hono_route_response(app : Hono[JSValue, JSValue, JSValue], r
   #|   return `${res.status}:${route.method}:${route.path}:${res.headers.get("content-type")}`;
   #| }
 
+fn[A, B] test_unsafe_cast(value : A) -> B = "%identity"
+
 test "generated real Hono bridge smoke" {
   let app : Hono[JSValue, JSValue, JSValue] = new_hono(None)
   let _ = app.get("/hello", test_hono_handler)
   let undefined_ = test_undefined()
   let res = app.request(
-    unsafeCast("/hello"),
-    unsafeCast(undefined_),
-    unsafeCast(undefined_),
-    unsafeCast(undefined_),
+    test_unsafe_cast("/hello"),
+    test_unsafe_cast(undefined_),
+    test_unsafe_cast(undefined_),
+    test_unsafe_cast(undefined_),
   )
   assert_eq(
     test_hono_route_response(app, res),
@@ -461,13 +463,15 @@ extern "js" fn test_forward_ref_render() -> ForwardRefRenderFunction[JSValue, JS
 extern "js" fn test_transition_scope() -> TransitionFunction =
   #| () => () => undefined
 
+fn[A, B] test_unsafe_cast(value : A) -> B = "%identity"
+
 test "generated @types/react bridge smoke" {
   let element = createElement("div", Some(test_props()), test_children())
   // `cloneElement` is typed against the generic `DetailedReactHTMLElement[
   // HTMLAttributes[JSValue], HTMLElement]` but `createElement("div", ...)`
-  // resolves to a more specific instantiation; unsafeCast bridges them.
-  let _ = cloneElement(unsafeCast(element), None, test_children())
-  assert_true(isValidElement(unsafeCast(element)))
+  // resolves to a more specific instantiation; the test helper bridges them.
+  let _ = cloneElement(test_unsafe_cast(element), None, test_children())
+  assert_true(isValidElement(test_unsafe_cast(element)))
   let _ = memo(test_function_component(), None)
   let _ = forwardRef(test_forward_ref_render())
   startTransition(test_transition_scope())
@@ -507,10 +511,12 @@ extern "js" fn test_forward_ref_render() -> @sut.ForwardRefRenderFunction[@sut.J
 extern "js" fn test_transition_scope() -> @sut.TransitionFunction =
   #| () => () => undefined
 
+fn[A, B] test_unsafe_cast(value : A) -> B = "%identity"
+
 fn main {
   let element = @sut.createElement("div", Some(test_props()), test_children())
-  let _ = @sut.cloneElement(@sut.unsafeCast(element), None, test_children())
-  if !@sut.isValidElement(@sut.unsafeCast(element)) {
+  let _ = @sut.cloneElement(test_unsafe_cast(element), None, test_children())
+  if !@sut.isValidElement(test_unsafe_cast(element)) {
     abort("expected generated React element to be valid")
   }
   let _ = @sut.memo(test_function_component(), None)
@@ -561,6 +567,8 @@ extern "js" fn test_vitest_vi(vi : VitestUtils) -> Unit =
   #|   if (!vi.isMockFunction(fn)) throw new Error("expected vi.fn mock");
   #| }
 
+fn[A, B] test_unsafe_cast(value : A) -> B = "%identity"
+
 test "generated real Vitest bridge smoke" {
   let expect = get_expect()
   // Build assertions to ensure the generic-preserved chain compiles. The
@@ -568,8 +576,8 @@ test "generated real Vitest bridge smoke" {
   // wrapper whose `(self.toBe)(arg)` form loses chai's `this`-bound
   // method receiver, so don't actually invoke `.toBe` here — the
   // `vi.fn` smoke below exercises the runtime path.
-  let _ = expect._call_(unsafeCast(test_number()), None)
-  let _ = expect._call_(unsafeCast(test_object()), None)
+  let _ = expect._call_(test_unsafe_cast(test_number()), None)
+  let _ = expect._call_(test_unsafe_cast(test_object()), None)
   test_vitest_vi(get_vi())
 }
 EOF

--- a/scripts/verify_scaffolds.sh
+++ b/scripts/verify_scaffolds.sh
@@ -624,8 +624,10 @@ extern "js" fn test_ref() -> Ref[JSValue] =
 extern "js" fn test_children() -> Array[JSValue] =
   #| () => []
 
+fn[A, B] test_unsafe_cast(value : A) -> B = "%identity"
+
 test "generated React package scaffold smoke" {
-  let element : ReactElement[JSValue, JSValue] = unsafeCast(createElement(
+  let element : ReactElement[JSValue, JSValue] = test_unsafe_cast(createElement(
     "div",
     Some(test_dom_attributes()),
     test_children(),
@@ -668,8 +670,10 @@ extern "js" fn test_ref() -> @sut.Ref[@sut.JSValue] =
 extern "js" fn test_children() -> Array[@sut.JSValue] =
   #| () => []
 
+fn[A, B] test_unsafe_cast(value : A) -> B = "%identity"
+
 fn main {
-  let element : @sut.ReactElement[@sut.JSValue, @sut.JSValue] = @sut.unsafeCast(
+  let element : @sut.ReactElement[@sut.JSValue, @sut.JSValue] = test_unsafe_cast(
     @sut.createElement(
       "div",
       Some(test_dom_attributes()),

--- a/src/bridge/mbti_typescript_decl.mbt
+++ b/src/bridge/mbti_typescript_decl.mbt
@@ -1156,6 +1156,14 @@ fn mbti_raw_facade_uses_external_import_types(
 }
 
 ///|
+/// MoonBit core collection and reference values are represented by stable
+/// JavaScript shapes in the generated package surface. They do not require a
+/// separately published MoonBit package at the npm boundary.
+fn mbti_import_requires_external_runtime_boundary(module_spec : String) -> Bool {
+  !module_spec.has_prefix("moonbitlang/core/")
+}
+
+///|
 fn parse_mbti_package_name(source : String) -> String? {
   for line_view in source.split("\n") {
     let trimmed = line_view.trim().to_owned()
@@ -1196,7 +1204,8 @@ fn render_autolink_diagnostics_md(
     let external_import_aliases : Array[String] = []
     for import_ref in parse_mbti_imports(source) {
       if mbti_local_package_segments(root_package_name, import_ref.module_spec)
-        is None {
+        is None &&
+        mbti_import_requires_external_runtime_boundary(import_ref.module_spec) {
         if !allowed_external_import_spec_rewrites.contains(
             import_ref.module_spec,
           ) {
@@ -2352,6 +2361,9 @@ fn collect_mbti_bundle_autolink_glue_decls(
               import_ref.module_spec,
             )
             is None &&
+            mbti_import_requires_external_runtime_boundary(
+              import_ref.module_spec,
+            ) &&
             !allowed_external_import_spec_rewrites.contains(
               import_ref.module_spec,
             ) {
@@ -6159,6 +6171,34 @@ fn mbti_ts_line_declares_type(line : String, name : String) -> Bool {
 }
 
 ///|
+fn mbti_ts_interface_generic_params(line : String, name : String) -> String {
+  let trimmed = line.trim().to_owned()
+  let prefix = "export interface " + name
+  if !trimmed.has_prefix(prefix) {
+    return ""
+  }
+  let suffix = trimmed[prefix.length():trimmed.length()].trim().to_owned()
+  if !suffix.has_prefix("<") {
+    return ""
+  }
+  let mut depth = 0
+  let mut idx = 0
+  while idx < suffix.length() {
+    let c = mbti_char_at(suffix, idx)
+    if c == '<' {
+      depth += 1
+    } else if c == '>' {
+      depth -= 1
+      if depth == 0 {
+        return suffix[:idx + 1].to_owned()
+      }
+    }
+    idx += 1
+  }
+  ""
+}
+
+///|
 /// The npm runtime adapter materializes structs as plain JavaScript objects.
 /// Their MoonBit trait implementations are not callable at this boundary and
 /// must not be advertised by the declaration surface.
@@ -6252,8 +6292,16 @@ fn add_mbti_runtime_value_brands(
   }
   let additions : Array[String] = ["declare const __tsmbt_raw: unique symbol;"]
   for struct_name in struct_names {
+    let mut generic_params = ""
+    for line in lines {
+      let found = mbti_ts_interface_generic_params(line, struct_name)
+      if found != "" {
+        generic_params = found
+        break
+      }
+    }
     additions.push(
-      "export interface \{struct_name} { readonly [__tsmbt_raw]: unknown; }",
+      "export interface \{struct_name}\{generic_params} { readonly [__tsmbt_raw]: unknown; }",
     )
   }
   additions.join("\n") + "\n\n" + lines.join("\n")
@@ -6309,6 +6357,7 @@ fn strip_runtime_inaccessible_typescript_package_files(
           import_ref.module_spec,
         )
         is None &&
+        mbti_import_requires_external_runtime_boundary(import_ref.module_spec) &&
         !allowed_external_import_spec_rewrites.contains(import_ref.module_spec) {
         external_import_aliases.push(import_ref.alias_name)
       }

--- a/src/bridge/mbti_typescript_decl.mbt
+++ b/src/bridge/mbti_typescript_decl.mbt
@@ -16,6 +16,8 @@ pub struct MbtiTypescriptScaffoldBundle {
   package_json : String
   autolink_diagnostics_md : String
   autolink_glue_mbt : String
+  runtime_value_adapter_js : String
+  runtime_boundary_export_names : Array[String]
   files : Array[MbtiTypescriptPackageFile]
 }
 
@@ -79,6 +81,10 @@ priv struct MbtiEnumLikeDecl {
   // emission can append `Extract<T, { $tag: "X" }>` aliases without
   // re-parsing the rendered union body.
   variant_names : Array[String]
+  // Public field names in declaration order for each variant. The MoonBit JS
+  // runtime stores enum payloads as `_0`, `_1`, ... so the npm facade uses
+  // these names when it turns a runtime value into its `.d.ts` shape.
+  variant_fields : Array[(String, Array[String])]
 }
 
 ///|
@@ -989,14 +995,73 @@ fn mbti_line_is_glue_eligible_generic_free_fn(
 }
 
 ///|
+/// Finds public aliases whose representation eventually mentions an imported
+/// MoonBit type outside the npm package tree. A function that accepts one of
+/// these aliases would otherwise admit an arbitrary JS lookalike.
+fn collect_mbti_public_type_aliases_with_external_import_types(
+  source : String,
+  external_import_aliases : Array[String],
+) -> Array[String] {
+  let imports = parse_mbti_imports(source)
+  let used_aliases : Array[String] = []
+  let aliases : Array[(String, String)] = []
+  for line_view in source.split("\n") {
+    let trimmed = line_view.trim().to_owned()
+    if !trimmed.has_prefix("pub type ") &&
+      !trimmed.has_prefix("pub(all) type ") {
+      continue
+    }
+    let equals_idx = match trimmed.find("=") {
+      Some(idx) => idx
+      None => continue
+    }
+    let alias_decl = parse_type_alias_decl(
+      trimmed, imports, used_aliases,
+    ) catch {
+      _ => continue
+    }
+    aliases.push((
+      alias_decl.name,
+      trimmed[equals_idx + 1:trimmed.length()].to_owned(),
+    ))
+  }
+  let names : Array[String] = []
+  let mut changed = true
+  while changed {
+    changed = false
+    for pair in aliases {
+      let (name, body) = pair
+      let mut mentions_external_import = false
+      for alias_name in external_import_aliases {
+        if body.contains("@" + alias_name + ".") {
+          mentions_external_import = true
+        }
+      }
+      if (mentions_external_import ||
+          mbti_type_source_mentions_private_local_type(body, names, [])) &&
+        !names.contains(name) {
+        names.push(name)
+        changed = true
+      }
+    }
+  }
+  names
+}
+
+///|
 fn collect_runtime_inaccessible_free_function_names(
   source : String,
+  external_import_aliases? : Array[String] = [],
 ) -> Array[String] {
   let imports = parse_mbti_imports(source)
   let used_aliases : Array[String] = []
   let private_type_names = collect_root_mbti_private_type_names(source) catch {
     _ => []
   }
+  let external_type_alias_names =
+    collect_mbti_public_type_aliases_with_external_import_types(
+      source, external_import_aliases,
+    )
   let names : Array[String] = []
   for line_view in source.split("\n") {
     let trimmed = line_view.trim().to_owned()
@@ -1045,9 +1110,16 @@ fn collect_runtime_inaccessible_free_function_names(
             let return_src_with_effect = mbti_return_source_with_effect_from_function_line(
               trimmed,
             )
-            if mbti_raw_facade_uses_private_types(
+            if (mbti_raw_facade_uses_private_types(
                 raw_params, return_src_with_effect, private_type_names, fn_type_param_names,
-              ) &&
+              ) || mbti_raw_facade_uses_external_import_types(
+                raw_params, return_src_with_effect, external_import_aliases,
+              ) || mbti_raw_facade_uses_private_types(
+                raw_params,
+                return_src_with_effect,
+                external_type_alias_names,
+                fn_type_param_names,
+              )) &&
               !names.contains(export_name) {
               names.push(export_name)
             }
@@ -1059,6 +1131,29 @@ fn collect_runtime_inaccessible_free_function_names(
     }
   }
   names
+}
+
+///|
+/// A package published as one npm artifact cannot safely expose a MoonBit
+/// value owned by an import outside its bundled package tree. Such a value
+/// has no independently publishable `.d.ts` or runtime identity boundary.
+fn mbti_raw_facade_uses_external_import_types(
+  raw_params : Array[MbtiRawFacadeParam],
+  return_src : String,
+  external_import_aliases : Array[String],
+) -> Bool {
+  for alias_name in external_import_aliases {
+    let prefix = "@" + alias_name + "."
+    if return_src.contains(prefix) {
+      return true
+    }
+    for param in raw_params {
+      if param.ty_src.contains(prefix) {
+        return true
+      }
+    }
+  }
+  false
 }
 
 ///|
@@ -1084,8 +1179,10 @@ fn parse_mbti_package_name(source : String) -> String? {
 
 ///|
 fn render_autolink_diagnostics_md(
+  root_package_name : String,
   ordered_packages : Array[String],
   package_sources : Map[String, String],
+  allowed_external_import_spec_rewrites? : Map[String, String] = {},
 ) -> String {
   let lines : Array[String] = [
     "# Autolink Diagnostics", "", "Public members omitted from link.js.exports because MoonBit JS autolink currently exports non-generic top-level public free functions with runtime-public boundary types.",
@@ -1097,7 +1194,24 @@ fn render_autolink_diagnostics_md(
       Some(source) => source
       None => continue
     }
+    let external_import_aliases : Array[String] = []
+    for import_ref in parse_mbti_imports(source) {
+      if mbti_local_package_segments(root_package_name, import_ref.module_spec) is None {
+        if !allowed_external_import_spec_rewrites.contains(
+            import_ref.module_spec,
+          ) {
+          external_import_aliases.push(import_ref.alias_name)
+        }
+      }
+    }
     let omitted_members = collect_mbti_omitted_autolink_members(source)
+    for name in collect_runtime_inaccessible_free_function_names(
+      source, external_import_aliases=external_import_aliases,
+    ) {
+      if !omitted_members.contains(name) {
+        omitted_members.push(name)
+      }
+    }
     if omitted_members.length() == 0 {
       continue
     }
@@ -1814,9 +1928,14 @@ fn collect_mbti_autolink_glue_decls(
   include_facades : Bool,
   local_package_import_alias_rewrites : Map[String, String],
   runtime_export_prefix : String,
+  external_import_aliases : Array[String],
 ) -> Array[MbtiAutolinkGlueDecl] raise MbtiTypescriptDeclError {
   let imports = parse_mbti_imports(source)
   let used_aliases : Array[String] = []
+  let external_type_alias_names =
+    collect_mbti_public_type_aliases_with_external_import_types(
+      source, external_import_aliases,
+    )
   let local_type_params = collect_root_mbti_local_type_params(source)
   let local_type_names : Array[String] = []
   for pair in local_type_params {
@@ -1883,6 +2002,13 @@ fn collect_mbti_autolink_glue_decls(
             }
             if mbti_raw_facade_uses_private_types(
                 raw_params, glue_return_src_with_effect, private_type_names, fn_type_param_names,
+              ) || mbti_raw_facade_uses_external_import_types(
+                raw_params, return_src_with_effect, external_import_aliases,
+              ) || mbti_raw_facade_uses_private_types(
+                raw_params,
+                return_src_with_effect,
+                external_type_alias_names,
+                fn_type_param_names,
               ) {
               continue
             }
@@ -2038,6 +2164,13 @@ fn collect_mbti_autolink_glue_decls(
                     ),
                     private_type_names,
                     fn_type_param_names,
+                  ) || mbti_raw_facade_uses_external_import_types(
+                    raw_params, return_src_with_effect, external_import_aliases,
+                  ) || mbti_raw_facade_uses_private_types(
+                    raw_params,
+                    return_src_with_effect,
+                    external_type_alias_names,
+                    fn_type_param_names,
                   ) {
                   continue
                 }
@@ -2182,6 +2315,7 @@ fn collect_mbti_autolink_glue_decls(
 fn collect_mbti_bundle_autolink_glue_decls(
   loaded : LoadedMbtiPackageSources,
   include_facades : Bool,
+  allowed_external_import_spec_rewrites? : Map[String, String] = {},
 ) -> Array[MbtiAutolinkGlueDecl] raise MbtiTypescriptDeclError {
   let decls : Array[MbtiAutolinkGlueDecl] = []
   let local_package_aliases : Map[String, String] = {}
@@ -2207,11 +2341,20 @@ fn collect_mbti_bundle_autolink_glue_decls(
         )
     }
     let local_package_import_alias_rewrites : Map[String, String] = {}
+    let external_import_aliases : Array[String] = []
     for import_ref in parse_mbti_imports(source) {
       match local_package_aliases.get(import_ref.module_spec) {
         Some(alias_name) if alias_name != import_ref.alias_name =>
           local_package_import_alias_rewrites[import_ref.alias_name] = alias_name
-        _ => ()
+        _ =>
+          if mbti_local_package_segments(
+              loaded.root_package_name, import_ref.module_spec,
+            ) is None &&
+            !allowed_external_import_spec_rewrites.contains(
+              import_ref.module_spec,
+            ) {
+            external_import_aliases.push(import_ref.alias_name)
+          }
       }
     }
     let runtime_export_prefix = if package_name == loaded.root_package_name {
@@ -2221,7 +2364,7 @@ fn collect_mbti_bundle_autolink_glue_decls(
     }
     let package_decls = collect_mbti_autolink_glue_decls(
       package_name, source, source_alias, include_facades, local_package_import_alias_rewrites,
-      runtime_export_prefix,
+      runtime_export_prefix, external_import_aliases,
     )
     for decl in package_decls {
       decls.push(decl)
@@ -3561,6 +3704,7 @@ fn parse_enum_like_block_decl(
       let owner_type_param_names = type_param_names(type_params)
       let variants : Array[String] = []
       let variant_names : Array[String] = []
+      let variant_fields : Array[(String, Array[String])] = []
       for idx in 1..<lines.length() {
         let trimmed = trim_trailing_comma_or_semicolon(
           lines[idx].trim().to_owned(),
@@ -3575,7 +3719,17 @@ fn parse_enum_like_block_decl(
             let fields = parse_variant_payload(
               payload_src, imports, used_aliases, name, owner_type_param_names,
             )
+            let field_names : Array[String] = []
+            for field in fields {
+              match field.find(":") {
+                Some(colon_idx) => field_names.push(
+                  field[:colon_idx].trim().to_owned(),
+                )
+                None => ()
+              }
+            }
             variant_names.push(variant_name)
+            variant_fields.push((variant_name, field_names))
             if fields.length() == 0 {
               variants.push("{ $tag: \"\{variant_name}\" }")
             } else {
@@ -3585,18 +3739,220 @@ fn parse_enum_like_block_decl(
           }
           _ => {
             variant_names.push(trimmed)
+            variant_fields.push((trimmed, []))
             variants.push("{ $tag: \"\{trimmed}\" }")
           }
         }
       }
       let joined_variants = variants.join(" | ")
-      { name, type_params, union_body: joined_variants, variant_names }
+      {
+        name,
+        type_params,
+        union_body: joined_variants,
+        variant_names,
+        variant_fields,
+      }
     }
     None =>
       raise MbtiTypescriptDeclError::ParseError(
         "invalid \{keyword} block: \{lines[0]}",
       )
   }
+}
+
+///|
+/// Render a conservative JavaScript boundary adapter for MoonBit values.
+/// MoonBit's JS backend represents structs as classes and enum payloads as
+/// `_0`, `_1`, ... fields. Those are intentionally not the structural values
+/// advertised by generated `.d.ts` files, so npm output normalizes every
+/// known public value before returning it to JavaScript.
+fn mbti_runtime_js_string(value : String) -> String {
+  "\"" + value.replace(old="\\", new="\\\\").replace(old="\"", new="\\\"") + "\""
+}
+
+fn mbti_runtime_struct_field_names(fields : Array[String]) -> Array[String] {
+  let names : Array[String] = []
+  for field in fields {
+    match field.find(":") {
+      Some(colon_idx) => names.push(field[:colon_idx].trim().to_owned())
+      None => ()
+    }
+  }
+  names
+}
+
+fn render_mbti_runtime_struct_descriptor(
+  decl : MbtiStructDecl,
+) -> String {
+  let fields : Array[String] = []
+  for name in mbti_runtime_struct_field_names(decl.fields) {
+    fields.push(mbti_runtime_js_string(name))
+  }
+  "[\{mbti_runtime_js_string(decl.name)}, [\{fields.join(", ")}]]"
+}
+
+fn render_mbti_runtime_enum_descriptor(
+  decl : MbtiEnumLikeDecl,
+) -> String {
+  let variants : Array[String] = []
+  for pair in decl.variant_fields {
+    let (variant_name, fields) = pair
+    let rendered_fields : Array[String] = []
+    for field in fields {
+      rendered_fields.push(mbti_runtime_js_string(field))
+    }
+    variants.push(
+      "[\{mbti_runtime_js_string(variant_name)}, [\{rendered_fields.join(", ")}]]",
+    )
+  }
+  "[\{mbti_runtime_js_string(decl.name)}, [\{variants.join(", ")}]]"
+}
+
+fn render_mbti_runtime_value_adapter_js(
+  loaded : LoadedMbtiPackageSources,
+) -> String raise MbtiTypescriptDeclError {
+  let struct_descriptors : Array[String] = []
+  let enum_descriptors : Array[String] = []
+  for package_name in loaded.ordered_packages {
+    let source = match loaded.package_sources.get(package_name) {
+      Some(source) => source
+      None => continue
+    }
+    let imports = parse_mbti_imports(source)
+    let used_aliases : Array[String] = []
+    let lines : Array[String] = []
+    for line in source.split("\n") {
+      lines.push(line.to_owned())
+    }
+    let mut idx = 0
+    while idx < lines.length() {
+      let trimmed = lines[idx].trim().to_owned()
+      if trimmed.has_prefix("pub struct ") ||
+        trimmed.has_prefix("pub(all) struct ") {
+        let (block, next_idx) = collect_mbti_decl_block(lines, idx)
+        let decl = parse_struct_block_decl(block, imports, used_aliases)
+        struct_descriptors.push(render_mbti_runtime_struct_descriptor(decl))
+        idx = next_idx
+        continue
+      }
+      if trimmed.has_prefix("pub enum ") || trimmed.has_prefix("pub(all) enum ") {
+        let (block, next_idx) = collect_brace_block(lines, idx)
+        let decl = parse_enum_like_block_decl(block, "enum", imports, used_aliases)
+        enum_descriptors.push(render_mbti_runtime_enum_descriptor(decl))
+        idx = next_idx
+        continue
+      }
+      if trimmed.has_prefix("pub suberror ") ||
+        trimmed.has_prefix("pub(all) suberror ") {
+        let (block, next_idx) = collect_brace_block(lines, idx)
+        let decl = parse_enum_like_block_decl(block, "suberror", imports, used_aliases)
+        enum_descriptors.push(render_mbti_runtime_enum_descriptor(decl))
+        idx = next_idx
+        continue
+      }
+      idx += 1
+    }
+  }
+  let adapter =
+    #|const __tsmbt_raw_value = Symbol("tsmbt.raw");
+    #|const __tsmbt_runtime_structs = [
+    #|__TSMBT_RUNTIME_STRUCTS__
+    #|];
+    #|const __tsmbt_runtime_enums = [
+    #|__TSMBT_RUNTIME_ENUMS__
+    #|];
+    #|
+    #|function __tsmbt_is_object(value) {
+    #|  return value !== null && typeof value === "object";
+    #|}
+    #|
+    #|function __tsmbt_public_value(value, seen = new WeakMap()) {
+    #|  if (!__tsmbt_is_object(value)) return value;
+    #|  if (seen.has(value)) return seen.get(value);
+    #|  if (Array.isArray(value)) {
+    #|    const output = [];
+    #|    seen.set(value, output);
+    #|    for (const item of value) output.push(__tsmbt_public_value(item, seen));
+    #|    return output;
+    #|  }
+    #|  if (value instanceof Map) {
+    #|    const output = new Map();
+    #|    seen.set(value, output);
+    #|    for (const [key, item] of value) {
+    #|      output.set(__tsmbt_public_value(key, seen), __tsmbt_public_value(item, seen));
+    #|    }
+    #|    return output;
+    #|  }
+    #|  if (value instanceof Set) {
+    #|    const output = new Set();
+    #|    seen.set(value, output);
+    #|    for (const item of value) output.add(__tsmbt_public_value(item, seen));
+    #|    return output;
+    #|  }
+    #|  const constructorName = value.constructor?.name ?? "";
+    #|  for (const [typeName, fields] of __tsmbt_runtime_structs) {
+    #|    if (!constructorName.endsWith(typeName)) continue;
+    #|    const output = {};
+    #|    seen.set(value, output);
+    #|    for (const field of fields) output[field] = __tsmbt_public_value(value[field], seen);
+    #|    Object.defineProperty(output, __tsmbt_raw_value, { value });
+    #|    return output;
+    #|  }
+    #|  for (const [typeName, variants] of __tsmbt_runtime_enums) {
+    #|    for (const [variantName, fields] of variants) {
+    #|      if (!constructorName.includes(typeName) || !constructorName.endsWith(variantName)) continue;
+    #|      const output = { $tag: variantName };
+    #|      seen.set(value, output);
+    #|      for (let index = 0; index < fields.length; index += 1) {
+    #|        output[fields[index]] = __tsmbt_public_value(value[`_${index}`], seen);
+    #|      }
+    #|      Object.defineProperty(output, __tsmbt_raw_value, { value });
+    #|      return output;
+    #|    }
+    #|  }
+    #|  return value;
+    #|}
+    #|
+    #|function __tsmbt_public_return(value) {
+    #|  if (value && typeof value.then === "function") {
+    #|    return value.then((resolved) => __tsmbt_public_value(resolved));
+    #|  }
+    #|  return __tsmbt_public_value(value);
+    #|}
+    #|
+    #|function __tsmbt_raw_argument(value, seen = new WeakMap()) {
+    #|  if (!__tsmbt_is_object(value)) return value;
+    #|  if (value[__tsmbt_raw_value] !== undefined) return value[__tsmbt_raw_value];
+    #|  if (seen.has(value)) return seen.get(value);
+    #|  if (Array.isArray(value)) {
+    #|    const output = [];
+    #|    seen.set(value, output);
+    #|    for (const item of value) output.push(__tsmbt_raw_argument(item, seen));
+    #|    return output;
+    #|  }
+    #|  if (value instanceof Map) {
+    #|    const output = new Map();
+    #|    seen.set(value, output);
+    #|    for (const [key, item] of value) {
+    #|      output.set(__tsmbt_raw_argument(key, seen), __tsmbt_raw_argument(item, seen));
+    #|    }
+    #|    return output;
+    #|  }
+    #|  if (value instanceof Set) {
+    #|    const output = new Set();
+    #|    seen.set(value, output);
+    #|    for (const item of value) output.add(__tsmbt_raw_argument(item, seen));
+    #|    return output;
+    #|  }
+  #|  return value;
+  #|}
+  return adapter.replace(
+    old="__TSMBT_RUNTIME_STRUCTS__",
+    new=struct_descriptors.join(",\n"),
+  ).replace(
+    old="__TSMBT_RUNTIME_ENUMS__",
+    new=enum_descriptors.join(",\n"),
+  )
 }
 
 ///|
@@ -5575,6 +5931,321 @@ fn strip_runtime_inaccessible_typescript_members(
 }
 
 ///|
+/// Removing an unsafe function can make an otherwise valid type-only import
+/// unused. Leave no unresolved ambient MoonBit package import in a standalone
+/// npm declaration file.
+fn strip_unused_typescript_type_imports(source : String) -> String {
+  let import_lines : Array[(String, String)] = []
+  let body_lines : Array[String] = []
+  let prefix = "import type * as "
+  for line_view in source.split("\n") {
+    let line = line_view.to_owned()
+    let trimmed = line.trim().to_owned()
+    if trimmed.has_prefix(prefix) {
+      let rest = trimmed[prefix.length():trimmed.length()].to_owned()
+      match rest.find(" from ") {
+        Some(from_idx) => {
+          let alias_name = rest[:from_idx].trim().to_owned()
+          if alias_name != "" {
+            import_lines.push((line, alias_name))
+            continue
+          }
+        }
+        None => ()
+      }
+    }
+    body_lines.push(line)
+  }
+  let body = body_lines.join("\n")
+  let kept_imports : Array[String] = []
+  for pair in import_lines {
+    let (line, alias_name) = pair
+    if body.contains(alias_name + ".") {
+      kept_imports.push(line)
+    }
+  }
+  if kept_imports.length() == 0 {
+    body
+  } else if body == "" {
+    kept_imports.join("\n")
+  } else {
+    kept_imports.join("\n") + "\n" + body
+  }
+}
+
+///|
+/// Collect namespace aliases whose declaration import is not a generated
+/// relative package edge. They refer to MoonBit packages that cannot be
+/// shipped as an ambient dependency of this standalone npm artifact.
+fn collect_typescript_external_type_import_aliases(
+  source : String,
+  allowed_external_module_specs : Array[String],
+) -> Array[String] {
+  let aliases : Array[String] = []
+  let prefix = "import type * as "
+  for line_view in source.split("\n") {
+    let trimmed = line_view.trim().to_owned()
+    if !trimmed.has_prefix(prefix) {
+      continue
+    }
+    let rest = trimmed[prefix.length():trimmed.length()].to_owned()
+    let from_idx = match rest.find(" from ") {
+      Some(idx) => idx
+      None => continue
+    }
+    let alias_name = rest[:from_idx].trim().to_owned()
+    let spec_src = rest[from_idx + " from ".length():rest.length()].trim().to_owned()
+    if alias_name == "" || spec_src.length() < 3 {
+      continue
+    }
+    let quote = mbti_char_at(spec_src, 0)
+    if quote != '"' && quote != '\'' {
+      continue
+    }
+    let after_open_quote = spec_src[1:spec_src.length()].to_owned()
+    match after_open_quote.find(quote.to_string()) {
+      Some(close_rel_idx) => {
+        let module_spec = after_open_quote[:close_rel_idx].to_owned()
+        if !module_spec.has_prefix(".") &&
+          !allowed_external_module_specs.contains(module_spec) &&
+          !aliases.contains(alias_name) {
+          aliases.push(alias_name)
+        }
+      }
+      _ => ()
+    }
+  }
+  aliases
+}
+
+///|
+/// Returns the end offset of a qualified TypeScript type reference. The
+/// declaration emitter only uses namespace-qualified names here, but nested
+/// generic arguments are consumed so `pkg.Type<A>` becomes one `unknown`.
+fn mbti_typescript_qualified_type_ref_end(source : String, start : Int) -> Int {
+  let mut idx = start
+  while idx < source.length() {
+    if !mbti_is_identifier_start(mbti_char_at(source, idx)) {
+      break
+    }
+    idx += 1
+    while idx < source.length() &&
+          mbti_is_identifier_continue(mbti_char_at(source, idx)) {
+      idx += 1
+    }
+    if idx < source.length() && mbti_char_at(source, idx) == '.' {
+      idx += 1
+      continue
+    }
+    break
+  }
+  if idx >= source.length() || mbti_char_at(source, idx) != '<' {
+    return idx
+  }
+  let mut depth = 0
+  while idx < source.length() {
+    let c = mbti_char_at(source, idx)
+    if c == '<' {
+      depth += 1
+    } else if c == '>' {
+      depth -= 1
+      if depth == 0 {
+        return idx + 1
+      }
+    }
+    idx += 1
+  }
+  source.length()
+}
+
+///|
+/// External MoonBit type references have no `.d.ts` module in a standalone
+/// npm package. Expose such nested value slots as `unknown`; direct API
+/// parameters and results are filtered before this rewrite runs.
+fn rewrite_external_moonbit_typescript_refs_to_unknown(
+  source : String,
+  external_aliases : Array[String],
+) -> String {
+  let mut rewritten = source
+  for alias_name in external_aliases {
+    let needle = alias_name + "."
+    let mut output = ""
+    let mut cursor = 0
+    while cursor < rewritten.length() {
+      let suffix = rewritten[cursor:rewritten.length()].to_owned()
+      let rel_idx = match suffix.find(needle) {
+        Some(idx) => idx
+        None => {
+          output += suffix
+          cursor = rewritten.length()
+          continue
+        }
+      }
+      let prefix_end = cursor + rel_idx
+      let ref_start = prefix_end + needle.length()
+      if ref_start >= rewritten.length() ||
+        !mbti_is_identifier_start(mbti_char_at(rewritten, ref_start)) {
+        output += rewritten[cursor:ref_start].to_owned()
+        cursor = ref_start
+        continue
+      }
+      let ref_end = mbti_typescript_qualified_type_ref_end(rewritten, ref_start)
+      output += rewritten[cursor:prefix_end].to_owned()
+      output += "unknown"
+      cursor = ref_end
+    }
+    rewritten = output
+  }
+  rewritten
+}
+
+///|
+/// Runtime structs and enums are returned as adapter-owned values. A private
+/// declaration-only symbol prevents TypeScript callers from passing a plain
+/// lookalike object back into MoonBit APIs that require the original runtime
+/// value.
+fn mbti_runtime_structural_type_names(
+  source : String,
+) -> (Array[String], Array[String]) raise MbtiTypescriptDeclError {
+  let imports = parse_mbti_imports(source)
+  let used_aliases : Array[String] = []
+  let structs : Array[String] = []
+  let enums : Array[String] = []
+  for line_view in source.split("\n") {
+    let trimmed = line_view.trim().to_owned()
+    if trimmed.has_prefix("pub struct ") ||
+      trimmed.has_prefix("pub(all) struct ") {
+      match parse_mbti_type_header(trimmed, "struct", imports, used_aliases) {
+        Some((name, _)) => structs.push(name)
+        None => ()
+      }
+    } else if trimmed.has_prefix("pub enum ") ||
+      trimmed.has_prefix("pub(all) enum ") {
+      match parse_mbti_type_header(trimmed, "enum", imports, used_aliases) {
+        Some((name, _)) => enums.push(name)
+        None => ()
+      }
+    } else if trimmed.has_prefix("pub suberror ") ||
+      trimmed.has_prefix("pub(all) suberror ") {
+      match parse_mbti_type_header(trimmed, "suberror", imports, used_aliases) {
+        Some((name, _)) => enums.push(name)
+        None => ()
+      }
+    }
+  }
+  (structs, enums)
+}
+
+fn mbti_ts_line_declares_type(line : String, name : String) -> Bool {
+  let trimmed = line.trim().to_owned()
+  let prefix = "export type " + name
+  if !trimmed.has_prefix(prefix) {
+    return false
+  }
+  if trimmed.length() == prefix.length() {
+    return false
+  }
+  let next = mbti_char_at(trimmed, prefix.length())
+  (next == ' ' || next == '<') && trimmed.contains("=")
+}
+
+///|
+/// The npm runtime adapter materializes structs as plain JavaScript objects.
+/// Their MoonBit trait implementations are not callable at this boundary and
+/// must not be advertised by the declaration surface.
+fn strip_mbti_runtime_struct_interface_traits(line : String, name : String) -> String {
+  let prefix = "export interface " + name
+  let trimmed = line.trim().to_owned()
+  if !trimmed.has_prefix(prefix) {
+    return line
+  }
+  let extends_idx = match line.find(" extends ") {
+    Some(idx) => idx
+    None => return line
+  }
+  let open_brace_idx = match line.find("{") {
+    Some(idx) if idx > extends_idx => idx
+    _ => return line
+  }
+  line[:extends_idx].to_owned() + " " +
+    line[open_brace_idx:line.length()].to_owned()
+}
+
+///|
+/// `render_enum_like_decl` wraps an enum union in parentheses before adding
+/// trait intersections. Retain only that union because the adapter returns a
+/// tagged plain object rather than an object with MoonBit trait methods.
+fn mbti_runtime_enum_shape_without_traits(rhs : String) -> String {
+  let trimmed = rhs.trim().to_owned()
+  if !trimmed.has_prefix("(") {
+    return trimmed
+  }
+  let mut depth = 0
+  let mut idx = 0
+  while idx < trimmed.length() {
+    let c = mbti_char_at(trimmed, idx)
+    if c == '(' {
+      depth += 1
+    } else if c == ')' {
+      depth -= 1
+      if depth == 0 {
+        return trimmed[:idx + 1].to_owned()
+      }
+    }
+    idx += 1
+  }
+  // Preserve malformed declarations rather than dropping their tail.
+  trimmed
+}
+
+fn add_mbti_runtime_value_brands(
+  source : String,
+  declaration : String,
+) -> String raise MbtiTypescriptDeclError {
+  let (struct_names, enum_names) = mbti_runtime_structural_type_names(source)
+  if struct_names.length() == 0 && enum_names.length() == 0 {
+    return declaration
+  }
+  let lines : Array[String] = []
+  for line_view in declaration.split("\n") {
+    let line = line_view.to_owned()
+    let mut rewritten = line
+    for struct_name in struct_names {
+      rewritten = strip_mbti_runtime_struct_interface_traits(
+        rewritten, struct_name,
+      )
+    }
+    for enum_name in enum_names {
+      if !mbti_ts_line_declares_type(rewritten, enum_name) {
+        continue
+      }
+      match rewritten.rev_find(";") {
+        Some(semicolon_idx) => {
+          let equals_idx = match rewritten.find("=") {
+            Some(idx) => idx
+            None => continue
+          }
+          let left = rewritten[:equals_idx + 1].to_owned()
+          let right = rewritten[equals_idx + 1:semicolon_idx].trim().to_owned()
+          let runtime_shape = mbti_runtime_enum_shape_without_traits(right)
+          rewritten = "\{left} (\{runtime_shape}) & { readonly [__tsmbt_raw]: unknown };" +
+            rewritten[semicolon_idx + 1:rewritten.length()].to_owned()
+        }
+        None => ()
+      }
+    }
+    lines.push(rewritten)
+  }
+  let additions : Array[String] = ["declare const __tsmbt_raw: unique symbol;"]
+  for struct_name in struct_names {
+    additions.push(
+      "export interface \{struct_name} { readonly [__tsmbt_raw]: unknown; }",
+    )
+  }
+  additions.join("\n") + "\n\n" + lines.join("\n")
+}
+
+///|
 /// Detects a flat-method export emission such as
 /// `export function Owner_member(...)`. Used to recognize both
 /// instance-method and static-method flattenings produced by mbt-to-ts
@@ -5603,8 +6274,10 @@ fn strip_runtime_inaccessible_typescript_package_files(
   files : Array[MbtiTypescriptPackageFile],
   runtime_export_names? : Array[String] = [],
   generic_glue_export_names? : Array[String] = [],
-) -> Array[MbtiTypescriptPackageFile] {
+  allowed_external_import_spec_rewrites? : Map[String, String] = {},
+) -> Array[MbtiTypescriptPackageFile] raise MbtiTypescriptDeclError {
   let inaccessible_by_path : Map[String, Array[String]] = {}
+  let source_by_path : Map[String, String] = {}
   for package_name in loaded.ordered_packages {
     let source = match loaded.package_sources.get(package_name) {
       Some(source) => source
@@ -5615,9 +6288,29 @@ fn strip_runtime_inaccessible_typescript_package_files(
       Some(segments) => segments
       None => continue
     }
-    inaccessible_by_path[mbti_bundle_relative_path_from_segments(segments)] = collect_runtime_inaccessible_free_function_names(
-      source,
+    let external_import_aliases : Array[String] = []
+    for import_ref in parse_mbti_imports(source) {
+      if mbti_local_package_segments(
+          loaded.root_package_name, import_ref.module_spec,
+        ) is None &&
+        !allowed_external_import_spec_rewrites.contains(
+          import_ref.module_spec,
+        ) {
+        external_import_aliases.push(import_ref.alias_name)
+      }
+    }
+    let relative_path = mbti_bundle_relative_path_from_segments(segments)
+    inaccessible_by_path[relative_path] = collect_runtime_inaccessible_free_function_names(
+      source, external_import_aliases=external_import_aliases,
     )
+    source_by_path[relative_path] = source
+  }
+  let allowed_external_module_specs : Array[String] = []
+  for pair in allowed_external_import_spec_rewrites {
+    let (_, rewritten_spec) = pair
+    if !allowed_external_module_specs.contains(rewritten_spec) {
+      allowed_external_module_specs.push(rewritten_spec)
+    }
   }
   let stripped : Array[MbtiTypescriptPackageFile] = []
   for file in files {
@@ -5626,13 +6319,29 @@ fn strip_runtime_inaccessible_typescript_package_files(
       Some(names) => names
       None => []
     }
+    let source = match source_by_path.get(file.relative_path) {
+      Some(source) => source
+      None => ""
+    }
+    let external_type_import_aliases =
+      collect_typescript_external_type_import_aliases(
+        file.content, allowed_external_module_specs,
+      )
     stripped.push({
       relative_path: file.relative_path,
-      content: strip_runtime_inaccessible_typescript_members(
-        file.content,
-        inaccessible_function_names,
-        runtime_export_names,
-        generic_glue_export_names,
+      content: add_mbti_runtime_value_brands(
+        source,
+        strip_unused_typescript_type_imports(
+          rewrite_external_moonbit_typescript_refs_to_unknown(
+            strip_runtime_inaccessible_typescript_members(
+              file.content,
+              inaccessible_function_names,
+              runtime_export_names,
+              generic_glue_export_names,
+            ),
+            external_type_import_aliases,
+          ),
+        ),
       ),
     })
   }
@@ -5753,7 +6462,11 @@ pub async fn emit_typescript_scaffold_bundle_from_mbti_path_with_import_rewrites
 ) -> MbtiTypescriptScaffoldBundle raise MbtiTypescriptDeclError {
   let loaded = load_mbti_package_sources(root_file_path)
   let root_package_name = loaded.root_package_name
-  let glue_decls = collect_mbti_bundle_autolink_glue_decls(loaded, false)
+  let glue_decls = collect_mbti_bundle_autolink_glue_decls(
+    loaded,
+    false,
+    allowed_external_import_spec_rewrites=external_import_spec_rewrites,
+  )
   let export_names : Array[String] = []
   let generic_glue_export_names : Array[String] = []
   for decl in glue_decls {
@@ -5770,6 +6483,7 @@ pub async fn emit_typescript_scaffold_bundle_from_mbti_path_with_import_rewrites
     ),
     runtime_export_names=export_names,
     generic_glue_export_names~,
+    allowed_external_import_spec_rewrites=external_import_spec_rewrites,
   )
   let files_with_runtime : Array[MbtiTypescriptPackageFile] = []
   for file in files {
@@ -5789,10 +6503,13 @@ pub async fn emit_typescript_scaffold_bundle_from_mbti_path_with_import_rewrites
       root_package_name, files_with_runtime,
     ),
     autolink_diagnostics_md: render_autolink_diagnostics_md(
-      loaded.ordered_packages,
+      root_package_name, loaded.ordered_packages,
       loaded.package_sources,
+      allowed_external_import_spec_rewrites=external_import_spec_rewrites,
     ),
     autolink_glue_mbt: render_autolink_glue_mbt(glue_decls),
+    runtime_value_adapter_js: render_mbti_runtime_value_adapter_js(loaded),
+    runtime_boundary_export_names: export_names,
     files: files_with_runtime,
   }
 }
@@ -5814,7 +6531,11 @@ pub async fn emit_typescript_facade_scaffold_bundle_from_mbti_path_with_import_r
 ) -> MbtiTypescriptScaffoldBundle raise MbtiTypescriptDeclError {
   let loaded = load_mbti_package_sources(root_file_path)
   let root_package_name = loaded.root_package_name
-  let glue_decls = collect_mbti_bundle_autolink_glue_decls(loaded, true)
+  let glue_decls = collect_mbti_bundle_autolink_glue_decls(
+    loaded,
+    true,
+    allowed_external_import_spec_rewrites=external_import_spec_rewrites,
+  )
   let facade_export_names : Array[String] = []
   let generic_glue_export_names : Array[String] = []
   let facade_ts_decls_by_path : Map[String, Array[String]] = {}
@@ -5844,6 +6565,7 @@ pub async fn emit_typescript_facade_scaffold_bundle_from_mbti_path_with_import_r
     ),
     runtime_export_names=facade_export_names,
     generic_glue_export_names~,
+    allowed_external_import_spec_rewrites=external_import_spec_rewrites,
   )
   let files_with_facades : Array[MbtiTypescriptPackageFile] = []
   for file in files {
@@ -5872,10 +6594,13 @@ pub async fn emit_typescript_facade_scaffold_bundle_from_mbti_path_with_import_r
       root_package_name, files_with_facades,
     ),
     autolink_diagnostics_md: render_autolink_diagnostics_md(
-      loaded.ordered_packages,
+      root_package_name, loaded.ordered_packages,
       loaded.package_sources,
+      allowed_external_import_spec_rewrites=external_import_spec_rewrites,
     ),
     autolink_glue_mbt: render_autolink_glue_mbt(glue_decls),
+    runtime_value_adapter_js: render_mbti_runtime_value_adapter_js(loaded),
+    runtime_boundary_export_names: facade_export_names,
     files: files_with_facades,
   }
 }

--- a/src/bridge/mbti_typescript_decl.mbt
+++ b/src/bridge/mbti_typescript_decl.mbt
@@ -1007,23 +1007,19 @@ fn collect_mbti_public_type_aliases_with_external_import_types(
   let aliases : Array[(String, String)] = []
   for line_view in source.split("\n") {
     let trimmed = line_view.trim().to_owned()
-    if !trimmed.has_prefix("pub type ") &&
-      !trimmed.has_prefix("pub(all) type ") {
+    if !trimmed.has_prefix("pub type ") && !trimmed.has_prefix("pub(all) type ") {
       continue
     }
     let equals_idx = match trimmed.find("=") {
       Some(idx) => idx
       None => continue
     }
-    let alias_decl = parse_type_alias_decl(
-      trimmed, imports, used_aliases,
-    ) catch {
+    let alias_decl = parse_type_alias_decl(trimmed, imports, used_aliases) catch {
       _ => continue
     }
-    aliases.push((
-      alias_decl.name,
-      trimmed[equals_idx + 1:trimmed.length()].to_owned(),
-    ))
+    aliases.push(
+      (alias_decl.name, trimmed[equals_idx + 1:trimmed.length()].to_owned()),
+    )
   }
   let names : Array[String] = []
   let mut changed = true
@@ -1037,8 +1033,10 @@ fn collect_mbti_public_type_aliases_with_external_import_types(
           mentions_external_import = true
         }
       }
-      if (mentions_external_import ||
-          mbti_type_source_mentions_private_local_type(body, names, [])) &&
+      if (
+          mentions_external_import ||
+          mbti_type_source_mentions_private_local_type(body, names, [])
+        ) &&
         !names.contains(name) {
         names.push(name)
         changed = true
@@ -1058,10 +1056,9 @@ fn collect_runtime_inaccessible_free_function_names(
   let private_type_names = collect_root_mbti_private_type_names(source) catch {
     _ => []
   }
-  let external_type_alias_names =
-    collect_mbti_public_type_aliases_with_external_import_types(
-      source, external_import_aliases,
-    )
+  let external_type_alias_names = collect_mbti_public_type_aliases_with_external_import_types(
+    source, external_import_aliases,
+  )
   let names : Array[String] = []
   for line_view in source.split("\n") {
     let trimmed = line_view.trim().to_owned()
@@ -1110,16 +1107,18 @@ fn collect_runtime_inaccessible_free_function_names(
             let return_src_with_effect = mbti_return_source_with_effect_from_function_line(
               trimmed,
             )
-            if (mbti_raw_facade_uses_private_types(
-                raw_params, return_src_with_effect, private_type_names, fn_type_param_names,
-              ) || mbti_raw_facade_uses_external_import_types(
-                raw_params, return_src_with_effect, external_import_aliases,
-              ) || mbti_raw_facade_uses_private_types(
-                raw_params,
-                return_src_with_effect,
-                external_type_alias_names,
-                fn_type_param_names,
-              )) &&
+            if (
+                mbti_raw_facade_uses_private_types(
+                  raw_params, return_src_with_effect, private_type_names, fn_type_param_names,
+                ) ||
+                mbti_raw_facade_uses_external_import_types(
+                  raw_params, return_src_with_effect, external_import_aliases,
+                ) ||
+                mbti_raw_facade_uses_private_types(
+                  raw_params, return_src_with_effect, external_type_alias_names,
+                  fn_type_param_names,
+                )
+              ) &&
               !names.contains(export_name) {
               names.push(export_name)
             }
@@ -1196,7 +1195,8 @@ fn render_autolink_diagnostics_md(
     }
     let external_import_aliases : Array[String] = []
     for import_ref in parse_mbti_imports(source) {
-      if mbti_local_package_segments(root_package_name, import_ref.module_spec) is None {
+      if mbti_local_package_segments(root_package_name, import_ref.module_spec)
+        is None {
         if !allowed_external_import_spec_rewrites.contains(
             import_ref.module_spec,
           ) {
@@ -1205,9 +1205,11 @@ fn render_autolink_diagnostics_md(
       }
     }
     let omitted_members = collect_mbti_omitted_autolink_members(source)
-    for name in collect_runtime_inaccessible_free_function_names(
-      source, external_import_aliases=external_import_aliases,
-    ) {
+    for
+      name in collect_runtime_inaccessible_free_function_names(
+        source,
+        external_import_aliases~,
+      ) {
       if !omitted_members.contains(name) {
         omitted_members.push(name)
       }
@@ -1932,10 +1934,9 @@ fn collect_mbti_autolink_glue_decls(
 ) -> Array[MbtiAutolinkGlueDecl] raise MbtiTypescriptDeclError {
   let imports = parse_mbti_imports(source)
   let used_aliases : Array[String] = []
-  let external_type_alias_names =
-    collect_mbti_public_type_aliases_with_external_import_types(
-      source, external_import_aliases,
-    )
+  let external_type_alias_names = collect_mbti_public_type_aliases_with_external_import_types(
+    source, external_import_aliases,
+  )
   let local_type_params = collect_root_mbti_local_type_params(source)
   let local_type_names : Array[String] = []
   for pair in local_type_params {
@@ -2002,13 +2003,12 @@ fn collect_mbti_autolink_glue_decls(
             }
             if mbti_raw_facade_uses_private_types(
                 raw_params, glue_return_src_with_effect, private_type_names, fn_type_param_names,
-              ) || mbti_raw_facade_uses_external_import_types(
+              ) ||
+              mbti_raw_facade_uses_external_import_types(
                 raw_params, return_src_with_effect, external_import_aliases,
-              ) || mbti_raw_facade_uses_private_types(
-                raw_params,
-                return_src_with_effect,
-                external_type_alias_names,
-                fn_type_param_names,
+              ) ||
+              mbti_raw_facade_uses_private_types(
+                raw_params, return_src_with_effect, external_type_alias_names, fn_type_param_names,
               ) {
               continue
             }
@@ -2164,12 +2164,12 @@ fn collect_mbti_autolink_glue_decls(
                     ),
                     private_type_names,
                     fn_type_param_names,
-                  ) || mbti_raw_facade_uses_external_import_types(
+                  ) ||
+                  mbti_raw_facade_uses_external_import_types(
                     raw_params, return_src_with_effect, external_import_aliases,
-                  ) || mbti_raw_facade_uses_private_types(
-                    raw_params,
-                    return_src_with_effect,
-                    external_type_alias_names,
+                  ) ||
+                  mbti_raw_facade_uses_private_types(
+                    raw_params, return_src_with_effect, external_type_alias_names,
                     fn_type_param_names,
                   ) {
                   continue
@@ -2348,8 +2348,10 @@ fn collect_mbti_bundle_autolink_glue_decls(
           local_package_import_alias_rewrites[import_ref.alias_name] = alias_name
         _ =>
           if mbti_local_package_segments(
-              loaded.root_package_name, import_ref.module_spec,
-            ) is None &&
+              loaded.root_package_name,
+              import_ref.module_spec,
+            )
+            is None &&
             !allowed_external_import_spec_rewrites.contains(
               import_ref.module_spec,
             ) {
@@ -3722,9 +3724,8 @@ fn parse_enum_like_block_decl(
             let field_names : Array[String] = []
             for field in fields {
               match field.find(":") {
-                Some(colon_idx) => field_names.push(
-                  field[:colon_idx].trim().to_owned(),
-                )
+                Some(colon_idx) =>
+                  field_names.push(field[:colon_idx].trim().to_owned())
                 None => ()
               }
             }
@@ -3767,9 +3768,12 @@ fn parse_enum_like_block_decl(
 /// advertised by generated `.d.ts` files, so npm output normalizes every
 /// known public value before returning it to JavaScript.
 fn mbti_runtime_js_string(value : String) -> String {
-  "\"" + value.replace(old="\\", new="\\\\").replace(old="\"", new="\\\"") + "\""
+  "\"" +
+  value.replace(old="\\", new="\\\\").replace(old="\"", new="\\\"") +
+  "\""
 }
 
+///|
 fn mbti_runtime_struct_field_names(fields : Array[String]) -> Array[String] {
   let names : Array[String] = []
   for field in fields {
@@ -3781,9 +3785,8 @@ fn mbti_runtime_struct_field_names(fields : Array[String]) -> Array[String] {
   names
 }
 
-fn render_mbti_runtime_struct_descriptor(
-  decl : MbtiStructDecl,
-) -> String {
+///|
+fn render_mbti_runtime_struct_descriptor(decl : MbtiStructDecl) -> String {
   let fields : Array[String] = []
   for name in mbti_runtime_struct_field_names(decl.fields) {
     fields.push(mbti_runtime_js_string(name))
@@ -3791,9 +3794,8 @@ fn render_mbti_runtime_struct_descriptor(
   "[\{mbti_runtime_js_string(decl.name)}, [\{fields.join(", ")}]]"
 }
 
-fn render_mbti_runtime_enum_descriptor(
-  decl : MbtiEnumLikeDecl,
-) -> String {
+///|
+fn render_mbti_runtime_enum_descriptor(decl : MbtiEnumLikeDecl) -> String {
   let variants : Array[String] = []
   for pair in decl.variant_fields {
     let (variant_name, fields) = pair
@@ -3808,6 +3810,7 @@ fn render_mbti_runtime_enum_descriptor(
   "[\{mbti_runtime_js_string(decl.name)}, [\{variants.join(", ")}]]"
 }
 
+///|
 fn render_mbti_runtime_value_adapter_js(
   loaded : LoadedMbtiPackageSources,
 ) -> String raise MbtiTypescriptDeclError {
@@ -3837,7 +3840,9 @@ fn render_mbti_runtime_value_adapter_js(
       }
       if trimmed.has_prefix("pub enum ") || trimmed.has_prefix("pub(all) enum ") {
         let (block, next_idx) = collect_brace_block(lines, idx)
-        let decl = parse_enum_like_block_decl(block, "enum", imports, used_aliases)
+        let decl = parse_enum_like_block_decl(
+          block, "enum", imports, used_aliases,
+        )
         enum_descriptors.push(render_mbti_runtime_enum_descriptor(decl))
         idx = next_idx
         continue
@@ -3845,7 +3850,9 @@ fn render_mbti_runtime_value_adapter_js(
       if trimmed.has_prefix("pub suberror ") ||
         trimmed.has_prefix("pub(all) suberror ") {
         let (block, next_idx) = collect_brace_block(lines, idx)
-        let decl = parse_enum_like_block_decl(block, "suberror", imports, used_aliases)
+        let decl = parse_enum_like_block_decl(
+          block, "suberror", imports, used_aliases,
+        )
         enum_descriptors.push(render_mbti_runtime_enum_descriptor(decl))
         idx = next_idx
         continue
@@ -3944,15 +3951,14 @@ fn render_mbti_runtime_value_adapter_js(
     #|    for (const item of value) output.add(__tsmbt_raw_argument(item, seen));
     #|    return output;
     #|  }
-  #|  return value;
-  #|}
-  return adapter.replace(
-    old="__TSMBT_RUNTIME_STRUCTS__",
-    new=struct_descriptors.join(",\n"),
-  ).replace(
-    old="__TSMBT_RUNTIME_ENUMS__",
-    new=enum_descriptors.join(",\n"),
-  )
+    #|  return value;
+    #|}
+  return adapter
+    .replace(
+      old="__TSMBT_RUNTIME_STRUCTS__",
+      new=struct_descriptors.join(",\n"),
+    )
+    .replace(old="__TSMBT_RUNTIME_ENUMS__", new=enum_descriptors.join(",\n"))
 }
 
 ///|
@@ -5994,7 +6000,9 @@ fn collect_typescript_external_type_import_aliases(
       None => continue
     }
     let alias_name = rest[:from_idx].trim().to_owned()
-    let spec_src = rest[from_idx + " from ".length():rest.length()].trim().to_owned()
+    let spec_src = rest[from_idx + " from ".length():rest.length()]
+      .trim()
+      .to_owned()
     if alias_name == "" || spec_src.length() < 3 {
       continue
     }
@@ -6136,6 +6144,7 @@ fn mbti_runtime_structural_type_names(
   (structs, enums)
 }
 
+///|
 fn mbti_ts_line_declares_type(line : String, name : String) -> Bool {
   let trimmed = line.trim().to_owned()
   let prefix = "export type " + name
@@ -6153,7 +6162,10 @@ fn mbti_ts_line_declares_type(line : String, name : String) -> Bool {
 /// The npm runtime adapter materializes structs as plain JavaScript objects.
 /// Their MoonBit trait implementations are not callable at this boundary and
 /// must not be advertised by the declaration surface.
-fn strip_mbti_runtime_struct_interface_traits(line : String, name : String) -> String {
+fn strip_mbti_runtime_struct_interface_traits(
+  line : String,
+  name : String,
+) -> String {
   let prefix = "export interface " + name
   let trimmed = line.trim().to_owned()
   if !trimmed.has_prefix(prefix) {
@@ -6167,8 +6179,9 @@ fn strip_mbti_runtime_struct_interface_traits(line : String, name : String) -> S
     Some(idx) if idx > extends_idx => idx
     _ => return line
   }
-  line[:extends_idx].to_owned() + " " +
-    line[open_brace_idx:line.length()].to_owned()
+  line[:extends_idx].to_owned() +
+  " " +
+  line[open_brace_idx:line.length()].to_owned()
 }
 
 ///|
@@ -6198,6 +6211,7 @@ fn mbti_runtime_enum_shape_without_traits(rhs : String) -> String {
   trimmed
 }
 
+///|
 fn add_mbti_runtime_value_brands(
   source : String,
   declaration : String,
@@ -6291,17 +6305,18 @@ fn strip_runtime_inaccessible_typescript_package_files(
     let external_import_aliases : Array[String] = []
     for import_ref in parse_mbti_imports(source) {
       if mbti_local_package_segments(
-          loaded.root_package_name, import_ref.module_spec,
-        ) is None &&
-        !allowed_external_import_spec_rewrites.contains(
+          loaded.root_package_name,
           import_ref.module_spec,
-        ) {
+        )
+        is None &&
+        !allowed_external_import_spec_rewrites.contains(import_ref.module_spec) {
         external_import_aliases.push(import_ref.alias_name)
       }
     }
     let relative_path = mbti_bundle_relative_path_from_segments(segments)
     inaccessible_by_path[relative_path] = collect_runtime_inaccessible_free_function_names(
-      source, external_import_aliases=external_import_aliases,
+      source,
+      external_import_aliases~,
     )
     source_by_path[relative_path] = source
   }
@@ -6323,10 +6338,10 @@ fn strip_runtime_inaccessible_typescript_package_files(
       Some(source) => source
       None => ""
     }
-    let external_type_import_aliases =
-      collect_typescript_external_type_import_aliases(
-        file.content, allowed_external_module_specs,
-      )
+    let external_type_import_aliases = collect_typescript_external_type_import_aliases(
+      file.content,
+      allowed_external_module_specs,
+    )
     stripped.push({
       relative_path: file.relative_path,
       content: add_mbti_runtime_value_brands(
@@ -6503,7 +6518,8 @@ pub async fn emit_typescript_scaffold_bundle_from_mbti_path_with_import_rewrites
       root_package_name, files_with_runtime,
     ),
     autolink_diagnostics_md: render_autolink_diagnostics_md(
-      root_package_name, loaded.ordered_packages,
+      root_package_name,
+      loaded.ordered_packages,
       loaded.package_sources,
       allowed_external_import_spec_rewrites=external_import_spec_rewrites,
     ),
@@ -6594,7 +6610,8 @@ pub async fn emit_typescript_facade_scaffold_bundle_from_mbti_path_with_import_r
       root_package_name, files_with_facades,
     ),
     autolink_diagnostics_md: render_autolink_diagnostics_md(
-      root_package_name, loaded.ordered_packages,
+      root_package_name,
+      loaded.ordered_packages,
       loaded.package_sources,
       allowed_external_import_spec_rewrites=external_import_spec_rewrites,
     ),

--- a/src/bridge/mbti_typescript_decl_wbtest.mbt
+++ b/src/bridge/mbti_typescript_decl_wbtest.mbt
@@ -1273,6 +1273,17 @@ async test "bridge: emit TypeScript scaffold bundle keeps optional named params 
   }
   assert_true(root_content.contains("export function identity<T>"))
   assert_false(root_content.contains("export function make_secret"))
+  assert_true(root_content.contains("export function update_ref"))
+  assert_true(
+    root_content.contains(
+      "export interface CallbackBox<T> { readonly [__tsmbt_raw]: unknown; }",
+    ),
+  )
+  assert_false(
+    root_content.contains(
+      "export interface CallbackBox { readonly [__tsmbt_raw]: unknown; }",
+    ),
+  )
   assert_true(
     bundle.autolink_glue_mbt.contains(
       "pub fn consume_callbacks(handler : (String, Int) -> Unit, on_error : ((Error) -> Unit)?, required : Array[String]) -> Unit {",

--- a/src/bridge/mbti_typescript_decl_wbtest.mbt
+++ b/src/bridge/mbti_typescript_decl_wbtest.mbt
@@ -1074,6 +1074,98 @@ async test "bridge: emit TypeScript scaffold bundle from mbti combines autolink 
   assert_true(bundle.autolink_diagnostics_md.contains("- `render`"))
   assert_true(bundle.autolink_diagnostics_md.contains("Item::new"))
   assert_eq(bundle.files.length(), 2)
+  assert_true(
+    bundle.runtime_value_adapter_js.contains(
+      "[\"Holder\", [\"item\"]]",
+    ),
+  )
+  assert_true(bundle.runtime_boundary_export_names.contains("make"))
+  let mut root_content = ""
+  for file in bundle.files {
+    if file.relative_path == "index.d.ts" {
+      root_content = file.content
+    }
+  }
+  assert_true(root_content.contains("declare const __tsmbt_raw: unique symbol;"))
+  assert_true(
+    root_content.contains(
+      "export interface Holder { readonly [__tsmbt_raw]: unknown; }",
+    ),
+  )
+}
+
+///|
+test "bridge: strips public functions that expose an external MoonBit type" {
+  let source =
+    #|package "demo/api"
+    #|
+    #|import {
+    #|  "demo/core" @core,
+    #|}
+    #|
+    #|pub type ExternalDocument = @core.Document
+    #|
+    #|pub fn document_to_json(@core.Document) -> String
+    #|pub fn render_external(ExternalDocument) -> String
+    #|pub fn render(String) -> String
+  let names = collect_runtime_inaccessible_free_function_names(
+    source,
+    external_import_aliases=["core"],
+  )
+  assert_true(names.contains("document_to_json"))
+  assert_true(names.contains("render_external"))
+  assert_false(names.contains("render"))
+  let declaration = parse_mbti_to_typescript(source) catch {
+    _ => fail("could not parse declaration")
+  }
+  let stripped = strip_unused_typescript_type_imports(
+    rewrite_external_moonbit_typescript_refs_to_unknown(
+    strip_runtime_inaccessible_typescript_members(
+      declaration, names, [], [],
+    ),
+    ["core"],
+    ),
+  )
+  assert_false(stripped.contains("document_to_json"))
+  assert_false(stripped.contains("render_external"))
+  assert_true(stripped.contains("export function render(s: string): string;"))
+  assert_true(stripped.contains("export type ExternalDocument = unknown;"))
+  assert_false(stripped.contains("import type"))
+  let sources : Map[String, String] = {}
+  sources["demo/api"] = source
+  let diagnostics = render_autolink_diagnostics_md(
+    "demo/api", ["demo/api"], sources,
+  )
+  assert_true(diagnostics.contains("- `document_to_json`"))
+  let glue_decls = collect_mbti_autolink_glue_decls(
+    "demo/api", source, "tsmbt_source", false, Map([]), "", ["core"],
+  ) catch {
+    _ => fail("could not collect autolink glue")
+  }
+  assert_eq(glue_decls.length(), 1)
+  assert_eq(glue_decls[0].export_name, "render")
+  let mapped_sources : Map[String, String] = {}
+  mapped_sources["demo/api"] = source
+  let import_rewrites : Map[String, String] = {}
+  import_rewrites["demo/core"] = "@demo/core-types"
+  let mapped_glue_decls = collect_mbti_bundle_autolink_glue_decls(
+    {
+      root_package_name: "demo/api",
+      ordered_packages: ["demo/api"],
+      package_sources: mapped_sources,
+    },
+    false,
+    allowed_external_import_spec_rewrites=import_rewrites,
+  ) catch {
+    _ => fail("could not collect mapped autolink glue")
+  }
+  // An explicit declaration-module rewrite is an opt-in integration point.
+  assert_true(mapped_glue_decls.any(fn(decl) {
+    decl.export_name == "document_to_json"
+  }))
+  assert_true(mapped_glue_decls.any(fn(decl) {
+    decl.export_name == "render_external"
+  }))
 }
 
 ///|
@@ -1121,7 +1213,7 @@ async test "bridge: emit TypeScript scaffold bundle exposes child package runtim
 }
 
 ///|
-async test "bridge: emit TypeScript scaffold bundle from mbti rewrites external imports through configured map" {
+async test "bridge: emit TypeScript scaffold bundle removes an unused configured external import" {
   let import_rewrites : Map[String, String] = {}
   import_rewrites["moonbitlang/core/debug"] = "demo-debug"
   let bundle = emit_typescript_scaffold_bundle_from_mbti_path_with_import_rewrites(
@@ -1139,9 +1231,9 @@ async test "bridge: emit TypeScript scaffold bundle from mbti rewrites external 
   }
   assert_true(bundle.package_json.contains("\"name\": \"@demo/pkg\""))
   assert_true(bundle.autolink_diagnostics_md.contains("Item::new"))
-  assert_true(
-    root_content.contains("import type * as debug from \"demo-debug\";"),
-  )
+  // `render` is a trait-bound generic and therefore is not part of the npm
+  // boundary. Its configured type import must disappear with that declaration.
+  assert_false(root_content.contains("import type * as debug"))
   assert_false(root_content.contains("\"moonbitlang/core/debug\""))
 }
 
@@ -1638,4 +1730,31 @@ async test "bridge: generic methods on non-generic owners export via monomorphiz
   // Trait-bounded methods stay omitted.
   assert_false(bundle.autolink_glue_mbt.contains("counter_describe"))
   assert_false(bundle.moon_pkg.contains("counter_describe"))
+}
+
+///|
+async test "bridge: npm structural value declarations omit MoonBit trait members" {
+  let bundle = emit_typescript_scaffold_bundle_from_mbti_path(
+    "fixtures/mbti_typescript/basic.pkg.generated.mbti",
+  ) catch {
+    MbtiTypescriptDeclError::ReadError(msg)
+    | MbtiTypescriptDeclError::ParseError(msg) =>
+      fail("MBTI scaffold bundle emit error: \{msg}")
+  }
+  let mut ts_decls = ""
+  for file in bundle.files {
+    if file.relative_path == "index.d.ts" {
+      ts_decls = file.content
+    }
+  }
+  // The runtime adapter returns plain JavaScript objects, so MoonBit's
+  // Eq/Show/etc. instance members must not appear on their npm-facing types.
+  assert_true(ts_decls.contains("export interface Box<T> {"))
+  assert_false(ts_decls.contains("export interface Box<T> extends"))
+  assert_true(
+    ts_decls.contains(
+      "export type ParseError = (({ $tag: \"InvalidFormat\"; _0: string } | { $tag: \"Overflow\"; _0: number; _1: string })) & { readonly [__tsmbt_raw]: unknown };",
+    ),
+  )
+  assert_false(ts_decls.contains("& Show & Eq<ParseError>"))
 }

--- a/src/bridge/mbti_typescript_decl_wbtest.mbt
+++ b/src/bridge/mbti_typescript_decl_wbtest.mbt
@@ -1075,9 +1075,7 @@ async test "bridge: emit TypeScript scaffold bundle from mbti combines autolink 
   assert_true(bundle.autolink_diagnostics_md.contains("Item::new"))
   assert_eq(bundle.files.length(), 2)
   assert_true(
-    bundle.runtime_value_adapter_js.contains(
-      "[\"Holder\", [\"item\"]]",
-    ),
+    bundle.runtime_value_adapter_js.contains("[\"Holder\", [\"item\"]]"),
   )
   assert_true(bundle.runtime_boundary_export_names.contains("make"))
   let mut root_content = ""
@@ -1086,7 +1084,9 @@ async test "bridge: emit TypeScript scaffold bundle from mbti combines autolink 
       root_content = file.content
     }
   }
-  assert_true(root_content.contains("declare const __tsmbt_raw: unique symbol;"))
+  assert_true(
+    root_content.contains("declare const __tsmbt_raw: unique symbol;"),
+  )
   assert_true(
     root_content.contains(
       "export interface Holder { readonly [__tsmbt_raw]: unknown; }",
@@ -1108,10 +1108,9 @@ test "bridge: strips public functions that expose an external MoonBit type" {
     #|pub fn document_to_json(@core.Document) -> String
     #|pub fn render_external(ExternalDocument) -> String
     #|pub fn render(String) -> String
-  let names = collect_runtime_inaccessible_free_function_names(
-    source,
-    external_import_aliases=["core"],
-  )
+  let names = collect_runtime_inaccessible_free_function_names(source, external_import_aliases=[
+    "core",
+  ])
   assert_true(names.contains("document_to_json"))
   assert_true(names.contains("render_external"))
   assert_false(names.contains("render"))
@@ -1120,10 +1119,8 @@ test "bridge: strips public functions that expose an external MoonBit type" {
   }
   let stripped = strip_unused_typescript_type_imports(
     rewrite_external_moonbit_typescript_refs_to_unknown(
-    strip_runtime_inaccessible_typescript_members(
-      declaration, names, [], [],
-    ),
-    ["core"],
+      strip_runtime_inaccessible_typescript_members(declaration, names, [], []),
+      ["core"],
     ),
   )
   assert_false(stripped.contains("document_to_json"))
@@ -1134,11 +1131,19 @@ test "bridge: strips public functions that expose an external MoonBit type" {
   let sources : Map[String, String] = {}
   sources["demo/api"] = source
   let diagnostics = render_autolink_diagnostics_md(
-    "demo/api", ["demo/api"], sources,
+    "demo/api",
+    ["demo/api"],
+    sources,
   )
   assert_true(diagnostics.contains("- `document_to_json`"))
   let glue_decls = collect_mbti_autolink_glue_decls(
-    "demo/api", source, "tsmbt_source", false, Map([]), "", ["core"],
+    "demo/api",
+    source,
+    "tsmbt_source",
+    false,
+    Map([]),
+    "",
+    ["core"],
   ) catch {
     _ => fail("could not collect autolink glue")
   }
@@ -1160,12 +1165,12 @@ test "bridge: strips public functions that expose an external MoonBit type" {
     _ => fail("could not collect mapped autolink glue")
   }
   // An explicit declaration-module rewrite is an opt-in integration point.
-  assert_true(mapped_glue_decls.any(fn(decl) {
-    decl.export_name == "document_to_json"
-  }))
-  assert_true(mapped_glue_decls.any(fn(decl) {
-    decl.export_name == "render_external"
-  }))
+  assert_true(
+    mapped_glue_decls.any(fn(decl) { decl.export_name == "document_to_json" }),
+  )
+  assert_true(
+    mapped_glue_decls.any(fn(decl) { decl.export_name == "render_external" }),
+  )
 }
 
 ///|

--- a/src/bridge/moonbit_bridge.mbt
+++ b/src/bridge/moonbit_bridge.mbt
@@ -1090,10 +1090,6 @@ fn add_bridge_ergonomic_helper_decls(
       None => ()
     }
   }
-  let unsafe_cast_decl = "declare pub fn[A, B] unsafeCast(value : A) -> B"
-  if !next_bridge_mbti.contains(unsafe_cast_decl) {
-    next_bridge_mbti += "\n\n///|\n" + unsafe_cast_decl
-  }
   for helper in collect_bridge_type_guard_helpers(bridge_mbti, bridge_mbt) {
     let helper_decl = "declare pub fn \{helper.helper_name}(self : \{helper.source_type}) -> \{helper.target_type}?"
     if !next_bridge_mbti.contains(helper_decl) {
@@ -1607,9 +1603,7 @@ fn add_bridge_public_wrappers(
       None => ()
     }
   }
-  let helpers : Array[String] = [
-    "pub fn[A, B] unsafeCast(value : A) -> B = \"%identity\"",
-  ]
+  let helpers : Array[String] = []
   if used_option_return_wrap &&
     !next_bridge_mbt.contains("fn[T] __ts_mbt_wrap_option_return") {
     helpers.push(bridge_option_return_wrap_helper_decls)
@@ -1641,6 +1635,14 @@ fn add_bridge_public_wrappers(
     )
   }
   let sections : Array[String] = []
+  let helper_text = helpers.join("\n")
+  if (
+      next_bridge_mbt.contains("unsafeCast(") ||
+      helper_text.contains("unsafeCast(")
+    ) &&
+    !next_bridge_mbt.contains("fn[A, B] unsafeCast(value : A) -> B") {
+    sections.push("fn[A, B] unsafeCast(value : A) -> B = \"%identity\"")
+  }
   for wrapper in wrappers {
     sections.push(wrapper)
   }

--- a/src/bridge/moonbit_bridge_wbtest.mbt
+++ b/src/bridge/moonbit_bridge_wbtest.mbt
@@ -987,7 +987,7 @@ async test "bridge: emit MoonBit TS bridge package bundle exposes namespace expo
 }
 
 ///|
-async test "bridge: emit MoonBit TS bridge package bundle adds ergonomic cast and guard helpers" {
+async test "bridge: emit MoonBit TS bridge package bundle keeps cast helper internal" {
   let bundle = emit_moonbit_ts_bridge_package_bundle_from_entry_path(
     "fixtures/resolver/project/types/type-guard-entry.d.ts", "/runtime/type-guard.js",
   ) catch {
@@ -999,16 +999,13 @@ async test "bridge: emit MoonBit TS bridge package bundle adds ergonomic cast an
       return
     }
   }
-  assert_true(
-    bundle.bridge_mbti.contains(
-      "declare pub fn[A, B] unsafeCast(value : A) -> B",
-    ),
-  )
+  assert_false(bundle.bridge_mbti.contains("unsafeCast"))
   assert_true(
     bundle.bridge_mbt.contains(
-      "pub fn[A, B] unsafeCast(value : A) -> B = \"%identity\"",
+      "fn[A, B] unsafeCast(value : A) -> B = \"%identity\"",
     ),
   )
+  assert_false(bundle.bridge_mbt.contains("pub fn[A, B] unsafeCast"))
   assert_true(
     bundle.bridge_mbti.contains(
       "declare pub fn asIdentifier(self : Node) -> Identifier?",

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -220,11 +220,43 @@ fn merge_interfaces(
 }
 
 ///|
+/// Build a resolver for one self-contained module. Graph-aware callers use
+/// `ingest_type_module` and `ingest_module` directly, while checker benchmarks
+/// use this helper to isolate the cost of the ordinary single-module setup.
 fn Resolver::from_module(module_ : @ast.TsModule) -> Resolver {
   let r = Resolver::empty()
   Resolver::ingest_module(r, module_, "")
   collect_module_value_names(module_, r.declared_value_names)
   r
+}
+
+///|
+/// Import only type declarations from another ES module. Value declarations
+/// intentionally stay out of `globals`: an embedding must still provide the
+/// concrete bindings it resolved for the current module's runtime imports.
+fn Resolver::ingest_type_module(
+  r : Resolver,
+  module_ : @ast.TsModule,
+  prefix : String,
+) -> Unit {
+  let types = Resolver::empty()
+  Resolver::ingest_module(types, module_, prefix)
+  for name, interface_ in types.interfaces {
+    match r.interfaces.get(name) {
+      Some(existing) =>
+        r.interfaces[name] = merge_interfaces(existing, interface_)
+      None => r.interfaces[name] = interface_
+    }
+  }
+  for name, class_ in types.classes {
+    r.classes[name] = class_
+  }
+  for name, alias_ in types.type_aliases {
+    r.type_aliases[name] = alias_
+  }
+  for name, enum_ in types.enums {
+    r.enums[name] = enum_
+  }
 }
 
 ///|
@@ -18705,7 +18737,40 @@ fn check_function_body_with(
 pub fn check_module_function_bodies(
   module_ : @ast.TsModule,
 ) -> Array[ExprIssue] {
-  check_module_function_bodies_layered(module_, [], false)
+  check_module_function_bodies_layered(module_, [], false, [], [])
+}
+
+///|
+/// Check a module with caller-supplied value bindings. This is intended for
+/// embeddings that resolve ES module imports outside the checker: each pair
+/// binds the import's local name to its resolved exported value type.
+///
+/// The checker remains filesystem- and bundler-independent; callers own
+/// module resolution and can provide only the bindings they can prove.
+pub fn check_module_function_bodies_with_globals(
+  module_ : @ast.TsModule,
+  globals : Array[(String, @ast.TsType)],
+) -> Array[ExprIssue] {
+  check_module_function_bodies_layered(module_, [], false, [], globals)
+}
+
+///|
+/// Check a module with caller-supplied runtime bindings and the type
+/// declarations reachable through those bindings. This keeps ES-module
+/// resolution outside the checker while preserving structural checks for
+/// parameters such as `import type { User } from "./model"`.
+pub fn check_module_function_bodies_with_context(
+  module_ : @ast.TsModule,
+  globals : Array[(String, @ast.TsType)],
+  type_modules : Array[@ast.TsModule],
+) -> Array[ExprIssue] {
+  check_module_function_bodies_layered(
+    module_,
+    [],
+    false,
+    type_modules,
+    globals,
+  )
 }
 
 ///|
@@ -19738,7 +19803,7 @@ fn check_circular_type_params(module_ : @ast.TsModule) -> Array[ExprIssue] {
 pub fn check_module_function_bodies_permissive(
   module_ : @ast.TsModule,
 ) -> Array[ExprIssue] {
-  check_module_function_bodies_layered(module_, [], true)
+  check_module_function_bodies_layered(module_, [], true, [], [])
 }
 
 ///|
@@ -25752,22 +25817,28 @@ fn check_module_function_bodies_layered(
   module_ : @ast.TsModule,
   outer_modules : Array[@ast.TsModule],
   permissive : Bool,
+  type_modules : Array[@ast.TsModule],
+  extra_globals : Array[(String, @ast.TsType)],
 ) -> Array[ExprIssue] {
-  let resolver = if outer_modules.length() == 0 {
-    Resolver::from_module(module_)
+  let resolver = Resolver::empty()
+  for type_module in type_modules {
+    Resolver::ingest_type_module(resolver, type_module, "")
+  }
+  if outer_modules.length() == 0 {
+    Resolver::ingest_module(resolver, module_, "")
+    collect_module_value_names(module_, resolver.declared_value_names)
   } else {
-    let r = Resolver::empty()
     for o in outer_modules {
-      Resolver::ingest_module(r, o, "")
+      Resolver::ingest_module(resolver, o, "")
     }
-    Resolver::ingest_module(r, module_, "")
+    Resolver::ingest_module(resolver, module_, "")
     // TS2304 backstop: collect declared value names from the *outermost*
     // module, which recurses into every nested namespace. This lets code
     // inside a namespace reference outer-scope (and sibling-namespace)
     // bindings unqualified without tripping a "cannot find name" false
-    // positive. `from_module` already does this for the top-level entry.
-    collect_module_value_names(outer_modules[0], r.declared_value_names)
-    r
+    // positive. The top-level branch above applies the same collection to its
+    // current module.
+    collect_module_value_names(outer_modules[0], resolver.declared_value_names)
   }
   // Strict-mode flag comes from the *outermost* (top-level) module's
   // header directive; namespace-nested modules don't carry their own
@@ -25780,6 +25851,10 @@ fn check_module_function_bodies_layered(
   }
   let strict_property_init = strict_root.strict_property_initialization
   let strict_null_checks = strict_root.strict_null_checks
+  for global in extra_globals {
+    resolver.globals[global.0] = global.1
+    resolver.declared_value_names[global.0] = true
+  }
   resolver.no_implicit_any = strict_root.no_implicit_any
   for gm in strict_root.grammar_misuses {
     if gm == "<lib-lacks-es2017>" {
@@ -26777,6 +26852,8 @@ fn check_module_function_bodies_layered(
       ns.module_,
       next_outers,
       permissive,
+      type_modules,
+      extra_globals,
     )
     let prefix = if ns.name == "<global>" {
       "declare global"

--- a/src/checker/pkg.generated.mbti
+++ b/src/checker/pkg.generated.mbti
@@ -25,6 +25,10 @@ pub fn check_module_function_bodies(@ast.TsModule) -> Array[ExprIssue]
 
 pub fn check_module_function_bodies_permissive(@ast.TsModule) -> Array[ExprIssue]
 
+pub fn check_module_function_bodies_with_context(@ast.TsModule, Array[(String, @ast.TsType)], Array[@ast.TsModule]) -> Array[ExprIssue]
+
+pub fn check_module_function_bodies_with_globals(@ast.TsModule, Array[(String, @ast.TsType)]) -> Array[ExprIssue]
+
 pub fn classify_optional_like_union(@ast.TsType) -> (@ast.TsType, Bool)?
 
 pub fn classify_promise_like_union(@ast.TsType) -> @ast.TsType?

--- a/src/cmd/mbt2ts/main_wbtest.mbt
+++ b/src/cmd/mbt2ts/main_wbtest.mbt
@@ -1,0 +1,18 @@
+///|
+test "mbt2ts keeps the unified package generator as its public CLI contract" {
+  let help = mbt2ts_help_lines()
+  assert_eq(
+    help[0],
+    "  --input <pkg-or-mbti> --out <dir> [--diagnostics <path>] [--strict] [--no-facade] [--import-rewrites <json>] Generate a complete build-backed TypeScript package from a MoonBit pkg.generated.mbti",
+  )
+  assert_true(
+    help.contains(
+      "  scaffold <mbti> <out-dir> [import-rewrite-json] Emit build-backed JS/TypeScript scaffold from a MoonBit package interface",
+    ),
+  )
+  assert_true(
+    help.contains(
+      "  facade-scaffold <mbti> <out-dir> [import-rewrite-json] Emit build-backed JS/TypeScript scaffold plus facade wrappers for omitted local methods",
+    ),
+  )
+}

--- a/src/cmd/mtsc/main.mbt
+++ b/src/cmd/mtsc/main.mbt
@@ -533,41 +533,14 @@ async fn mtsc_path_exists(path : String) -> Bool {
 }
 
 ///|
-/// Parse a source file and run the full strict expression/body checker.
-/// Kept separate from CLI output so the checker contract can be tested
-/// directly.
-fn mtsc_is_unresolved_import_binding(
-  issue : @checker.ExprIssue,
-  imported_binding_names : Array[String],
-) -> Bool {
-  for name in imported_binding_names {
-    if issue.message == "cannot find name `\{name}`" {
-      return true
-    }
-  }
-  false
-}
-
-///|
+/// Compatibility wrapper for the command's focused tests. The checker itself
+/// lives in `mizchi/ts/mtsc` so the JavaScript module and CLI use one strict
+/// implementation.
 fn mtsc_collect_type_issues(
   source : String,
   allow_jsx : Bool,
-) -> Result[Array[@checker.ExprIssue], String] {
-  let module_ = @parser.Parser::from_source_with_jsx(source, allow_jsx).parse_module() catch {
-    e => return Err("\{e}")
-  }
-  let issues : Array[@checker.ExprIssue] = []
-  for issue in @checker.check_module_function_bodies(module_) {
-    // The checker runs on a parsed source file rather than a linked module
-    // graph, so imported value bindings have no declaration available to its
-    // resolver. They are nevertheless valid names in this module; suppress
-    // only that known single-file false positive. The bundled dependency is
-    // checked independently below, so type errors in it are still reported.
-    if !mtsc_is_unresolved_import_binding(issue, module_.imported_binding_names) {
-      issues.push(issue)
-    }
-  }
-  Ok(issues)
+) -> Result[Array[@mtsc_core.MtscTypeIssue], String] {
+  @mtsc_core.collect_type_issues(source, allow_jsx)
 }
 
 ///|

--- a/src/cmd/mtsc/moon.pkg
+++ b/src/cmd/mtsc/moon.pkg
@@ -3,7 +3,7 @@ import {
   "moonbitlang/core/env",
   "mizchi/x/fs",
   "mizchi/ts/ast",
-  "mizchi/ts/checker",
+  "mizchi/ts/mtsc" @mtsc_core,
   "mizchi/ts/parser",
   "mizchi/ts/transform",
 }

--- a/src/cmd/ts2mbt/main.mbt
+++ b/src/cmd/ts2mbt/main.mbt
@@ -29,6 +29,7 @@ pub fn ts2mbt_help_lines() -> Array[String] {
     "  ffi <ts-entry> <module-spec> [ffi-out] [bridge-out] Emit MoonBit JS FFI stubs and ESM bridge from a TypeScript entrypoint",
     "  bridge <ts-entry> <module-spec> [decl-out] [ffi-out] [bridge-out] Emit a full MoonBit bridge bundle from a TypeScript entrypoint",
     "  package <ts-entry> <module-spec> <out-dir> Emit a generated MoonBit bridge package directory",
+    "  package-validated <ts-entry> <module-spec> <out-dir> Emit a bridge package with opt-in structural runtime validators",
     "  scaffold <ts-entry> <module-spec> <out-dir> Emit a MoonBit bridge scaffold from a TypeScript entrypoint",
   ]
 }
@@ -294,6 +295,22 @@ async fn ts2mbt_main_async() -> Unit {
         3,
         "ts2mbt package: expected <ts-entry> <module-spec> <out-dir>",
         async fn(p) { @ts.emit_moonbit_bridge_package(p[0], p[1], p[2]) },
+      )
+    "package-validated" =>
+      ts2mbt_dispatch(
+        args,
+        2,
+        "package-validated",
+        3,
+        "ts2mbt package-validated: expected <ts-entry> <module-spec> <out-dir>",
+        async fn(p) {
+          @ts.emit_moonbit_bridge_package(
+            p[0],
+            p[1],
+            p[2],
+            runtime_validation=true,
+          )
+        },
       )
     "scaffold" =>
       ts2mbt_dispatch(

--- a/src/main.mbt
+++ b/src/main.mbt
@@ -748,7 +748,7 @@ fn rewrite_runtime_boundary_js_exports(
         let raw_name = "__tsmbt_raw_export_" + export_name
         output_lines.push("const \{raw_name} = \{local_name};")
         output_lines.push(
-          "export function \{export_name}(...args) { return __tsmbt_public_return(\{raw_name}(...args.map(__tsmbt_raw_argument))); }",
+          "export function \{export_name}(...args) { return __tsmbt_public_return(\{raw_name}(...args.map((arg) => __tsmbt_raw_argument(arg)))); }",
         )
       }
       inserted_wrappers = true
@@ -762,7 +762,7 @@ fn rewrite_runtime_boundary_js_exports(
       let raw_name = "__tsmbt_raw_export_" + export_name
       output_lines.push("const \{raw_name} = \{local_name};")
       output_lines.push(
-        "export function \{export_name}(...args) { return __tsmbt_public_return(\{raw_name}(...args.map(__tsmbt_raw_argument))); }",
+        "export function \{export_name}(...args) { return __tsmbt_public_return(\{raw_name}(...args.map((arg) => __tsmbt_raw_argument(arg)))); }",
       )
     }
   }

--- a/src/main.mbt
+++ b/src/main.mbt
@@ -258,9 +258,37 @@ priv struct MoonbitJsBuildContext {
 }
 
 ///|
+fn parse_moon_mod_dsl_string_field(
+  source : String,
+  field_name : String,
+) -> String? {
+  let prefix = field_name + " ="
+  for line_view in source.split("\n") {
+    let line = line_view.trim().to_owned()
+    if !line.has_prefix(prefix) {
+      continue
+    }
+    let value = line[prefix.length():line.length()].trim().to_owned()
+    if value.length() < 2 || value[0].unsafe_to_char() != '"' {
+      return None
+    }
+    let closing = value[1:].find("\"")
+    match closing {
+      Some(index) => return Some(value[1:index + 1].to_owned())
+      None => return None
+    }
+  }
+  None
+}
+
+///|
 fn parse_moon_mod_string_field(source : String, field_name : String) -> String? {
-  let json = @json.parse(source) catch { _ => return None }
-  guard json is Object(members) else { return None }
+  let json = @json.parse(source) catch {
+    _ => return parse_moon_mod_dsl_string_field(source, field_name)
+  }
+  guard json is Object(members) else {
+    return parse_moon_mod_dsl_string_field(source, field_name)
+  }
   for pair in members {
     let (name, value) = pair
     if name == field_name {
@@ -326,6 +354,22 @@ async fn find_nearest_moon_mod_dir(start_dir : String) -> String? {
 }
 
 ///|
+/// Read the active module manifest after preferring the current DSL form.
+/// MoonBit accepts both forms during migration, but a project may have only
+/// `moon.mod`, so callers must not assume the legacy JSON manifest exists.
+async fn read_moon_mod_source(module_root : String) -> String? {
+  for manifest in ["moon.mod", "moon.mod.json"] {
+    let path = main_join_path(module_root, manifest)
+    if !@fs.exists(path) {
+      continue
+    }
+    let source = @fs.read_file(path).text() catch { _ => continue }
+    return Some(source)
+  }
+  None
+}
+
+///|
 fn strip_dir_prefix(root : String, path : String) -> String? {
   if path == root {
     return Some("")
@@ -354,9 +398,9 @@ async fn resolve_moonbit_js_build_context(
     Some(root) => @fs.realpath(root) catch { _ => root }
     None => return None
   }
-  let moon_mod_path = main_join_path(module_root, "moon.mod.json")
-  let moon_mod_source = @fs.read_file(moon_mod_path).text() catch {
-    _ => return None
+  let moon_mod_source = match read_moon_mod_source(module_root) {
+    Some(source) => source
+    None => return None
   }
   let source_root_rel = match
     parse_moon_mod_string_field(moon_mod_source, "source") {
@@ -519,6 +563,7 @@ fn collect_async_js_export_modes_from_glue(
 ///|
 fn render_async_js_export_wrappers(
   async_exports : Array[(String, String, Bool)],
+  adapt_public_values : Bool,
 ) -> Array[String] {
   if async_exports.length() == 0 {
     return []
@@ -559,8 +604,13 @@ fn render_async_js_export_wrappers(
   for item in async_exports {
     let (local_name, export_name, preserve_result) = item
     let preserve_result_js = if preserve_result { "true" } else { "false" }
+    let resolve_adapter = if adapt_public_values {
+      "__tsmbt_public_return"
+    } else {
+      "(value) => value"
+    }
     lines.push(
-      "export function \{export_name}(...args) { const callArgs = args.slice(); while (callArgs.length < \{local_name}.length - 2) { callArgs.push(undefined); } return __tsmbt_async_result_to_promise((ok, err) => \{local_name}(...callArgs, ok, err), \{preserve_result_js}); }",
+      "export function \{export_name}(...args) { const callArgs = args.slice(); while (callArgs.length < \{local_name}.length - 2) { callArgs.push(undefined); } return __tsmbt_async_result_to_promise((ok, err) => \{local_name}(...callArgs, (value) => ok(\{resolve_adapter}(value)), err), \{preserve_result_js}); }",
     )
   }
   lines
@@ -570,6 +620,7 @@ fn render_async_js_export_wrappers(
 fn rewrite_async_js_exports(
   source : String,
   async_modes : Map[String, Bool],
+  adapt_public_values? : Bool = false,
 ) -> String {
   if async_modes.length() == 0 {
     return source
@@ -616,7 +667,10 @@ fn rewrite_async_js_exports(
       }
     }
     if !inserted_wrappers && trimmed.has_prefix("//# sourceMappingURL=") {
-      for wrapper_line in render_async_js_export_wrappers(async_exports) {
+      for
+        wrapper_line in render_async_js_export_wrappers(
+          async_exports, adapt_public_values,
+        ) {
         output_lines.push(wrapper_line)
       }
       inserted_wrappers = true
@@ -624,7 +678,10 @@ fn rewrite_async_js_exports(
     output_lines.push(line)
   }
   if !inserted_wrappers {
-    for wrapper_line in render_async_js_export_wrappers(async_exports) {
+    for
+      wrapper_line in render_async_js_export_wrappers(
+        async_exports, adapt_public_values,
+      ) {
       output_lines.push(wrapper_line)
     }
   }
@@ -632,9 +689,115 @@ fn rewrite_async_js_exports(
 }
 
 ///|
+/// Replace MoonBit glue exports with small JavaScript boundary wrappers.
+/// The raw JS backend exposes classes and positional enum fields; the
+/// adapter generated from the MBTI converts those return values to the public
+/// structural values described by the emitted `.d.ts` file.
+fn rewrite_runtime_boundary_js_exports(
+  source : String,
+  adapter_js : String,
+  runtime_export_names : Array[String],
+  async_modes : Map[String, Bool],
+) -> String {
+  if runtime_export_names.length() == 0 {
+    return source
+  }
+  let output_lines : Array[String] = []
+  let wrapped_exports : Array[(String, String)] = []
+  let mut inserted_wrappers = false
+  for line_view in source.split("\n") {
+    let line = line_view.to_owned()
+    let trimmed = line.trim().to_owned()
+    if trimmed.has_prefix("export {") {
+      match (line.find("{"), line.rev_find("}")) {
+        (Some(open_idx), Some(close_idx)) if close_idx > open_idx => {
+          let inner = line[open_idx + 1:close_idx].to_owned()
+          let kept_specs : Array[String] = []
+          for raw_spec in inner.split(",") {
+            let spec = raw_spec.trim().to_owned()
+            if spec == "" {
+              continue
+            }
+            let (local_name, export_name) = match spec.find(" as ") {
+              Some(as_idx) =>
+                (
+                  spec[:as_idx].trim().to_owned(),
+                  spec[as_idx + " as ".length():spec.length()].trim().to_owned(),
+                )
+              None => (spec, spec)
+            }
+            if runtime_export_names.contains(export_name) &&
+              !async_modes.contains(export_name) {
+              wrapped_exports.push((local_name, export_name))
+            } else {
+              kept_specs.push(spec)
+            }
+          }
+          if kept_specs.length() > 0 {
+            output_lines.push("export { " + kept_specs.join(", ") + " }")
+          }
+          continue
+        }
+        _ => ()
+      }
+    }
+    if !inserted_wrappers && trimmed.has_prefix("//# sourceMappingURL=") {
+      output_lines.push(adapter_js)
+      for pair in wrapped_exports {
+        let (local_name, export_name) = pair
+        let raw_name = "__tsmbt_raw_export_" + export_name
+        output_lines.push("const \{raw_name} = \{local_name};")
+        output_lines.push(
+          "export function \{export_name}(...args) { return __tsmbt_public_return(\{raw_name}(...args.map(__tsmbt_raw_argument))); }",
+        )
+      }
+      inserted_wrappers = true
+    }
+    output_lines.push(line)
+  }
+  if !inserted_wrappers {
+    output_lines.push(adapter_js)
+    for pair in wrapped_exports {
+      let (local_name, export_name) = pair
+      let raw_name = "__tsmbt_raw_export_" + export_name
+      output_lines.push("const \{raw_name} = \{local_name};")
+      output_lines.push(
+        "export function \{export_name}(...args) { return __tsmbt_public_return(\{raw_name}(...args.map(__tsmbt_raw_argument))); }",
+      )
+    }
+  }
+  output_lines.join("\n")
+}
+
+///|
+async fn rewrite_runtime_boundary_js_exports_file(
+  path : String,
+  adapter_js : String,
+  runtime_export_names : Array[String],
+  async_modes : Map[String, Bool],
+) -> Bool {
+  if runtime_export_names.length() == 0 {
+    return true
+  }
+  let source = @fs.read_file(path).text() catch {
+    e => {
+      println("Read error: \{e}")
+      return false
+    }
+  }
+  write_text_file(
+    path,
+    rewrite_runtime_boundary_js_exports(
+      source, adapter_js, runtime_export_names, async_modes,
+    ),
+  )
+}
+
+///|
 async fn rewrite_async_js_exports_file(
   path : String,
   async_modes : Map[String, Bool],
+  adapt_public_values? : Bool = false,
 ) -> Bool {
   if async_modes.length() == 0 {
     return true
@@ -645,7 +808,10 @@ async fn rewrite_async_js_exports_file(
       return false
     }
   }
-  write_text_file(path, rewrite_async_js_exports(source, async_modes))
+  write_text_file(
+    path,
+    rewrite_async_js_exports(source, async_modes, adapt_public_values~),
+  )
 }
 
 ///|
@@ -714,9 +880,22 @@ async fn build_moonbit_js_runtime_from_mbti(
     remove_moonbit_js_glue_dir(context.glue_dir_path)
     return false
   }
+  let async_modes = collect_async_js_export_modes_from_glue(
+    bundle.autolink_glue_mbt,
+  )
+  if !rewrite_runtime_boundary_js_exports_file(
+      output_js_path,
+      bundle.runtime_value_adapter_js,
+      bundle.runtime_boundary_export_names,
+      async_modes,
+    ) {
+    remove_moonbit_js_glue_dir(context.glue_dir_path)
+    return false
+  }
   if !rewrite_async_js_exports_file(
       output_js_path,
-      collect_async_js_export_modes_from_glue(bundle.autolink_glue_mbt),
+      async_modes,
+      adapt_public_values=bundle.runtime_boundary_export_names.length() > 0,
     ) {
     remove_moonbit_js_glue_dir(context.glue_dir_path)
     return false
@@ -964,6 +1143,7 @@ pub async fn emit_moonbit_bridge_package(
   output_dir : String,
   bare_module_specifier? : String? = None,
   moonbitlang_async_integration? : Bool = false,
+  runtime_validation? : Bool = false,
 ) -> Bool {
   let bundle = emit_moonbit_bridge_package_texts(file_path, module_spec) catch {
     @bridge.ModuleGraphError::ReadError(msg)
@@ -1021,34 +1201,73 @@ pub async fn emit_moonbit_bridge_package(
   let bridge_mbt = rewrite_bridge_package_module_path(
     bundle_bridge_mbt, resolved_specifier,
   )
+  let (bridge_mbti, bridge_mbt) = if runtime_validation {
+    add_bridge_runtime_validation(bundle.bridge_mbti, bridge_mbt)
+  } else {
+    (bundle.bridge_mbti, bridge_mbt)
+  }
   let package_json = render_bridge_package_json(resolved_specifier)
   let files : Array[(String, String)] = [
     ("moon.pkg", bundle_moon_pkg),
-    ("bridge.mbti", bundle.bridge_mbti),
+    ("bridge.mbti", bridge_mbti),
     ("package.json", package_json),
   ]
   for file in bridge_package_mbt_files(bridge_mbt, force_split=false) {
     files.push(file)
   }
   files.push(("bridge.js", bundle.bridge_js))
-  // Refresh the sibling `node_modules/@tsmbt-bridge/<safe>` symlink so
-  // `require("@tsmbt-bridge/<safe>")` from generated test code lands at
-  // the bridge dir. The vendor flow expects users to also list this
-  // bridge as a `file:` dependency; `pnpm install` then replaces our
-  // symlink with its own pnpm-managed link, but both states resolve to
-  // the same bridge directory.
-  if !ensure_bridge_node_modules_link(output_dir, resolved_specifier) {
-    return false
-  }
+  // Stage every generated file beside its destination first.  A rename in
+  // one directory is atomic, so a reader observes either the old complete
+  // file or the new complete file — never a truncated bridge while Vite or
+  // Moon is rebuilding.  Only these reserved, generator-owned temporary
+  // paths and the named generated files are touched; user-authored files in
+  // the output directory are left alone.
   for file in files {
     let (name, content) = file
-    let path = join_output_path(output_dir, name)
-    let _ = @fs.write_file(path, string_to_bytes(content), create=0o644) catch {
+    let stage_path = join_output_path(
+      output_dir,
+      bridge_package_stage_file_name(name),
+    )
+    let _ = @fs.write_file(stage_path, string_to_bytes(content), create=0o644) catch {
       e => {
         println("Write error: \{e}")
         return false
       }
     }
+  }
+  for file in files {
+    let (name, _) = file
+    let stage_path = join_output_path(
+      output_dir,
+      bridge_package_stage_file_name(name),
+    )
+    let output_path = join_output_path(output_dir, name)
+    let _ = @async_fs.rename(stage_path, output_path, replace=true) catch {
+      e => {
+        println("Write error: could not publish \{output_path}: \{e}")
+        return false
+      }
+    }
+  }
+  // MoonBit now uses the DSL manifest. Remove the legacy JSON manifest only
+  // after every current generated file has been published successfully, so a
+  // migration cannot leave the output directory without a valid manifest.
+  let legacy_manifest = join_output_path(output_dir, "moon.pkg.json")
+  if @fs.exists(legacy_manifest) {
+    let _ = @fs.remove(legacy_manifest) catch {
+      e => {
+        println(
+          "Write error: could not remove legacy manifest \{legacy_manifest}: \{e}",
+        )
+        return false
+      }
+    }
+  }
+  // Refresh the sibling `node_modules/@tsmbt-bridge/<safe>` symlink only
+  // after the package is fully published, so it never points consumers at a
+  // directory with staged-but-unpublished output.
+  if !ensure_bridge_node_modules_link(output_dir, resolved_specifier) {
+    return false
   }
   println("Wrote MoonBit bridge package to \{output_dir}")
   true
@@ -1452,6 +1671,121 @@ fn rewrite_bridge_package_module_path(
 }
 
 ///|
+/// Runtime validation is deliberately opt-in. It protects generated
+/// structural structs at a JS boundary without changing the default bridge
+/// size or adding checks to every call. Supported fields are primitive
+/// `String`, `Bool`, `Int`, and `Double`; other declared fields are checked
+/// for presence and keep their static MoonBit contract.
+fn bridge_runtime_validation_field_check(
+  field : String,
+  type_ : String,
+) -> String {
+  let value = "value[\"\{field}\"]"
+  let (inner_type, optional) = if type_.has_suffix("?") {
+    (type_[:type_.length() - 1].to_owned().trim().to_owned(), true)
+  } else {
+    (type_, false)
+  }
+  let required_check = match inner_type {
+    "String" => "typeof \{value} === \"string\""
+    "Bool" => "typeof \{value} === \"boolean\""
+    "Int" | "Double" => "typeof \{value} === \"number\""
+    _ => "\"\{field}\" in value"
+  }
+  if optional {
+    "(\{value} === undefined || \{required_check})"
+  } else {
+    required_check
+  }
+}
+
+///|
+/// Append public `validate<Type>` functions for generated structural structs.
+/// Invalid values become `None`; callers can reject them before an
+/// `%identity` conversion exposes the value as the generated MoonBit type.
+fn add_bridge_runtime_validation(
+  bridge_mbti : String,
+  bridge_mbt : String,
+) -> (String, String) {
+  let mut mbti = bridge_mbti
+  let mut mbt = bridge_mbt
+  let mbti_sections : Array[String] = []
+  let mbt_sections : Array[String] = []
+  for block in bridge_package_split_top_level_blocks(bridge_mbt) {
+    // Generated doc comments share the top-level block with the declaration,
+    // so locate the struct line rather than requiring the block to start with
+    // it.
+    let mut struct_line : String? = None
+    for line_view in block.split("\n") {
+      let line = line_view.to_owned().trim().to_owned()
+      if line.has_prefix("pub(all) struct ") {
+        struct_line = Some(line)
+        break
+      }
+    }
+    let declaration = match struct_line {
+      Some(line) => line
+      None => continue
+    }
+    let prefix = "pub(all) struct "
+    let rest = declaration[prefix.length():].to_owned()
+    let open_index = match rest.find("{") {
+      Some(index) => index
+      None => continue
+    }
+    let type_name = rest[:open_index].to_owned().trim().to_owned()
+    if type_name == "" || type_name.contains("[") {
+      continue
+    }
+    let checks : Array[String] = [
+      "value !== null", "typeof value === \"object\"",
+    ]
+    for line_view in block.split("\n") {
+      let line = line_view.to_owned().trim().to_owned()
+      match line.find(":") {
+        Some(separator) if !line.has_prefix("pub") => {
+          let field = line[:separator].to_owned().trim().to_owned()
+          let type_ = line[separator + 1:].to_owned().trim().to_owned()
+          if field != "" && type_ != "" {
+            checks.push(bridge_runtime_validation_field_check(field, type_))
+          }
+        }
+        _ => ()
+      }
+    }
+    let validator_name = "validate\{type_name}"
+    let internal_name = "__ts_mbt_validate_\{type_name}"
+    let public_decl = "declare pub fn \{validator_name}(value : JSValue) -> \{type_name}?"
+    if !mbti.contains(public_decl) {
+      mbti_sections.push(
+        "///|\n/// Validates the runtime structural shape of `\{type_name}`.\n\{public_decl}",
+      )
+    }
+    let condition = checks.join(" && ")
+    let body = "extern \"js\" fn \{internal_name}(value : JSValue) -> Bool =\n  #| (value) => \{condition}\n\npub fn \{validator_name}(value : JSValue) -> \{type_name}? {\n  if \{internal_name}(value) {\n    Some(unsafeCast(value))\n  } else {\n    None\n  }\n}"
+    if !mbt.contains("fn \{validator_name}(") {
+      mbt_sections.push(body)
+    }
+  }
+  if mbt_sections.length() == 0 {
+    return (mbti, mbt)
+  }
+  if !mbti.contains("declare pub type JSValue") {
+    mbti = "#external\ndeclare pub type JSValue\n\n" + mbti
+  }
+  if !mbt.contains("type JSValue") {
+    mbt = "#external\ntype JSValue\n\n" + mbt
+  }
+  if !mbt.contains("fn[A, B] unsafeCast(value : A) -> B") {
+    mbt += "\n\nfn[A, B] unsafeCast(value : A) -> B = \"%identity\""
+  }
+  (
+    mbti + "\n\n" + mbti_sections.join("\n\n"),
+    mbt + "\n\n" + mbt_sections.join("\n\n"),
+  )
+}
+
+///|
 let bridge_package_split_line_threshold : Int = 2000
 
 ///|
@@ -1642,6 +1976,14 @@ fn join_output_path(base : String, child : String) -> String {
   } else {
     base + "/" + child
   }
+}
+
+///|
+/// Reserved adjacent staging name for a generator-owned bridge file.  The
+/// file remains in the destination directory so publishing with `rename` is
+/// an atomic operation on every supported target.
+fn bridge_package_stage_file_name(name : String) -> String {
+  ".tsmbt-next-" + name
 }
 
 ///|

--- a/src/main_wbtest.mbt
+++ b/src/main_wbtest.mbt
@@ -26,6 +26,16 @@ fn wbtest_tmp_project_benchmark_root(name : String) -> String {
 }
 
 ///|
+async test "mtsc JavaScript module exposes only the Vite graph checker ABI" {
+  let manifest = @fs.read_file("src/mtsc/moon.pkg").text() catch {
+    e => fail("failed to read mtsc package manifest: \{e}")
+  }
+  assert_true(manifest.contains("\"check_module_graph:checkModuleGraph\""))
+  assert_false(manifest.contains("check_source:checkSource"))
+  assert_false(manifest.contains("check_module_sources:checkModuleSources"))
+}
+
+///|
 async fn wbtest_collect_relative_files(
   root : String,
   relative_dir : String,
@@ -425,7 +435,8 @@ async test "emit_unified_tsmbt_scaffold emits MoonBit to TypeScript scaffold fro
     ].join("\n"),
   )
   assert_true(root_decl.contains("import type * as child from \"./child\";"))
-  assert_true(root_js.contains("export {"))
+  assert_true(root_js.contains("function __tsmbt_public_return(value)"))
+  assert_true(root_js.contains("export function create(...args)"))
   assert_true(package_json.contains("\"name\": \"@examples/counter\""))
   assert_true(package_json.contains("\"type\": \"module\""))
   assert_true(
@@ -799,7 +810,8 @@ async test "emit_typescript_scaffold_from_mbti writes declaration package metada
   assert_true(diagnostics_md.contains("Counter::label"))
   assert_true(root_decl.contains("import type * as child from \"./child\";"))
   assert_false(root_decl.contains("counter_label"))
-  assert_true(root_js.contains("export {"))
+  assert_true(root_js.contains("function __tsmbt_public_return(value)"))
+  assert_true(root_js.contains("export function create(...args)"))
 }
 
 ///|
@@ -908,7 +920,70 @@ async test "emit_typescript_scaffold_from_mbti handles moon.mod source subdir" {
   }
   assert_true(package_json.contains("\"name\": \"@fixture/source-subdir-pkg\""))
   assert_true(root_decl.contains("export function make(s: string): Cell;"))
-  assert_true(root_js.contains("export {"))
+  assert_true(root_js.contains("function __tsmbt_public_return(value)"))
+  assert_true(root_js.contains("export function make(...args)"))
+}
+
+///|
+async test "emit_typescript_scaffold_from_mbti handles DSL moon.mod source subdir" {
+  let root = wbtest_tmp_project_benchmark_root(
+    "mbti_typescript_scaffold_dsl_source_subdir",
+  )
+  let _ = try? @fs.rmdir(root, recursive=true)
+  let pkg_dir = wbtest_join_path(root, "src/pkg")
+  ensure_dir_tree(pkg_dir)
+  @fs.write_file(
+    wbtest_join_path(root, "moon.mod"),
+    (
+      #|name = "fixture/dsl-source-subdir"
+      #|version = "0.1.0"
+      #|source = "src"
+    ),
+    create=0o644,
+  )
+  @fs.write_file(wbtest_join_path(pkg_dir, "moon.pkg"), "", create=0o644)
+  @fs.write_file(
+    wbtest_join_path(pkg_dir, "pkg.mbt"),
+    (
+      #|///|
+      #|pub struct Cell {
+      #|  value : String
+      #|}
+      #|
+      #|///|
+      #|pub fn make(value : String) -> Cell {
+      #|  { value }
+      #|}
+    ),
+    create=0o644,
+  )
+  let (info_exit, info_output) = @process.collect_output_merged(
+    "moon",
+    ["-C", root, "info"],
+    cwd=".",
+  )
+  if info_exit != 0 {
+    fail("moon info failed: \{info_output.text()}")
+  }
+  let out = wbtest_join_path(root, "dist")
+  assert_true(
+    emit_typescript_scaffold_from_mbti(
+      wbtest_join_path(pkg_dir, "pkg.generated.mbti"),
+      out,
+      None,
+    ),
+  )
+  let package_json = @fs.read_file(wbtest_join_path(out, "package.json")).text() catch {
+    e => fail("failed to read DSL source-subdir package.json: \{e}")
+  }
+  let root_js = @fs.read_file(wbtest_join_path(out, "index.js")).text() catch {
+    e => fail("failed to read DSL source-subdir index.js: \{e}")
+  }
+  assert_true(
+    package_json.contains("\"name\": \"@fixture/dsl-source-subdir-pkg\""),
+  )
+  assert_true(root_js.contains("function __tsmbt_public_return(value)"))
+  assert_true(root_js.contains("export function make(...args)"))
 }
 
 ///|
@@ -1279,6 +1354,14 @@ async test "emit_moonbit_bridge_package writes package files to output dir" {
     "fixtures/resolver/project/types/runtime-function-entry.ts", "/runtime/runtime-function.js",
     root,
   )
+  let legacy_manifest = wbtest_join_path(root, "moon.pkg.json")
+  let _ = @fs.write_file(legacy_manifest, string_to_bytes("{}\n"))
+  let user_file = wbtest_join_path(root, "user-authored.mbt")
+  let _ = @fs.write_file(user_file, string_to_bytes("// keep\n"))
+  let _ = emit_moonbit_bridge_package(
+    "fixtures/resolver/project/types/runtime-function-entry.ts", "/runtime/runtime-function.js",
+    root,
+  )
   let pkg_json = @fs.read_file(wbtest_join_path(root, "moon.pkg")).text() catch {
     e => {
       fail("Read error: \{e}")
@@ -1304,6 +1387,9 @@ async test "emit_moonbit_bridge_package writes package files to output dir" {
     }
   }
   @test.assert_eq(pkg_json, "")
+  assert_false(@fs.exists(legacy_manifest))
+  assert_true(@fs.exists(user_file))
+  assert_false(@fs.exists(wbtest_join_path(root, ".tsmbt-next-bridge.mbt")))
   assert_true(bridge_mbti.contains("declare pub fn scalePoint("))
   assert_true(
     bridge_mbt.contains(
@@ -1316,7 +1402,53 @@ async test "emit_moonbit_bridge_package writes package files to output dir" {
     ),
   )
   assert_false(bridge_js.contains("__ts_mbt_scale_point"))
+  assert_false(bridge_mbt.contains("unsafeCast"))
   let _ = try? @fs.rmdir(root, recursive=true)
+}
+
+///|
+test "bridge runtime validation emits public validators without exposing unsafeCast" {
+  let bridge_mbti =
+    #|/// TS interface RuntimePoint
+    #|pub(all) struct RuntimePoint {
+    #|  x : Double
+    #|  label : String
+    #|}
+  let bridge_mbt =
+    #|/// TS interface RuntimePoint
+    #|pub(all) struct RuntimePoint {
+    #|  x : Double
+    #|  label : String
+    #|}
+  let (mbti, mbt) = add_bridge_runtime_validation(bridge_mbti, bridge_mbt)
+  assert_true(
+    mbti.contains(
+      "declare pub fn validateRuntimePoint(value : JSValue) -> RuntimePoint?",
+    ),
+  )
+  assert_true(
+    mbt.contains("fn __ts_mbt_validate_RuntimePoint(value : JSValue) -> Bool"),
+  )
+  assert_true(mbt.contains("typeof value[\"x\"] === \"number\""))
+  assert_true(mbt.contains("typeof value[\"label\"] === \"string\""))
+  assert_true(mbt.contains("fn[A, B] unsafeCast(value : A) -> B"))
+  assert_false(mbti.contains("unsafeCast"))
+}
+
+///|
+test "bridge runtime validation permits absent optional primitive fields" {
+  let bridge_mbt =
+    #|pub(all) struct OptionalProfile {
+    #|  name : String
+    #|  age : Double?
+    #|}
+  let (_, mbt) = add_bridge_runtime_validation("", bridge_mbt)
+  assert_true(
+    mbt.contains(
+      "(value[\"age\"] === undefined || typeof value[\"age\"] === \"number\")",
+    ),
+  )
+  assert_false(mbt.contains("\"age\" in value"))
 }
 
 ///|
@@ -5819,5 +5951,28 @@ test "compute_vendor_root: nested source path stacks under module root" {
   @test.assert_eq(
     compute_vendor_root("/proj", mod_json),
     "/proj/packages/lib/internal/generated",
+  )
+}
+
+///|
+test "npm runtime boundary wraps generated MoonBit exports" {
+  let source =
+    #|const raw_parse = (value) => value;
+    #|const untouched = 1;
+    #|export { raw_parse as parse, untouched };
+    #|//# sourceMappingURL=glue.js.map
+  let modes : Map[String, Bool] = {}
+  let rewritten = rewrite_runtime_boundary_js_exports(
+    source,
+    "function __tsmbt_public_return(value) { return value; }\nfunction __tsmbt_raw_argument(value) { return value; }",
+    ["parse"],
+    modes,
+  )
+  assert_true(rewritten.contains("export { untouched }"))
+  assert_true(rewritten.contains("const __tsmbt_raw_export_parse = raw_parse;"))
+  assert_true(
+    rewritten.contains(
+      "export function parse(...args) { return __tsmbt_public_return(__tsmbt_raw_export_parse(...args.map(__tsmbt_raw_argument))); }",
+    ),
   )
 }

--- a/src/main_wbtest.mbt
+++ b/src/main_wbtest.mbt
@@ -5972,7 +5972,7 @@ test "npm runtime boundary wraps generated MoonBit exports" {
   assert_true(rewritten.contains("const __tsmbt_raw_export_parse = raw_parse;"))
   assert_true(
     rewritten.contains(
-      "export function parse(...args) { return __tsmbt_public_return(__tsmbt_raw_export_parse(...args.map(__tsmbt_raw_argument))); }",
+      "export function parse(...args) { return __tsmbt_public_return(__tsmbt_raw_export_parse(...args.map((arg) => __tsmbt_raw_argument(arg)))); }",
     ),
   )
 }

--- a/src/moon.pkg
+++ b/src/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "mizchi/x/fs",
   "mizchi/x/process",
+  "moonbitlang/async/fs" @async_fs,
   "moonbitlang/core/json",
   "moonbitlang/core/string",
   "mizchi/ts/parser",

--- a/src/mtsc/checker.mbt
+++ b/src/mtsc/checker.mbt
@@ -1,0 +1,431 @@
+///|
+/// A strict TypeScript diagnostic that can be consumed by command-line and
+/// JavaScript-module callers alike.
+pub(all) struct MtscTypeIssue {
+  path : String
+  message : String
+}
+
+///|
+/// One caller-resolved TypeScript module for the JavaScript checker API.
+/// Resolution intentionally belongs to the embedding build tool; the checker
+/// only parses and validates the source texts it is given.
+pub(all) struct MtscModuleSource {
+  path : String
+  source : String
+  allowJsx : Bool
+}
+
+///|
+/// A caller-resolved import edge. Module resolution belongs to the embedding
+/// build tool, so aliases and virtual files never leak into the checker.
+pub(all) struct MtscModuleEdge {
+  importerPath : String
+  moduleSpecifier : String
+  targetPath : String
+}
+
+///|
+/// A filesystem-free module graph consumed by `checkModuleGraph`.
+pub(all) struct MtscModuleGraph {
+  modules : Array[MtscModuleSource]
+  edges : Array[MtscModuleEdge]
+}
+
+///|
+priv struct ParsedMtscModule {
+  source : MtscModuleSource
+  module_ : @ast.TsModule
+  module_block : @ast.TsModuleBlock
+}
+
+///|
+fn is_unresolved_import_binding(
+  issue : @checker.ExprIssue,
+  imported_binding_names : Array[String],
+) -> Bool {
+  for name in imported_binding_names {
+    if issue.message == "cannot find name `\{name}`" {
+      return true
+    }
+  }
+  false
+}
+
+///|
+/// Parse source and run the strict checker. Imported bindings are checked in
+/// their own modules, so their known single-file unresolved-name false
+/// positives are omitted from this module's result.
+fn collect_type_issues_from_module(
+  module_ : @ast.TsModule,
+  globals : Array[(String, @ast.TsType)],
+  type_modules : Array[@ast.TsModule],
+) -> Result[Array[MtscTypeIssue], String] {
+  let issues : Array[MtscTypeIssue] = []
+  for
+    issue in @checker.check_module_function_bodies_with_context(
+      module_, globals, type_modules,
+    ) {
+    if !is_unresolved_import_binding(issue, module_.imported_binding_names) {
+      issues.push({ path: issue.path, message: issue.message })
+    }
+  }
+  Ok(issues)
+}
+
+///|
+pub fn collect_type_issues(
+  source : String,
+  allow_jsx : Bool,
+) -> Result[Array[MtscTypeIssue], String] {
+  let module_ = @parser.Parser::from_source_with_jsx(source, allow_jsx).parse_module() catch {
+    e => return Err("\{e}")
+  }
+  collect_type_issues_from_module(module_, [], [])
+}
+
+///|
+/// JavaScript-facing strict checker API. Returns an empty string for valid
+/// source; otherwise each diagnostic occupies one line as
+/// `<path>: <message>`. This keeps the JS ABI plain while the MoonBit CLI can
+/// still use `collect_type_issues` for structured diagnostics.
+pub fn check_source(source : String, allow_jsx : Bool) -> String {
+  match collect_type_issues(source, allow_jsx) {
+    Err(e) => "parse error: \{e}"
+    Ok(issues) =>
+      issues.map(fn(issue) { "\{issue.path}: \{issue.message}" }).join("\n")
+  }
+}
+
+///|
+/// JavaScript-facing strict checker API for a resolved module graph.
+/// Resolution remains the caller's responsibility so this package stays
+/// independent of filesystems and bundlers.
+///
+/// Returns an empty string when every supplied module is valid. Diagnostics
+/// are prefixed with the caller-provided module path and preserve input order,
+/// making the string ABI stable for build-tool integrations.
+pub fn check_module_sources(modules : Array[MtscModuleSource]) -> String {
+  let diagnostics : Array[String] = []
+  for module_ in modules {
+    match collect_type_issues(module_.source, module_.allowJsx) {
+      Err(e) => diagnostics.push("\{module_.path}: parse error: \{e}")
+      Ok(issues) =>
+        for issue in issues {
+          diagnostics.push("\{module_.path}: \{issue.message}")
+        }
+    }
+  }
+  diagnostics.join("\n")
+}
+
+///|
+fn parse_graph_module(
+  source : MtscModuleSource,
+) -> Result[ParsedMtscModule, String] {
+  let module_ = @parser.Parser::from_source_with_jsx(
+    source.source,
+    source.allowJsx,
+  ).parse_module() catch {
+    e => return Err("\{e}")
+  }
+  let module_block = @parser.Parser::from_source_with_jsx(
+    source.source,
+    source.allowJsx,
+  ).parse_module_block() catch {
+    e => return Err("\{e}")
+  }
+  Ok({ source, module_, module_block })
+}
+
+///|
+fn function_value_type(func : @ast.TsFunc) -> @ast.TsType {
+  let params : Array[@ast.TsType] = []
+  for param in func.params {
+    if param.is_rest {
+      params.push(@ast.TsType::Rest(param.type_))
+    } else {
+      params.push(param.type_)
+    }
+  }
+  @ast.TsType::Func(params, func.return_type)
+}
+
+///|
+fn local_value_type(module_ : @ast.TsModule, name : String) -> @ast.TsType? {
+  for value in module_.values {
+    if value.name == name {
+      return Some(value.type_)
+    }
+  }
+  for func in module_.funcs {
+    if func.name == name {
+      return Some(function_value_type(func))
+    }
+  }
+  for import_ in module_.imports {
+    if import_.name == name {
+      let params : Array[@ast.TsType] = []
+      for param in import_.params {
+        params.push(param.1)
+      }
+      return Some(@ast.TsType::Func(params, import_.return_type))
+    }
+  }
+  for enum_ in module_.enums {
+    if enum_.name == name {
+      return Some(@ast.TsType::Named(name))
+    }
+  }
+  for class_ in module_.classes {
+    if class_.name == name {
+      return Some(@ast.TsType::Named(name))
+    }
+  }
+  None
+}
+
+///|
+fn exported_value_type(
+  module_ : ParsedMtscModule,
+  export_name : String,
+  modules : Array[ParsedMtscModule],
+  edges : Array[MtscModuleEdge],
+  seen : Array[(String, String)],
+) -> @ast.TsType? {
+  for export_ in module_.module_block.exports {
+    if export_.export_name == export_name {
+      return local_value_type(module_.module_, export_.local_name)
+    }
+  }
+  // `export { value } from "./module"` is the ordinary public-barrel style.
+  // Follow only value reexports here; `export type` never introduces a
+  // runtime binding for an importing module.
+  for item in seen {
+    if item.0 == module_.source.path && item.1 == export_name {
+      return None
+    }
+  }
+  let next_seen : Array[(String, String)] = []
+  for item in seen {
+    next_seen.push(item)
+  }
+  next_seen.push((module_.source.path, export_name))
+  for reexport_ in module_.module_block.reexports {
+    if reexport_.type_only {
+      continue
+    }
+    let target_path = match
+      find_graph_target(edges, module_.source.path, reexport_.module_spec) {
+      Some(path) => path
+      None => continue
+    }
+    let target = match find_graph_module(modules, target_path) {
+      Some(target) => target
+      None => continue
+    }
+    match reexport_.kind {
+      @ast.TsReExportKind::Named(items) =>
+        for item in items {
+          let (imported_name, reexported_name) = item
+          if reexported_name == export_name {
+            match
+              exported_value_type(
+                target, imported_name, modules, edges, next_seen,
+              ) {
+              Some(type_) => return Some(type_)
+              None => ()
+            }
+          }
+        }
+      @ast.TsReExportKind::All =>
+        if export_name != "default" {
+          match
+            exported_value_type(target, export_name, modules, edges, next_seen) {
+            Some(type_) => return Some(type_)
+            None => ()
+          }
+        }
+      // A namespace is an object-like value with members that the lightweight
+      // checker cannot faithfully describe as one static function/value type.
+      @ast.TsReExportKind::Namespace(_) => ()
+    }
+  }
+  None
+}
+
+///|
+fn find_graph_module(
+  modules : Array[ParsedMtscModule],
+  path : String,
+) -> ParsedMtscModule? {
+  for module_ in modules {
+    if module_.source.path == path {
+      return Some(module_)
+    }
+  }
+  None
+}
+
+///|
+fn find_graph_target(
+  edges : Array[MtscModuleEdge],
+  importer_path : String,
+  module_specifier : String,
+) -> String? {
+  for edge in edges {
+    if edge.importerPath == importer_path &&
+      edge.moduleSpecifier == module_specifier {
+      return Some(edge.targetPath)
+    }
+  }
+  None
+}
+
+///|
+fn is_local_module_specifier(module_specifier : String) -> Bool {
+  module_specifier.has_prefix("./") ||
+  module_specifier.has_prefix("../") ||
+  module_specifier.has_prefix("/")
+}
+
+///|
+/// Collect type declarations from the caller-resolved transitive dependency
+/// graph. Runtime names are deliberately not injected from these modules;
+/// `graph_import_globals` remains the only path for value bindings.
+fn graph_type_modules(
+  module_ : ParsedMtscModule,
+  modules : Array[ParsedMtscModule],
+  edges : Array[MtscModuleEdge],
+) -> Array[@ast.TsModule] {
+  let type_modules : Array[@ast.TsModule] = []
+  let visited_paths : Array[String] = []
+  let pending_paths : Array[String] = [module_.source.path]
+  let mut cursor = 0
+  while cursor < pending_paths.length() {
+    let importer_path = pending_paths[cursor]
+    cursor = cursor + 1
+    let mut already_visited = false
+    for path in visited_paths {
+      if path == importer_path {
+        already_visited = true
+        break
+      }
+    }
+    if already_visited {
+      continue
+    }
+    visited_paths.push(importer_path)
+    for edge in edges {
+      if edge.importerPath != importer_path {
+        continue
+      }
+      let target = match find_graph_module(modules, edge.targetPath) {
+        Some(target) => target
+        None => continue
+      }
+      type_modules.push(target.module_)
+      pending_paths.push(target.source.path)
+    }
+  }
+  type_modules
+}
+
+///|
+fn graph_import_globals(
+  module_ : ParsedMtscModule,
+  modules : Array[ParsedMtscModule],
+  edges : Array[MtscModuleEdge],
+) -> (Array[(String, @ast.TsType)], Array[String]) {
+  let globals : Array[(String, @ast.TsType)] = []
+  let diagnostics : Array[String] = []
+  for import_ in module_.module_block.imports {
+    let target_path = match
+      find_graph_target(edges, module_.source.path, import_.module_spec) {
+      Some(path) => path
+      None => {
+        if is_local_module_specifier(import_.module_spec) {
+          diagnostics.push(
+            "cannot resolve local module `\{import_.module_spec}`",
+          )
+        }
+        continue
+      }
+    }
+    let target = match find_graph_module(modules, target_path) {
+      Some(target) => target
+      None => {
+        diagnostics.push(
+          "resolved module `\{import_.module_spec}` is absent at `\{target_path}`",
+        )
+        continue
+      }
+    }
+    match import_.default_binding {
+      Some(local_name) =>
+        match exported_value_type(target, "default", modules, edges, []) {
+          Some(type_) => globals.push((local_name, type_))
+          None =>
+            diagnostics.push(
+              "module `\{import_.module_spec}` has no default value export",
+            )
+        }
+      None => ()
+    }
+    for index, binding in import_.named_bindings {
+      let type_only = import_.type_only ||
+        (
+          index < import_.named_type_only.length() &&
+          import_.named_type_only[index]
+        )
+      if type_only {
+        continue
+      }
+      let (imported_name, local_name) = binding
+      match exported_value_type(target, imported_name, modules, edges, []) {
+        Some(type_) => globals.push((local_name, type_))
+        None =>
+          diagnostics.push(
+            "module `\{import_.module_spec}` has no value export `\{imported_name}`",
+          )
+      }
+    }
+  }
+  (globals, diagnostics)
+}
+
+///|
+/// JavaScript-facing graph checker. The caller supplies modules and resolved
+/// import edges; this package then performs deterministic parsing, local
+/// checking, and value-level import contract propagation without reading the
+/// filesystem or knowing about a particular bundler.
+pub fn check_module_graph(graph : MtscModuleGraph) -> String {
+  let parsed_modules : Array[ParsedMtscModule] = []
+  let diagnostics : Array[String] = []
+  for source in graph.modules {
+    match parse_graph_module(source) {
+      Ok(module_) => parsed_modules.push(module_)
+      Err(e) => diagnostics.push("\{source.path}: parse error: \{e}")
+    }
+  }
+  for module_ in parsed_modules {
+    let (globals, import_diagnostics) = graph_import_globals(
+      module_,
+      parsed_modules,
+      graph.edges,
+    )
+    for diagnostic in import_diagnostics {
+      diagnostics.push("\{module_.source.path}: \{diagnostic}")
+    }
+    let type_modules = graph_type_modules(module_, parsed_modules, graph.edges)
+    match
+      collect_type_issues_from_module(module_.module_, globals, type_modules) {
+      Err(e) => diagnostics.push("\{module_.source.path}: parse error: \{e}")
+      Ok(issues) =>
+        for issue in issues {
+          diagnostics.push("\{module_.source.path}: \{issue.message}")
+        }
+    }
+  }
+  diagnostics.join("\n")
+}

--- a/src/mtsc/checker_wbtest.mbt
+++ b/src/mtsc/checker_wbtest.mbt
@@ -1,0 +1,250 @@
+///|
+test "mtsc module reports a strict return mismatch" {
+  let diagnostics = check_source(
+    "function formatScore(score: number): string { return score; }", false,
+  )
+  assert_true(diagnostics.contains("expected `string` but got `number`"))
+}
+
+///|
+test "mtsc module accepts a valid function" {
+  let diagnostics = check_source(
+    "function formatScore(score: number): string { return \"score: \" + score; }",
+    false,
+  )
+  assert_eq(diagnostics, "")
+}
+
+///|
+test "mtsc module reports an error from an imported module source" {
+  let diagnostics = check_module_sources([
+    {
+      path: "/src/entry.ts",
+      source: "import { formatScore } from \"./score\";\nexport const result = formatScore(1);",
+      allowJsx: false,
+    },
+    {
+      path: "/src/score.ts",
+      source: "export function formatScore(score: number): string { return score; }",
+      allowJsx: false,
+    },
+  ])
+  assert_true(diagnostics.contains("/src/score.ts:"))
+  assert_true(diagnostics.contains("expected `string` but got `number`"))
+}
+
+///|
+test "mtsc graph checker propagates a named import type to its consumer" {
+  let diagnostics = check_module_graph({
+    modules: [
+      {
+        path: "/src/entry.ts",
+        source: "import { score } from \"./score\";\nexport const label: string = score;",
+        allowJsx: false,
+      },
+      {
+        path: "/src/score.ts",
+        source: "export const score: number = 1;",
+        allowJsx: false,
+      },
+    ],
+    edges: [
+      {
+        importerPath: "/src/entry.ts",
+        moduleSpecifier: "./score",
+        targetPath: "/src/score.ts",
+      },
+    ],
+  })
+  assert_true(diagnostics.contains("/src/entry.ts:"))
+  assert_true(diagnostics.contains("expected `string` but got `number`"))
+}
+
+///|
+test "mtsc graph checker follows named value reexports" {
+  let diagnostics = check_module_graph({
+    modules: [
+      {
+        path: "/src/entry.ts",
+        source: "import { score } from \"./index\";\nexport const label: string = score;",
+        allowJsx: false,
+      },
+      {
+        path: "/src/index.ts",
+        source: "export { score } from \"./score\";",
+        allowJsx: false,
+      },
+      {
+        path: "/src/score.ts",
+        source: "export const score: number = 1;",
+        allowJsx: false,
+      },
+    ],
+    edges: [
+      {
+        importerPath: "/src/entry.ts",
+        moduleSpecifier: "./index",
+        targetPath: "/src/index.ts",
+      },
+      {
+        importerPath: "/src/index.ts",
+        moduleSpecifier: "./score",
+        targetPath: "/src/score.ts",
+      },
+    ],
+  })
+  assert_true(diagnostics.contains("expected `string` but got `number`"))
+  assert_false(diagnostics.contains("has no value export `score`"))
+}
+
+///|
+test "mtsc graph checker checks objects against imported interface parameters" {
+  let diagnostics = check_module_graph({
+    modules: [
+      {
+        path: "/src/consumer.ts",
+        source: (
+          #|import { greeting } from "./index";
+          #|export const preview: string = greeting({ id: 42, displayName: "Ada" });
+        ),
+        allowJsx: false,
+      },
+      {
+        path: "/src/index.ts",
+        source: (
+          #|export { greeting } from "./user-service";
+          #|export type { User } from "./model";
+        ),
+        allowJsx: false,
+      },
+      {
+        path: "/src/user-service.ts",
+        source: (
+          #|import type { User } from "./model";
+          #|export function greeting(user: User): string { return `Hello, ${user.displayName}`; }
+        ),
+        allowJsx: false,
+      },
+      {
+        path: "/src/model.ts",
+        source: "export interface User { id: string; displayName: string; }",
+        allowJsx: false,
+      },
+    ],
+    edges: [
+      {
+        importerPath: "/src/consumer.ts",
+        moduleSpecifier: "./index",
+        targetPath: "/src/index.ts",
+      },
+      {
+        importerPath: "/src/index.ts",
+        moduleSpecifier: "./user-service",
+        targetPath: "/src/user-service.ts",
+      },
+      {
+        importerPath: "/src/index.ts",
+        moduleSpecifier: "./model",
+        targetPath: "/src/model.ts",
+      },
+      {
+        importerPath: "/src/user-service.ts",
+        moduleSpecifier: "./model",
+        targetPath: "/src/model.ts",
+      },
+    ],
+  })
+  assert_true(diagnostics.contains("expected `string` but got `number`"))
+}
+
+///|
+test "mtsc graph checker supports aliased and default imports" {
+  let diagnostics = check_module_graph({
+    modules: [
+      {
+        path: "/src/entry.ts",
+        source: (
+          #|import getAnswer, { count as answerCount } from "./answer";
+          #|export const fromDefault: string = getAnswer();
+          #|export const fromAlias: string = answerCount;
+        ),
+        allowJsx: false,
+      },
+      {
+        path: "/src/answer.ts",
+        source: (
+          #|export default function getAnswer(): number { return 1; }
+          #|export const count: number = 2;
+        ),
+        allowJsx: false,
+      },
+    ],
+    edges: [
+      {
+        importerPath: "/src/entry.ts",
+        moduleSpecifier: "./answer",
+        targetPath: "/src/answer.ts",
+      },
+    ],
+  })
+  // Both the default and aliased named import are injected with their
+  // exporter types, producing one mismatch each in the consuming module.
+  assert_eq(diagnostics.split("expected `string` but got `number`").length(), 3)
+}
+
+///|
+test "mtsc graph checker handles cycles and reports missing local modules" {
+  let diagnostics = check_module_graph({
+    modules: [
+      {
+        path: "/src/a.ts",
+        source: (
+          #|import { label } from "./b";
+          #|import { absent } from "./absent";
+          #|export const count: number = 1;
+          #|export const invalid: number = label;
+          #|void absent;
+        ),
+        allowJsx: false,
+      },
+      {
+        path: "/src/b.ts",
+        source: (
+          #|import { count } from "./a";
+          #|export const label: string = "value";
+          #|export const copy: number = count;
+        ),
+        allowJsx: false,
+      },
+    ],
+    edges: [
+      {
+        importerPath: "/src/a.ts",
+        moduleSpecifier: "./b",
+        targetPath: "/src/b.ts",
+      },
+      {
+        importerPath: "/src/b.ts",
+        moduleSpecifier: "./a",
+        targetPath: "/src/a.ts",
+      },
+    ],
+  })
+  assert_true(diagnostics.contains("cannot resolve local module `./absent`"))
+  assert_true(diagnostics.contains("expected `number` but got `string`"))
+}
+
+///|
+test "mtsc graph checker accepts JSX when the module opts in" {
+  let diagnostics = check_module_graph({
+    modules: [
+      {
+        path: "/src/view.tsx",
+        source: "export const view = <div />;",
+        allowJsx: true,
+      },
+    ],
+    edges: [],
+  })
+  assert_false(diagnostics.contains("parse error"))
+}

--- a/src/mtsc/moon.pkg
+++ b/src/mtsc/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "mizchi/ts/ast",
+  "mizchi/ts/checker",
+  "mizchi/ts/parser",
+}
+
+options(
+  link: {
+    "js": {
+      "exports": [ "check_module_graph:checkModuleGraph" ],
+      "format": "esm",
+    },
+  },
+)

--- a/src/mtsc/pkg.generated.mbti
+++ b/src/mtsc/pkg.generated.mbti
@@ -1,0 +1,41 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "mizchi/ts/mtsc"
+
+// Values
+pub fn check_module_graph(MtscModuleGraph) -> String
+
+pub fn check_module_sources(Array[MtscModuleSource]) -> String
+
+pub fn check_source(String, Bool) -> String
+
+pub fn collect_type_issues(String, Bool) -> Result[Array[MtscTypeIssue], String]
+
+// Errors
+
+// Types and methods
+pub(all) struct MtscModuleEdge {
+  importerPath : String
+  moduleSpecifier : String
+  targetPath : String
+}
+
+pub(all) struct MtscModuleGraph {
+  modules : Array[MtscModuleSource]
+  edges : Array[MtscModuleEdge]
+}
+
+pub(all) struct MtscModuleSource {
+  path : String
+  source : String
+  allowJsx : Bool
+}
+
+pub(all) struct MtscTypeIssue {
+  path : String
+  message : String
+}
+
+// Type aliases
+
+// Traits
+

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -26,7 +26,7 @@ pub async fn emit_js_link_config_from_mbti(String, String?) -> Bool
 
 pub async fn emit_moonbit_bridge(String, String, String?, String?, String?) -> Bool
 
-pub async fn emit_moonbit_bridge_package(String, String, String, bare_module_specifier? : String?, moonbitlang_async_integration? : Bool) -> Bool
+pub async fn emit_moonbit_bridge_package(String, String, String, bare_module_specifier? : String?, moonbitlang_async_integration? : Bool, runtime_validation? : Bool) -> Bool
 
 pub async fn emit_moonbit_decl(String, String?) -> Bool
 

--- a/src/unified_cli.mbt
+++ b/src/unified_cli.mbt
@@ -304,12 +304,9 @@ async fn ghq_module_name_candidate_repo_paths(
     if !(kind is @fs.FileKind::Directory) {
       continue
     }
-    let moon_mod_path = main_join_path(repo_path, "moon.mod.json")
-    if !main_file_exists(moon_mod_path) {
-      continue
-    }
-    let moon_mod_source = @fs.read_file(moon_mod_path).text() catch {
-      _ => continue
+    let moon_mod_source = match read_moon_mod_source(repo_path) {
+      Some(source) => source
+      None => continue
     }
     match parse_moon_mod_string_field(moon_mod_source, "name") {
       Some(module_name) if module_name == input => paths.push(repo_path)

--- a/src/vendor.mbt
+++ b/src/vendor.mbt
@@ -602,15 +602,17 @@ pub fn compute_vendor_root(
 }
 
 ///|
-/// Resolve `<moon.mod source>/internal/generated` from the cwd's
-/// nearest `moon.mod.json`. Returns `None` if no module is found.
+/// Resolve `<moon.mod source>/internal/generated` from the cwd's nearest
+/// module manifest. Returns `None` if no module is found.
 async fn resolve_default_vendor_root() -> String? {
   let module_root = match find_nearest_moon_mod_dir(".") {
     Some(root) => root
     None => return None
   }
-  let moon_mod_path = main_join_path(module_root, "moon.mod.json")
-  let source = @fs.read_file(moon_mod_path).text() catch { _ => return None }
+  let source = match read_moon_mod_source(module_root) {
+    Some(source) => source
+    None => return None
+  }
   Some(compute_vendor_root(module_root, source))
 }
 


### PR DESCRIPTION
## Summary

- integrate the MoonBit checker as the internal Vite JS module API
- generate safe, npm-publishable MoonBit-to-TypeScript facades
- document and lock the public CLI, Vite, generated package, and checker boundaries

## Validation

- moon check
- moon test src --target native
- moon test src/checker --target native
- moon test src/mtsc --target native
- moon publish --dry-run --frozen