### PR TITLE
docs: add TypeScript and node fs import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,10 @@ trailing underscore (e.g. `match` → `match_`). The generated
 `SCAFFOLD_DIAGNOSTICS.md` records anything that was widened to
 `JSValue` so you know where the typed surface ends.
 
+For a complete two-bridge consumer — importing the TypeScript compiler API and
+Node's `node:fs` from one `moon.pkg`, then running both at runtime — see
+[`examples/typescript-to-moonbit/typescript-node-imports`](./examples/typescript-to-moonbit/typescript-node-imports/).
+
 Build & run as usual: `moon run <your-pkg> --target js`. With
 `"preferred-target": "js"` in `moon.mod.json` you can drop the
 `--target js` flag.

--- a/examples/README.md
+++ b/examples/README.md
@@ -47,6 +47,8 @@ Input:
 - `typescript-to-moonbit/node-sqlite/smoke/main.mbt`
 - `typescript-to-moonbit/node-fs/smoke/main.mbt`
 - `typescript-to-moonbit/typescript-ast/smoke/main.mbt`
+- `typescript-to-moonbit/typescript-node-imports/` (complete MoonBit consumer
+  importing both the TypeScript compiler API and `node:fs`)
 
 Generate a MoonBit bridge package:
 

--- a/examples/typescript-to-moonbit/README.md
+++ b/examples/typescript-to-moonbit/README.md
@@ -33,3 +33,4 @@ Additional TypeScript -> MoonBit patterns are available under:
 - `node-sqlite/`
 - `node-fs/`
 - `typescript-ast/`
+- `typescript-node-imports/` (a complete consumer that imports both bridges)

--- a/examples/typescript-to-moonbit/typescript-node-imports/.gitignore
+++ b/examples/typescript-to-moonbit/typescript-node-imports/.gitignore
@@ -1,0 +1,1 @@
+src/internal/generated/

--- a/examples/typescript-to-moonbit/typescript-node-imports/README.md
+++ b/examples/typescript-to-moonbit/typescript-node-imports/README.md
@@ -1,0 +1,72 @@
+# TypeScript compiler + `node:fs` from MoonBit
+
+This is a complete MoonBit consumer package. It generates two bridge packages,
+imports both from `src/main/moon.pkg`, prints a TypeScript source file with the
+compiler API, then writes and reads that result through Node's `node:fs`.
+
+## 1. Install the TypeScript inputs
+
+```bash
+pnpm install
+moon install mizchi/ts/cmd/ts2mbt
+```
+
+`typescript` is a runtime dependency. `@types/node` is needed only to generate
+the `node:fs` declarations.
+
+## 2. Generate the bridges
+
+Run these commands at this example's root (or use the same layout in your own
+MoonBit module):
+
+```bash
+# Keep the runtime import as the `typescript` npm package.
+ts2mbt \
+  --input node_modules/typescript/lib/typescript.d.ts \
+  --out src/internal/generated/typescript \
+  --module-spec typescript
+
+# Node built-ins are declared by @types/node. Keep the runtime import as node:fs.
+ts2mbt \
+  --input node_modules/@types/node/fs.d.ts \
+  --out src/internal/generated/node_fs \
+  --module-spec node:fs
+```
+
+Add both generated bridges as `file:` dependencies, so a later `pnpm install`
+preserves their runtime links:
+
+```json
+{
+  "dependencies": {
+    "@tsmbt-bridge/typescript": "file:./src/internal/generated/typescript",
+    "@tsmbt-bridge/node_fs": "file:./src/internal/generated/node_fs",
+    "typescript": "^6.0.3"
+  }
+}
+```
+
+Then run `pnpm install` once more. Generated bridges are intentionally ignored;
+regenerate them after changing the upstream package versions.
+
+## 3. Import and run
+
+`src/main/moon.pkg` imports the generated packages with ordinary MoonBit
+aliases:
+
+```moonbit
+import {
+  "examples/typescript_node_imports/internal/generated/node_fs" @fs,
+  "examples/typescript_node_imports/internal/generated/typescript" @ts,
+}
+```
+
+The `main.mbt` program calls `@ts.createSourceFile` and
+`@ts.createPrinter(...).printFile`, then uses `@fs.writeFileSync` and
+`@fs.readFileSync`. Run it with:
+
+```bash
+moon run src/main --target js
+```
+
+It prints `ok` after the TypeScript → file → MoonBit round trip succeeds.

--- a/examples/typescript-to-moonbit/typescript-node-imports/moon.mod.json
+++ b/examples/typescript-to-moonbit/typescript-node-imports/moon.mod.json
@@ -1,0 +1,6 @@
+{
+  "name": "examples/typescript_node_imports",
+  "version": "0.1.0",
+  "source": "src",
+  "preferred-target": "js"
+}

--- a/examples/typescript-to-moonbit/typescript-node-imports/package.json
+++ b/examples/typescript-to-moonbit/typescript-node-imports/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "typescript-node-imports-example",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "typescript": "^6.0.3"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0"
+  }
+}

--- a/examples/typescript-to-moonbit/typescript-node-imports/src/main/main.mbt
+++ b/examples/typescript-to-moonbit/typescript-node-imports/src/main/main.mbt
@@ -1,0 +1,40 @@
+///| Convert Node's Buffer result to a MoonBit String without weakening the
+///| generated `readFileSync` return type.
+extern "js" fn utf8_text(data : @fs.NonSharedBuffer) -> String =
+  #| (data) => data.toString("utf8")
+
+fn script_target() -> @ts.ScriptTarget {
+  @ts.ScriptTarget::ES2024
+}
+
+fn main {
+  // This is the generated TypeScript compiler API, imported just like a
+  // normal MoonBit package through `moon.pkg`.
+  let source = @ts.createSourceFile(
+    "answer.ts",
+    "export const answer: number = 42",
+    script_target(),
+    Some(true),
+    None,
+  )
+  let printed = @ts.createPrinter(None, None).printFile(source)
+  if !printed.contains("answer") {
+    abort("expected TypeScript printer output")
+  }
+
+  // `node:fs` is another generated package. The generated union helpers keep
+  // the filename typed as `PathLike` / `PathOrFileDescriptor`.
+  let path = @fs.path_like_from_string("typescript-node-imports-example.ts")
+  let file = @fs.path_or_file_descriptor_from_path_like(path)
+  if @fs.existsSync(path) {
+    @fs.unlinkSync(path)
+  }
+  @fs.writeFileSync(file, printed, None)
+  let disk_text = utf8_text(@fs.readFileSync(file, None))
+  @fs.unlinkSync(path)
+
+  if disk_text != printed {
+    abort("node:fs round trip changed the TypeScript output")
+  }
+  println("ok")
+}

--- a/examples/typescript-to-moonbit/typescript-node-imports/src/main/moon.pkg
+++ b/examples/typescript-to-moonbit/typescript-node-imports/src/main/moon.pkg
@@ -1,0 +1,8 @@
+import {
+  "examples/typescript_node_imports/internal/generated/node_fs" @fs,
+  "examples/typescript_node_imports/internal/generated/typescript" @ts,
+}
+
+options(
+  "is-main": true,
+)

--- a/scripts/verify_examples.sh
+++ b/scripts/verify_examples.sh
@@ -923,6 +923,60 @@ EOF
   run_typescript_ast_build_smoke "$out" "examples/typescript_to_moonbit_typescript_ast"
 }
 
+# A consumer-shaped example: one MoonBit executable imports both the
+# TypeScript compiler API and Node's `node:fs` bridge. Keeping its source under
+# examples/ makes the package imports and the two-stage generation workflow
+# copyable without reading this verification harness.
+verify_typescript_node_imports_example() {
+  local root="_build/examples/typescript-to-moonbit-typescript-node-imports"
+  local node_fs_types
+  node_fs_types="$(find "$repo_root/node_modules" -path '*/@types/node/fs.d.ts' -type f -print -quit)"
+  if [ -z "$node_fs_types" ]; then
+    echo "@types/node/fs.d.ts is required for the TypeScript + node:fs example" >&2
+    exit 1
+  fi
+
+  rm -rf "$root"
+  mkdir -p "$root"
+  cp examples/typescript-to-moonbit/typescript-node-imports/moon.mod.json "$root/"
+  cp examples/typescript-to-moonbit/typescript-node-imports/package.json "$root/"
+  cp -R examples/typescript-to-moonbit/typescript-node-imports/src "$root/"
+
+  (
+    cd "$root"
+    moon run "$repo_root/src/cmd/ts2mbt" -- \
+      --input "$repo_root/node_modules/typescript/lib/typescript.d.ts" \
+      --out src/internal/generated/typescript \
+      --module-spec typescript
+    moon run "$repo_root/src/cmd/ts2mbt" -- \
+      --input "$node_fs_types" \
+      --out src/internal/generated/node_fs \
+      --module-spec node:fs
+  )
+
+  [ -f "$root/src/internal/generated/typescript/bridge.mbt" ]
+  [ -f "$root/src/internal/generated/typescript/bridge.js" ]
+  [ -f "$root/src/internal/generated/node_fs/bridge.mbt" ]
+  [ -f "$root/src/internal/generated/node_fs/bridge.js" ]
+
+  moon -C "$root" check --target js
+  moon -C "$root" build --target js src/main
+
+  local built_js
+  built_js="$(find "$root/_build/js/debug/build/main" -type f -name '*.js' | head -n 1)"
+  if [ -z "$built_js" ]; then
+    echo "moon build did not emit JS for the TypeScript + node:fs example" >&2
+    exit 1
+  fi
+
+  local output
+  output="$(command node "$built_js")"
+  if [ "$output" != "ok" ]; then
+    echo "expected TypeScript + node:fs example to print 'ok', got: $output" >&2
+    exit 1
+  fi
+}
+
 # `ts2mbt generate` E2E: synthesize a tiny consumer project that
 # depends on both `hono` and `@hono/node-server`, drive the bridge
 # pipeline through the canonical `generate` command, and run the
@@ -1132,4 +1186,5 @@ verify_typescript_to_moonbit_reducer_example
 verify_typescript_to_moonbit_default_class_example
 verify_typescript_to_moonbit_const_table_example
 verify_typescript_to_moonbit_typescript_ast_example
+verify_typescript_node_imports_example
 verify_typescript_to_moonbit_drizzle_example


### PR DESCRIPTION
## Summary
- add a runnable MoonBit consumer example importing generated `typescript` and `node:fs` bridges
- document generation, persistent `file:` dependencies, and MoonBit imports
- verify generation, type checking, JS build, and Node runtime in `just verify-examples`

## Validation
- `just verify-examples`
- `moon fmt --check`