### PR TITLE
feat: publish MoonBit packages to npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,16 @@ $ ls src/internal/generated/
 hono/  zod/  types__react/  ...
 ```
 
-MoonBit -> TypeScript (emit a build-backed `.d.ts` package from a MoonBit
-package):
+MoonBit -> TypeScript (build the current MoonBit package and prepare an npm
+publish directory):
 
 ```bash
 $ moon install mizchi/ts/cmd/mbt2ts
-$ mbt2ts --input mizchi/foo --out dist
-$ ls dist/
-index.js  package.json  AUTOLINK_DIAGNOSTICS.md  ...
+$ cd my-moonbit-library
+$ mbt2ts --pkg
+$ ls npm/
+bin/  index.js  index.d.ts  mtsc/  package.json  AUTOLINK_DIAGNOSTICS.md  ...
+$ cd npm && npm publish --access public
 ```
 
 End-to-end Hono walkthrough: [docs/quick-start.md](./docs/quick-start.md).
@@ -65,7 +67,7 @@ Install whichever direction(s) you need; each binary is independent.
 
 ```bash
 moon install mizchi/ts/cmd/ts2mbt   # TS  -> MoonBit (generate / vendor / scaffold)
-moon install mizchi/ts/cmd/mbt2ts   # MoonBit -> TS  (decl / scaffold / facade-scaffold)
+moon install mizchi/ts/cmd/mbt2ts   # MoonBit -> TS  (npm package / decl / scaffold)
 
 # Or install both binaries in one go
 moon install mizchi/ts/...
@@ -86,13 +88,18 @@ Bridge generation is split into two binaries, one per direction:
 - `ts2mbt` — TypeScript `.d.ts` / `.ts` entrypoint → MoonBit bridge package
   (`bridge.mbti`, `bridge.mbt`, `bridge.js`, `moon.pkg`).
 
-Each CLI exposes a high-level `--input ... --out ...` "do everything" flow
-plus low-level subcommands.
+`mbt2ts` has a project-oriented `--pkg` command for publishing and retains a
+lower-level `--input ... --out ...` flow for tooling that already has an
+interface. `ts2mbt` exposes a high-level `--input ... --out ...` flow plus
+low-level subcommands.
 
 ```bash
-# MoonBit -> TypeScript. Run `moon info` first so pkg.generated.mbti exists.
-# This creates temporary MoonBit glue code, runs `moon build --target js`,
-# and emits a TypeScript package backed by the built JS output.
+# MoonBit -> npm. `--pkg` runs `moon info`, uses the version in moon.mod,
+# builds facade glue with `moon build --target js`, and defaults to ./npm.
+mbt2ts --pkg
+cd npm && npm publish --access public
+
+# Lower-level MoonBit -> TypeScript flow for an existing interface.
 mbt2ts --input mizchi/foo --out dist
 
 # TypeScript -> MoonBit. For bare npm-style inputs, the runtime module spec
@@ -108,9 +115,27 @@ ts2mbt --input path/to/entry.d.ts --module-spec /runtime/module.js --out dist
 ts2mbt --input neverthrow --out dist --diagnostics dist/diagnostics.md --strict
 ```
 
-The MoonBit -> TypeScript unified path emits facade glue by default, builds
-it with `moon build --target js`, and copies the built JS to `index.js`;
-pass `--no-facade` to emit only top-level free-function glue.
+`mbt2ts --pkg` emits facade glue by default, builds it with `moon build
+--target js`, and copies the built JS to `index.js`; pass `--no-facade` to
+emit only top-level free-function glue. Every library subdirectory containing
+`moon.pkg` is emitted as an npm subpath export: for example `src/mtsc` becomes
+`@scope/package/mtsc`. Command packages are not library subpath exports; a
+package that defines `main` is compiled to `bin/<command>.js` and registered in
+`package.json#bin` instead; paths excluded by `moon.mod` are kept private. It
+takes the package version, description, license,
+and repository from `moon.mod` / `moon.mod.json`, copies an optional project
+`README` and license file, and adds a `files` allowlist so `npm/` can be
+published as generated.
+
+`--pkg` options:
+
+- `--out <dir>` — override `./npm`. Relative paths remain relative to the
+  MoonBit module root.
+- `--import-rewrites <json>` — map MoonBit package imports to public
+  TypeScript specifiers.
+- `--strict` / `--no-strict` — fail when generated autolink diagnostics report
+  omitted members.
+- `--no-facade` — generate only top-level free-function glue.
 
 Shared `--input` flow flags:
 
@@ -138,10 +163,13 @@ The following are the supported integration APIs for the current `0.4.x`
 series. Treat generated files as outputs: consume their documented package
 surface, rather than importing temporary MoonBit glue or build artifacts.
 
-- **MoonBit → TypeScript CLI:** `mbt2ts --input <pkg-or-mbti> --out <dir>` is
-  the canonical package-generation command. It generates facade wrappers by
-  default; `--no-facade`, `--strict`, `--diagnostics`, and
-  `--import-rewrites` are its supported controls. The named subcommands remain
+- **MoonBit → npm CLI:** `mbt2ts --pkg` is the canonical publish workflow. It
+  discovers the enclosing module, runs `moon info`, and generates `npm/` with
+  the manifest version, root and library-submodule npm exports, JS, and `.d.ts`
+  files. Packages with `main` are npm `bin` commands rather than subpath
+  exports. `--out`, `--no-facade`, `--strict`, and `--import-rewrites` are
+  supported controls.
+  `mbt2ts --input <pkg-or-mbti> --out <dir>` and the named subcommands remain
   lower-level stage APIs for tooling.
 - **Vite integration:** use `moonbit({ tsBridge: { generatorRoot, entries } })`
   to check a TypeScript module graph before generating a MoonBit bridge, and

--- a/README.md
+++ b/README.md
@@ -2,649 +2,104 @@
 
 Status: Experimental
 
-A bridge-generation toolchain between TypeScript and MoonBit, written in
-MoonBit. It reads TypeScript declaration files and MoonBit `pkg.generated.mbti`
-interfaces, then emits the corresponding bridge package for the other side so
-that MoonBit code can call typed JavaScript libraries and JavaScript / TypeScript
-code can call build-backed MoonBit packages.
-
-The earlier JS interpreter / wasm codegen / AOT compiler lived in this repo
-during exploration but has been removed. The supported surface is now the
-bridge generator only.
+MoonBit と TypeScript の間で bridge package を生成する toolchain です。TypeScript の
+型定義から MoonBit bridge を生成し、MoonBit package から JavaScript runtime と
+`.d.ts` を持つ npm package を生成します。生成物は再生成可能な output として扱います。
 
 ## Quick start
 
-TypeScript -> MoonBit (vendor every npm dep in `./package.json` as MoonBit
-bridges):
+TypeScript dependencies を MoonBit から使う場合:
 
-```bash
-$ moon install mizchi/ts/cmd/ts2mbt
-$ ts2mbt generate
-$ ls src/internal/generated/
-hono/  zod/  types__react/  ...
-```
-
-MoonBit -> TypeScript (build the current MoonBit package and prepare an npm
-publish directory):
-
-```bash
-$ moon install mizchi/ts/cmd/mbt2ts
-$ cd my-moonbit-library
-$ mbt2ts --pkg
-$ ls npm/
-bin/  index.js  index.d.ts  mtsc/  package.json  AUTOLINK_DIAGNOSTICS.md  ...
-$ cd npm && npm publish --access public
-```
-
-End-to-end Hono walkthrough: [docs/quick-start.md](./docs/quick-start.md).
-
-## Supported directions
-
-- **TypeScript -> MoonBit**: read a `.d.ts` (or `.ts`) entry plus a runtime
-  module specifier and emit a MoonBit bridge package (`bridge.mbti`,
-  `bridge.mbt`, `bridge.js`, `moon.pkg`, plus split source files for
-  larger packages).
-- **MoonBit -> TypeScript**: read a `pkg.generated.mbti` interface (and its
-  recursively discovered child packages) and emit a TypeScript declaration
-  package backed by `moon build --target js`.
-
-Generated packages are deterministic and diff-friendly. Each side writes a
-diagnostics file (`SCAFFOLD_DIAGNOSTICS.md` or `AUTOLINK_DIAGNOSTICS.md`) so
-widened, omitted, or wrapped surfaces stay inspectable.
-
-## Prerequisites
-
-- [MoonBit toolchain](https://www.moonbitlang.com/) (`moon` on `$PATH`).
-- Node.js 24+ (the verification harness imports built JS through Node).
-- `pnpm` (used by `just verify-mbti-dts` to run `tsc`).
-- Optional: [`just`](https://github.com/casey/just) for the `just verify-*`
-  recipes; otherwise invoke the corresponding `bash scripts/*.sh` directly.
-
-## Install
-
-`ts2mbt` and `mbt2ts` are MoonBit binaries published to mooncakes.
-Install whichever direction(s) you need; each binary is independent.
-
-```bash
-moon install mizchi/ts/cmd/ts2mbt   # TS  -> MoonBit (generate / vendor / scaffold)
-moon install mizchi/ts/cmd/mbt2ts   # MoonBit -> TS  (npm package / decl / scaffold)
-
-# Or install both binaries in one go
-moon install mizchi/ts/...
-```
-
-Both land at `~/.moon/bin/` and are usable as `ts2mbt` / `mbt2ts` once
-that directory is on `$PATH`. Verify with `ts2mbt --version`.
-
-To run from source (for hacking on the bridge generator itself), clone
-the repo and use `moon run src/cmd/{ts2mbt,mbt2ts} -- ...` instead.
-
-## Two CLIs
-
-Bridge generation is split into two binaries, one per direction:
-
-- `mbt2ts` — MoonBit `pkg.generated.mbti` → TypeScript declaration package
-  (build-backed by `moon build --target js`).
-- `ts2mbt` — TypeScript `.d.ts` / `.ts` entrypoint → MoonBit bridge package
-  (`bridge.mbti`, `bridge.mbt`, `bridge.js`, `moon.pkg`).
-
-`mbt2ts` has a project-oriented `--pkg` command for publishing and retains a
-lower-level `--input ... --out ...` flow for tooling that already has an
-interface. `ts2mbt` exposes a high-level `--input ... --out ...` flow plus
-low-level subcommands.
-
-```bash
-# MoonBit -> npm. `--pkg` runs `moon info`, uses the version in moon.mod,
-# builds facade glue with `moon build --target js`, and defaults to ./npm.
-mbt2ts --pkg
-cd npm && npm publish --access public
-
-# Lower-level MoonBit -> TypeScript flow for an existing interface.
-mbt2ts --input mizchi/foo --out dist
-
-# TypeScript -> MoonBit. For bare npm-style inputs, the runtime module spec
-# defaults to the input specifier.
-ts2mbt --input neverthrow --out dist
-
-# File input also works; pass the runtime module when it differs from the
-# declaration entry path.
-ts2mbt --input path/to/entry.d.ts --module-spec /runtime/module.js --out dist
-
-# Diagnostics can be redirected. Strict mode fails when unsupported exports,
-# omitted MoonBit autolink members, or unbudgeted TS JSValue fallbacks are found.
-ts2mbt --input neverthrow --out dist --diagnostics dist/diagnostics.md --strict
-```
-
-`mbt2ts --pkg` emits facade glue by default, builds it with `moon build
---target js`, and copies the built JS to `index.js`; pass `--no-facade` to
-emit only top-level free-function glue. Every library subdirectory containing
-`moon.pkg` is emitted as an npm subpath export: for example `src/mtsc` becomes
-`@scope/package/mtsc`. Command packages are not library subpath exports; a
-package that defines `main` is compiled to `bin/<command>.js` and registered in
-`package.json#bin` instead; paths excluded by `moon.mod` are kept private. It
-takes the package version, description, license,
-and repository from `moon.mod` / `moon.mod.json`, copies an optional project
-`README` and license file, and adds a `files` allowlist so `npm/` can be
-published as generated.
-
-`--pkg` options:
-
-- `--out <dir>` — override `./npm`. Relative paths remain relative to the
-  MoonBit module root.
-- `--import-rewrites <json>` — map MoonBit package imports to public
-  TypeScript specifiers.
-- `--strict` / `--no-strict` — fail when generated autolink diagnostics report
-  omitted members.
-- `--no-facade` — generate only top-level free-function glue.
-
-Shared `--input` flow flags:
-
-- `--input <pkg-or-entry>` — for `mbt2ts` accepts a MoonBit package name or
-  `pkg.generated.mbti` path; for `ts2mbt` accepts a TypeScript declaration /
-  source entrypoint or an installed package specifier.
-- `--out <dir>` — writes a complete scaffold package.
-- `--module-spec <specifier>` (`ts2mbt` only) — overrides the runtime import
-  used by generated bridge code.
-- `--import-rewrites <json>` (`mbt2ts` only) — JSON map of MoonBit-package
-  imports to publishable TypeScript specifiers.
-- `--diagnostics <path>` — redirects the generated diagnostics report.
-  Without it, `ts2mbt` writes `SCAFFOLD_DIAGNOSTICS.md` and `mbt2ts` writes
-  `AUTOLINK_DIAGNOSTICS.md` in the output directory.
-- `--strict` — fails when diagnostics contain unsupported exports, omitted
-  autolink members, or unbudgeted `JSValue` fallbacks. The default
-  non-strict mode still emits a buildable scaffold with diagnostics when
-  possible.
-- `--no-facade` (`mbt2ts` only) — skip facade-wrapper generation and emit
-  only top-level free-function glue.
-
-## Public integration contract
-
-The following are the supported integration APIs for the current `0.4.x`
-series. Treat generated files as outputs: consume their documented package
-surface, rather than importing temporary MoonBit glue or build artifacts.
-
-- **MoonBit → npm CLI:** `mbt2ts --pkg` is the canonical publish workflow. It
-  discovers the enclosing module, runs `moon info`, and generates `npm/` with
-  the manifest version, root and library-submodule npm exports, JS, and `.d.ts`
-  files. Packages with `main` are npm `bin` commands rather than subpath
-  exports. `--out`, `--no-facade`, `--strict`, and `--import-rewrites` are
-  supported controls.
-  `mbt2ts --input <pkg-or-mbti> --out <dir>` and the named subcommands remain
-  lower-level stage APIs for tooling.
-- **Vite integration:** use `moonbit({ tsBridge: { generatorRoot, entries } })`
-  to check a TypeScript module graph before generating a MoonBit bridge, and
-  `moonbit({ npmPackage: { entry, outDir } })` to generate a publishable npm
-  package. `generatorRoot` and `command` are shared when `npmPackage` is used
-  with `tsBridge`; `facade` and `bundle` default to `true`, and
-  `runtimeValidation` defaults to `false`.
-- **Generated npm package:** `index.js`, `index.d.ts`, `package.json`, and
-  `AUTOLINK_DIAGNOSTICS.md` are its public artifacts. Structs are plain
-  objects, enum values use `$tag`, and opaque declaration brands prevent a
-  TypeScript lookalike from being passed back as a MoonBit value. Trait methods
-  and temporary glue files are not part of that API.
-- **`mtsc` checker:** Vite builds and imports the MoonBit JS module directly;
-  its sole JS ABI is `checkModuleGraph`. `checkSource`,
-  `checkModuleSources`, and the command-line checker are implementation and
-  development APIs, not consumer-facing interfaces.
-
-## Generate / vendor (TypeScript -> MoonBit)
-
-When you're consuming a MoonBit package and want bridges for the
-TypeScript libraries listed in your `package.json`, run `ts2mbt vendor`
-or `ts2mbt generate` from inside your moon module.
-
-```bash
-# Vendor one npm package: resolve its types via node_modules and write a
-# bridge sub-package under <moon-source>/internal/generated/<safe>/.
-ts2mbt vendor hono
-
-# Vendor everything in dependencies + devDependencies of ./package.json.
+```sh
+moon install mizchi/ts/cmd/ts2mbt
 ts2mbt generate
 ```
 
-Output layout (with `moon.mod.json`'s `source` set to `src`):
+MoonBit package を npm package にする場合:
 
-```
-src/
-└── internal/
-    └── generated/
-        ├── hono/
-        │   ├── bridge.mbti
-        │   ├── bridge.mbt
-        │   ├── bridge.js
-        │   ├── moon.pkg
-        │   ├── package.json    # type=module + self-contained imports
-        │   └── SCAFFOLD_DIAGNOSTICS.md
-        └── types__react/
-            └── ... (same shape, runtime spec defaults to `react`)
+```sh
+moon install mizchi/ts/cmd/mbt2ts
+cd my-moonbit-library
+mbt2ts --pkg
+cd npm && npm publish --access public
 ```
 
-The bridge `bridge.mbt` references each helper via a scoped npm
-specifier: `#module("@tsmbt-bridge/<safe>")`. Resolution goes
-through standard `node_modules/@tsmbt-bridge/<safe>` lookup, with
-each generated bridge listed as a `file:` dependency in the
-consumer's `package.json` — `vendor` / `generate` print a
-copy-paste-ready snippet on first run:
+公開済み `@mizchi/ts` の type checker は global install なしで実行できます。
 
-```json
-{
-  "dependencies": {
-    "@tsmbt-bridge/hono": "file:./src/internal/generated/hono"
-  }
-}
+```sh
+npx --package=@mizchi/ts mtsc --help
 ```
 
-`pnpm install` / `npm install` then materializes the bridge under
-`node_modules/@tsmbt-bridge/`, and that link survives every
-subsequent install (it's a real dep, not an ad-hoc symlink). The
-scoped-name approach also lets `moon test --target js` resolve
-`require("@tsmbt-bridge/<safe>")` from any depth — the test
-scaffold writes intermediate empty `package.json {}` files that
-would otherwise shadow a `package.json#imports` mapping. The
-generated `moon.pkg` is empty (no extra imports needed); the
-consumer adds the `import` line themselves to their own `moon.pkg`
-(see "Consume the generated bridge" below).
+Hono を MoonBit から使う完全な手順は [Quick start](./docs/quick-start.md) を参照してください。
 
-Naming: the directory slug strips the leading `@`, replaces `/` with
-`__`, and replaces other non-`[A-Za-z0-9]` characters with `_`.
-`@types/<name>` packages default the runtime module spec to the unscoped
-name (`react`, `express`, ...), since the runtime code lives in the
-non-types package.
+## Requirements
 
-### Generated artifact size
+- [MoonBit toolchain](https://www.moonbitlang.com/)（`moon` が `$PATH` にあること）
+- Node.js 24+
+- `pnpm`（verification scripts 用）
+- 任意: [`just`](https://github.com/casey/just)
 
-Generated bridges scale with the upstream `.d.ts` surface. Tiny
-packages produce a few KB; large packages (`typescript`, `react`,
-`vitest`, `node:fs`) produce hundreds of KB of `bridge.mbti` /
-`bridge.js` / split source files. Rely on tree-shaking on the JS
-side to drop unused bindings.
+## Install
 
-### Guardrails for generated code
+```sh
+moon install mizchi/ts/cmd/ts2mbt
+moon install mizchi/ts/cmd/mbt2ts
 
-Treat `<source>/internal/generated/` as a cache, not as source. The
-first `generate` / `vendor` invocation drops two markers at the vendor
-root so humans and AI agents can recognise the boundary:
-
-- `.gitignore` — `*` plus `!.gitignore` `!AGENTS.md`, so the directory
-  stays out of version control by default while the guardrail markers
-  remain visible to anyone browsing the tree. Move the entries up to
-  your repo-root `.gitignore` if you'd rather track nothing here.
-- `AGENTS.md` — the standard "do not edit this directory by hand"
-  notice for AI coding agents (Claude / Cursor / Aider / Codex). The
-  generated `bridge.{mbti,mbt,js}` headers also start with an
-  `AUTO-GENERATED ... DO NOT EDIT` line that points at the regenerate
-  command.
-
-Regenerate via `ts2mbt vendor <pkg>` or `ts2mbt generate`.
-
-### Consume the generated bridge
-
-The bridge is just another MoonBit sub-package. `generate` and
-`vendor` print a copy-paste-ready import block (with your module
-name resolved from `moon.mod.json`) in the new `moon.pkg` text
-format:
-
-```
-import {
-  "yourname/yourmod/internal/generated/hono" @hono,
-}
-
-options(
-  "is-main": true,
-)
+# 両方を一度に install
+moon install mizchi/ts/...
 ```
 
-Then call it from MoonBit as `@hono.<exported-symbol>`. Class
-methods preserve their TypeScript names — `app.get("/", ...)`,
-`c.text("ok", None, None)` — and reserved-word collisions get a
-trailing underscore (e.g. `match` → `match_`). The generated
-`bridge.mbti` is the source of truth for the public surface;
-`SCAFFOLD_DIAGNOSTICS.md` records anything that was widened to
-`JSValue` so you know where the typed surface ends.
+install 後は `~/.moon/bin/` を `$PATH` に追加します。source checkout から実行する
+場合は `moon run src/cmd/{ts2mbt,mbt2ts} -- ...` を使います。
 
-For a complete two-bridge consumer — importing the TypeScript compiler API and
-Node's `node:fs` from one `moon.pkg`, then running both at runtime — see
-[`examples/typescript-to-moonbit/typescript-node-imports`](./examples/typescript-to-moonbit/typescript-node-imports/).
+## Tools
 
-Build & run as usual: `moon run <your-pkg> --target js`. With
-`"preferred-target": "js"` in `moon.mod.json` you can drop the
-`--target js` flag.
+| Tool     | 概要                                                           | 詳細                                 |
+| -------- | -------------------------------------------------------------- | ------------------------------------ |
+| `ts2mbt` | TypeScript declaration / npm package を MoonBit bridge に変換  | [`docs/ts2mbt.md`](./docs/ts2mbt.md) |
+| `mbt2ts` | MoonBit package を TypeScript declaration / npm package に変換 | [`docs/mbt2ts.md`](./docs/mbt2ts.md) |
+| `mtsc`   | TypeScript / TSX を型検査して JavaScript に変換                | [`docs/mtsc.md`](./docs/mtsc.md)     |
 
-Flags:
+`tscheck` と `tsacc` は開発用 command であり、公開 tool には含めません。
 
-- `--module-spec <spec>` (`vendor`) — override the runtime import used by
-  the generated `bridge.js`. Useful when the package ships its types
-  separately from its runtime entry.
-- `--out <dir>` — override the vendor root. Defaults to
-  `<moon source>/internal/generated`.
-- `--package-json <path>` (`generate`) — read deps from a non-default
-  `package.json`.
+## Generated package contract
 
-## MoonBit -> TypeScript
+- `ts2mbt` の output は consumer module の `internal/generated/` に置く bridge package
+  です。`SCAFFOLD_DIAGNOSTICS.md` で widen / omit した surface を確認します。
+- `mbt2ts --pkg` の output は `npm/` です。`moon.mod` の version と metadata を使い、
+  `package.json`、`index.js`、`.d.ts`、subpath export、必要なら npm `bin` を生成します。
+- どちらも output を手編集せず、入力と option から再生成してください。
 
-Start from a root `pkg.generated.mbti` for a real MoonBit source package and
-emit:
+詳細な type boundary、facade、runtime validation、package export、unsupported surface は
+各 tool guide に記載しています。
 
-- `index.js` copied from the temporary glue package's `moon build --target js`
-  output
-- child package `index.js` files that re-export their runtime surface from the
-  built root JS
-- `package.json` with `types` / `exports` metadata for the emitted
-  declaration package
-- `AUTOLINK_DIAGNOSTICS.md` listing public methods / constructors omitted from
-  `link.js.exports`
-- recursive `.d.ts` files with local MoonBit package imports rewritten to
-  sibling relative imports
+## Diagnostics and examples
 
-The temporary glue package contains generated wrapper functions and
-`link.js.exports`, is built with `moon build --target js`, and is removed
-after the built JS is copied to `index.js`.
-
-```bash
-mbt2ts scaffold src/pkg.generated.mbti out/ts-pkg
-
-# optional: rewrite external MoonBit package imports to publishable TS specifiers
-mbt2ts scaffold src/pkg.generated.mbti out/ts-pkg import-rewrites.json
-
-# opt-in: also emit top-level MoonBit wrappers for omitted local methods/constructors
-mbt2ts facade-scaffold src/pkg.generated.mbti out/ts-pkg
-```
-
-Lower-level commands are also available:
-
-```bash
-# only link.js.exports JSON
-mbt2ts link-config src/pkg.generated.mbti
-
-# only recursive .d.ts package
-mbt2ts package src/pkg.generated.mbti out/ts-pkg
-
-# single .d.ts from one .mbti file without recursive rewrite
-mbt2ts decl src/pkg.generated.mbti
-```
-
-Current export model:
-
-- JS autolink is generated from top-level public free functions across the
-  root package and recursively discovered local child packages.
-- Runtime-inaccessible method / namespace declarations are stripped from
-  scaffold `.d.ts` output unless wrapper glue is generated for them.
-- Scaffold output includes `AUTOLINK_DIAGNOSTICS.md` so omitted public members
-  are explicit.
-- `mbt2ts facade-scaffold` is an opt-in variant that adds
-  generated top-level wrappers for local non-generic methods and constructors
-  to the temporary glue package, then exposes those wrappers from the built
-  JS and the matching package `.d.ts`. Async wrappers are exposed as
-  Promise-returning JavaScript functions.
-- Scaffold runtime wrappers normalize public MoonBit structs and enums into
-  ordinary JavaScript objects; enum cases use a `$tag` discriminant. Their
-  `.d.ts` values carry an internal opaque brand, so a returned value can be
-  passed back to MoonBit but a plain TypeScript lookalike cannot.
-- MoonBit trait methods are not part of this plain-object npm boundary.
-  `mbt2ts decl` continues to describe traits, while scaffold declarations
-  remove trait intersections from runtime-normalized structs and enums.
-- Generated glue declarations, runtime export lists, package `exports`, and
-  child-package re-export files are sorted deterministically to keep scaffold
-  diffs reviewable.
-- The temporary `moon.pkg` and wrapper `.mbt` files are build inputs
-  only; they are not written to the final TypeScript package.
-- Recursive `.mbti` resolution rewrites imports that stay under the same root
-  package prefix. Unmapped external MoonBit values in public function
-  parameters/results are omitted from the npm surface and listed in
-  `AUTOLINK_DIAGNOSTICS.md`; nested external slots become `unknown` so the
-  declaration remains standalone. An explicit import rewrite opts into the
-  mapped TypeScript package instead.
-- `mbt2ts package` and `mbt2ts scaffold`
-  accept an optional JSON object for external import rewrites, for example
-  `{ "moonbitlang/core/debug": "demo-debug" }`.
-- Generated `package.json` names are derived from the MoonBit package path,
-  for example `demo/pkg` -> `@demo/pkg` and `mizchi/ts/analysis` ->
-  `@mizchi/ts-analysis`.
-
-Supported surface:
-
-- Top-level public free functions whose parameter and return types can cross
-  the MoonBit JS backend boundary.
-- Root and nested local child-package exports, with generated `package.json`
-  subpath exports.
-- `raise` effects in `.mbti`, represented in TypeScript declarations as
-  `Result<Return, ErrorType>`.
-- Opaque MoonBit-defined types in TypeScript declarations.
-- Declaration-only structural interfaces for public MoonBit traits and local
-  trait impl relationships.
-- Opt-in facade wrappers for local non-generic methods and constructors via
-  `mbt2ts facade-scaffold`, including async constructors and methods.
-- Unconstrained generic free functions (`pub fn[T] identity(T) -> T`) and
-  unconstrained generic METHODS on non-generic owners
-  (`pub fn[T] Counter::tap(Self, T) -> T`, via `mbt2ts facade-scaffold`)
-  export through a monomorphized glue wrapper: each type parameter is
-  instantiated at an opaque `TsMbtGenericAny` boundary type (values cross
-  the JS boundary unchanged) while the emitted `.d.ts` keeps the full
-  generic signature (`counter_tap<T>(self: Counter, arg1: T): T`).
-  Bare `T?` returns unwrap to `value | undefined` at the boundary.
-
-Unsupported or limited surface:
-
-- Generic constructors, trait methods, methods on GENERIC owners, and
-  generic functions with trait bounds are not exported by JS autolink.
-  Generic functions whose type parameters appear inside tuples or
-  non-top-level `Option` payloads also stay omitted (their runtime
-  representation would not match the declared TypeScript signature).
-- Public members omitted from the runtime export surface are listed in
-  `AUTOLINK_DIAGNOSTICS.md`.
-- External MoonBit imports are left as bare TypeScript imports unless an
-  import rewrite map is provided.
-- The final package should not contain temporary glue files such as
-  `moon.pkg` or generated facade `.mbt`; those are build inputs only.
-
-## TypeScript -> MoonBit
-
-Start from a TypeScript entrypoint and emit a MoonBit bridge scaffold:
-
-```bash
-ts2mbt scaffold path/to/entry.d.ts /runtime/module.js out/moonbit-pkg
-```
-
-Lower-level commands are also available:
-
-```bash
-# full bridge package
-ts2mbt package path/to/entry.d.ts /runtime/module.js out/moonbit-pkg
-
-# opt in to public validate<Type>(JSValue) -> Type? boundary functions for
-# generated structural types; normal bridge calls stay unchecked
-ts2mbt package-validated path/to/entry.d.ts /runtime/module.js out/moonbit-pkg
-
-# inspect generated decl/ffi/bridge snippets without writing a package
-ts2mbt bridge path/to/entry.d.ts /runtime/module.js
-ts2mbt ffi path/to/entry.d.ts /runtime/module.js
-ts2mbt decl path/to/entry.d.ts
-```
-
-The TS -> MoonBit path resolves exported surface recursively through local
-package structure and package exports, but the generated MoonBit package
-still targets the exported top-level surface rather than arbitrary internal
-module state.
-
-- Namespace exports are emitted as opaque getter-style bindings such as
-  `get_shapes() -> Shapes`.
-- Ambiguous re-exports no longer block scaffold generation. They are
-  widened / omitted the same way as the lower-level emitters, and the scaffold
-  writes `SCAFFOLD_DIAGNOSTICS.md` so the dropped surface is explicit.
-- Literal unions such as `"solid" | "ghost"` and `true | false` are narrowed
-  to `String` / `Bool` instead of being widened to `JSValue`.
-- Generated bridge packages preserve camelCase top-level export names in
-  their public MoonBit API, even when the internal JS extern binding is
-  lowered to snake_case. Value exports use the explicit public
-  `get_<snake_case>()` convention. Internal conversion and identity-cast
-  helpers are private implementation details and never appear in `bridge.mbti`.
-- `package-validated` is an opt-in boundary-safety mode: generated structural
-  types get public `validate<Type>(value : JSValue) -> Type?` functions. It
-  checks supported primitive fields at runtime and returns `None` for invalid
-  values without changing the default bridge API or adding per-call checks.
-
-Supported surface:
-
-- Exported functions, classes, interfaces, constants, default exports,
-  package `exports`, `types` / `typings`, common subpath exports, `@types/*`
-  fallbacks, and configured Node built-in declaration files.
-- Primitive values, arrays, optionals, literal string / boolean unions,
-  object option bags, and representable readonly fields.
-- Common utility types including concrete `Pick` / `Omit` projections,
-  `NonNullable`, direct-union `Exclude` / `Extract`, direct function
-  `ReturnType` / `Parameters`, alias-position passthrough for simple resolved
-  utility aliases, `InstanceType<typeof Class>` /
-  `ConstructorParameters<typeof Class>` for local class values, and
-  `Record<K, V>` as named opaque JS object boundary types such as
-  `StringRecordOfFoo`.
-- Non-empty homogeneous rest tuples such as `[T, ...T[]]` are lowered to
-  `Array[T]` for class properties, constructors, functions, and imports.
-- Common real-world package shapes covered by the probe corpus, including
-  function libraries, schema libraries, web libraries, callback-heavy Node
-  APIs, Promise-heavy APIs, CJS-style packages, and Node built-ins.
-- Generated packages are expected to pass `moon check --target js`,
-  `moon test --target js`, `moon build --target js`, and a Node smoke run
-  without editing generated glue.
-
-Fallback and unsupported surface:
-
-- Complex `any` / `unknown`, overloads, conditional / mapped types,
-  function-valued callbacks, heterogeneous tuple edge cases, and
-  namespace / value merge surfaces may be widened to `JSValue`.
-- Ambiguous re-exports are intentionally not bound unsafely. The generated
-  package remains buildable and reports the candidate source files.
-- Unsupported exports are either absent or explicitly budgeted in
-  verification; new unsupported surfaces should be minimized into fixtures
-  before broadening the generator.
-
-Package-specific practical coverage:
-
-- Small Node built-ins (`node:path`, `node:os`, `node:url`,
-  `node:querystring`, `node:buffer`) and the focused `node:crypto` surface
-  are expected to generate with zero public `JSValue` fallback in the
-  real-world probe corpus.
-- Naturalization targets are packages where remaining fallback should keep
-  shrinking because the useful API shape is finite or common: Hono,
-  React Router, JOSE, Glob, `date-fns`, `magic-string`, `source-map`,
-  `node:sqlite`, `node:fs`, `node:assert`, and `node:util`.
-- Hono is the current example of that policy: the basic application route
-  shape works directly from MoonBit as
-  `app.get("/", fn(c) { c.text("ok", None, None) })`, with route paths
-  as `String`, handlers as `(Context) -> Response`, and common `Context`
-  response helpers returning `Response`.
-- Glob now exercises the same policy for function-valued constant exports.
-  Natural function signatures such as `escape(pattern, options)` /
-  `unescape` are emitted as direct MoonBit calls, and
-  `hasMagic(pattern: string | string[], options: GlobOptions)` also gets a
-  string-subset wrapper as
-  `has_magic(pattern : String, options : GlobOptions) -> Bool`. The common
-  single-pattern path no longer needs a manual `JSValue` argument or a
-  getter-returned function call.
-- Zod, Valibot, Preact, and broad Playwright event / callback surfaces are
-  currently treated as buildable interop probes rather than fully ergonomic
-  API surfaces. Their high-order schema, parser, JSX / component, and event
-  callback APIs still rely on explicit `JSValue` budgets; this is a
-  documented fallback policy, not a claim that those APIs are naturally
-  typed in MoonBit yet.
-- `just verify-realworld-typescript` appends a fallback policy table to
-  `_build/realworld-typescript/METRICS.md`, and new corpus entries must be
-  classified before their `JSValue` budget is accepted.
-
-Supported subset examples:
-
-```ts
-// TypeScript -> MoonBit: supported declaration shapes
-export interface User {
-  readonly id: string;
-  name?: string;
-}
-
-export type UserPatch = Partial<Pick<User, "name">>;
-export declare function parseUser(input: string): User;
-export declare function listUsers(): Promise<User[]>;
-```
-
-```moonbit
-// MoonBit -> TypeScript: supported JS-exportable public surface
-pub struct User {
-  id : String
-  name : String?
-}
-
-pub fn parse_user(input : String) -> User {
-  { id: input, name: None }
-}
-
-pub async fn list_users() -> Array[User] {
-  []
-}
-```
-
-Keep unsupported surfaces inspectable. Callback-heavy TypeScript parameters
-and generic MoonBit methods can remain in source packages, but the bridge
-may widen or omit them and report the decision in diagnostics.
-
-## Diagnostics and quality reports
-
-- `SCAFFOLD_DIAGNOSTICS.md` explains each widened, omitted, or
-  bridge-wrapped TypeScript export, including whether the generated decision
-  is runtime-safe.
-- `AUTOLINK_DIAGNOSTICS.md` explains MoonBit public members omitted from JS
-  autolink output.
-- `just bridge-quality` writes `_build/bridge-quality/REPORT.md` with
-  fixture-backed metrics, unsupported export budgets, and `JSValue` cause
-  breakdowns.
-- `just verify-realworld-typescript` writes
-  `_build/realworld-typescript/METRICS.md` with per-package `JSValue` budgets
-  and generated-glue immutability checks.
-- `just verify-realworld-moonbit` writes
-  `_build/realworld-moonbit/REPORT.md` with per-package status and
-  generated-package immutability checks.
-- The project does not claim arbitrary npm or MoonBit package conversion.
-  Treat a clean report plus diagnostics review as the supported workflow.
-
-## Examples
-
-- [Quick start](./docs/quick-start.md) — vendor `hono` and
-  `@hono/node-server` from npm and serve real HTTP from MoonBit.
-- [`examples/`](./examples/) — runnable fixtures used by
-  `just verify-examples`.
+- [`docs/ts2mbt.md`](./docs/ts2mbt.md) — `SCAFFOLD_DIAGNOSTICS.md`、vendor と bridge。
+- [`docs/mbt2ts.md`](./docs/mbt2ts.md) — `AUTOLINK_DIAGNOSTICS.md`、npm publish。
+- [`docs/mtsc.md`](./docs/mtsc.md) — checker の CLI、ABI、既知ギャップ。
+- [`examples/`](./examples/) — `just verify-examples` で検証する runnable fixture。
 
 ## Development
 
-```bash
-# Check for errors
-moon check --deny-warn
-
-# Run tests
-moon test --target native
-
-# Verify high-level scaffold commands end-to-end
-just verify-scaffolds
-
-# Fixture-backed bridge quality report
-just bridge-quality
-
-# Optional local real-world probes
-just verify-realworld-typescript
-just verify-realworld-moonbit
-
-# Format code
+```sh
 moon fmt
+moon info
+just check
+just test
+just verify-scaffolds
+just verify-examples
 ```
 
-Release checklist:
+checker の TypeScript conformance gate は次を使います。
 
-- Run `moon fmt`, `moon info`, `just check`, and `just test`.
-- Run `just verify-scaffolds`, `just verify-mbti-dts`,
-  `just verify-generated-fixtures`, and `just verify-examples`.
-- Run or review `just bridge-quality`, `just verify-realworld-typescript`,
-  and `just verify-realworld-moonbit` before claiming broader package
-  coverage.
-- Refresh generated docs / reports and confirm `TODO.md` reflects the current
-  quality gate.
-- Add a changelog entry covering CLI contract, bridge behavior changes,
-  fallback budgets, and known unsupported surfaces.
+```sh
+just checker-conformance-oracle --max-fp 0 --max-legal-parsefail 1
+```
+
+軽量な conformance 集計には [tsacc guide](./docs/tsacc.md) を参照してください。
+
+優先度と既知の制約は [checker priority](./docs/checker-priority.md) を参照してください。
 
 ## License
 

--- a/docs/mbt2ts.md
+++ b/docs/mbt2ts.md
@@ -1,0 +1,94 @@
+# `mbt2ts`: MoonBit package を TypeScript / npm として公開する
+
+`mbt2ts` は MoonBit の `pkg.generated.mbti` と JavaScript build output から、
+`.d.ts` と runtime JS を持つ TypeScript package を生成します。生成物は毎回
+再生成する publish artifact です。
+
+## Install
+
+```sh
+moon install mizchi/ts/cmd/mbt2ts
+```
+
+開発中は `moon run src/cmd/mbt2ts -- ...` を使えます。
+
+## npm package を生成する: `--pkg`
+
+MoonBit module root で実行します。
+
+```sh
+mbt2ts --pkg
+cd npm
+npm pack --dry-run
+npm publish --access public
+```
+
+`--pkg` は `moon info` を実行し、`moon.mod` の version、description、license、
+repository を manifest にコピーします。facade glue を生成して `moon build --target js`
+で build し、`npm/` に `index.js`、`index.d.ts`、source map、`package.json`、
+`AUTOLINK_DIAGNOSTICS.md` を書きます。README と license があれば同梱します。
+
+library subdirectory の `moon.pkg` は npm subpath export になります。たとえば
+`src/mtsc` は `@scope/package/mtsc` です。一方、`main` を持つ package は
+`bin/<command>.js` と `package.json#bin` に出力されます。`moon.mod` の
+`options(exclude: ...)` にある path は公開しません。
+
+`--pkg` の主なオプション:
+
+- `--out <dir>` — publish directory。既定は module root の `npm/`。
+- `--import-rewrites <json>` — MoonBit import を公開 TypeScript specifier へ rewrite。
+- `--strict` / `--no-strict` — autolink diagnostics に omitted member があれば失敗。
+- `--no-facade` — top-level free function glue のみを生成。
+
+生成済み `@mizchi/ts` の `mtsc` はグローバル install なしで実行できます。
+
+```sh
+npx --package=@mizchi/ts mtsc --help
+```
+
+## Interface から生成する
+
+既存 interface を使う低水準フローです。
+
+```sh
+# Recursive .d.ts package と build-backed runtime scaffold
+mbt2ts scaffold src/pkg.generated.mbti out/ts-pkg
+
+# External MoonBit import を npm specifier へ置き換える
+mbt2ts scaffold src/pkg.generated.mbti out/ts-pkg import-rewrites.json
+
+# Local method / constructor の facade を opt-in
+mbt2ts facade-scaffold src/pkg.generated.mbti out/ts-pkg
+
+# 個別段階
+mbt2ts link-config src/pkg.generated.mbti
+mbt2ts package src/pkg.generated.mbti out/ts-pkg
+mbt2ts decl src/pkg.generated.mbti
+```
+
+`--input <pkg-or-mbti> --out <dir>` は project-oriented lower-level flow です。
+`--diagnostics <path>` で `AUTOLINK_DIAGNOSTICS.md` の出力先を変えられます。
+完全な引数は `mbt2ts --help` を参照してください。
+
+## 公開 API の契約
+
+- root と child package の top-level public free function を JavaScript runtime から
+  export します。
+- struct は plain object、enum は `$tag` discriminant を使います。opaque brand により
+  TypeScript の lookalike object を MoonBit value として渡せません。
+- `raise` effect は TypeScript では `Result<Return, ErrorType>` になります。
+- facade を有効にすると local の non-generic method / constructor と async member に
+  top-level wrapper を生成します。
+- runtime に届かない member、external import、omitted autolink surface は
+  `AUTOLINK_DIAGNOSTICS.md` に記録します。
+
+generic constructor、trait method、generic owner の method、trait-bound generic
+function は安全な JS surface を作れないため export しません。temporary glue の
+`moon.pkg` や generated `.mbt` は build input であり、最終 npm package には含めません。
+
+## Vite integration
+
+`vite-plugin-moonbit` では `moonbit({ npmPackage: { entry, outDir } })` を使って
+publishable npm package を生成できます。TypeScript bridge と併用するときは
+`generatorRoot` と command を共有します。詳細は plugin 側の API documentation を
+参照し、package output の契約はこのページの `--pkg` と同じものとして扱ってください。

--- a/docs/mtsc.md
+++ b/docs/mtsc.md
@@ -1,0 +1,56 @@
+# `mtsc`: TypeScript の型検査と JavaScript 変換
+
+`mtsc` は TypeScript / TSX を JavaScript へ変換する CLI です。変換前に MoonBit
+checker を実行し、診断があれば JavaScript を書き出さず non-zero で終了します。
+
+## Run without a global install
+
+公開済みの `@mizchi/ts` package を使う場合:
+
+```sh
+npx --package=@mizchi/ts mtsc src/index.ts --out dist/index.js
+```
+
+`npx` を実行する前に、存在する directory へ `cd` してください。削除済みの
+directory を current working directory にした Node/npm は `uv_cwd` で開始前に
+失敗します。
+
+## CLI
+
+```sh
+mtsc <input.ts> [options]
+```
+
+主なオプション:
+
+- `--out`, `-o <file.js>` — 出力先。指定しなければ stdout。
+- `--bundle` — relative import をたどり単一 bundle を出力。
+- `--treeshake` / `--fold` / `--minify` — bundle を最適化。
+- `--dts` — `--bundle` と併用して entry の `.d.ts` を出力。
+- `--sourcemap` — output の隣に v3 source map を出力。
+- `--mangle`、`--mangle-properties` — internal name / property の rename。
+- `--jsx-runtime automatic|classic`、`--jsx-import-source <pkg>`、`--jsx-dev` — JSX
+  transform の設定。
+
+すべてのオプションは `mtsc --help` で確認できます。
+
+## Module graph checker ABI
+
+Vite integration が使う公開 JavaScript ABI は `checkModuleGraph` だけです。Vite が
+解決済み module と edge を渡し、`mtsc` は import / re-export を含めて checker を走らせ
+ます。CLI の単一 source checker と `checkSource` / `checkModuleSources` は実装・開発用
+API であり、consumer ABI には含めません。
+
+## 現在の既知ギャップ
+
+checker は TypeScript 全仕様の代替ではありません。次の「`tsc --strict` は失敗するが、
+現在の `mtsc` は診断しない」fixture を明示的な backlog として管理しています。
+
+- implicit `any` parameter（TS7006）
+- primitive prototype member（TS2551）
+- aliased discriminant narrowing（TS2339）
+- overload resolution（TS2769）
+
+ソース・TypeScript baseline・更新ルールは
+[`fixtures/mtsc/known-gaps`](../fixtures/mtsc/known-gaps/README.md) を参照してください。
+対応時は fixture を通常の diagnostic test へ移します。

--- a/docs/ts2mbt.md
+++ b/docs/ts2mbt.md
@@ -1,0 +1,97 @@
+# `ts2mbt`: TypeScript を MoonBit から使う
+
+`ts2mbt` は TypeScript の宣言またはソースを読み、MoonBit から JavaScript
+ライブラリを呼ぶための bridge package を生成します。生成物は再生成可能な出力です。
+手編集せず、入力の型定義または生成オプションを変更して再実行してください。
+
+## Install
+
+```sh
+moon install mizchi/ts/cmd/ts2mbt
+```
+
+開発中はリポジトリから `moon run src/cmd/ts2mbt -- ...` として実行できます。
+
+## 最短の使い方
+
+1つの npm パッケージを MoonBit module 内へ vendor します。
+
+```sh
+ts2mbt vendor hono
+```
+
+`package.json` の `dependencies` と `devDependencies` をまとめて処理するには:
+
+```sh
+ts2mbt generate
+```
+
+出力先の既定値は `<moon source>/internal/generated/<package>/` です。各 bridge
+には `bridge.mbti`、`bridge.mbt`、`bridge.js`、`moon.pkg`、`package.json`、
+`SCAFFOLD_DIAGNOSTICS.md` が入ります。
+
+生成後、案内された `@tsmbt-bridge/<name>` の `file:` dependency を consumer の
+`package.json` に追加して `pnpm install` または `npm install` を実行します。次に
+consumer の `moon.pkg` から生成 package を import します。
+
+```moonbit
+import {
+  "yourname/yourmod/internal/generated/hono" @hono,
+}
+```
+
+完全な Hono の例は [Quick start](./quick-start.md) を参照してください。
+
+## Project-oriented input
+
+`--input` は宣言ファイル、TypeScript source、または npm package specifier を受けます。
+
+```sh
+# Installed package の型を bridge package にする
+ts2mbt --input neverthrow --out dist
+
+# ファイル入力では runtime module specifier も与える
+ts2mbt --input path/to/entry.d.ts --module-spec /runtime/module.js --out dist
+```
+
+`--diagnostics <path>` は `SCAFFOLD_DIAGNOSTICS.md` の出力先を変更します。
+`--strict` は unsupported export、unsafe fallback、未予算の `JSValue` が残る場合に
+失敗させます。通常モードでは生成可能な package を出力し、判断理由を diagnostics に
+残します。
+
+## Low-level commands
+
+高水準の `--input` / `vendor` / `generate` を通常は使います。個別の生成段階が必要な
+tooling には以下もあります。
+
+```sh
+ts2mbt scaffold path/to/entry.d.ts /runtime/module.js out/moonbit-pkg
+ts2mbt package path/to/entry.d.ts /runtime/module.js out/moonbit-pkg
+# runtime validator を public API に追加する opt-in variant
+ts2mbt package-validated path/to/entry.d.ts /runtime/module.js out/moonbit-pkg
+ts2mbt bridge path/to/entry.d.ts /runtime/module.js
+ts2mbt ffi path/to/entry.d.ts /runtime/module.js
+ts2mbt decl path/to/entry.d.ts
+```
+
+`vendor` は `--module-spec <specifier>` と `--out <dir>` を、`generate` は
+`--package-json <path>` と `--out <dir>` を受けます。完全なオプションは
+`ts2mbt --help` を参照してください。
+
+## 型境界と diagnostics
+
+primitive、array、optional、literal union、object option bag、および多くの一般的な
+utility type は MoonBit の型へ写されます。複雑な `any` / `unknown`、conditional /
+mapped type、overload、function callback、異種 tuple、namespace/value merge は
+`JSValue` へ widen されることがあります。
+
+`SCAFFOLD_DIAGNOSTICS.md` が唯一の判断記録です。頻繁に使う widened surface は、
+consumer 側の小さな `extern "js"` shim で補うのが推奨されます。実 package の
+fallback budget と品質確認は `just bridge-quality` および
+`just verify-realworld-typescript` を使います。
+
+## Generated output の扱い
+
+`internal/generated/` は cache です。`ts2mbt generate` / `vendor` は `.gitignore`
+と `AGENTS.md` を置き、生成ファイルには `AUTO-GENERATED` ヘッダーを付けます。
+upstream typings が変わったら同じコマンドを再実行してください。

--- a/docs/tsacc.md
+++ b/docs/tsacc.md
@@ -1,0 +1,21 @@
+# `tsacc`: checker conformance accuracy の計測
+
+`tsacc` は contributor 用の measurement CLI です。pinned TypeScript conformance
+corpus を走査し、checker の recall と false positive 数を素早く集計します。アプリケーション
+利用者向けの bridge generator ではありません。
+
+```sh
+moon run src/cmd/tsacc
+moon run src/cmd/tsacc --list-misses
+moon run src/cmd/tsacc --list-misses controlFlow
+```
+
+前提として `typescript/` corpus と baseline が checkout 済みである必要があります。
+CI gate や詳細な TS7 baseline との照合には、より完全な次の command を使います。
+
+```sh
+just checker-conformance-oracle --max-fp 0 --max-legal-parsefail 1
+```
+
+未対応機能の優先順位と false-positive を避ける制約は
+[checker priority](./checker-priority.md) に記録しています。

--- a/fixtures/mtsc/known-gaps/README.md
+++ b/fixtures/mtsc/known-gaps/README.md
@@ -1,0 +1,29 @@
+# `mtsc` known checker gaps
+
+Each fixture is a valid TypeScript program for which `tsc --noEmit --strict`
+reports the listed error, but the current `mtsc` checker emits no diagnostic.
+They are an explicit backlog, not supported behavior.
+
+| Fixture                   | TypeScript diagnostic | Missing checker capability                                            |
+| ------------------------- | --------------------- | --------------------------------------------------------------------- |
+| `no-implicit-any.ts`      | TS7006                | Preserve missing parameter annotations and implement `noImplicitAny`. |
+| `primitive-member.ts`     | TS2551                | Model primitive prototype members without flagging valid members.     |
+| `aliased-discriminant.ts` | TS2339                | Propagate narrowing through an aliased discriminant.                  |
+| `overload-resolution.ts`  | TS2769                | Resolve overload candidates at a call site.                           |
+
+The focused `mtsc` test asserts that every fixture is currently accepted. When
+a checker capability is implemented, move the fixture's assertion to a normal
+"reports an error" test and remove it from that known-gap corpus.
+
+Compare the TypeScript baseline locally:
+
+```sh
+pnpm exec tsc --noEmit --strict fixtures/mtsc/known-gaps/*.ts
+```
+
+Run the focused corpus status test:
+
+```sh
+moon test src/cmd/mtsc/main_wbtest.mbt --target native \
+  --filter 'mtsc known-gap corpus records current missed diagnostics'
+```

--- a/fixtures/mtsc/known-gaps/aliased-discriminant.ts
+++ b/fixtures/mtsc/known-gaps/aliased-discriminant.ts
@@ -1,0 +1,12 @@
+// tsc --strict: TS2339 — Property 'number' does not exist on type '{ text: string }'.
+type Value =
+  | { kind: "text"; payload: { text: string } }
+  | { kind: "number"; payload: { number: number } }
+
+export function format(value: Value): string {
+  const kind = value.kind
+  if (kind === "text") {
+    return value.payload.number.toFixed()
+  }
+  return ""
+}

--- a/fixtures/mtsc/known-gaps/no-implicit-any.ts
+++ b/fixtures/mtsc/known-gaps/no-implicit-any.ts
@@ -1,0 +1,4 @@
+// tsc --strict: TS7006 — Parameter 'value' implicitly has an 'any' type.
+export function identity(value) {
+  return value
+}

--- a/fixtures/mtsc/known-gaps/overload-resolution.ts
+++ b/fixtures/mtsc/known-gaps/overload-resolution.ts
@@ -1,0 +1,8 @@
+// tsc --strict: TS2769 — No overload matches this call.
+function parse(value: string): string
+function parse(value: number): number
+function parse(value: string | number): string | number {
+  return value
+}
+
+export const result = parse(true)

--- a/fixtures/mtsc/known-gaps/primitive-member.ts
+++ b/fixtures/mtsc/known-gaps/primitive-member.ts
@@ -1,0 +1,2 @@
+// tsc --strict: TS2551 — Property 'toFixed' does not exist on type '"ready"'.
+export const result = "ready".toFixed()

--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/ts"
 
-version = "0.5.0"
+version = "0.5.1"
 
 import {
   "moonbitlang/async@0.20.2",

--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/ts"
 
-version = "0.4.1"
+version = "0.5.0"
 
 import {
   "moonbitlang/async@0.20.2",

--- a/src/bridge/pkg.generated.mbti
+++ b/src/bridge/pkg.generated.mbti
@@ -128,6 +128,8 @@ pub struct MbtiTypescriptScaffoldBundle {
   package_json : String
   autolink_diagnostics_md : String
   autolink_glue_mbt : String
+  runtime_value_adapter_js : String
+  runtime_boundary_export_names : Array[String]
   files : Array[MbtiTypescriptPackageFile]
 }
 

--- a/src/cmd/mbt2ts/main.mbt
+++ b/src/cmd/mbt2ts/main.mbt
@@ -1,7 +1,7 @@
 ///|
 fn mbt2ts_print_usage() -> Unit {
   println(
-    "Usage: mbt2ts [--input <pkg-or-mbti> --out <dir>] [<subcommand> args...]",
+    "Usage: mbt2ts --pkg [options] | [--input <pkg-or-mbti> --out <dir>] [<subcommand> args...]",
   )
   println("")
   println(
@@ -24,6 +24,7 @@ fn mbt2ts_print_usage() -> Unit {
 /// stable.
 pub fn mbt2ts_help_lines() -> Array[String] {
   [
+    "  --pkg [--out <dir>] [--strict] [--no-facade] [--import-rewrites <json>] Build current MoonBit library packages and write an npm-publishable package to ./npm",
     "  --input <pkg-or-mbti> --out <dir> [--diagnostics <path>] [--strict] [--no-facade] [--import-rewrites <json>] Generate a complete build-backed TypeScript package from a MoonBit pkg.generated.mbti",
     "  decl <mbti> [out] Emit TypeScript declarations directly from a MoonBit .mbti interface",
     "  link-config <mbti> [out] Emit MoonBit link.js.exports config from a .mbti interface",
@@ -68,6 +69,12 @@ async fn mbt2ts_main_async() -> Unit {
   }
   if @ts.cli_token_is_version(args[1]) {
     @ts.cli_print_version("mbt2ts")
+    return
+  }
+  if args[1] == "--pkg" {
+    if !@ts.run_mbt_to_ts_pkg_cli(args, 2, print_help=mbt2ts_print_usage) {
+      @ts.cli_fail("mbt2ts")
+    }
     return
   }
   if args[1].has_prefix("--") || args[1] == "-h" {

--- a/src/cmd/mbt2ts/main_wbtest.mbt
+++ b/src/cmd/mbt2ts/main_wbtest.mbt
@@ -3,6 +3,10 @@ test "mbt2ts keeps the unified package generator as its public CLI contract" {
   let help = mbt2ts_help_lines()
   assert_eq(
     help[0],
+    "  --pkg [--out <dir>] [--strict] [--no-facade] [--import-rewrites <json>] Build current MoonBit library packages and write an npm-publishable package to ./npm",
+  )
+  assert_eq(
+    help[1],
     "  --input <pkg-or-mbti> --out <dir> [--diagnostics <path>] [--strict] [--no-facade] [--import-rewrites <json>] Generate a complete build-backed TypeScript package from a MoonBit pkg.generated.mbti",
   )
   assert_true(

--- a/src/cmd/mtsc/main_wbtest.mbt
+++ b/src/cmd/mtsc/main_wbtest.mbt
@@ -23,3 +23,18 @@ test "mtsc typecheck accepts an imported binding" {
   ).unwrap()
   assert_true(issues.length() == 0)
 }
+
+///|
+async test "mtsc known-gap corpus records current missed diagnostics" {
+  let cases = [
+    "fixtures/mtsc/known-gaps/no-implicit-any.ts", "fixtures/mtsc/known-gaps/primitive-member.ts",
+    "fixtures/mtsc/known-gaps/aliased-discriminant.ts", "fixtures/mtsc/known-gaps/overload-resolution.ts",
+  ]
+  for path in cases {
+    let source = @fs.read_file(path).text() catch {
+      e => fail("failed to read known mtsc gap fixture \{path}: \{e}")
+    }
+    let issues = mtsc_collect_type_issues(source, false).unwrap()
+    assert_eq(issues.length(), 0)
+  }
+}

--- a/src/main.mbt
+++ b/src/main.mbt
@@ -530,6 +530,53 @@ async fn copy_binary_file(from : String, to : String) -> Bool {
 }
 
 ///|
+/// Publish a staged generated bridge file. The async filesystem's atomic
+/// rename is only available to the native backend today; the JS fallback
+/// writes the complete staging contents before removing that staging file.
+/// Keeping this target-specific boundary lets the bridge generator itself be
+/// built for JavaScript and therefore published through `mbt2ts --pkg`.
+#cfg(not(target="js"))
+async fn publish_staged_bridge_file(
+  stage_path : String,
+  output_path : String,
+) -> Bool {
+  let _ = @async_fs.rename(stage_path, output_path, replace=true) catch {
+    e => {
+      println("Write error: could not publish \{output_path}: \{e}")
+      return false
+    }
+  }
+  true
+}
+
+///|
+#cfg(target="js")
+async fn publish_staged_bridge_file(
+  stage_path : String,
+  output_path : String,
+) -> Bool {
+  let bytes = @fs.read_file(stage_path) catch {
+    e => {
+      println("Write error: could not read staged file \{stage_path}: \{e}")
+      return false
+    }
+  }
+  let _ = @fs.write_file(output_path, bytes, create=0o644) catch {
+    e => {
+      println("Write error: could not publish \{output_path}: \{e}")
+      return false
+    }
+  }
+  let _ = @fs.remove(stage_path) catch {
+    e => {
+      println("Write error: could not remove staged file \{stage_path}: \{e}")
+      return false
+    }
+  }
+  true
+}
+
+///|
 async fn remove_moonbit_js_glue_dir(path : String) -> Unit {
   let _ = @fs.rmdir(path, recursive=true) catch { _ => () }
 }
@@ -1242,11 +1289,8 @@ pub async fn emit_moonbit_bridge_package(
       bridge_package_stage_file_name(name),
     )
     let output_path = join_output_path(output_dir, name)
-    let _ = @async_fs.rename(stage_path, output_path, replace=true) catch {
-      e => {
-        println("Write error: could not publish \{output_path}: \{e}")
-        return false
-      }
+    if !publish_staged_bridge_file(stage_path, output_path) {
+      return false
     }
   }
   // MoonBit now uses the DSL manifest. Remove the legacy JSON manifest only
@@ -1988,9 +2032,50 @@ fn bridge_package_stage_file_name(name : String) -> String {
 
 ///|
 fn string_to_bytes(s : String) -> Bytes {
+  // MoonBit strings are indexed by UTF-16 code units. Generated source can
+  // contain documentation and string literals outside ASCII, so truncating a
+  // unit to its low byte produces malformed JavaScript and declaration files.
   let arr : Array[Byte] = []
-  for i = 0; i < s.length(); i = i + 1 {
-    arr.push((s[i].to_int() & 0xFF).to_byte())
+  let mut i = 0
+  while i < s.length() {
+    let unit = s[i].to_int()
+    if unit < 0x80 {
+      arr.push(unit.to_byte())
+      i += 1
+    } else if unit < 0x800 {
+      arr.push(((unit >> 6) | 0xC0).to_byte())
+      arr.push(((unit & 0x3F) | 0x80).to_byte())
+      i += 1
+    } else if unit >= 0xD800 && unit < 0xDC00 {
+      if i + 1 < s.length() {
+        let low = s[i + 1].to_int()
+        if low >= 0xDC00 && low < 0xE000 {
+          let code_point = (((unit - 0xD800) << 10) | (low - 0xDC00)) + 0x10000
+          arr.push(((code_point >> 18) | 0xF0).to_byte())
+          arr.push((((code_point >> 12) & 0x3F) | 0x80).to_byte())
+          arr.push((((code_point >> 6) & 0x3F) | 0x80).to_byte())
+          arr.push(((code_point & 0x3F) | 0x80).to_byte())
+          i += 2
+          continue
+        }
+      }
+      // Unpaired high surrogate: encode the Unicode replacement character.
+      arr.push((0xEF : Int).to_byte())
+      arr.push((0xBF : Int).to_byte())
+      arr.push((0xBD : Int).to_byte())
+      i += 1
+    } else if unit >= 0xDC00 && unit < 0xE000 {
+      // Stray low surrogate: encode the Unicode replacement character.
+      arr.push((0xEF : Int).to_byte())
+      arr.push((0xBF : Int).to_byte())
+      arr.push((0xBD : Int).to_byte())
+      i += 1
+    } else {
+      arr.push(((unit >> 12) | 0xE0).to_byte())
+      arr.push((((unit >> 6) & 0x3F) | 0x80).to_byte())
+      arr.push(((unit & 0x3F) | 0x80).to_byte())
+      i += 1
+    }
   }
   Bytes::from_array(arr)
 }

--- a/src/main_wbtest.mbt
+++ b/src/main_wbtest.mbt
@@ -36,6 +36,20 @@ async test "mtsc JavaScript module exposes only the Vite graph checker ABI" {
 }
 
 ///|
+async test "write_text_file preserves UTF-8 text in generated outputs" {
+  let root = wbtest_tmp_project_benchmark_root("write_text_file_utf8")
+  let _ = try? @fs.rmdir(root, recursive=true)
+  ensure_dir_tree(root)
+  let path = wbtest_join_path(root, "unicode.txt")
+  let expected = "MoonBit — 日本語 😀\n"
+  assert_true(write_text_file(path, expected))
+  let actual = @fs.read_file(path).text() catch {
+    e => fail("generated text was not valid UTF-8: \{e}")
+  }
+  assert_eq(actual, expected)
+}
+
+///|
 async fn wbtest_collect_relative_files(
   root : String,
   relative_dir : String,
@@ -984,6 +998,192 @@ async test "emit_typescript_scaffold_from_mbti handles DSL moon.mod source subdi
   )
   assert_true(root_js.contains("function __tsmbt_public_return(value)"))
   assert_true(root_js.contains("export function make(...args)"))
+}
+
+///|
+async test "emit_typescript_npm_package_from_project creates a publishable npm directory" {
+  let root = wbtest_tmp_project_benchmark_root("mbt2ts_pkg_publishable")
+  let _ = try? @fs.rmdir(root, recursive=true)
+  let source_root = wbtest_join_path(root, "src")
+  ensure_dir_tree(source_root)
+  @fs.write_file(
+    wbtest_join_path(root, "moon.mod.json"),
+    (
+      #|{
+      #|  "name": "fixture/npm-ready",
+      #|  "version": "1.2.3",
+      #|  "description": "A publishable MoonBit fixture",
+      #|  "license": "Apache-2.0",
+      #|  "repository": "https://github.com/fixture/npm-ready",
+      #|  "source": "src",
+      #|  "preferred-target": "js"
+      #|}
+    ),
+    create=0o644,
+  )
+  @fs.write_file(wbtest_join_path(source_root, "moon.pkg"), "", create=0o644)
+  @fs.write_file(
+    wbtest_join_path(source_root, "lib.mbt"),
+    (
+      #|///|
+      #|pub fn greet(name : String) -> String {
+      #|  "Hello, " + name
+      #|}
+    ),
+    create=0o644,
+  )
+  @fs.write_file(
+    wbtest_join_path(root, "README.md"),
+    "# fixture npm package\n",
+    create=0o644,
+  )
+  @fs.write_file(
+    wbtest_join_path(root, "LICENSE"),
+    "Apache-2.0\n",
+    create=0o644,
+  )
+
+  assert_true(
+    emit_typescript_npm_package_from_project(root, None, None, false, true),
+  )
+
+  let npm_dir = wbtest_join_path(root, "npm")
+  let package_json = @fs.read_file(wbtest_join_path(npm_dir, "package.json")).text() catch {
+    e => fail("failed to read generated npm package.json: \{e}")
+  }
+  assert_true(package_json.contains("\"name\": \"@fixture/npm-ready\""))
+  assert_true(package_json.contains("\"version\": \"1.2.3\""))
+  assert_true(
+    package_json.contains("\"description\": \"A publishable MoonBit fixture\""),
+  )
+  assert_true(package_json.contains("\"license\": \"Apache-2.0\""))
+  assert_true(
+    package_json.contains(
+      "\"repository\": { \"type\": \"git\", \"url\": \"git+https://github.com/fixture/npm-ready.git\" }",
+    ),
+  )
+  assert_true(package_json.contains("\"files\": ["))
+  assert_true(package_json.contains("\"index.d.ts\""))
+  assert_true(package_json.contains("\"index.js\""))
+  assert_false(package_json.contains("**/*.d.ts"))
+  assert_true(@fs.exists(wbtest_join_path(npm_dir, "index.js")))
+  assert_true(@fs.exists(wbtest_join_path(npm_dir, "index.d.ts")))
+  assert_true(@fs.exists(wbtest_join_path(npm_dir, "README.md")))
+  assert_true(@fs.exists(wbtest_join_path(npm_dir, "LICENSE")))
+  let (pack_exit, pack_output) = @process.collect_output_merged(
+    "npm",
+    ["pack", "--dry-run"],
+    cwd=npm_dir,
+  )
+  if pack_exit != 0 {
+    fail("npm pack --dry-run failed: \{pack_output.text()}")
+  }
+}
+
+///|
+async test "emit_typescript_npm_package_from_project exports unreferenced source submodules" {
+  let root = wbtest_tmp_project_benchmark_root("mbt2ts_pkg_submodule_exports")
+  let _ = try? @fs.rmdir(root, recursive=true)
+  let source_root = wbtest_join_path(root, "src")
+  let mtsc_root = wbtest_join_path(source_root, "mtsc")
+  let command_root = wbtest_join_path(source_root, "cmd/checker")
+  let ignored_command_root = wbtest_join_path(source_root, "cmd/ignored")
+  ensure_dir_tree(mtsc_root)
+  ensure_dir_tree(command_root)
+  ensure_dir_tree(ignored_command_root)
+  @fs.write_file(
+    wbtest_join_path(root, "moon.mod.json"),
+    (
+      #|{
+      #|  "name": "fixture/npm-submodule-exports",
+      #|  "version": "1.2.3",
+      #|  "source": "src",
+      #|  "preferred-target": "js",
+      #|  "options": { "exclude": ["src/cmd/ignored"] }
+      #|}
+    ),
+    create=0o644,
+  )
+  @fs.write_file(
+    wbtest_join_path(source_root, "moon.pkg"),
+    "pkgtype(kind: \"executable\")\n",
+    create=0o644,
+  )
+  @fs.write_file(
+    wbtest_join_path(source_root, "root.mbt"),
+    "pub fn root_value() -> String { \"root\" }\n",
+    create=0o644,
+  )
+  @fs.write_file(
+    wbtest_join_path(source_root, "main.mbt"),
+    "pub fn main_helper() -> String { \"helper\" }\nfn main { println(\"root command\") }\n",
+    create=0o644,
+  )
+  @fs.write_file(wbtest_join_path(mtsc_root, "moon.pkg"), "", create=0o644)
+  @fs.write_file(
+    wbtest_join_path(mtsc_root, "checker.mbt"),
+    "pub fn check_source(source : String) -> String { if source == \"bad\" { \"type error\" } else { \"\" } }\n",
+    create=0o644,
+  )
+  @fs.write_file(
+    wbtest_join_path(command_root, "moon.pkg"),
+    "pkgtype(kind: \"executable\")\n",
+    create=0o644,
+  )
+  @fs.write_file(
+    wbtest_join_path(command_root, "main.mbt"),
+    "fn main { println(\"checker command\") }\n",
+    create=0o644,
+  )
+  @fs.write_file(
+    wbtest_join_path(ignored_command_root, "moon.pkg"),
+    "pkgtype(kind: \"executable\")\n",
+    create=0o644,
+  )
+  @fs.write_file(
+    wbtest_join_path(ignored_command_root, "main.mbt"),
+    "fn main { println(\"ignored command\") }\n",
+    create=0o644,
+  )
+
+  assert_true(
+    emit_typescript_npm_package_from_project(root, None, None, false, true),
+  )
+
+  let npm_dir = wbtest_join_path(root, "npm")
+  let package_json = @fs.read_file(wbtest_join_path(npm_dir, "package.json")).text() catch {
+    e => fail("failed to read generated submodule package.json: \{e}")
+  }
+  let mtsc_decl = @fs.read_file(wbtest_join_path(npm_dir, "mtsc/index.d.ts")).text() catch {
+    e => fail("failed to read generated mtsc declaration: \{e}")
+  }
+  assert_true(
+    package_json.contains(
+      "\"./mtsc\": { \"types\": \"./mtsc/index.d.ts\", \"import\": \"./mtsc/index.js\" }",
+    ),
+  )
+  assert_true(@fs.exists(wbtest_join_path(npm_dir, "mtsc/index.js")))
+  assert_true(mtsc_decl.contains("export function check_source"))
+  assert_true(package_json.contains("\"bin\": {"))
+  assert_true(package_json.contains("\"checker\": \"./bin/checker.js\""))
+  let command_bin = @fs.read_file(wbtest_join_path(npm_dir, "bin/checker.js")).text() catch {
+    e => fail("failed to read generated command bin: \{e}")
+  }
+  assert_true(command_bin.has_prefix("#!/usr/bin/env node\n"))
+  assert_false(package_json.contains("\"./cmd/checker\""))
+  assert_true(
+    package_json.contains(
+      "\"npm-submodule-exports\": \"./bin/npm-submodule-exports.js\"",
+    ),
+  )
+  let root_command_bin = @fs.read_file(
+    wbtest_join_path(npm_dir, "bin/npm-submodule-exports.js"),
+  ).text() catch {
+    e => fail("failed to read generated root command bin: \{e}")
+  }
+  assert_true(root_command_bin.has_prefix("#!/usr/bin/env node\n"))
+  assert_false(package_json.contains("\"ignored\": \"./bin/ignored.js\""))
+  assert_false(@fs.exists(wbtest_join_path(npm_dir, "bin/ignored.js")))
 }
 
 ///|

--- a/src/main_wbtest.mbt
+++ b/src/main_wbtest.mbt
@@ -16,6 +16,12 @@ fn wbtest_basename(path : String) -> String {
 }
 
 ///|
+test "types package hint rewrites scoped package names" {
+  assert_eq(types_package_hint("@scope/no-types"), "@types/scope__no-types")
+  assert_eq(types_package_hint("no-types"), "@types/no-types")
+}
+
+///|
 fn wbtest_tmp_neverthrow_like_root(name : String) -> String {
   "/tmp/ts_mbt_neverthrow_like_" + name
 }

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -44,6 +44,8 @@ pub async fn emit_typescript_package_from_mbti(String, String, String?) -> Bool
 
 pub async fn emit_typescript_scaffold_from_mbti(String, String, String?) -> Bool
 
+pub async fn run_mbt_to_ts_pkg_cli(Array[String], Int, print_help~ : () -> Unit) -> Bool
+
 pub async fn run_mbt_to_ts_unified_cli(Array[String], Int, print_help~ : () -> Unit) -> Bool
 
 pub async fn run_ts_to_mbt_unified_cli(Array[String], Int, print_help~ : () -> Unit) -> Bool

--- a/src/unified_cli.mbt
+++ b/src/unified_cli.mbt
@@ -18,6 +18,97 @@ priv struct UnifiedTsmbtOptions {
 }
 
 ///|
+/// Options that belong to the project-level `mbt2ts --pkg` entrypoint.
+/// Unlike the lower-level unified input flow, this command owns `moon info`,
+/// derives package metadata from the module manifest, and defaults to a
+/// publish directory at `<module>/npm`.
+priv struct Mbt2tsPkgOptions {
+  out : String?
+  import_rewrite_path : String?
+  strict : Bool
+  facade : Bool
+}
+
+///|
+/// An executable source package to publish through `package.json#bin`.
+/// Commands stay out of the TypeScript library export graph, but their
+/// compiled JavaScript remains available to npm's command shim.
+priv struct Mbt2tsPkgCommand {
+  name : String
+  source_relative_dir : String
+}
+
+///|
+fn parse_mbt2ts_pkg_options(
+  args : Array[String],
+  start : Int,
+) -> (Mbt2tsPkgOptions?, String?) {
+  let mut out : String? = None
+  let mut import_rewrite_path : String? = None
+  let mut strict = false
+  let mut facade = true
+  let mut idx = start
+  while idx < args.length() {
+    let arg = args[idx]
+    match arg {
+      "--help" | "-h" => return (None, Some("help"))
+      "--out" | "-o" => {
+        if idx + 1 >= args.length() {
+          return (None, Some("missing value for \{arg}"))
+        }
+        out = Some(args[idx + 1])
+        idx += 2
+        continue
+      }
+      "--import-rewrites" | "--import-rewrite" => {
+        if idx + 1 >= args.length() {
+          return (None, Some("missing value for \{arg}"))
+        }
+        import_rewrite_path = Some(args[idx + 1])
+        idx += 2
+        continue
+      }
+      "--strict" => {
+        strict = true
+        idx += 1
+        continue
+      }
+      "--no-strict" => {
+        strict = false
+        idx += 1
+        continue
+      }
+      "--facade" => {
+        facade = true
+        idx += 1
+        continue
+      }
+      "--no-facade" => {
+        facade = false
+        idx += 1
+        continue
+      }
+      _ => ()
+    }
+    if arg.has_prefix("--out=") {
+      out = Some(arg["--out=".length():arg.length()].to_owned())
+    } else if arg.has_prefix("--import-rewrites=") {
+      import_rewrite_path = Some(
+        arg["--import-rewrites=".length():arg.length()].to_owned(),
+      )
+    } else if arg.has_prefix("--import-rewrite=") {
+      import_rewrite_path = Some(
+        arg["--import-rewrite=".length():arg.length()].to_owned(),
+      )
+    } else {
+      return (None, Some("unknown option: \{arg}"))
+    }
+    idx += 1
+  }
+  (Some({ out, import_rewrite_path, strict, facade }), None)
+}
+
+///|
 fn parse_tsmbt_direction(value : String) -> TsmbtDirection? {
   match value {
     "auto" => Some(TsmbtDirection::Auto)
@@ -767,6 +858,890 @@ async fn emit_unified_tsmbt_scaffold(
 }
 
 ///|
+fn mbt2ts_pkg_path_is_absolute(path : String) -> Bool {
+  path.has_prefix("/")
+}
+
+///|
+fn mbt2ts_pkg_source_root(
+  project_root : String,
+  moon_mod_source : String,
+) -> String {
+  match parse_moon_mod_string_field(moon_mod_source, "source") {
+    Some(source) if source != "" && source != "." =>
+      main_join_path(project_root, source)
+    _ => project_root
+  }
+}
+
+///|
+/// Development commands are executable implementation details, not library
+/// subpath exports. Every other source directory with a `moon.pkg` becomes a
+/// publishable npm submodule.
+fn mbt2ts_pkg_skip_submodule_dir(name : String) -> Bool {
+  unified_tsmbt_skip_scan_dir(name) ||
+  name == "cmd" ||
+  name.has_prefix("__tsmbt_")
+}
+
+///|
+fn mbt2ts_pkg_skip_command_scan_dir(name : String) -> Bool {
+  unified_tsmbt_skip_scan_dir(name) || name.has_prefix("__tsmbt_")
+}
+
+///|
+fn mbt2ts_pkg_line_defines_main(line : String, prefix : String) -> Bool {
+  if !line.has_prefix(prefix) {
+    return false
+  }
+  if line.length() == prefix.length() {
+    return true
+  }
+  let next = line[prefix.length()].unsafe_to_char()
+  next == ' ' || next == '(' || next == '{'
+}
+
+///|
+fn mbt2ts_pkg_source_defines_main(source : String) -> Bool {
+  for line_view in source.split("\n") {
+    let line = line_view.trim().to_owned()
+    if mbt2ts_pkg_line_defines_main(line, "fn main") ||
+      mbt2ts_pkg_line_defines_main(line, "async fn main") ||
+      mbt2ts_pkg_line_defines_main(line, "pub fn main") ||
+      mbt2ts_pkg_line_defines_main(line, "pub async fn main") {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn mbt2ts_pkg_last_path_segment(path : String) -> String {
+  match path.rev_find("/") {
+    Some(idx) => path[idx + 1:path.length()].to_owned()
+    None => path
+  }
+}
+
+///|
+fn mbt2ts_pkg_root_command_name(root_package_name : String) -> String {
+  mbt2ts_pkg_last_path_segment(root_package_name)
+}
+
+///|
+fn mbt2ts_pkg_command_name(
+  source_relative_dir : String,
+  root_package_name : String,
+) -> String {
+  if source_relative_dir == "" {
+    mbt2ts_pkg_root_command_name(root_package_name)
+  } else {
+    mbt2ts_pkg_last_path_segment(source_relative_dir)
+  }
+}
+
+///|
+fn mbt2ts_pkg_quoted_strings(source : String) -> Array[String] {
+  let values : Array[String] = []
+  let mut cursor = 0
+  while cursor < source.length() {
+    let remaining = source[cursor:].to_owned()
+    match remaining.find("\"") {
+      None => return values
+      Some(open_relative) => {
+        let value_start = cursor + open_relative + 1
+        let after_open = source[value_start:].to_owned()
+        match after_open.find("\"") {
+          None => return values
+          Some(close_relative) => {
+            values.push(
+              source[value_start:value_start + close_relative].to_owned(),
+            )
+            cursor = value_start + close_relative + 1
+          }
+        }
+      }
+    }
+  }
+  values
+}
+
+///|
+fn mbt2ts_pkg_normalize_excluded_source_dir(
+  path : String,
+  source_root_rel : String,
+) -> String? {
+  let normalized = path.trim().to_owned()
+  if normalized == "" {
+    return None
+  }
+  let source_root = source_root_rel.trim().to_owned()
+  if source_root == "" || source_root == "." {
+    return Some(normalized)
+  }
+  if normalized == source_root {
+    return Some("")
+  }
+  let source_prefix = source_root + "/"
+  if normalized.has_prefix(source_prefix) {
+    return Some(normalized[source_prefix.length():].to_owned())
+  }
+  // MoonBit accepts an exclusion relative to the source root as well as a
+  // module-root-relative one. Keeping the value lets either form match.
+  Some(normalized)
+}
+
+///|
+fn mbt2ts_pkg_manifest_excluded_command_dirs(
+  moon_mod_source : String,
+  source_root_rel : String,
+) -> Array[String] {
+  let dirs : Array[String] = []
+  let mut cursor = 0
+  while cursor < moon_mod_source.length() {
+    let remaining = moon_mod_source[cursor:].to_owned()
+    match remaining.find("exclude") {
+      None => return dirs
+      Some(exclude_relative) => {
+        let after_key = cursor + exclude_relative + "exclude".length()
+        let after_key_source = moon_mod_source[after_key:].to_owned()
+        match after_key_source.find("[") {
+          None => cursor = after_key
+          Some(open_relative) => {
+            let values_start = after_key + open_relative + 1
+            let values_tail = moon_mod_source[values_start:].to_owned()
+            match values_tail.find("]") {
+              None => return dirs
+              Some(close_relative) => {
+                let values_source = moon_mod_source[values_start:values_start +
+                close_relative].to_owned()
+                for path in mbt2ts_pkg_quoted_strings(values_source) {
+                  match
+                    mbt2ts_pkg_normalize_excluded_source_dir(
+                      path, source_root_rel,
+                    ) {
+                    Some(dir) if !dirs.contains(dir) => dirs.push(dir)
+                    _ => ()
+                  }
+                }
+                cursor = values_start + close_relative + 1
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  dirs
+}
+
+///|
+fn mbt2ts_pkg_command_dir_is_excluded(
+  source_relative_dir : String,
+  excluded_dirs : Array[String],
+) -> Bool {
+  excluded_dirs.any(fn(excluded) {
+    source_relative_dir == excluded ||
+    source_relative_dir.has_prefix(excluded + "/")
+  })
+}
+
+///|
+async fn mbt2ts_pkg_collect_commands_from_dir(
+  source_root : String,
+  source_relative_dir : String,
+  root_package_name : String,
+  excluded_dirs : Array[String],
+  commands : Array[Mbt2tsPkgCommand],
+) -> Bool {
+  if mbt2ts_pkg_command_dir_is_excluded(source_relative_dir, excluded_dirs) {
+    return true
+  }
+  let dir = if source_relative_dir == "" {
+    source_root
+  } else {
+    main_join_path(source_root, source_relative_dir)
+  }
+  let moon_pkg_path = main_join_path(dir, "moon.pkg")
+  let main_path = main_join_path(dir, "main.mbt")
+  if main_file_exists(moon_pkg_path) && main_file_exists(main_path) {
+    let main_source = @fs.read_file(main_path).text() catch {
+      e => {
+        println("Error: --pkg could not read command source \{main_path}: \{e}")
+        return false
+      }
+    }
+    if mbt2ts_pkg_source_defines_main(main_source) {
+      let name = mbt2ts_pkg_command_name(source_relative_dir, root_package_name)
+      if name == "" || commands.any(fn(command) { command.name == name }) {
+        println("Error: --pkg found duplicate or empty command name \{name}")
+        return false
+      }
+      commands.push({ name, source_relative_dir })
+    }
+  }
+  let entries = @fs.readdir(
+    dir,
+    include_hidden=false,
+    include_special=false,
+    sort=true,
+  ) catch {
+    e => {
+      println("Error: --pkg could not read source directory \{dir}: \{e}")
+      return false
+    }
+  }
+  for name in entries {
+    if mbt2ts_pkg_skip_command_scan_dir(name) {
+      continue
+    }
+    let child_dir = main_join_path(dir, name)
+    let kind = @fs.kind(child_dir, follow_symlink=false) catch {
+      _ => @fs.FileKind::Unknown
+    }
+    if !(kind is @fs.FileKind::Directory) {
+      continue
+    }
+    let child_relative_dir = if source_relative_dir == "" {
+      name
+    } else {
+      source_relative_dir + "/" + name
+    }
+    if !mbt2ts_pkg_collect_commands_from_dir(
+        source_root, child_relative_dir, root_package_name, excluded_dirs, commands,
+      ) {
+      return false
+    }
+  }
+  true
+}
+
+///|
+async fn mbt2ts_pkg_collect_commands(
+  source_root : String,
+  root_package_name : String,
+  source_root_rel : String,
+  moon_mod_source : String,
+) -> Array[Mbt2tsPkgCommand]? {
+  let commands : Array[Mbt2tsPkgCommand] = []
+  let excluded_dirs = mbt2ts_pkg_manifest_excluded_command_dirs(
+    moon_mod_source, source_root_rel,
+  )
+  if !mbt2ts_pkg_collect_commands_from_dir(
+      source_root, "", root_package_name, excluded_dirs, commands,
+    ) {
+    return None
+  }
+  Some(commands)
+}
+
+///|
+/// Collect generated interfaces for every library package below the source
+/// root. `moon info` runs before this scan, so a package without its generated
+/// interface is an actionable generation failure rather than a silent omission.
+async fn mbt2ts_pkg_collect_submodule_mbti_paths(
+  dir : String,
+  paths : Array[String],
+) -> Bool {
+  let entries = @fs.readdir(
+    dir,
+    include_hidden=false,
+    include_special=false,
+    sort=true,
+  ) catch {
+    e => {
+      println("Error: --pkg could not read source directory \{dir}: \{e}")
+      return false
+    }
+  }
+  for name in entries {
+    if mbt2ts_pkg_skip_submodule_dir(name) {
+      continue
+    }
+    let path = main_join_path(dir, name)
+    let kind = @fs.kind(path, follow_symlink=false) catch {
+      _ => @fs.FileKind::Unknown
+    }
+    if !(kind is @fs.FileKind::Directory) {
+      continue
+    }
+    let moon_pkg_path = main_join_path(path, "moon.pkg")
+    if main_file_exists(moon_pkg_path) {
+      let mbti_path = main_join_path(path, "pkg.generated.mbti")
+      if !main_file_exists(mbti_path) {
+        println(
+          "Error: moon info did not generate submodule interface \{mbti_path}",
+        )
+        return false
+      }
+      paths.push(mbti_path)
+    }
+    if !mbt2ts_pkg_collect_submodule_mbti_paths(path, paths) {
+      return false
+    }
+  }
+  true
+}
+
+///|
+/// Select the local source submodules that belong to the root MoonBit package.
+/// The generated umbrella MBTI below makes otherwise-unreferenced packages
+/// visible to the existing recursive TypeScript scaffold emitter.
+async fn mbt2ts_pkg_collect_submodule_names(
+  source_root : String,
+  root_package_name : String,
+) -> Array[String]? {
+  let paths : Array[String] = []
+  if !mbt2ts_pkg_collect_submodule_mbti_paths(source_root, paths) {
+    return None
+  }
+  let names : Array[String] = []
+  let prefix = root_package_name + "/"
+  for path in paths {
+    let source = @fs.read_file(path).text() catch {
+      e => {
+        println("Error: --pkg could not read submodule interface \{path}: \{e}")
+        return None
+      }
+    }
+    let name = match parse_mbti_package_name_from_source(source) {
+      Some(name) => name
+      None => {
+        println(
+          "Error: --pkg submodule interface has no package declaration: \{path}",
+        )
+        return None
+      }
+    }
+    if !name.has_prefix(prefix) {
+      println(
+        "Error: --pkg submodule \{name} is outside root package \{root_package_name}",
+      )
+      return None
+    }
+    if !names.contains(name) {
+      names.push(name)
+    }
+  }
+  names.sort()
+  Some(names)
+}
+
+///|
+/// Preserve the real root declarations while adding synthetic local imports.
+/// The bridge emitter already knows how to turn a recursively loaded MBTI
+/// graph into npm subpath exports; this only supplies the complete graph.
+fn mbt2ts_pkg_render_umbrella_mbti(
+  root_source : String,
+  submodule_names : Array[String],
+) -> String {
+  let lines : Array[String] = []
+  let mut inserted_imports = false
+  for line_view in root_source.split("\n") {
+    let line = line_view.to_owned()
+    lines.push(line)
+    if !inserted_imports && line.trim().has_prefix("package \"") {
+      lines.push("")
+      lines.push("import {")
+      for idx in 0..<submodule_names.length() {
+        lines.push("  \"\{submodule_names[idx]}\" @tsmbt_submodule_\{idx},")
+      }
+      lines.push("}")
+      inserted_imports = true
+    }
+  }
+  lines.join("\n")
+}
+
+///|
+fn mbt2ts_pkg_output_dir(project_root : String, requested : String?) -> String {
+  match requested {
+    Some(path) if mbt2ts_pkg_path_is_absolute(path) => path
+    Some(path) => main_join_path(project_root, path)
+    None => main_join_path(project_root, "npm")
+  }
+}
+
+///|
+fn mbt2ts_pkg_command_build_target(
+  source_root_rel : String,
+  source_relative_dir : String,
+) -> String {
+  let root = if source_root_rel == "." { "" } else { source_root_rel }
+  if root == "" {
+    source_relative_dir
+  } else if source_relative_dir == "" {
+    root
+  } else {
+    root + "/" + source_relative_dir
+  }
+}
+
+///|
+fn mbt2ts_pkg_command_build_output_dir(
+  module_root : String,
+  command : Mbt2tsPkgCommand,
+) -> String {
+  let build_root = main_join_path(
+    main_join_path(main_join_path(module_root, "_build"), "js"),
+    "debug/build",
+  )
+  if command.source_relative_dir == "" {
+    build_root
+  } else {
+    main_join_path(build_root, command.source_relative_dir)
+  }
+}
+
+///|
+async fn mbt2ts_pkg_copy_command_bin(
+  built_js_path : String,
+  command : Mbt2tsPkgCommand,
+  output_dir : String,
+) -> Bool {
+  let source = @fs.read_file(built_js_path).text() catch {
+    e => {
+      println(
+        "Error: --pkg could not read command build output \{built_js_path}: \{e}",
+      )
+      return false
+    }
+  }
+  let command_js_name = command.name + ".js"
+  let rendered = rewrite_moonbit_js_runtime_text(
+    source,
+    mbt2ts_pkg_last_path_segment(built_js_path) + ".map",
+    command_js_name + ".map",
+  )
+  let bin_path = main_join_path(
+    main_join_path(output_dir, "bin"),
+    command_js_name,
+  )
+  let _ = ensure_dir_tree(main_dirname(bin_path)) catch {
+    e => {
+      println("Write error: could not create command bin directory: \{e}")
+      return false
+    }
+  }
+  let script = if rendered.has_prefix("#!") {
+    rendered
+  } else {
+    "#!/usr/bin/env node\n" + rendered
+  }
+  let _ = @fs.write_file(bin_path, string_to_bytes(script), create=0o755) catch {
+    e => {
+      println("Write error: could not write command bin \{bin_path}: \{e}")
+      return false
+    }
+  }
+  let map_path = built_js_path + ".map"
+  if @fs.exists(map_path) &&
+    !copy_binary_file(
+      map_path,
+      main_join_path(
+        main_join_path(output_dir, "bin"),
+        command_js_name + ".map",
+      ),
+    ) {
+    return false
+  }
+  true
+}
+
+///|
+async fn emit_mbt2ts_pkg_command_bins(
+  module_root : String,
+  source_root_rel : String,
+  output_dir : String,
+  commands : Array[Mbt2tsPkgCommand],
+) -> Bool {
+  for command in commands {
+    let target = mbt2ts_pkg_command_build_target(
+      source_root_rel,
+      command.source_relative_dir,
+    )
+    let args = ["-C", module_root, "build", "--target", "js"]
+    if target != "" {
+      args.push(target)
+    }
+    let (exit_code, output) = @process.collect_output_merged(
+      "moon",
+      args,
+      cwd=".",
+    )
+    if exit_code != 0 {
+      println("Error: --pkg could not build command \{command.name}")
+      println(output.text())
+      return false
+    }
+    let built_js_path = main_join_path(
+      mbt2ts_pkg_command_build_output_dir(module_root, command),
+      command.name + ".js",
+    )
+    if !mbt2ts_pkg_copy_command_bin(built_js_path, command, output_dir) {
+      return false
+    }
+  }
+  true
+}
+
+///|
+fn mbt2ts_pkg_escape_json_string(source : String) -> String {
+  let mut escaped = ""
+  for c in source {
+    if c == '\\' {
+      escaped += "\\\\"
+    } else if c == '"' {
+      escaped += "\\\""
+    } else if c == '\n' {
+      escaped += "\\n"
+    } else if c == '\r' {
+      escaped += "\\r"
+    } else if c == '\t' {
+      escaped += "\\t"
+    } else {
+      escaped += c.to_string()
+    }
+  }
+  escaped
+}
+
+///|
+fn mbt2ts_pkg_publish_path_is_safe(path : String) -> Bool {
+  path != "" &&
+  !path.has_prefix("/") &&
+  !path.contains("\\") &&
+  !path.contains("..")
+}
+
+///|
+fn mbt2ts_pkg_add_publish_path(paths : Array[String], path : String) -> Unit {
+  if mbt2ts_pkg_publish_path_is_safe(path) && !paths.contains(path) {
+    paths.push(path)
+  }
+}
+
+///|
+fn mbt2ts_pkg_collect_publish_paths(
+  source : String,
+  commands : Array[Mbt2tsPkgCommand],
+) -> Array[String] {
+  let paths : Array[String] = []
+  for line_view in source.split("\n") {
+    let line = line_view.to_owned()
+    for marker in ["\"types\": \"./", "\"import\": \"./"] {
+      match line.find(marker) {
+        Some(index) => {
+          let start = index + marker.length()
+          let remainder = line[start:line.length()].to_owned()
+          match remainder.find("\"") {
+            Some(end) => {
+              let path = remainder[:end].to_owned()
+              mbt2ts_pkg_add_publish_path(paths, path)
+              if path.has_suffix(".js") {
+                mbt2ts_pkg_add_publish_path(paths, path + ".map")
+              }
+            }
+            None => ()
+          }
+        }
+        None => ()
+      }
+    }
+  }
+  for command in commands {
+    let path = "bin/" + command.name + ".js"
+    mbt2ts_pkg_add_publish_path(paths, path)
+    mbt2ts_pkg_add_publish_path(paths, path + ".map")
+  }
+  paths.sort()
+  paths
+}
+
+///|
+fn mbt2ts_pkg_npm_repository_url(repository : String) -> String {
+  if !repository.has_prefix("https://") {
+    return repository
+  }
+  let git_url = "git+" + repository
+  if git_url.has_suffix(".git") {
+    git_url
+  } else {
+    git_url + ".git"
+  }
+}
+
+///|
+fn rewrite_mbt2ts_pkg_package_json(
+  source : String,
+  version : String,
+  description : String?,
+  license : String?,
+  repository : String?,
+  commands : Array[Mbt2tsPkgCommand],
+) -> String? {
+  let publish_paths = mbt2ts_pkg_collect_publish_paths(source, commands)
+  if publish_paths.length() == 0 {
+    return None
+  }
+  let lines : Array[String] = []
+  let mut rewrote_version = false
+  for line_view in source.split("\n") {
+    let line = line_view.to_owned()
+    if line.trim().has_prefix("\"version\":") {
+      lines.push(
+        "  \"version\": \"\{mbt2ts_pkg_escape_json_string(version)}\",",
+      )
+      match description {
+        Some(value) =>
+          lines.push(
+            "  \"description\": \"\{mbt2ts_pkg_escape_json_string(value)}\",",
+          )
+        None => ()
+      }
+      match license {
+        Some(value) =>
+          lines.push(
+            "  \"license\": \"\{mbt2ts_pkg_escape_json_string(value)}\",",
+          )
+        None => ()
+      }
+      match repository {
+        Some(value) =>
+          lines.push(
+            "  \"repository\": { \"type\": \"git\", \"url\": \"\{mbt2ts_pkg_escape_json_string(mbt2ts_pkg_npm_repository_url(value))}\" },",
+          )
+        None => ()
+      }
+      if commands.length() > 0 {
+        lines.push("  \"bin\": {")
+        for idx in 0..<commands.length() {
+          let command = commands[idx]
+          let suffix = if idx + 1 < commands.length() { "," } else { "" }
+          lines.push(
+            "    \"\{mbt2ts_pkg_escape_json_string(command.name)}\": \"./bin/\{mbt2ts_pkg_escape_json_string(command.name)}.js\"\{suffix}",
+          )
+        }
+        lines.push("  },")
+      }
+      lines.push("  \"files\": [")
+      for idx in 0..<publish_paths.length() {
+        let suffix = if idx + 1 < publish_paths.length() { "," } else { "" }
+        lines.push(
+          "    \"\{mbt2ts_pkg_escape_json_string(publish_paths[idx])}\"\{suffix}",
+        )
+      }
+      lines.push("  ],")
+      rewrote_version = true
+    } else {
+      lines.push(line)
+    }
+  }
+  if !rewrote_version {
+    return None
+  }
+  Some(lines.join("\n"))
+}
+
+///|
+async fn copy_mbt2ts_pkg_publish_file(
+  project_root : String,
+  output_dir : String,
+  candidate_names : Array[String],
+) -> Bool {
+  for name in candidate_names {
+    let source = main_join_path(project_root, name)
+    if main_file_exists(source) {
+      return copy_binary_file(source, main_join_path(output_dir, name))
+    }
+  }
+  true
+}
+
+///|
+async fn copy_mbt2ts_pkg_publish_docs(
+  project_root : String,
+  output_dir : String,
+) -> Bool {
+  if !copy_mbt2ts_pkg_publish_file(project_root, output_dir, [
+      "README.md", "README", "README.txt",
+    ]) {
+    return false
+  }
+  copy_mbt2ts_pkg_publish_file(project_root, output_dir, [
+    "LICENSE", "LICENSE.md", "LICENSE.txt", "LICENCE", "LICENCE.md",
+  ])
+}
+
+///|
+/// Build the current MoonBit root package and write an npm publish directory.
+///
+/// This is deliberately project-oriented: it refreshes `pkg.generated.mbti`
+/// from the module's `moon.mod`, sends the root source package through the
+/// build-backed TypeScript scaffold, and then applies publish metadata owned
+/// by the manifest. Low-level `--input` generation remains available for
+/// tooling that already has an interface file.
+async fn emit_typescript_npm_package_from_project(
+  project_root : String,
+  output_dir : String?,
+  import_rewrite_path : String?,
+  strict : Bool,
+  facade : Bool,
+) -> Bool {
+  let module_root = @fs.realpath(project_root) catch { _ => project_root }
+  let moon_mod_source = match read_moon_mod_source(module_root) {
+    Some(source) => source
+    None => {
+      println("Error: --pkg could not read moon.mod from \{module_root}")
+      return false
+    }
+  }
+  let version = match parse_moon_mod_string_field(moon_mod_source, "version") {
+    Some(version) if version != "" => version
+    _ => {
+      println("Error: --pkg requires a non-empty version in moon.mod")
+      return false
+    }
+  }
+  let description = parse_moon_mod_string_field(moon_mod_source, "description")
+  let license = parse_moon_mod_string_field(moon_mod_source, "license")
+  let repository = parse_moon_mod_string_field(moon_mod_source, "repository")
+  let source_root_rel = match
+    parse_moon_mod_string_field(moon_mod_source, "source") {
+    Some(source) if source != "" => source
+    _ => "."
+  }
+  let source_root = mbt2ts_pkg_source_root(module_root, moon_mod_source)
+  let moon_pkg_path = main_join_path(source_root, "moon.pkg")
+  if !main_file_exists(moon_pkg_path) {
+    println(
+      "Error: --pkg expects the module root package at \{moon_pkg_path}; add a root moon.pkg or use the lower-level --input flow.",
+    )
+    return false
+  }
+  let (info_exit, info_output) = @process.collect_output_merged(
+    "moon",
+    ["-C", module_root, "info"],
+    cwd=".",
+  )
+  if info_exit != 0 {
+    println("Error: moon info failed while preparing --pkg")
+    println(info_output.text())
+    return false
+  }
+  let mbti_path = main_join_path(source_root, "pkg.generated.mbti")
+  if !main_file_exists(mbti_path) {
+    println("Error: moon info did not generate \{mbti_path}")
+    return false
+  }
+  let root_mbti_source = @fs.read_file(mbti_path).text() catch {
+    e => {
+      println("Error: --pkg could not read \{mbti_path}: \{e}")
+      return false
+    }
+  }
+  let root_package_name = match
+    parse_mbti_package_name_from_source(root_mbti_source) {
+    Some(name) => name
+    None => {
+      println(
+        "Error: --pkg root interface has no package declaration: \{mbti_path}",
+      )
+      return false
+    }
+  }
+  let submodule_names = match
+    mbt2ts_pkg_collect_submodule_names(source_root, root_package_name) {
+    Some(names) => names
+    None => return false
+  }
+  let commands = match
+    mbt2ts_pkg_collect_commands(
+      source_root, root_package_name, source_root_rel, moon_mod_source,
+    ) {
+    Some(commands) => commands
+    None => return false
+  }
+  let mut umbrella_mbti_path : String? = None
+  let scaffold_mbti_path = if submodule_names.length() == 0 {
+    mbti_path
+  } else {
+    let path = main_join_path(
+      source_root, "__tsmbt_pkg_umbrella.generated.mbti",
+    )
+    if !write_text_file(
+        path,
+        mbt2ts_pkg_render_umbrella_mbti(root_mbti_source, submodule_names),
+      ) {
+      return false
+    }
+    umbrella_mbti_path = Some(path)
+    path
+  }
+  let out = mbt2ts_pkg_output_dir(module_root, output_dir)
+  let scaffold_ok = if facade {
+    emit_typescript_facade_scaffold_from_mbti(
+      scaffold_mbti_path, out, import_rewrite_path,
+    )
+  } else {
+    emit_typescript_scaffold_from_mbti(
+      scaffold_mbti_path, out, import_rewrite_path,
+    )
+  }
+  match umbrella_mbti_path {
+    Some(path) => {
+      let _ = @fs.remove(path) catch { _ => () }
+    }
+    None => ()
+  }
+  if !scaffold_ok {
+    return false
+  }
+  if !emit_mbt2ts_pkg_command_bins(module_root, source_root_rel, out, commands) {
+    return false
+  }
+  let package_json_path = main_join_path(out, "package.json")
+  let generated_package_json = @fs.read_file(package_json_path).text() catch {
+    e => {
+      println("Error: could not read generated package.json: \{e}")
+      return false
+    }
+  }
+  let publish_package_json = match
+    rewrite_mbt2ts_pkg_package_json(
+      generated_package_json, version, description, license, repository, commands,
+    ) {
+    Some(source) => source
+    None => {
+      println("Error: could not apply the moon.mod version to package.json")
+      return false
+    }
+  }
+  if !write_text_file(package_json_path, publish_package_json) {
+    return false
+  }
+  if !copy_mbt2ts_pkg_publish_docs(module_root, out) {
+    return false
+  }
+  let diagnostics_md = @fs.read_file(
+    main_join_path(out, "AUTOLINK_DIAGNOSTICS.md"),
+  ).text() catch {
+    e => {
+      println("Read error: \{e}")
+      return false
+    }
+  }
+  if strict && unified_autolink_diagnostics_has_omissions(diagnostics_md) {
+    println(
+      "Strict mode rejected MoonBit package: omitted autolink members detected.",
+    )
+    return false
+  }
+  println("Wrote publishable npm package to \{out}")
+  true
+}
+
+///|
 /// Run the unified `--input/--out/...` driver with a forced direction.
 /// `print_help` is invoked on `--help`, missing required flags, or option
 /// errors so each cmd module owns its own help banner.
@@ -864,5 +1839,49 @@ pub async fn run_mbt_to_ts_unified_cli(
     start,
     forced_direction=TsmbtDirection::MbtToTs,
     print_help~,
+  )
+}
+
+///|
+/// Public entry for `mbt2ts --pkg`. It discovers the enclosing MoonBit module
+/// from the caller's working directory and leaves all package policy to the
+/// project-level generator above.
+pub async fn run_mbt_to_ts_pkg_cli(
+  args : Array[String],
+  start : Int,
+  print_help~ : () -> Unit,
+) -> Bool {
+  let options = match parse_mbt2ts_pkg_options(args, start) {
+    (Some(options), None) => options
+    (_, Some("help")) => {
+      print_help()
+      return true
+    }
+    (_, Some(message)) => {
+      println("Error: \{message}")
+      print_help()
+      return false
+    }
+    _ => {
+      print_help()
+      return false
+    }
+  }
+  let cwd = @fs.realpath(".") catch { _ => "." }
+  let module_root = match find_nearest_moon_mod_dir(cwd) {
+    Some(root) => root
+    None => {
+      println(
+        "Error: --pkg must run inside a MoonBit module containing moon.mod",
+      )
+      return false
+    }
+  }
+  emit_typescript_npm_package_from_project(
+    module_root,
+    options.out,
+    options.import_rewrite_path,
+    options.strict,
+    options.facade,
   )
 }

--- a/src/vendor.mbt
+++ b/src/vendor.mbt
@@ -13,6 +13,22 @@
 ///
 /// `vendor_root_override` overrides the output root. Defaults to
 /// `<moon-mod source>/internal/generated`.
+fn types_package_hint(pkg_spec : String) -> String {
+  if pkg_spec.has_prefix("@") {
+    match pkg_spec.find("/") {
+      Some(idx) =>
+        "@types/" +
+        pkg_spec[1:idx].to_owned() +
+        "__" +
+        pkg_spec[idx + 1:].to_owned()
+      None => "@types/\{pkg_spec}"
+    }
+  } else {
+    "@types/\{pkg_spec}"
+  }
+}
+
+///|
 pub async fn ts2mbt_vendor_package(
   pkg_spec : String,
   module_spec_override? : String? = None,
@@ -48,18 +64,7 @@ pub async fn ts2mbt_vendor_package(
   if entry_path.has_suffix(".js") ||
     entry_path.has_suffix(".cjs") ||
     entry_path.has_suffix(".mjs") {
-    let types_pkg_hint = if pkg_spec.has_prefix("@") {
-      match pkg_spec.find("/") {
-        Some(idx) =>
-          "@types/" +
-          pkg_spec.substring(start=1, end=idx).to_string() +
-          "__" +
-          pkg_spec.substring(start=idx + 1).to_string()
-        None => "@types/\{pkg_spec}"
-      }
-    } else {
-      "@types/\{pkg_spec}"
-    }
+    let types_pkg_hint = types_package_hint(pkg_spec)
     println(
       "vendor: WARNING '\{pkg_spec}' ships no TypeScript declarations (resolved \{entry_path}); the generated API surface will be minimal — try `npm i -D \{types_pkg_hint}` and re-run",
     )


### PR DESCRIPTION
## Summary

- generate npm packages from a MoonBit module with `mbt2ts --pkg`, including subpath exports and executable bins
- expose the full MoonBit checker through `mtsc` and remove deprecated vendor string slicing
- split the README into focused tool guides and add an explicit `mtsc` known-gap corpus

## Validation

- `moon check --target native`
- `moon test src/cmd/mtsc/main_wbtest.mbt --target native --filter 'mtsc known-gap corpus records current missed diagnostics'`\n- TypeScript baseline for the known-gap fixtures