### PR TITLE
Attribute the loader's time honestly, then cut the three costs it exposed

### DIFF
--- a/docs/real-world-minify.md
+++ b/docs/real-world-minify.md
@@ -97,6 +97,77 @@ valibot の伸びが一番大きいのは 578 file あって 1 file あたりの
 支配的だからです。残っているのは依然 parse（33〜79%）ですが、今度は
 **1 回分**です。次があるなら parser 本体か、file 単位の並列化になります。
 
+### 「parse が 33〜79%」は測り方の嘘だった
+
+`parser 本体` に手を付ける前に、その 1 行が何を含んでいるのかを分けました。
+`cli: read + parse files` は loader 全体を 1 行にまとめたもので、実際には
+4 つの別物が入っていました。tokenize / recursive descent / file 読み込み +
+UTF-8 decode / **path 解決**です。分けたら順位が入れ替わりました。
+
+```
+valibot   235 ms  59.6%  cli: read files + resolve   ← 内訳を取ると
+           49 ms  12.4%  cli: parse (recursive descent)
+           24 ms   6.1%  cli: tokenize
+```
+
+parse + tokenize は合わせて 18.5%、支配していたのは **module 解決**でした。
+原因は算術です。`mtsc_resolve_existing` は 1 つの import につき最大 13 個の
+候補 path を試し、その各々が `@fs.exists` + `@fs.kind`。1 file を見つける
+のに ~26 syscall です。directory を 1 回 listing して、存在しない候補は
+map 参照で答えるようにしました。listing にある名前だけが `kind` を払い、
+それは import ごとに最大 1 回です。解決結果も memo しました（loader は
+同じ path を edge 記録時と queue 到達時の 2 回解決していた）。
+
+| | 前 | 後 |
+| --- | --- | --- |
+| valibot の解決 | 235 ms | **45 ms** |
+| hono の解決 | 30 ms | **5 ms** |
+
+### parser 本体（分離したあとの本題）
+
+分離して残った recursive descent を callgrind にかけると、費用は
+**二項演算子の precedence cascade** にありました。どの式も演算子を含むか
+どうかに関わらず 11 段を降り、各段が候補演算子ごとに `check` 呼び出しと
+out-of-line の `TokenKind::equal` を払っていました。`parse_assignment` で
+15 個、`parse_comparison` で 6 個です。各段を peek 1 回 + jump table 1 回に
+しました。
+
+式ごとの allocation が 3 つ道連れになりました。`parse_equality` は何も
+判定する前に loop 先頭で closure を作っていました。`parse_unary` は
+`kind == Ident("await")` を比較していて、**その比較のために `Ident` node を
+allocate** していました（`await` は contextual keyword なので識別子として
+来る）。compound assignment の 15 arm はそれぞれ、既に手元にある node と
+構造的に同一の代入先を組み直していました。
+
+```
+checker.ts    parse  120 ms -> 85 ms
+valibot       parse   48 ms -> 43 ms
+```
+
+### 次に出てきたのは parser ではなく scope の複製だった
+
+同じ profile で `String::hash` が 7.4%、`Map[String, TsType]` の操作が
+合わせて 11.5% ありました。`type_fold_block_in` が **block ごとに scope map
+を entry 単位で複製**していて、`checker.ts` で ~100 万回の entry copy です。
+親を指す layer に置き換えました（copy が表現できて素の親 chain が
+できない唯一のもの——annotation のない引数による outer binding の
+shadowing——は `hidden` で持つ）。
+
+| | 前 | 後 |
+| --- | --- | --- |
+| `type-fold`（checker.ts） | 126 ms | **13 ms** |
+| `type-fold`（typescript.js） | 410 ms | **65 ms** |
+
+`--sourcemap` なしのときに全 module の `LineIndex` を作っていたのも
+やめました（誰も読まない表のために 3 MB を走査していた）。
+
+wall clock は `checker.ts` が 843 ms → **631 ms**（5 回の中央値）、
+`typescript.js` が 3.90 s → **3.55 s**。出力は 5 target すべて byte 一致、
+mangle-safety は 161/161 pass です。
+
+いま上に立っているのは `class-method-dce`（checker.ts の 24%、
+typescript.js の 22%）で、parse は 14% です。
+
 ## 見つかった bug
 
 ### 1. 比較演算子が file を丸ごと食う（parser）

--- a/src/cmd/mtsc/main.mbt
+++ b/src/cmd/mtsc/main.mbt
@@ -393,6 +393,14 @@ fn mtsc_dirname(path : String) -> String {
 }
 
 ///|
+fn mtsc_basename(path : String) -> String {
+  match path.rev_find("/") {
+    Some(i) => path[i + 1:].to_owned()
+    None => path
+  }
+}
+
+///|
 fn mtsc_join_path(dir : String, child : String) -> String {
   if dir == "" {
     child
@@ -475,6 +483,12 @@ async fn mtsc_load_bundle_files(
   // parse of every file in the graph — 0.9 s of the 2.1 s read+parse
   // phase on 9 MB of `typescript.js`. Skip it when nobody asked.
   want_type_props : Bool,
+  // `[tokenize, parse, read+decode, resolve]` micros accumulated across
+  // every file, so `--timing` can separate the lexer from the recursive
+  // descent and both from the filesystem. Reported as four rows because
+  // the single "read + parse files" row hid the actual hot spot: path
+  // resolution, not parsing, was 42-60% of a multi-file compile.
+  parse_split : Array[Double],
   // Every block this walk parses, keyed the way `files` is, so the
   // bundler can reuse them instead of parsing the same sources again.
   // The walk has to parse each file to find its imports, and the
@@ -490,6 +504,20 @@ async fn mtsc_load_bundle_files(
   // a cooperative single-threaded scheduler, so spawning per-file
   // tasks adds task-group overhead without overlapping any real
   // work — the parser itself stays the dominant CPU cost.
+  let mut tokenize_micros = 0.0
+  let mut parse_micros = 0.0
+  let mut read_micros = 0.0
+  let mut resolve_micros = 0.0
+  // Time every `mtsc_resolve_existing` call, cache hits included, so the
+  // row measures what resolution costs the compile rather than what it
+  // costs on a miss.
+  async fn timed_resolve(base : String) -> String {
+    let started = @bench.monotonic_clock_start()
+    let r = mtsc_resolve_existing(base)
+    resolve_micros = resolve_micros + @bench.monotonic_clock_end(started)
+    r
+  }
+
   let queue : Array[String] = [entry_path]
   while queue.length() > 0 {
     let disk_path = queue[queue.length() - 1]
@@ -497,7 +525,7 @@ async fn mtsc_load_bundle_files(
     if files.contains(disk_path) {
       continue
     }
-    let resolved = mtsc_resolve_existing(disk_path)
+    let resolved = timed_resolve(disk_path)
     // A relative import that names no file on disk is not a reason to
     // fail the compile. It is what a build-generated module looks like
     // from a source checkout: TypeScript's own `checker.ts` imports
@@ -511,9 +539,11 @@ async fn mtsc_load_bundle_files(
       )
       continue
     }
+    let read_started = @bench.monotonic_clock_start()
     let source = @fs.read_file(resolved).text() catch {
       e => return Err("read error \{resolved}: \{e}")
     }
+    read_micros = read_micros + @bench.monotonic_clock_end(read_started)
     files[resolved] = source
     // The extension-less form is also keyed, so the bundler can look up
     // the specifier a module actually spelled (`./sub` -> `/dir/sub`).
@@ -528,9 +558,18 @@ async fn mtsc_load_bundle_files(
       !files.contains(disk_path) {
       files[disk_path] = source
     }
-    let mb = @parser.Parser::from_source(source).parse_module_block() catch {
+    // Split so `--timing` says which half of "parse" is which:
+    // tokenizing builds the whole token array up front, walking it is a
+    // separate cost, and the two want different fixes.
+    let tokenize_started = @bench.monotonic_clock_start()
+    let parser = @parser.Parser::from_source(source)
+    tokenize_micros = tokenize_micros +
+      @bench.monotonic_clock_end(tokenize_started)
+    let parse_started = @bench.monotonic_clock_start()
+    let mb = parser.parse_module_block() catch {
       e => return Err("parse \{resolved}: \{e}")
     }
+    parse_micros = parse_micros + @bench.monotonic_clock_end(parse_started)
     // Keyed exactly like `files` above, including the extension-less
     // alias, because the bundler looks a module up by whichever form
     // the importing specifier spelled.
@@ -580,7 +619,7 @@ async fn mtsc_load_bundle_files(
         edges.push({
           importerPath: resolved,
           moduleSpecifier: spec,
-          targetPath: mtsc_resolve_existing(combined),
+          targetPath: timed_resolve(combined),
         })
         queue.push(combined)
         continue
@@ -624,7 +663,7 @@ async fn mtsc_load_bundle_files(
         edges.push({
           importerPath: resolved,
           moduleSpecifier: spec,
-          targetPath: mtsc_resolve_existing(combined),
+          targetPath: timed_resolve(combined),
         })
         queue.push(combined)
         continue
@@ -678,6 +717,10 @@ async fn mtsc_load_bundle_files(
       Err(_) => ()
     }
   }
+  parse_split.push(tokenize_micros)
+  parse_split.push(parse_micros)
+  parse_split.push(read_micros)
+  parse_split.push(resolve_micros)
   Ok(())
 }
 
@@ -722,7 +765,70 @@ fn mtsc_ts_equivalents(base : String) -> Array[String] {
 }
 
 ///|
+/// Resolution caches. A compile is one process over a snapshot of the
+/// tree, so nothing here can go stale within a run.
+///
+/// They exist because module resolution, not parsing, was the largest
+/// phase on every multi-file target once `--timing` could separate it
+/// from reading: 235 ms of valibot's 394 ms (59.6%) and 30 ms of hono's
+/// 71 ms (42.4%), against 12-18% for tokenize plus recursive descent
+/// combined. The cause is arithmetic — `mtsc_resolve_existing` probed up
+/// to thirteen candidate paths per import, and every probe was an
+/// `@fs.exists` plus an `@fs.kind`, so one import cost ~26 syscalls to
+/// find one file.
+///
+/// `mtsc_dir_entries` turns that around: list a directory once, and a
+/// candidate that does not exist is then a map lookup rather than a
+/// syscall. Only a candidate the listing admits costs an `@fs.kind`, and
+/// that is at most one per import.
+let mtsc_dir_entries : Map[String, Map[String, Bool]] = {}
+
+///|
+/// `@fs.kind(path) is Regular`, memoized. Distinct from the listing:
+/// the listing says a *name* is there, this says it is a file and not a
+/// directory.
+let mtsc_regular_files : Map[String, Bool] = {}
+
+///|
+/// `mtsc_resolve_existing` results. The loader resolves the same path
+/// twice per edge — once to record the edge, once when the queue reaches
+/// it — and a module imported from n places is resolved n times.
+let mtsc_resolved_paths : Map[String, String] = {}
+
+///|
+/// The names directly inside `dir`, read once. A directory that cannot
+/// be read caches as empty: that is the same answer every candidate
+/// under it would have got, and it stops a missing directory from being
+/// re-probed per candidate.
+async fn mtsc_dir_listing(dir : String) -> Map[String, Bool] {
+  let key = if dir == "" { "." } else { dir }
+  match mtsc_dir_entries.get(key) {
+    Some(m) => m
+    None => {
+      let m : Map[String, Bool] = {}
+      let names = @fs.readdir(key) catch { _ => [] }
+      for n in names {
+        m[n] = true
+      }
+      mtsc_dir_entries[key] = m
+      m
+    }
+  }
+}
+
+///|
 async fn mtsc_resolve_existing(base : String) -> String {
+  match mtsc_resolved_paths.get(base) {
+    Some(r) => return r
+    None => ()
+  }
+  let r = mtsc_resolve_existing_uncached(base)
+  mtsc_resolved_paths[base] = r
+  r
+}
+
+///|
+async fn mtsc_resolve_existing_uncached(base : String) -> String {
   if mtsc_file_exists(base) {
     return base
   }
@@ -768,10 +874,33 @@ async fn mtsc_path_exists(path : String) -> Bool {
 /// itself, and the read then failed with "Is a directory" instead of
 /// falling through to `client/index.ts`.
 async fn mtsc_file_exists(path : String) -> Bool {
-  if !@fs.exists(path) {
+  match mtsc_regular_files.get(path) {
+    Some(v) => return v
+    None => ()
+  }
+  let base = mtsc_basename(path)
+  // `.` and `..` are not in a listing (`readdir` drops the special
+  // entries) and are directories anyway, so answer without one. An empty
+  // base means a trailing slash, which likewise names a directory.
+  if base == "" || base == "." || base == ".." {
+    mtsc_regular_files[path] = false
     return false
   }
-  (@fs.kind(path) catch { _ => return false }) is Regular
+  // The parent's listing settles non-existence for free. Only a name
+  // that IS there is worth a `kind` syscall.
+  if !mtsc_dir_listing(mtsc_dirname(path)).contains(base) {
+    mtsc_regular_files[path] = false
+    return false
+  }
+  let v = (@fs.kind(path) catch {
+      _ => {
+        mtsc_regular_files[path] = false
+        return false
+      }
+    })
+    is Regular
+  mtsc_regular_files[path] = v
+  v
 }
 
 ///|
@@ -959,6 +1088,7 @@ async fn main {
     let aliases : Map[String, String] = {}
     let type_props : Map[String, Bool] = {}
     let parsed_blocks : Map[String, @ast.TsModuleBlock] = {}
+    let parse_split : Array[Double] = []
     // `--timing` covers the CLI's own work too. The transform pipeline
     // reports its own phases, but the first measurement of `checker.ts`
     // put 731 ms of 31.6 s inside them — everything that mattered was
@@ -977,6 +1107,7 @@ async fn main {
         opts.externals,
         type_props,
         opts.reserve_typed_props,
+        parse_split,
         parsed_blocks,
         edges,
       ) {
@@ -986,10 +1117,27 @@ async fn main {
         return
       }
     }
-    cli_timer.record(
-      "cli: read + parse files",
-      @bench.monotonic_clock_end(load_started),
-    )
+    // Report the lexer and the recursive descent separately, and keep
+    // the remainder (disk reads, path resolution) as its own row.
+    let load_total = @bench.monotonic_clock_end(load_started)
+    if parse_split.length() == 4 {
+      cli_timer.record("cli: tokenize", parse_split[0])
+      cli_timer.record("cli: parse (recursive descent)", parse_split[1])
+      cli_timer.record("cli: read + decode files", parse_split[2])
+      cli_timer.record("cli: resolve module paths", parse_split[3])
+      // Whatever the four measured spans do not account for: queue
+      // bookkeeping, the import walk, the sibling `.d.ts` scan.
+      let rest = load_total -
+        parse_split[0] -
+        parse_split[1] -
+        parse_split[2] -
+        parse_split[3]
+      if rest > 0.0 {
+        cli_timer.record("cli: module graph walk", rest)
+      }
+    } else {
+      cli_timer.record("cli: read + parse files", load_total)
+    }
     // Type-check the whole graph in one go. Checking each file alone
     // leaves every imported type unresolvable, which both hides real
     // errors and invents fake ones — an identical shape compared against

--- a/src/parser/parser_core.mbt
+++ b/src/parser/parser_core.mbt
@@ -536,7 +536,10 @@ fn Parser::advance(self : Parser) -> Token {
     return { kind: Gt, pos: self.pending_gt_pos, has_newline_before: false }
   }
   let tok = self.peek()
-  if tok.kind != Eof {
+  // `is Eof` rather than `!= Eof`: the derived `TokenKind::equal` is an
+  // out-of-line call over an enum with payloads, and `advance` runs once
+  // per token in the file. A pattern test is a tag compare.
+  if !(tok.kind is Eof) {
     self.pos += 1
   }
   tok

--- a/src/parser/parser_expr.mbt
+++ b/src/parser/parser_expr.mbt
@@ -374,7 +374,7 @@ fn Parser::parse_assignment(self : Parser) -> @ast.TsExpr raise ParseError {
     _ => ()
   }
   if self.check(Eq) {
-    match left {
+    return match left {
       Var(name) => {
         // In strict mode, `eval` / `arguments` are not valid assignment
         // targets (TS1100 family). Recorded -- not raised -- so the file
@@ -410,163 +410,39 @@ fn Parser::parse_assignment(self : Parser) -> @ast.TsExpr raise ParseError {
       }
       _ => left
     }
-  } else if self.match_(PlusEq) {
-    let right = self.parse_assignment()
-    match left {
-      Var(name) => CompoundAssignExpr(Var(name), AddAssign, right)
-      PropAccess(obj, prop) =>
-        CompoundAssignExpr(PropAccess(obj, prop), AddAssign, right)
-      IndexAccess(obj, index) =>
-        CompoundAssignExpr(IndexAccess(obj, index), AddAssign, right)
-      // A non-reference LHS (`1 += 2`) is never a valid assignment
-      // target (TS2364). Preserve the node instead of discarding it so
-      // the checker sees the invalid target; pre-existing reference
-      // targets above are unaffected.
-      _ => CompoundAssignExpr(left, AddAssign, right)
-    }
-  } else if self.match_(MinusEq) {
-    let right = self.parse_assignment()
-    match left {
-      Var(name) => CompoundAssignExpr(Var(name), SubAssign, right)
-      PropAccess(obj, prop) =>
-        CompoundAssignExpr(PropAccess(obj, prop), SubAssign, right)
-      IndexAccess(obj, index) =>
-        CompoundAssignExpr(IndexAccess(obj, index), SubAssign, right)
-      _ => CompoundAssignExpr(left, SubAssign, right)
-    }
-  } else if self.match_(StarEq) {
-    let right = self.parse_assignment()
-    match left {
-      Var(name) => CompoundAssignExpr(Var(name), MulAssign, right)
-      PropAccess(obj, prop) =>
-        CompoundAssignExpr(PropAccess(obj, prop), MulAssign, right)
-      IndexAccess(obj, index) =>
-        CompoundAssignExpr(IndexAccess(obj, index), MulAssign, right)
-      _ => CompoundAssignExpr(left, MulAssign, right)
-    }
-  } else if self.match_(SlashEq) {
-    let right = self.parse_assignment()
-    match left {
-      Var(name) => CompoundAssignExpr(Var(name), DivAssign, right)
-      PropAccess(obj, prop) =>
-        CompoundAssignExpr(PropAccess(obj, prop), DivAssign, right)
-      IndexAccess(obj, index) =>
-        CompoundAssignExpr(IndexAccess(obj, index), DivAssign, right)
-      _ => CompoundAssignExpr(left, DivAssign, right)
-    }
-  } else if self.match_(PercentEq) {
-    let right = self.parse_assignment()
-    match left {
-      Var(name) => CompoundAssignExpr(Var(name), ModAssign, right)
-      PropAccess(obj, prop) =>
-        CompoundAssignExpr(PropAccess(obj, prop), ModAssign, right)
-      IndexAccess(obj, index) =>
-        CompoundAssignExpr(IndexAccess(obj, index), ModAssign, right)
-      _ => CompoundAssignExpr(left, ModAssign, right)
-    }
-  } else if self.match_(AmpEq) {
-    let right = self.parse_assignment()
-    match left {
-      Var(name) => CompoundAssignExpr(Var(name), BitAndAssign, right)
-      PropAccess(obj, prop) =>
-        CompoundAssignExpr(PropAccess(obj, prop), BitAndAssign, right)
-      IndexAccess(obj, index) =>
-        CompoundAssignExpr(IndexAccess(obj, index), BitAndAssign, right)
-      _ => CompoundAssignExpr(left, BitAndAssign, right)
-    }
-  } else if self.match_(PipeEq) {
-    let right = self.parse_assignment()
-    match left {
-      Var(name) => CompoundAssignExpr(Var(name), BitOrAssign, right)
-      PropAccess(obj, prop) =>
-        CompoundAssignExpr(PropAccess(obj, prop), BitOrAssign, right)
-      IndexAccess(obj, index) =>
-        CompoundAssignExpr(IndexAccess(obj, index), BitOrAssign, right)
-      _ => CompoundAssignExpr(left, BitOrAssign, right)
-    }
-  } else if self.match_(CaretEq) {
-    let right = self.parse_assignment()
-    match left {
-      Var(name) => CompoundAssignExpr(Var(name), BitXorAssign, right)
-      PropAccess(obj, prop) =>
-        CompoundAssignExpr(PropAccess(obj, prop), BitXorAssign, right)
-      IndexAccess(obj, index) =>
-        CompoundAssignExpr(IndexAccess(obj, index), BitXorAssign, right)
-      _ => CompoundAssignExpr(left, BitXorAssign, right)
-    }
-  } else if self.match_(LtLtEq) {
-    let right = self.parse_assignment()
-    match left {
-      Var(name) => CompoundAssignExpr(Var(name), ShlAssign, right)
-      PropAccess(obj, prop) =>
-        CompoundAssignExpr(PropAccess(obj, prop), ShlAssign, right)
-      IndexAccess(obj, index) =>
-        CompoundAssignExpr(IndexAccess(obj, index), ShlAssign, right)
-      _ => CompoundAssignExpr(left, ShlAssign, right)
-    }
-  } else if self.match_(GtGtEq) {
-    let right = self.parse_assignment()
-    match left {
-      Var(name) => CompoundAssignExpr(Var(name), ShrAssign, right)
-      PropAccess(obj, prop) =>
-        CompoundAssignExpr(PropAccess(obj, prop), ShrAssign, right)
-      IndexAccess(obj, index) =>
-        CompoundAssignExpr(IndexAccess(obj, index), ShrAssign, right)
-      _ => CompoundAssignExpr(left, ShrAssign, right)
-    }
-  } else if self.match_(GtGtGtEq) {
-    let right = self.parse_assignment()
-    match left {
-      Var(name) => CompoundAssignExpr(Var(name), UShrAssign, right)
-      PropAccess(obj, prop) =>
-        CompoundAssignExpr(PropAccess(obj, prop), UShrAssign, right)
-      IndexAccess(obj, index) =>
-        CompoundAssignExpr(IndexAccess(obj, index), UShrAssign, right)
-      _ => CompoundAssignExpr(left, UShrAssign, right)
-    }
-  } else if self.match_(StarStarEq) {
-    let right = self.parse_assignment()
-    match left {
-      Var(name) => CompoundAssignExpr(Var(name), PowAssign, right)
-      PropAccess(obj, prop) =>
-        CompoundAssignExpr(PropAccess(obj, prop), PowAssign, right)
-      IndexAccess(obj, index) =>
-        CompoundAssignExpr(IndexAccess(obj, index), PowAssign, right)
-      _ => CompoundAssignExpr(left, PowAssign, right)
-    }
-  } else if self.match_(AmpAmpEq) {
-    let right = self.parse_assignment()
-    match left {
-      Var(name) => CompoundAssignExpr(Var(name), AndAssign, right)
-      PropAccess(obj, prop) =>
-        CompoundAssignExpr(PropAccess(obj, prop), AndAssign, right)
-      IndexAccess(obj, index) =>
-        CompoundAssignExpr(IndexAccess(obj, index), AndAssign, right)
-      _ => CompoundAssignExpr(left, AndAssign, right)
-    }
-  } else if self.match_(PipePipeEq) {
-    let right = self.parse_assignment()
-    match left {
-      Var(name) => CompoundAssignExpr(Var(name), OrAssign, right)
-      PropAccess(obj, prop) =>
-        CompoundAssignExpr(PropAccess(obj, prop), OrAssign, right)
-      IndexAccess(obj, index) =>
-        CompoundAssignExpr(IndexAccess(obj, index), OrAssign, right)
-      _ => CompoundAssignExpr(left, OrAssign, right)
-    }
-  } else if self.match_(QuestionQuestionEq) {
-    let right = self.parse_assignment()
-    match left {
-      Var(name) => CompoundAssignExpr(Var(name), CoalesceAssign, right)
-      PropAccess(obj, prop) =>
-        CompoundAssignExpr(PropAccess(obj, prop), CoalesceAssign, right)
-      IndexAccess(obj, index) =>
-        CompoundAssignExpr(IndexAccess(obj, index), CoalesceAssign, right)
-      _ => CompoundAssignExpr(left, CoalesceAssign, right)
-    }
-  } else {
-    left
   }
+  // Every compound-assignment operator took its own `match_` test, and a
+  // non-assignment expression paid all fifteen on the way out. One jump
+  // table decides which operator it is; the body they all shared follows
+  // once.
+  let compound : @ast.TsCompoundOp? = match self.peek().kind {
+    PlusEq => Some(AddAssign)
+    MinusEq => Some(SubAssign)
+    StarEq => Some(MulAssign)
+    SlashEq => Some(DivAssign)
+    PercentEq => Some(ModAssign)
+    AmpEq => Some(BitAndAssign)
+    PipeEq => Some(BitOrAssign)
+    CaretEq => Some(BitXorAssign)
+    LtLtEq => Some(ShlAssign)
+    GtGtEq => Some(ShrAssign)
+    GtGtGtEq => Some(UShrAssign)
+    StarStarEq => Some(PowAssign)
+    AmpAmpEq => Some(AndAssign)
+    PipePipeEq => Some(OrAssign)
+    QuestionQuestionEq => Some(CoalesceAssign)
+    _ => None
+  }
+  if compound is Some(op) {
+    let _ = self.advance()
+    let right = self.parse_assignment()
+    // The old per-operator bodies rebuilt a `Var` / `PropAccess` /
+    // `IndexAccess` target from its own parts and fell back to `left` for
+    // anything else. Every one of those rebuilds was structurally the
+    // node it came from, so `left` covers all four cases.
+    return CompoundAssignExpr(left, op, right)
+  }
+  left
 }
 
 ///|
@@ -796,18 +672,32 @@ fn Parser::parse_ternary(self : Parser) -> @ast.TsExpr raise ParseError {
   }
 }
 
+// The binary-precedence cascade below dispatches each level with ONE
+// `match` on the peeked token instead of a run of `match_(K)` calls.
+//
+// The rewrite is mechanical — the kinds a level accepts are disjoint, so
+// testing them in one jump table is the same decision the `if`-chain
+// made — but it is worth the churn because the cascade is the parser's
+// hottest path. Every expression in the file descends all eleven levels
+// whether or not it contains an operator, and the old form paid a
+// `check` call plus an out-of-line `TokenKind::equal` per candidate
+// operator on the way down: six of them in `parse_comparison` alone.
+// Together the chain accounted for ~4% of the compile's instructions in
+// pass-through cost alone (callgrind, hono).
+
 ///|
 // / || (OR) and ?? (Nullish Coalesce)
 fn Parser::parse_or(self : Parser) -> @ast.TsExpr raise ParseError {
   let mut left = self.parse_and()
-  while self.check(PipePipe) || self.check(QuestionQuestion) {
-    if self.match_(PipePipe) {
-      let right = self.parse_and()
-      left = BinOp(Or, left, right)
-    } else if self.match_(QuestionQuestion) {
-      let right = self.parse_and()
-      left = BinOp(Coalesce, left, right)
+  while true {
+    let op : @ast.TsBinOp = match self.peek().kind {
+      PipePipe => Or
+      QuestionQuestion => Coalesce
+      _ => break
     }
+    let _ = self.advance()
+    let right = self.parse_and()
+    left = BinOp(op, left, right)
   }
   left
 }
@@ -816,7 +706,8 @@ fn Parser::parse_or(self : Parser) -> @ast.TsExpr raise ParseError {
 // / && (AND)
 fn Parser::parse_and(self : Parser) -> @ast.TsExpr raise ParseError {
   let mut left = self.parse_bit_or()
-  while self.match_(AmpAmp) {
+  while self.peek().kind is AmpAmp {
+    let _ = self.advance()
     let right = self.parse_bit_or()
     left = BinOp(And, left, right)
   }
@@ -827,7 +718,8 @@ fn Parser::parse_and(self : Parser) -> @ast.TsExpr raise ParseError {
 // / | (OR)
 fn Parser::parse_bit_or(self : Parser) -> @ast.TsExpr raise ParseError {
   let mut left = self.parse_bit_xor()
-  while self.match_(Pipe) {
+  while self.peek().kind is Pipe {
+    let _ = self.advance()
     let right = self.parse_bit_xor()
     left = BinOp(BitOr, left, right)
   }
@@ -838,7 +730,8 @@ fn Parser::parse_bit_or(self : Parser) -> @ast.TsExpr raise ParseError {
 // / ^ (XOR)
 fn Parser::parse_bit_xor(self : Parser) -> @ast.TsExpr raise ParseError {
   let mut left = self.parse_bit_and()
-  while self.match_(Caret) {
+  while self.peek().kind is Caret {
+    let _ = self.advance()
     let right = self.parse_bit_and()
     left = BinOp(BitXor, left, right)
   }
@@ -849,7 +742,8 @@ fn Parser::parse_bit_xor(self : Parser) -> @ast.TsExpr raise ParseError {
 // / & (AND)
 fn Parser::parse_bit_and(self : Parser) -> @ast.TsExpr raise ParseError {
   let mut left = self.parse_equality()
-  while self.match_(Amp) {
+  while self.peek().kind is Amp {
+    let _ = self.advance()
     let right = self.parse_equality()
     left = BinOp(BitAnd, left, right)
   }
@@ -861,32 +755,27 @@ fn Parser::parse_bit_and(self : Parser) -> @ast.TsExpr raise ParseError {
 fn Parser::parse_equality(self : Parser) -> @ast.TsExpr raise ParseError {
   let mut left = self.parse_comparison()
   while true {
+    let op : @ast.TsBinOp = match self.peek().kind {
+      EqEqEq => BinEq
+      BangEqEq => BinNe
+      EqEq => AbstractEq
+      BangEq => AbstractNe
+      _ => break
+    }
+    let _ = self.advance()
     // `as T` / `satisfies T` sit at unary precedence in the TS spec,
     // so `a === b as T` is `a === (b as T)`. Without consuming the
     // assertion here the AST would wrap the whole equality and our
     // "always-false" overlap diagnostic would compare the un-cast
     // literals (`"foo" === ("bar" as string)`).
-    let consume_rhs_assertion = fn(
-      right : @ast.TsExpr,
-    ) -> @ast.TsExpr raise ParseError {
-      let (_, wrapped) = self.consume_trailing_assertions_wrap(right)
-      wrapped
-    }
-    if self.match_(EqEqEq) {
-      let right = consume_rhs_assertion(self.parse_comparison())
-      left = BinOp(BinEq, left, right)
-    } else if self.match_(BangEqEq) {
-      let right = consume_rhs_assertion(self.parse_comparison())
-      left = BinOp(BinNe, left, right)
-    } else if self.match_(EqEq) {
-      let right = consume_rhs_assertion(self.parse_comparison())
-      left = BinOp(AbstractEq, left, right)
-    } else if self.match_(BangEq) {
-      let right = consume_rhs_assertion(self.parse_comparison())
-      left = BinOp(AbstractNe, left, right)
-    } else {
-      break
-    }
+    //
+    // This used to be a closure built at the top of the loop body,
+    // which allocated one per expression parsed — including the
+    // overwhelming majority that carry no equality operator at all.
+    let (_, right) = self.consume_trailing_assertions_wrap(
+      self.parse_comparison(),
+    )
+    left = BinOp(op, left, right)
   }
   left
 }
@@ -896,27 +785,18 @@ fn Parser::parse_equality(self : Parser) -> @ast.TsExpr raise ParseError {
 fn Parser::parse_comparison(self : Parser) -> @ast.TsExpr raise ParseError {
   let mut left = self.parse_shift()
   while true {
-    if self.match_(Lt) {
-      let right = self.parse_shift()
-      left = BinOp(BinLt, left, right)
-    } else if self.match_(Le) {
-      let right = self.parse_shift()
-      left = BinOp(BinLe, left, right)
-    } else if self.match_(Gt) {
-      let right = self.parse_shift()
-      left = BinOp(BinGt, left, right)
-    } else if self.match_(Ge) {
-      let right = self.parse_shift()
-      left = BinOp(BinGe, left, right)
-    } else if self.match_(Instanceof) {
-      let right = self.parse_shift()
-      left = BinOp(Instanceof, left, right)
-    } else if self.match_(In) {
-      let right = self.parse_shift()
-      left = BinOp(In, left, right)
-    } else {
-      break
+    let op : @ast.TsBinOp = match self.peek().kind {
+      Lt => BinLt
+      Le => BinLe
+      Gt => BinGt
+      Ge => BinGe
+      Instanceof => Instanceof
+      In => In
+      _ => break
     }
+    let _ = self.advance()
+    let right = self.parse_shift()
+    left = BinOp(op, left, right)
   }
   left
 }
@@ -926,18 +806,15 @@ fn Parser::parse_comparison(self : Parser) -> @ast.TsExpr raise ParseError {
 fn Parser::parse_shift(self : Parser) -> @ast.TsExpr raise ParseError {
   let mut left = self.parse_additive()
   while true {
-    if self.match_(LtLt) {
-      let right = self.parse_additive()
-      left = BinOp(Shl, left, right)
-    } else if self.match_(GtGt) {
-      let right = self.parse_additive()
-      left = BinOp(Shr, left, right)
-    } else if self.match_(GtGtGt) {
-      let right = self.parse_additive()
-      left = BinOp(UShr, left, right)
-    } else {
-      break
+    let op : @ast.TsBinOp = match self.peek().kind {
+      LtLt => Shl
+      GtGt => Shr
+      GtGtGt => UShr
+      _ => break
     }
+    let _ = self.advance()
+    let right = self.parse_additive()
+    left = BinOp(op, left, right)
   }
   left
 }
@@ -947,15 +824,14 @@ fn Parser::parse_shift(self : Parser) -> @ast.TsExpr raise ParseError {
 fn Parser::parse_additive(self : Parser) -> @ast.TsExpr raise ParseError {
   let mut left = self.parse_multiplicative()
   while true {
-    if self.match_(Plus) {
-      let right = self.parse_multiplicative()
-      left = BinOp(Add, left, right)
-    } else if self.match_(Minus) {
-      let right = self.parse_multiplicative()
-      left = BinOp(Sub, left, right)
-    } else {
-      break
+    let op : @ast.TsBinOp = match self.peek().kind {
+      Plus => Add
+      Minus => Sub
+      _ => break
     }
+    let _ = self.advance()
+    let right = self.parse_multiplicative()
+    left = BinOp(op, left, right)
   }
   left
 }
@@ -965,18 +841,15 @@ fn Parser::parse_additive(self : Parser) -> @ast.TsExpr raise ParseError {
 fn Parser::parse_multiplicative(self : Parser) -> @ast.TsExpr raise ParseError {
   let mut left = self.parse_exponent()
   while true {
-    if self.match_(Star) {
-      let right = self.parse_exponent()
-      left = BinOp(Mul, left, right)
-    } else if self.match_(Slash) {
-      let right = self.parse_exponent()
-      left = BinOp(Div, left, right)
-    } else if self.match_(Percent) {
-      let right = self.parse_exponent()
-      left = BinOp(Mod, left, right)
-    } else {
-      break
+    let op : @ast.TsBinOp = match self.peek().kind {
+      Star => Mul
+      Slash => Div
+      Percent => Mod
+      _ => break
     }
+    let _ = self.advance()
+    let right = self.parse_exponent()
+    left = BinOp(op, left, right)
   }
   left
 }
@@ -985,7 +858,8 @@ fn Parser::parse_multiplicative(self : Parser) -> @ast.TsExpr raise ParseError {
 // / ** ()
 fn Parser::parse_exponent(self : Parser) -> @ast.TsExpr raise ParseError {
   let left = self.parse_unary()
-  if self.match_(StarStar) {
+  if self.peek().kind is StarStar {
+    let _ = self.advance()
     let right = self.parse_exponent()
     BinOp(Pow, left, right)
   } else {
@@ -996,40 +870,30 @@ fn Parser::parse_exponent(self : Parser) -> @ast.TsExpr raise ParseError {
 ///|
 // / unaryoperator
 fn Parser::parse_unary(self : Parser) -> @ast.TsExpr raise ParseError {
-  if self.match_(Minus) {
-    let operand = self.parse_unary()
-    UnaryOp(Neg, operand)
-  } else if self.match_(Plus) {
-    let operand = self.parse_unary()
-    UnaryOp(Plus, operand)
-  } else if self.match_(Typeof) {
-    let operand = self.parse_unary()
-    UnaryOp(Typeof, operand)
-  } else if self.match_(Delete) {
-    let operand = self.parse_unary()
-    UnaryOp(Delete, operand)
-  } else if self.match_(VoidType) {
-    let operand = self.parse_unary()
-    UnaryOp(Void, operand)
-  } else if self.match_(Bang) {
-    let operand = self.parse_unary()
-    UnaryOp(Not, operand)
-  } else if self.match_(Tilde) {
-    let operand = self.parse_unary()
-    UnaryOp(BitwiseNot, operand)
-  } else if self.match_(PlusPlus) {
-    // ++x ()
-    let operand = self.parse_unary()
-    UnaryOp(PreInc, operand)
-  } else if self.match_(MinusMinus) {
-    // --x ()
-    let operand = self.parse_unary()
-    UnaryOp(PreDec, operand)
-  } else if self.match_(Yield) {
+  // The prefix operators dispatch in one jump table. `yield` and `await`
+  // stay behind it because each needs more than "consume and recurse".
+  let prefix : @ast.TsUnaryOp? = match self.peek().kind {
+    Minus => Some(Neg)
+    Plus => Some(Plus)
+    Typeof => Some(Typeof)
+    Delete => Some(Delete)
+    VoidType => Some(Void)
+    Bang => Some(Not)
+    Tilde => Some(BitwiseNot)
+    PlusPlus => Some(PreInc) // ++x
+    MinusMinus => Some(PreDec) // --x
+    _ => None
+  }
+  if prefix is Some(op) {
+    let _ = self.advance()
+    return UnaryOp(op, self.parse_unary())
+  }
+  if self.peek().kind is Yield {
+    let _ = self.advance()
     if self.in_generator {
       if self.match_(Star) {
         let expr = self.parse_assignment()
-        YieldStar(expr)
+        return YieldStar(expr)
       } else {
         // yield takes AssignmentExpression as operand (ES6 14.4)
         // Check for end of yield expression
@@ -1044,7 +908,7 @@ fn Parser::parse_unary(self : Parser) -> @ast.TsExpr raise ParseError {
         } else {
           Some(self.parse_assignment())
         }
-        Yield(expr)
+        return Yield(expr)
       }
     } else {
       // TS1163: outside a generator, `yield <expr>` on one line can only be
@@ -1068,19 +932,22 @@ fn Parser::parse_unary(self : Parser) -> @ast.TsExpr raise ParseError {
           "a `yield` expression is only allowed in a generator body",
         )
         let expr = self.parse_assignment()
-        Yield(Some(expr))
+        return Yield(Some(expr))
       } else {
-        Var("yield")
+        return Var("yield")
       }
     }
-  } else if self.peek().kind == Ident("await") {
+  }
+  // `await` is contextual, so it arrives as a plain identifier. Comparing
+  // `kind == Ident("await")` allocated an `Ident` node per expression
+  // parsed — this is the same test without the allocation.
+  if self.peek().kind is Ident("await") {
     // await expression - valid in async functions or top-level await
     let _ = self.advance()
     let expr = self.parse_unary()
-    Await(expr)
-  } else {
-    self.parse_postfix()
+    return Await(expr)
   }
+  self.parse_postfix()
 }
 
 ///|
@@ -1094,13 +961,13 @@ fn Parser::parse_postfix(self : Parser) -> @ast.TsExpr raise ParseError {
     if tok.has_newline_before {
       break
     }
-    if self.match_(PlusPlus) {
-      expr = UnaryOp(PostInc, expr)
-    } else if self.match_(MinusMinus) {
-      expr = UnaryOp(PostDec, expr)
-    } else {
-      break
+    let op : @ast.TsUnaryOp = match tok.kind {
+      PlusPlus => PostInc
+      MinusMinus => PostDec
+      _ => break
     }
+    let _ = self.advance()
+    expr = UnaryOp(op, expr)
   }
   expr
 }

--- a/src/transform/bundle.mbt
+++ b/src/transform/bundle.mbt
@@ -617,7 +617,17 @@ pub fn bundle_modules(
       combined_source_count = combined_source_count + 1
       sources.push(path)
       sources_content.push(m.source)
-      combined_line_indices.push(LineIndex::new(m.source))
+      // Only the `with_sourcemap` emit path reads this table, and
+      // building an entry scans the module's whole source for line
+      // breaks — 3 MB of it for `checker.ts`, for a map nobody asked
+      // for. Keep the slot so `source_id` still indexes it.
+      combined_line_indices.push(
+        if opts.with_sourcemap {
+          LineIndex::new(m.source)
+        } else {
+          LineIndex::new("")
+        },
+      )
       let has_positions = m.block.stmt_positions.length() ==
         m.block.stmts.length()
       for j, s in m.block.stmts {

--- a/src/transform/type_fold.mbt
+++ b/src/transform/type_fold.mbt
@@ -11,12 +11,82 @@
 // etc.), the result is statically `true` / `false` and the
 // surrounding fold pass folds it further.
 //
-// Scope tracking is intentionally simple: we maintain a
-// `Map[String, TsType]` that grows as we enter function /
-// arrow bodies (for parameters) and Let / Const / Var
-// declarations. We do NOT do narrowing across `if (typeof x ===
-// "string")` branches — that's full flow-sensitive analysis and
-// out of scope for this pass.
+// Scope tracking is intentionally simple: a chain of layers that
+// grows as we enter blocks, function / arrow bodies (for
+// parameters) and Let / Const / Var declarations. We do NOT do
+// narrowing across `if (typeof x === "string")` branches — that's
+// full flow-sensitive analysis and out of scope for this pass.
+
+///|
+/// One lexical layer of the fold's type environment, pointing at its
+/// parent rather than copying it.
+///
+/// This used to be a plain `Map[String, TsType]` that every block and
+/// every function body copied entry by entry. The copy is what made the
+/// pass expensive on deeply nested code: `checker.ts` spent roughly a
+/// tenth of the whole compile inserting into and re-hashing those
+/// copies (callgrind put ~1M scope-entry copies in `type_fold_block_in`
+/// alone, plus the `String::hash` on each insert). A layer costs two
+/// empty maps regardless of how large the enclosing scope is.
+///
+/// The semantics are the ones copying gave: a write lands in the
+/// innermost layer, so it is visible to the rest of that block and to
+/// blocks nested inside it, and invisible to the parent and to
+/// siblings. `hidden` carries the one thing a copy could express and a
+/// bare parent chain cannot — a parameter with no useful annotation
+/// shadowing an outer binding of the same name, which must read as
+/// "unknown" inside the body rather than falling through to the outer
+/// type.
+priv struct TypeScope {
+  own : Map[String, @ast.TsType]
+  hidden : Map[String, Bool]
+  parent : TypeScope?
+}
+
+///|
+fn TypeScope::root() -> TypeScope {
+  { own: {}, hidden: {}, parent: None }
+}
+
+///|
+fn TypeScope::child(self : TypeScope) -> TypeScope {
+  { own: {}, hidden: {}, parent: Some(self) }
+}
+
+///|
+fn TypeScope::set(self : TypeScope, name : String, ty : @ast.TsType) -> Unit {
+  let _ = self.hidden.remove(name)
+  self.own[name] = ty
+}
+
+///|
+/// Shadow `name` in this layer with no type — the layered form of the
+/// `remove` a copied map used to do.
+fn TypeScope::hide(self : TypeScope, name : String) -> Unit {
+  let _ = self.own.remove(name)
+  self.hidden[name] = true
+}
+
+///|
+fn TypeScope::get(self : TypeScope, name : String) -> @ast.TsType? {
+  let mut cur : TypeScope? = Some(self)
+  while true {
+    match cur {
+      Some(layer) => {
+        match layer.own.get(name) {
+          Some(t) => return Some(t)
+          None => ()
+        }
+        if layer.hidden.contains(name) {
+          return None
+        }
+        cur = layer.parent
+      }
+      None => break
+    }
+  }
+  None
+}
 
 ///|
 pub fn type_fold_block(
@@ -31,7 +101,7 @@ pub fn type_fold_block(
   if !block_needs_type_fold(block) {
     return block
   }
-  let scope : Map[String, @ast.TsType] = {}
+  let scope = TypeScope::root()
   let alias_table : Map[String, @ast.TsType] = {}
   // Cross-module bundles can contribute multiple aliases sharing one
   // name (e.g. two modules each declaring `type Shape = …`). Keying by
@@ -365,16 +435,12 @@ fn expr_needs_type_fold(expr : @ast.TsExpr) -> Bool {
 ///|
 fn type_fold_block_in(
   block : @ast.TsBlock,
-  scope : Map[String, @ast.TsType],
+  scope : TypeScope,
   aliases : Map[String, @ast.TsType],
 ) -> @ast.TsBlock {
-  // Each block introduces a fresh layer — we just copy-extend
-  // the parent scope so we don't pollute siblings.
-  let local_ : Map[String, @ast.TsType] = {}
-  for entry in scope {
-    let (k, v) = entry
-    local_[k] = v
-  }
+  // Each block introduces a fresh layer over the parent, so writes
+  // inside it don't pollute siblings.
+  let local_ = scope.child()
   let stmts : Array[@ast.TsStmt] = []
   for s in block.stmts {
     stmts.push(type_fold_stmt(s, local_, aliases))
@@ -385,7 +451,7 @@ fn type_fold_block_in(
 ///|
 fn type_fold_stmt(
   stmt : @ast.TsStmt,
-  scope : Map[String, @ast.TsType],
+  scope : TypeScope,
   aliases : Map[String, @ast.TsType],
 ) -> @ast.TsStmt {
   match stmt {
@@ -403,7 +469,7 @@ fn type_fold_stmt(
           }
           match effective_type {
             @ast.TsType::Any => ()
-            ty => scope[name] = ty
+            ty => scope.set(name, ty)
           }
         }
         _ => ()
@@ -573,7 +639,7 @@ fn type_fold_stmt(
 ///|
 fn type_fold_expr(
   expr : @ast.TsExpr,
-  scope : Map[String, @ast.TsType],
+  scope : TypeScope,
   aliases : Map[String, @ast.TsType],
 ) -> @ast.TsExpr {
   match expr {
@@ -721,17 +787,14 @@ fn type_fold_expr(
         type_fold_expr(v, scope, aliases),
       )
     ArrowFunc(params, ret, body, is_async) => {
-      let local_ : Map[String, @ast.TsType] = {}
-      for entry in scope {
-        local_[entry.0] = entry.1
-      }
+      let local_ = scope.child()
       for p in params {
         // Parameters always shadow outer bindings with the same name.
         // Remove any outer type first so the outer type is not used
         // inside the function body when the param has no annotation.
-        local_.remove(p.name)
+        local_.hide(p.name)
         if is_useful_type(p.type_) {
-          local_[p.name] = p.type_
+          local_.set(p.name, p.type_)
         }
       }
       let new_body = match body {
@@ -743,17 +806,14 @@ fn type_fold_expr(
       ArrowFunc(params, ret, new_body, is_async)
     }
     FuncExpr(f) => {
-      let local_ : Map[String, @ast.TsType] = {}
-      for entry in scope {
-        local_[entry.0] = entry.1
-      }
+      let local_ = scope.child()
       for p in f.params {
         // Parameters always shadow outer bindings with the same name.
         // Remove any outer type first so the outer type is not used
         // inside the function body when the param has no annotation.
-        local_.remove(p.name)
+        local_.hide(p.name)
         if is_useful_type(p.type_) {
-          local_[p.name] = p.type_
+          local_.set(p.name, p.type_)
         }
       }
       FuncExpr({ ..f, body: type_fold_block_in(f.body, local_, aliases) })
@@ -942,7 +1002,7 @@ fn try_typeof_fold(
   op : @ast.TsBinOp,
   x_name : String,
   lit : String,
-  scope : Map[String, @ast.TsType],
+  scope : TypeScope,
 ) -> Bool? {
   let ty = match scope.get(x_name) {
     Some(t) => t
@@ -968,7 +1028,7 @@ fn try_typeof_fold(
 fn drop_exhaustive_default(
   disc : @ast.TsExpr,
   cases : Array[@ast.TsSwitchCase],
-  scope : Map[String, @ast.TsType],
+  scope : TypeScope,
   aliases : Map[String, @ast.TsType],
 ) -> Array[@ast.TsSwitchCase] {
   if cases.length() == 0 {
@@ -1058,7 +1118,7 @@ fn try_null_check_fold(
   op : @ast.TsBinOp,
   x_name : String,
   rhs_kind : String,
-  scope : Map[String, @ast.TsType],
+  scope : TypeScope,
 ) -> Bool? {
   let ty = match scope.get(x_name) {
     Some(t) => t


### PR DESCRIPTION
`--timing` reported `cli: read + parse files` as one row, and on every
multi-file target that row was the largest thing in the compile. The
previous round read it as "the parser dominates". Splitting it four ways
— tokenize, recursive descent, read + UTF-8 decode, path resolution —
says otherwise, and each of the three fixes here came out of that split.

## 1. Module resolution was the real hot spot

```
valibot   235 ms  59.6%  cli: read files + resolve
           49 ms  12.4%  cli: parse (recursive descent)
           24 ms   6.1%  cli: tokenize
```

Parse plus tokenize together were 18.5%. The cause is arithmetic:
`mtsc_resolve_existing` probed up to thirteen candidate paths per import
and every probe was an `@fs.exists` plus an `@fs.kind`, so finding one
file cost ~26 syscalls.

A directory is now listed once and a candidate that does not exist is a
map lookup; only a name the listing admits costs a `kind` call, at most
one per import. Resolution results are memoized too — the loader resolved
the same path once when recording the edge and again when the queue
reached it.

| | before | after |
| --- | --- | --- |
| valibot resolve | 235 ms | **45 ms** |
| hono resolve | 30 ms | **5 ms** |

## 2. The parser: the binary-precedence cascade

With the loader's rows separated, callgrind puts the recursive descent's
cost in the precedence chain. Every expression descends eleven levels
whether or not it contains an operator, and each level paid a `check`
call plus an out-of-line `TokenKind::equal` per candidate operator —
fifteen of them in `parse_assignment`, six in `parse_comparison`. Each
level now dispatches on the peeked token in one jump table.

Three allocations per expression went with it:

- `parse_equality` built a closure at the top of its loop before testing
  anything.
- `parse_unary` compared `kind == Ident("await")`, allocating an `Ident`
  node to do the comparison (`await` is contextual, so it arrives as a
  plain identifier).
- The fifteen compound-assignment arms each rebuilt an assignment target
  that was structurally the node they already had.

```
checker.ts    parse  120 ms -> 85 ms
valibot       parse   48 ms -> 43 ms
```

## 3. What turned up next to the parser: scope copying in type-fold

The same profile put `String::hash` at 7.4% of the compile and
`Map[String, TsType]` operations at another 11.5%. Both came from
`type_fold_block_in`, which copied the scope map entry by entry for every
block it entered — roughly a million scope-entry copies on `checker.ts`.

The scope is now a chain of layers pointing at the parent. Semantics are
the ones copying gave: a write lands in the innermost layer, visible to
the rest of that block and to blocks nested inside it, invisible to the
parent and to siblings. The one thing a copy could express that a bare
parent chain cannot — a parameter with no useful annotation shadowing an
outer binding of the same name, which must read as unknown inside the
body rather than falling through to the outer type — is carried by a
`hidden` set.

Also stopped building a `LineIndex` per module when `--sourcemap` is off:
only the sourcemap emit path reads that table, and filling one entry
scans the module's whole source for line breaks.

| | before | after |
| --- | --- | --- |
| `type-fold` (checker.ts) | 126 ms | **13 ms** |
| `type-fold` (typescript.js) | 410 ms | **65 ms** |

## Result

| | before | after |
| --- | --- | --- |
| checker.ts wall | 843 ms | **631 ms** (median of 5) |
| typescript.js wall | 3.90 s | **3.55 s** |

## Verification

Output is unchanged, which is the point — these are all rewrites of how
the same decisions are reached.

- `moon test --target native`: 2725 pass. The 8 failures are the
  pre-existing environment ones (`@process.run(): No such file or
  directory` — the scaffold tests shell out to `moon`).
- `scripts/verify_mangle_safety.mjs`: 161/161 cases pass, including the
  mutation self-check.
- `scripts/verify_real_world_minify.mjs`: 5/5 targets byte-identical to
  before — hono 18,097, valibot 88,578, react 493,376, typescript
  3,581,914, checker.ts 1,542,261.

`docs/real-world-minify.md` records the measurements, including the
correction: "parse is 33-79%" was one row conflating four costs, and the
largest of them was path resolution. The phase now on top is
`class-method-dce` (24% of checker.ts, 22% of typescript.js); parse is
14%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ygRti5U1q3rrdrLM5euqM


---
_Generated by [Claude Code](https://claude.ai/code/session_016ygRti5U1q3rrdrLM5euqM)_