### PR TITLE
Triage the conformance misses into a declared scope, then take Tier 1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -848,6 +848,88 @@ product surfaces now.
   is spread proportionately across fifty rules with no single one to
   attribute, which is the shape a linear checker should have, and the
   20% on a 3.8 MB concatenation of every lib file is the whole price.
+  Every number above ranks work by CORPUS COUNT, and
+  `docs/checker-triage.md` is where that stops: `MISS 176` sums work
+  worth doing now with files nobody should ever fix, so it can rank
+  nothing and can never reach zero — the defect that retired
+  `docs/checker-priority.md`. All 176 are classified there by the
+  MACHINERY a rule needs, priced against how often the feature appears
+  in 3,000 real `.d.ts` files and 2,697 real `.ts` sources, and assigned
+  four tiers with the reason written down. Two measurements decide two
+  tiers outright: `using` declarations occur in **zero** of 5,697 real
+  files and are 6 of the misses, and the 48-file assignability bucket is
+  ~10 unrelated causes, so the largest bucket ranks no work — the same
+  label-for-objective substitution recorded four times above.
+  Its most useful output is a CAPABILITY PROBE, because the
+  classification says what a file NEEDS and not what we HAVE, and
+  guessing at that was wrong twice in one session. Probed against
+  `tscheck --strict`: mapped types, `keyof`, strictNullChecks,
+  `this`-types, index signatures, variadic tuples, generic function
+  inference and basic assignability are all CAUGHT at the common shape,
+  while conditional-via-generic-alias, the whole utility-type table,
+  template-literal types with a placeholder, computed `unique symbol`
+  keys and overload resolution were BLIND at the shape real code writes.
+  The first probe run reported every family blind and that was harness
+  error, not a finding: these entry points check function BODIES and the
+  probes put the error at top level, where nothing visits it.
+  Batches DI–DM took the Tier 1 rows and every one was the
+  applied-in-some-places family, four levels deep in the same feature.
+  `Resolver::unwrap` reduces `Keyof`, `TypeOf`, `MappedType`,
+  `IndexedAccess` and `TemplateLiteralType` and had **no `Conditional`
+  arm**; the evaluator itself works, since an inline conditional and a
+  non-generic alias for one both resolve — only the composition with a
+  generic alias abstained. `standard_utility_types()` had been
+  unit-tested for years behind `module_alias_resolver`, a `pub fn` with
+  **no caller outside its own file and its tests**, so a `.d.ts` using
+  `ReturnType<typeof f>` type-checked BY ABSTAINING. `simplify_type`
+  decides through the three-valued `extends_decision`, which cannot bind
+  an `infer`, and `reduce_conditional` — the reducer that can — was
+  reachable from `is_assignable_to` and not from alias resolution. And
+  `contains_infer_marker` descended into `Func` with no `Constructor`
+  arm, so `new (...args) => infer R` never ran the infer path at all,
+  while `match_infer_pattern` and `substitute_inferred_type` both
+  handled `Constructor` already: two of the trio right, the GATE wrong.
+  Three of those took a wrong diagnosis first, and the corrections are
+  the reusable part. `typeof C` really does arrive unresolved (the
+  `TypeOf` arm reads `globals`, a class lives in `classes`) and was NOT
+  why `InstanceType` was inert — `InstanceType<new () => C>`, with no
+  `typeof` anywhere, was equally silent, and that inline case is kept as
+  a test precisely because it is what distinguishes the gate from the
+  class lookup. Wiring the WHOLE utility table in was wrong: the
+  property-shape entries (`Partial`, `Record`, `Pick`, …) already have
+  dedicated `lookup_field` arms and resolving them here moved the shape
+  out from under those arms — three real regressions, not tests pinning
+  old behaviour. The fallback is gated on the body being a `Conditional`,
+  a SHAPE test rather than a name list, because a second copy of those
+  names is the defect the batch removes. And the conformance gate caught
+  a false positive the moment the resolver read that table:
+  `ThisType<T>` is `interface ThisType<T> {}` in `lib.es5.d.ts`, an
+  EMPTY marker, while the table encodes it as the identity and says why
+  in its own comment — that is the useful answer to "what is `this`
+  here", a different question from "what members does this type have",
+  and the identity answer used structurally makes
+  `PropDesc<U> & ThisType<T>` demand every member of `T`.
+  The ceiling is honest about itself: DI, DK and DM buy **zero** corpus
+  files each and DJ and DL buy one apiece, which is what the triage
+  predicted in writing ("take these for the capability, not the count").
+  What they buy instead is that `Exclude` / `Extract` / `NonNullable` /
+  `ReturnType` / `Parameters` / `Awaited` / `InstanceType` /
+  `ConstructorParameters` now decide, an index signature constrains the
+  MERGED interface rather than one declaration of it, and an overloaded
+  call's arguments are checked at all — they were checked by NOTHING,
+  because `check_union_callee_arity` is correctly excluded from overload
+  sets (every member must accept, right for a union VALUE and wrong for
+  an overload set) and nothing took over. Two of the five cost a false
+  positive whose hazard was already written down twenty lines away, both
+  about optionality widened into a parameter type.
+  The one Tier 1 row that did not survive contact is the `unique symbol`
+  cluster, and the label was mine: opening all 16 files gives ELEVEN
+  distinct error codes. Two are already rejected with measured evidence,
+  two need overload resolution, two need lib interface merging, two need
+  block-scope resolution of a shadowed `Infinity`, and the rest are one
+  unrelated thing each — so the one genuinely cheap file turned out not
+  to be a symbol rule at all. Recorded in TODO.md so the 16 are not
+  re-attacked as a group.
 - `src/transform` is the JS-side pipeline behind `mtsc`: bundling, folding,
   tree-shaking, and the property mangler. Its safety story is type-driven and
   has two halves — `export_surface.mbt` (names reachable from the entry's

--- a/TODO.md
+++ b/TODO.md
@@ -4516,9 +4516,35 @@ inside a function body:
   ABSTAINING, which is a silent hole in the bridge's primary input.
   Check first whether these blind rows are ONE abstention path: the
   control `Bogus<number>` (an unresolved generic name) is also silent.
-- [ ] **Computed `unique symbol` keys** (16 files). 183 real `.d.ts`
-  declare `unique symbol`, 72 use `[Symbol.x]` keys; blind at the common
-  shape.
+- [x] **Computed `unique symbol` keys — REFRAMED, and the label was
+  mine.** Opening all 16 files shows **11 distinct error codes**, so this
+  was never one feature: the same "a NAME is not a feature cluster"
+  mistake CLAUDE.md already records for the 21 `Symbol`-ish files. What
+  the 16 actually are:
+  - REJECTED already, with evidence: TS2466 x2 (batch CL measured 6 FPs
+    for 2 TPs on object-literal computed keys, and
+    `computedPropertyNames28` vs `30` is a distinction ONE file draws),
+    and TS2464 `symbolProperty3` (`var s = Symbol` infers `Any`).
+  - BLOCKED on overload resolution: TS2464 `computedPropertyNames9_*` x2
+    (`[f(true)]` needs the right overload picked to see the key is
+    `boolean`).
+  - BLOCKED on lib interface merging: TS2411 x2
+    (`objectType*HidingObjectIndexer`) augment the global `Object` and
+    the error comes from the LIB's members conflicting with the user's
+    index signature, under `skipDefaultLibCheck: false`.
+  - BLOCKED on block-scope resolution: TS18033 x2 (`let Infinity = {}`
+    shadowing the global inside a block, then `enum En { X = Infinity }`).
+  - The rest (TS1166 x2, TS2322, TS2339, TS2353, TS2416, TS2403) are one
+    unrelated thing each.
+  DONE (batch DL) is the one genuinely cheap file, and it is not a symbol
+  rule at all: TS2411 / TS2413 across MERGED interface declarations. The
+  rule was complete and correct and read `module_.interfaces`, the
+  per-DECLARATION list, so `interface A { [x: number]: string }` beside
+  `interface A { [y: string]: {length: string} }` was silent while the
+  identical members in ONE body were reported. **TP 2559 -> 2560, MISS
+  175 -> 174.** Worth more than its one file: `interface Config {
+  [k: string]: string; port: number }` is a mistake people actually make,
+  and index signatures appear in 102 of 3,000 real `.d.ts` files.
 - [ ] **Overload resolution** — select the right signature (2 solo files,
   contributes to TS2345 / TS2769). Overloads are the reason `.d.ts`
   files exist, and 566 of the 3,000 sampled carry repeated signatures.

--- a/TODO.md
+++ b/TODO.md
@@ -4545,9 +4545,48 @@ inside a function body:
   175 -> 174.** Worth more than its one file: `interface Config {
   [k: string]: string; port: number }` is a mistake people actually make,
   and index signatures appear in 102 of 3,000 real `.d.ts` files.
-- [ ] **Overload resolution** — select the right signature (2 solo files,
-  contributes to TS2345 / TS2769). Overloads are the reason `.d.ts`
-  files exist, and 566 of the 3,000 sampled carry repeated signatures.
+- [x] **Overload resolution — DONE (batch DM), as TS2769.** The finding
+  is bigger than the rule: an overloaded call had its arguments checked
+  by NOTHING AT ALL. `g(true)` against `g(a: string)` / `g(a: number)`
+  was silent, as were wrong arity and zero arguments, while the
+  identical call to a single-signature `h(a: string)` was reported.
+  Most of the standard library is overloaded, so the hole is wide on
+  real input.
+  Why it existed is worth keeping: overload sets ingest as a `Union` of
+  call signatures, and `check_union_callee_arity` is DELIBERATELY not
+  applied to them — its rule is that EVERY member must accept, right
+  for a union-typed value and wrong for an overload set where one match
+  is enough. That exclusion is correct and its comment says so; what
+  was missing is that nothing took over.
+  `check_overload_set_no_match` reports only when EVERY member is
+  PROVEN unable to accept (arity, or a definite-primitive argument
+  against a definite-primitive parameter it is not assignable to).
+  That makes it sound for a union-typed VALUE too — if no constituent
+  can accept, the call is wrong under either reading — so it is not
+  gated on `resolver.signatures` and the two rules need not be told
+  apart. Abstention is per-member with an early return: one member that
+  merely MIGHT accept silences the call, which is what keeps a generic
+  overload, an object-typed parameter, a rest parameter, a spread
+  argument and an unreadable member silent.
+  Cost one FALSE POSITIVE first, and the hazard was already written
+  down: `check_union_callee_arity`'s comment records that "two callables
+  can have identical widened parameter types while differing in whether
+  that parameter was written with `?`", and a `declare function`
+  overload arrives with its optionality widened into the type
+  (`a?: string` becomes `string | undefined`) and an empty
+  `optional_params` — so `t()` against `t(a?: string)` was reported. A
+  parameter that ACCEPTS undefined is now treated as omittable, which
+  over-counts optionals and therefore only ever weakens the proof
+  (batch CU's decorator arity took the same trade).
+  0 corpus files (the one TS2769 miss is a generic-inference case), but
+  it CLOSES a known-gap fixture: `fixtures/mtsc/known-gaps/overload-resolution.ts`
+  moves from "records what we miss" to a regression pin.
+  KNOWN LIMIT, silence not a finding: an overload set declared as real
+  `function` declarations WITH an implementation does not reach this
+  check on the strict path — the `resolver.signatures` branch claims the
+  callee first. It works on the permissive path (which is what the
+  fixture exercises). Filed rather than fixed: the fix means touching
+  the single-signature argument checker.
 
 ### Tier 2 — SUPPORT (cheap, mechanical, ~25 files)
 

--- a/TODO.md
+++ b/TODO.md
@@ -4465,10 +4465,25 @@ inside a function body:
   FP 0**. The extends side is deliberately NOT resolved through the
   resolver when a marker is present — that would rewrite the shape the
   pattern exists to align with.
-  STILL BLIND: `InstanceType<typeof C>` (needs `typeof C`'s
-  constructor side resolved — a different gap), and
-  `ThisParameterType` / `OmitThisParameter` /
-  `ConstructorParameters`, untested so far.
+  DONE too (batch DK): `InstanceType` and `ConstructorParameters`.
+  The obvious suspect was `typeof C` — `unwrap`'s `TypeOf` arm reads
+  `globals` and a class lives in `classes`, so `typeof C` really does
+  arrive unresolved — and that was NOT the cause.
+  `InstanceType<new () => C>`, with no `typeof` anywhere, was equally
+  silent, which is what found the real defect: `contains_infer_marker`
+  descended into `Func` and had NO `Constructor` arm, so it answered
+  "no markers here" and the infer path never ran.
+  `match_infer_pattern` and `substitute_inferred_type` both already
+  handled `Constructor` — two of the trio right, the GATE wrong. Both
+  fixes are needed (`class_construct_signature` for the `typeof`
+  spelling), and the inline case is what proves which one mattered.
+  The construct signature is supplied for the conditional DECISION
+  only: a class's constructor side also carries its statics, which the
+  checker states it does not model, so resolving `typeof C` everywhere
+  would turn every static access through such a binding into a missing
+  property. A derived class with no constructor of its own abstains —
+  it inherits the base's.
+  Buys 0 corpus files again; the capability is the point.
   Two things measured rather than assumed, both worth keeping:
   the whole change bought **ZERO corpus files** (predicted — take it
   for the capability), and wiring the FULL table was wrong: the

--- a/TODO.md
+++ b/TODO.md
@@ -4448,14 +4448,27 @@ inside a function body:
   reachable ONLY through `module_alias_resolver`, a `pub fn` with no
   caller outside its own file and its tests. Live now in both
   directions: `Exclude`, `Extract`, `NonNullable`.
-  STILL BLIND: `ReturnType`, `Awaited`, `Parameters`,
-  `ThisParameterType`, `OmitThisParameter`, `ConstructorParameters`,
-  `InstanceType` — every one of them binds an `infer`, and
-  `extends_decision` cannot, so `simplify_type` abstains. The infer
-  matcher exists (`infer.mbt`, `substitute_inferred_type`) and is
-  wired into `is_assignable_to_with_generics`, NOT into this path —
-  the same disconnection this batch just fixed one layer up. That is
-  the next step and it is the same shape of work.
+  DONE too (batch DJ): the `infer`-binding half. `simplify_type`
+  decides through the three-valued `extends_decision`, which cannot
+  bind an `infer`, so `ReturnType` / `Parameters` / `Awaited` still
+  abstained even with the `Conditional` arm in place.
+  `reduce_conditional` (assignability.mbt) is the reducer that CAN —
+  it runs `match_infer_pattern` and substitutes the captures — and it
+  was reachable from `is_assignable_to` and from three return-type
+  sites, but not from alias resolution. It is now tried from the
+  `Conditional` arm, and ONLY when the extends type carries a marker:
+  its non-infer path is `is_assignable_to`, which is two-valued, so as
+  a general fallback it would take the FALSE branch on an undecidable
+  `extends` and answer confidently exactly where `extends_decision`
+  correctly says "don't know". `ReturnType`, `Parameters`, `Awaited`
+  now decide in both directions; **TP 2558 -> 2559, MISS 176 -> 175,
+  FP 0**. The extends side is deliberately NOT resolved through the
+  resolver when a marker is present — that would rewrite the shape the
+  pattern exists to align with.
+  STILL BLIND: `InstanceType<typeof C>` (needs `typeof C`'s
+  constructor side resolved — a different gap), and
+  `ThisParameterType` / `OmitThisParameter` /
+  `ConstructorParameters`, untested so far.
   Two things measured rather than assumed, both worth keeping:
   the whole change bought **ZERO corpus files** (predicted — take it
   for the capability), and wiring the FULL table was wrong: the

--- a/TODO.md
+++ b/TODO.md
@@ -4395,3 +4395,159 @@ parser768531 (regex/division ambiguity needs parser-fed lexer context).
    the IteratorObject `using` fixtures (need lib-level
    `Iterator.prototype[Symbol.dispose]` type modeling), and NOBASE
    variant-baseline files (oracle artifacts, not checker gaps).
+
+## Checker conformance triage (MISS 176 -> a declared scope)
+
+Full analysis and the measurements behind it: `docs/checker-triage.md`.
+
+`MISS 176` is not a backlog. It sums work worth doing now with files
+nobody should ever fix, so it can rank nothing and can never reach zero.
+That is the defect that retired `docs/checker-priority.md`.
+
+All 176 classified by the MACHINERY a rule would need (not by error code
+— a code is not a difficulty class):
+
+| family | files | | family | files |
+|---|---|---|---|---|
+| assignability-core | 48 | | strict-null / narrowing | 8 |
+| symbol + computed key | 16 | | `this` typing | 7 |
+| other (singletons) | 16 | | decorator signature | 7 |
+| legacy / broken syntax | 15 | | locally accepted | 6 |
+| mapped / conditional / template | 13 | | resource mgmt (`using`) | 6 |
+| generic inference | 11 | | overload resolution | 2 |
+| iterator protocol | 11 | | implicit-any / strict | 10 |
+
+The biggest bucket ranks no work: all 48 `assignability-core` files open
+to ~10 unrelated causes (variadic tuples, intersections, contextual
+typing, `globalThis`, index-signature subtyping, spread types).
+
+Feature frequency, measured over 3,000 real `.d.ts` + 2,697 real `.ts`:
+conditional type **345**, `unique symbol` 183, mapped 143, `this` return
+115, index signature 102, `[Symbol.x]` key 72, template-literal 57/151,
+variadic tuple 20, **`using` 0**, **decorator 1**.
+
+CAPABILITY PROBE (the table that reorders everything — the classification
+says what a file NEEDS, not what we HAVE, and guessing at that was wrong
+twice). Common shape of each family, probed against `tscheck --strict`
+inside a function body:
+
+- CAUGHT: basic assignability, argument count, missing property, mapped
+  type via generic alias, `keyof`, strictNullChecks, `this` return type,
+  index signature, variadic tuple, generic function inference.
+- BLIND: conditional-via-generic-alias, the whole utility-type table,
+  template-literal with a placeholder, computed `unique symbol` key,
+  overload resolution.
+
+### Tier 1 — SUPPORT NOW
+
+- [~] **Conditional through a generic alias + the utility-type table.**
+  PARTLY DONE (batch DI). `Resolver::unwrap` now has a `Conditional`
+  arm — it was the only computed-type form of six without one — so
+  `type E<T> = T extends string ? … ; E<string>` reduces, and the
+  resolver consults `standard_utility_types()`, which had been
+  reachable ONLY through `module_alias_resolver`, a `pub fn` with no
+  caller outside its own file and its tests. Live now in both
+  directions: `Exclude`, `Extract`, `NonNullable`.
+  STILL BLIND: `ReturnType`, `Awaited`, `Parameters`,
+  `ThisParameterType`, `OmitThisParameter`, `ConstructorParameters`,
+  `InstanceType` — every one of them binds an `infer`, and
+  `extends_decision` cannot, so `simplify_type` abstains. The infer
+  matcher exists (`infer.mbt`, `substitute_inferred_type`) and is
+  wired into `is_assignable_to_with_generics`, NOT into this path —
+  the same disconnection this batch just fixed one layer up. That is
+  the next step and it is the same shape of work.
+  Two things measured rather than assumed, both worth keeping:
+  the whole change bought **ZERO corpus files** (predicted — take it
+  for the capability), and wiring the FULL table was wrong: the
+  property-shape entries (`Partial`, `Required`, `Readonly`, `Pick`,
+  `Record`, `Omit`) already have dedicated `lookup_field` arms and
+  resolving them here moved the shape out from under those arms,
+  failing three tests. The fallback is gated on the body being a
+  `Conditional` — a shape test, not a name list, because a second copy
+  of those names is the defect the batch exists to remove.
+  And the conformance gate earned itself again: `ThisType<T>` is
+  `interface ThisType<T> {}` in `lib.es5.d.ts`, an EMPTY marker, while
+  the table encodes it as the identity for the contextual-`this`
+  question. Taking that answer structurally made
+  `PropDesc<U> & ThisType<T>` demand every member of `T` — one FP on
+  `thisTypeInObjectLiterals2`, now resolved to `{}` ahead of the
+  generic arm with the shared table left alone.
+- [ ] (original entry, for reference)
+  The single highest-value item. `(string extends string ? number :
+  boolean)` inline is CAUGHT and `type E = string extends …` is CAUGHT,
+  but `type E<T> = T extends string ? … ; E<string>` is BLIND — while
+  generic alias instantiation itself works for object / array / union /
+  passthrough / interface bodies, and `substitute_params`
+  (`generics.mbt:63`) and `substitute_named` (`simplify.mbt:57`) both
+  already have a `Conditional` arm. So this is a WIRING or
+  reduction-order gap, one investigation rather than one implementation.
+  It matters far beyond its 13 corpus files: every standard utility type
+  is a generic alias over a conditional body, so `ReturnType`,
+  `Exclude`, `NonNullable`, `Parameters` and `Awaited` are all inert in
+  the body-checking path — a `.d.ts` using them type-checks by
+  ABSTAINING, which is a silent hole in the bridge's primary input.
+  Check first whether these blind rows are ONE abstention path: the
+  control `Bogus<number>` (an unresolved generic name) is also silent.
+- [ ] **Computed `unique symbol` keys** (16 files). 183 real `.d.ts`
+  declare `unique symbol`, 72 use `[Symbol.x]` keys; blind at the common
+  shape.
+- [ ] **Overload resolution** — select the right signature (2 solo files,
+  contributes to TS2345 / TS2769). Overloads are the reason `.d.ts`
+  files exist, and 566 of the 3,000 sampled carry repeated signatures.
+
+### Tier 2 — SUPPORT (cheap, mechanical, ~25 files)
+
+- [ ] Remaining grammar / declaration rules: TS2371 (default parameter on
+  a bodiless overload), TS2394 (overload incompatible with its
+  implementation), TS2386, TS2448, TS1308, TS2842, TS2708, TS1166,
+  TS2300. `has_body_block` at `parser_class.mbt:2936` already separates a
+  signature from an implementation and that site's own comment states
+  the abstention. NOTE: `parserParameterList16`/`17` and
+  `parserClassDeclaration12` are filed under legacy/broken-syntax and are
+  really these rules — they belong here, not in Tier 4.
+- [ ] implicit-any / strict family (10): TS7009/7010/7018/7022/7023/7031/
+  7053, TS2564/2565/2729. Small corpus count, highest USER-facing value
+  in this tier — it is what a real codebase hits the day it turns
+  `strict` on.
+- [ ] strict-null / narrowing (8).
+
+### Tier 3 — DEFER (~93 files, real but expensive)
+
+`assignability-core` (48), `generic-inference` (11), `iterator-protocol`
+(11), `this-typing` (7), `other` (16). Every one is genuine TS behaviour
+needing machinery we have not built: intersection reduction, contextual
+typing, `globalThis` modelling, index-signature subtyping, the
+async-iterator protocol. Do NOT take these for the MISS count — the
+measured rate is 2-12 files per batch. Take an individual file only when
+a real bridge input or `mtsc` target demands it, and record which one did.
+
+`decorator-signature` (7) sits here on a CAVEAT rather than a
+measurement: this corpus samples no Angular / NestJS / TypeORM. Promote
+if a bridge target uses them.
+
+### Tier 4 — WON'T SUPPORT (~24 files, declared out of scope)
+
+- [ ] Record the reasons in a scope file so they are not re-litigated:
+  - **legacy / broken syntax, 12 of 15.** Deliberately malformed input
+    (`parserErrorRecovery_ParameterList6`) and removed language features
+    (`import x = module("m")`, `/// <reference>` resolution). CLAUDE.md
+    already records that taking this cluster for its size is fitting the
+    corpus.
+  - **`using` declarations, 6.** ZERO occurrences in 5,697 real files.
+    The strongest out-of-scope case here. Revisit if a real dependency
+    adopts explicit resource management.
+  - **locally accepted, 6.** TS7 errors and local tsc 6.0.3 accepts, so
+    there is no oracle to develop against and no way to write the
+    legal-neighbour test this repo requires of every rule.
+
+### The recommendation that is not a rule
+
+- [ ] **Stop reporting one MISS number.** Check the Tier 4 list in as
+  `scripts/checker_out_of_scope.txt` (one path per line + reason), have
+  `checker_conformance_oracle.sh` read it, and report TWO numbers:
+  `MISS (in scope)` ~152 — the real backlog, which can reach zero — and
+  `OUT OF SCOPE` ~24. Gate on the former.
+  The FP budget is explicitly UNCHANGED: out-of-scope means "we will not
+  add a rule for it", never "we may flag it wrongly". A false positive on
+  one of these files is still a soundness bug, and the scope file must not
+  become a place to hide files we flag incorrectly.

--- a/docs/checker-triage.md
+++ b/docs/checker-triage.md
@@ -1,0 +1,241 @@
+# What the checker supports, what it will not, and why
+
+`MISS 176` is not a backlog. It mixes three unrelated things — work worth
+doing, work that needs machinery we have not built, and files nobody
+should ever fix — so the number cannot rank anything and cannot tell you
+when you are done. `docs/checker-priority.md` was retired for exactly
+this reason: it concluded that incremental recall wins were exhausted,
+having measured against the wrong oracle.
+
+So this document classifies all 176 remaining MISSes by the **machinery a
+rule would need**, prices each family against **how often the feature
+appears in real code**, and assigns each one to a tier: SUPPORT NOW,
+SUPPORT, DEFER, or WON'T SUPPORT. Everything below is measured. Where a
+number is a judgement rather than a measurement, it says so.
+
+The headline recommendation is at the bottom and it is not a rule: it is
+to **stop reporting one MISS number**, because a single figure that mixes
+declared-out-of-scope with real backlog is the thing that made this
+document necessary.
+
+## 1. The 176, by machinery
+
+From `node scripts/checker_miss_rank.mjs` — every remaining MISS file run
+through the locally installed compiler under its own `// @option:` header,
+then grouped by what a rule for it would need. Grouped by **machinery**
+and not by error code, because CLAUDE.md records twice that a code is not
+a difficulty class (`symbolProperty*` spans seven codes and is one
+feature; the decorator cluster looks like cheap grammar and is mostly
+assignability).
+
+| family | files | share |
+|---|---|---|
+| assignability-core | 48 | 27.3% |
+| symbol + computed key | 16 | 9.1% |
+| other (singletons) | 16 | 9.1% |
+| legacy / broken syntax | 15 | 8.5% |
+| mapped / conditional / template | 13 | 7.4% |
+| generic inference | 11 | 6.3% |
+| iterator protocol | 11 | 6.3% |
+| implicit-any / strict | 10 | 5.7% |
+| strict-null / narrowing | 8 | 4.5% |
+| `this` typing | 7 | 4.0% |
+| decorator signature | 7 | 4.0% |
+| locally accepted | 6 | 3.4% |
+| resource management (`using`) | 6 | 3.4% |
+| overload resolution | 2 | 1.1% |
+
+The largest bucket is the least useful one. Opening all 48
+`assignability-core` files shows about ten unrelated causes — variadic
+tuples, intersections, contextual typing, `globalThis`, index-signature
+subtyping, spread types, enum indexers — so "TS2322 is the biggest
+bucket" ranks no work at all. That is the same substitution this repo has
+made four times before (`computed_props`, `loops`, `typeofs`,
+`sequences`): a label standing in for the objective.
+
+## 2. How often each feature appears in real code
+
+A corpus count is not real-world frequency —
+`parser/ecmascript5/parserErrorRecovery_ParameterList6` is broken syntax
+nobody writes. So the second axis is measured against real input instead:
+3,000 `.d.ts` files from `node_modules` (what the bridge consumes) and
+2,697 `.ts` sources from the type-aware corpus (what `mtsc` consumes).
+
+| feature | real `.d.ts` | real `.ts` app |
+|---|---|---|
+| conditional type | **345** | 24 |
+| `keyof` | 194 | — |
+| `unique symbol` | 183 | — |
+| `infer` | 156 | — |
+| mapped type | 143 | 31 |
+| `this` return type | 115 | — |
+| index signature | 102 | — |
+| computed `[Symbol.x]` key | 72 | — |
+| template-literal type | 57 | 151 |
+| variadic tuple | 20 | — |
+| `satisfies` | — | 238 |
+| optional chaining | — | 144 |
+| `as const` | — | 108 |
+| **`using` / `await using`** | **0** | **0** |
+| **decorator** | **1** | **0** |
+
+Two rows decide two tiers on their own. `using` declarations occur in
+**zero** of 5,697 real files, and they are 6 of our MISSes. Decorators
+occur in one `.d.ts` and no application source — though that is a
+property of *this* corpus, which contains no Angular, NestJS or TypeORM,
+so the decorator row is a caveat rather than a verdict.
+
+## 3. What the checker can already do — probed, not assumed
+
+The classification above says what a file *needs*. It does not say what we
+already have, and guessing at that was wrong twice while writing this
+document. So each family's **common shape** was probed directly against
+`tscheck --strict`.
+
+The first probe run reported every family BLIND, which was a harness
+error, not a finding: `check_module_function_bodies` checks function
+bodies, and the probes put the error at top level where nothing visits it.
+Re-probed inside a function:
+
+| common shape | verdict |
+|---|---|
+| basic assignability (`const n: number = "s"`) | CAUGHT |
+| argument count | CAUGHT |
+| property missing on object literal | CAUGHT |
+| mapped type, via a generic alias | CAUGHT |
+| `keyof` | CAUGHT |
+| strictNullChecks (`o.a` where `a?:`) | CAUGHT |
+| `this` return type | CAUGHT |
+| index signature value type | CAUGHT |
+| variadic tuple | CAUGHT |
+| generic function inference | CAUGHT |
+| **conditional type via a generic alias** | **BLIND** |
+| **utility types** (`Exclude`/`NonNullable`/`ReturnType`/`Awaited`) | **BLIND** |
+| **template-literal type with a placeholder** | **BLIND** |
+| **computed `unique symbol` key** | **BLIND** |
+| **overload resolution** | **BLIND** |
+
+This is the most useful table in the document, and it reorders everything.
+Four of the five blind rows are features that appear in *hundreds* of real
+`.d.ts` files, and they are blind at the shape real code actually writes —
+not at a corner.
+
+### The conditional-type finding is narrower than it looks
+
+Worth stating precisely, because the cost estimate depends on it:
+
+```
+const x: (string extends string ? number : boolean) = true;  // CAUGHT
+type E = string extends string ? number : boolean;           // CAUGHT
+type E<T> = T extends string ? number : boolean; E<string>   // BLIND
+```
+
+The conditional evaluator **works** on concrete types, and
+`substitute_params` (`generics.mbt:63`) and `substitute_named`
+(`simplify.mbt:57`) both already have a `Conditional` arm. Generic alias
+instantiation also works — object, array, union, passthrough and
+interface bodies all resolve correctly, as does the same shape written as
+an interface. It is only the composition of the two that abstains.
+
+So this is a **wiring or reduction-order gap, not a missing feature** —
+one investigation, not one implementation. And it is the single
+highest-value item on the list, because every utility type in the standard
+table is a generic alias over a conditional body, which means
+`ReturnType`, `Exclude`, `NonNullable`, `Parameters` and `Awaited` are all
+inert in the body-checking path today.
+
+One control matters for interpreting all of this: `Bogus<number>`, an
+*unresolved* generic name, is also silent. Some of these blind rows may be
+one abstention path rather than five, which is the first thing to check
+and would make the fix cheaper still.
+
+## 4. The proposed triage
+
+### Tier 1 — SUPPORT NOW (~31 files, and the real prize is not the files)
+
+| item | why | MISS files |
+|---|---|---|
+| conditional through a generic alias + the utility-type table | 345 real `.d.ts` files; a wiring gap, not a feature; unblocks `ReturnType`/`Exclude`/`Awaited`/`Parameters` wholesale | 13 |
+| computed `unique symbol` keys | 183 `.d.ts` declare `unique symbol`, 72 use `[Symbol.x]` keys; blind at the common shape | 16 |
+| overload resolution (select the right signature) | overloads are the reason `.d.ts` files exist; blind | 2 |
+
+Take these for the capability, not the count. The conformance yield is
+modest; the difference is that a `.d.ts` using `ReturnType<typeof f>`
+currently type-checks by *abstaining*, which is a silent hole in the
+bridge's primary input.
+
+### Tier 2 — SUPPORT (~25 files, cheap and mechanical)
+
+- **Remaining grammar / declaration rules.** TS2371 (default parameter on
+  a bodiless overload), TS2394 (overload incompatible with its
+  implementation), TS2386, TS2448, TS1308, TS2842, TS2708, TS1166, TS2300.
+  These are the batch-DI shape: `has_body_block` at
+  `parser_class.mbt:2936` already separates a signature from an
+  implementation, and that site's own comment states the abstention.
+- **implicit-any / strict family** (10 files): TS7009/7010/7018/7022/7023/
+  7031/7053, TS2564/2565/2729. This is what a real codebase hits the day
+  it turns `strict` on, which makes it the highest *user-facing* value in
+  Tier 2 even though the corpus count is small.
+- **strict-null / narrowing** (8 files).
+
+### Tier 3 — DEFER (~93 files, real but expensive)
+
+`assignability-core` (48), `generic-inference` (11), `iterator-protocol`
+(11), `this-typing` (7), `other` (16). Every one is a genuine TypeScript
+behaviour and none is reachable without machinery we would have to build
+— intersection reduction, contextual typing, `globalThis` modelling,
+index-signature subtyping, the async-iterator protocol.
+
+Do not take these for the MISS count. Take an individual file only when a
+real bridge input or `mtsc` target demands it, and record which one did.
+The measured rate here is 2–12 files per batch, so the count will not move
+meaningfully and pretending otherwise is how `docs/checker-priority.md`
+went wrong.
+
+`decorator-signature` (7) sits here rather than in WON'T SUPPORT on a
+caveat, not a measurement: this corpus samples no decorator-heavy
+framework. Promote it if a bridge target uses Angular/NestJS/TypeORM.
+
+### Tier 4 — WON'T SUPPORT (~24 files, declared out of scope)
+
+Each with the reason written down so it is not re-litigated:
+
+- **`legacy` / broken syntax — 12 of the 15.** `parser/ecmascript5/*` is
+  deliberately malformed input (`parserErrorRecovery_ParameterList6`) and
+  removed language features (`import x = module("m")`, `/// <reference>`
+  path resolution). CLAUDE.md already records that taking this cluster for
+  its size is fitting the corpus: it is the largest and cheapest cluster
+  and the wrong one to take. **Three of the fifteen are not legacy at all**
+  — `parserParameterList16`/`17` and `parserClassDeclaration12` are the
+  TS2371/TS2394 overload rules, and they belong in Tier 2.
+- **`resource-mgmt` (`using`) — 6.** Zero occurrences in 5,697 real files.
+  The strongest out-of-scope case on the list. Revisit if a real
+  dependency adopts explicit resource management.
+- **`locally-accepted` — 6.** TS7 errors on these and the local compiler
+  6.0.3 accepts them, so there is no oracle to develop against and no way
+  to write the legal-neighbour test this repo requires of every rule.
+
+## 5. The recommendation that is not a rule
+
+**Stop reporting a single MISS number.** It currently sums Tier 1 (worth
+doing now) with Tier 4 (declared never), so it cannot answer "are we
+done?" or "what next?" — and a metric that answers neither is what
+produced a retired strategy document.
+
+Concretely:
+
+1. Check in the Tier 4 list as a scope file (`scripts/checker_out_of_scope.txt`),
+   one path per line, each with its reason.
+2. Have `checker_conformance_oracle.sh` read it and report **two** numbers:
+   `MISS (in scope)` — the real backlog, ~152 today — and
+   `OUT OF SCOPE` — declared, ~24.
+3. Keep the FP budget exactly where it is. Out-of-scope means "we will not
+   add a rule for it", never "we may flag it wrongly": a false positive on
+   one of these files is still a soundness bug.
+4. Gate on the in-scope number. It can then legitimately reach zero, which
+   the current number never can.
+
+The one thing to preserve from the old regime: the asymmetry. A MISS is
+expected because we model a subset of TypeScript; an FP never is. Nothing
+in this triage weakens that, and the scope file must not become a place to
+hide files we flag incorrectly.

--- a/src/checker/assignability.mbt
+++ b/src/checker/assignability.mbt
@@ -1139,7 +1139,17 @@ fn contains_infer_marker(t : @ast.TsType) -> Bool {
       }
       false
     }
-    Func(params, ret) => {
+    // `Func` and `Constructor` are the two callable shapes, and for a
+    // long time this walk descended into one of them. The other two
+    // functions of the infer trio both handle `Constructor` already —
+    // `match_infer_pattern` has an arm that even reuses the `Func`
+    // rest-tuple path, and `substitute_inferred_type` rebuilds one — so
+    // a `new (...args: any[]) => infer R` pattern matched and
+    // substituted correctly and was never REACHED, because this
+    // predicate is the gate that decides whether the infer path runs at
+    // all. `InstanceType` and `ConstructorParameters` were inert for
+    // that one missing arm.
+    Func(params, ret) | Constructor(params, ret, _) => {
       for p in params {
         if contains_infer_marker(p) {
           return true

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -1799,6 +1799,61 @@ fn Resolver::unwrap_element(
 }
 
 ///|
+/// The CONSTRUCT signature of `typeof ClassName`, or `None` when it
+/// cannot be known.
+///
+/// `Resolver::unwrap`'s `TypeOf` arm resolves a name through
+/// `self.globals`, and a class is recorded in `self.classes`, so
+/// `typeof C` resolves to nothing at all — which is why
+/// `InstanceType<typeof C>` and `ConstructorParameters<typeof C>` both
+/// abstained however well the `infer` matcher worked.
+///
+/// This deliberately answers ONLY the construct question, and is called
+/// only from the conditional decision. The constructor side of a class
+/// also carries its STATIC members, and `resolver_class_method_signature`
+/// says in its own comment that those are not modelled — so resolving
+/// `typeof C` to a bare `Constructor(...)` everywhere would make every
+/// static access through such a binding look like a missing property.
+/// Supplying it where a construct signature is what the pattern asked
+/// for cannot do that.
+///
+/// Two shapes abstain rather than guess, both for the same reason — the
+/// real signature is somewhere this function cannot see:
+///  - `extends mixin(Base)`, where `<expr-base>` marks a base whose
+///    constructor is the result of a call (the guard
+///    `class_constructor_signature` already applies for `new`);
+///  - a class with no constructor of its own but with a base, which
+///    INHERITS the base's constructor.
+/// A class with no constructor and no base is `new () => C`, which is
+/// what TypeScript gives it.
+fn Resolver::class_construct_signature(
+  self : Resolver,
+  name : String,
+) -> @ast.TsType? {
+  guard self.classes.get(name) is Some(cls) else { return None }
+  if cls.base_names.contains("<expr-base>") {
+    return None
+  }
+  match cls.constructor_params {
+    Some(params) => {
+      let types : Array[@ast.TsType] = []
+      for p in params {
+        types.push(p.1)
+      }
+      Some(Constructor(types, Named(name), cls.is_abstract))
+    }
+    // No constructor of its own: implicit `new () => C` only when there
+    // is no base to inherit one from.
+    None =>
+      if cls.base_names.length() == 0 {
+        Some(Constructor([], Named(name), cls.is_abstract))
+      } else {
+        None
+      }
+  }
+}
+
+///|
 fn Resolver::unwrap(self : Resolver, ty : @ast.TsType) -> @ast.TsType {
   let seen : Map[String, Bool] = {}
   let mut cur = ty
@@ -2060,8 +2115,23 @@ fn Resolver::unwrap(self : Resolver, ty : @ast.TsType) -> @ast.TsType {
         // pattern exists to align with. Only the check side is resolved
         // when a marker is present.
         let has_infer = contains_infer_marker(ext)
+        // `unwrap` leaves a `TypeOf` untouched when the name is not a
+        // global, and a CLASS is not one — so `typeof C` arrives here
+        // unresolved, which is why `InstanceType<typeof C>` and
+        // `ConstructorParameters<typeof C>` abstained however well the
+        // `infer` matcher worked. Its construct signature is supplied
+        // for the DECISION only; see `class_construct_signature` for why
+        // it is not supplied everywhere.
+        let resolved_check = match self.unwrap(check) {
+          TypeOf(n) =>
+            match self.class_construct_signature(n) {
+              Some(ctor) => ctor
+              None => TypeOf(n)
+            }
+          other => other
+        }
         let probe = @ast.TsType::Conditional(
-          self.unwrap(check),
+          resolved_check,
           if has_infer {
             ext
           } else {

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -2055,11 +2055,49 @@ fn Resolver::unwrap(self : Resolver, ty : @ast.TsType) -> @ast.TsType {
       // re-entering it) and what keeps an undecidable conditional a MISS
       // instead of a wrong answer.
       Conditional(check, ext, t_branch, f_branch) => {
-        let simplified = simplify_type(
-          Conditional(self.unwrap(check), self.unwrap(ext), t_branch, f_branch),
+        // An `infer` pattern is matched against the EXTENDS type as
+        // WRITTEN: resolving that side could rewrite the very shape the
+        // pattern exists to align with. Only the check side is resolved
+        // when a marker is present.
+        let has_infer = contains_infer_marker(ext)
+        let probe = @ast.TsType::Conditional(
+          self.unwrap(check),
+          if has_infer {
+            ext
+          } else {
+            self.unwrap(ext)
+          },
+          t_branch,
+          f_branch,
         )
+        let simplified = simplify_type(probe)
         match simplified {
-          Conditional(_, _, _, _) => keep_going = false
+          Conditional(_, _, _, _) =>
+            // `simplify_type` decides through the three-valued
+            // `extends_decision`, which cannot bind an `infer` — so
+            // every infer-shaped utility (`ReturnType`, `Parameters`,
+            // `Awaited`, `InstanceType`, …) abstained here.
+            // `reduce_conditional` is the reducer that can: it runs
+            // `match_infer_pattern` and substitutes the captures into
+            // the true branch.
+            //
+            // It is tried ONLY for the infer case, and deliberately not
+            // as a general fallback. Its non-infer path is
+            // `is_assignable_to`, which is two-valued: an undecidable
+            // `extends` would take the FALSE branch and answer
+            // confidently exactly where `extends_decision` correctly
+            // says "don't know". Keeping it behind `has_infer` is what
+            // stops this arm from turning an abstention into a wrong
+            // answer.
+            if has_infer {
+              let reduced = reduce_conditional(probe)
+              match reduced {
+                Conditional(_, _, _, _) => keep_going = false
+                _ => cur = reduced
+              }
+            } else {
+              keep_going = false
+            }
           _ => cur = simplified
         }
       }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -27,6 +27,19 @@ priv struct Resolver {
   interfaces : Map[String, @ast.TsInterface]
   classes : Map[String, @ast.TsClassDecl]
   type_aliases : Map[String, @ast.TsTypeAlias]
+  // The standard TypeScript utility types (`Exclude`, `ReturnType`,
+  // `Partial`, …) as alias bindings, consulted only when
+  // `type_aliases` has no entry for a name — so a module that declares
+  // its own `Exclude` still shadows the standard one.
+  //
+  // Held on the resolver rather than looked up through a helper because
+  // `standard_utility_types()` allocates an 18-entry map and
+  // `Resolver::unwrap` runs on every assignability diagnostic: this is
+  // one allocation per resolver instead of one per unwrap. Keeping the
+  // whole table (rather than a hand-written list of the names that
+  // happen to matter) is deliberate — a second copy of those names is
+  // the "one rule written in two places" defect this repo keeps finding.
+  standard_aliases : Map[String, AliasBinding]
   // Module-level identifier types: top-level functions, ambient values,
   // imports. Looked up when an identifier is unbound in the local env.
   globals : Map[String, @ast.TsType]
@@ -177,6 +190,7 @@ fn Resolver::empty() -> Resolver {
     interfaces: {},
     classes: {},
     type_aliases: {},
+    standard_aliases: standard_utility_types(),
     globals: {},
     signatures: {},
     func_type_params: {},
@@ -1819,27 +1833,84 @@ fn Resolver::unwrap(self : Resolver, ty : @ast.TsType) -> @ast.TsType {
       // shadows the name with its own alias, handled below).
       Applied("NoInfer", [inner]) if !self.type_aliases.contains("NoInfer") =>
         cur = inner
+      // `ThisType<T>` is declared in `lib.es5.d.ts` as
+      // `interface ThisType<T> {}` — an EMPTY marker whose only job is to
+      // set the contextual `this` type of an object literal's methods. It
+      // contributes no members, so structurally it is `{}` and
+      // `PropDesc<U> & ThisType<T>` is satisfied by a `PropDesc<U>`.
+      //
+      // The standard-utility table encodes it as the IDENTITY (`Named(T)`)
+      // and says in its own comment why: without a contextual-inference
+      // engine that is the useful answer to "what is `this` in here".
+      // That is a different question from "what members does this type
+      // have", and taking the identity answer for the structural one
+      // makes an intersection demand every member of `T` — which is
+      // exactly the false positive the conformance gate caught on
+      // `thisTypeInObjectLiterals2` the moment the resolver started
+      // consulting that table. So the marker is resolved here, ahead of
+      // the generic `Applied` arm, and the shared table is left alone for
+      // the consumer it was written for.
+      Applied("ThisType", _) if !self.type_aliases.contains("ThisType") =>
+        cur = Object([])
       Applied(n, args) =>
         if seen.contains(n) {
           keep_going = false
         } else {
-          match self.type_aliases.get(n) {
-            Some(aliased) if aliased.type_params.length() > 0 => {
+          // A module's own alias first, then the standard utility table.
+          // Both arrive here as (type_params, body); the module side
+          // wins on a name conflict, which is what lets a module
+          // override a stdlib utility shape.
+          let binding : (Array[String], @ast.TsType)? = match
+            self.type_aliases.get(n) {
+            Some(aliased) if aliased.type_params.length() > 0 =>
+              Some((aliased.type_params, aliased.type_))
+            Some(_) => None
+            None =>
+              // Only the CONDITIONAL-bodied entries of the standard
+              // table are taken here, and the gate is the body's SHAPE
+              // rather than a list of names — a second copy of those
+              // names is the defect this whole change exists to remove.
+              //
+              // The split is not arbitrary, it is the line between the
+              // entries that were inert and the ones that already work.
+              // A conditional body reduces to a concrete type by
+              // DECIDING, which nothing on this path did, so
+              // `Exclude` / `Extract` / `NonNullable` / `ReturnType` /
+              // `Parameters` / `Awaited` were all silent. The
+              // property-shape entries (`Partial`, `Required`,
+              // `Readonly`, `Pick`, `Record`, `Omit`) are mapped types
+              // over `keyof`, and `lookup_field` already has dedicated
+              // arms for them — resolving those here instead moves the
+              // shape out from under those arms and breaks them. That is
+              // measured, not predicted: wiring the whole table failed
+              // three tests (`Record<string, number>` losing `r.foo`,
+              // `Partial<Config>` losing `p.name`'s `| undefined`, and a
+              // `Record`-typed `satisfies` target), all of them real
+              // regressions rather than tests pinning old behaviour.
+              match self.standard_aliases.get(n) {
+                Some(std) if std.type_params.length() > 0 &&
+                  std.body is Conditional(_, _, _, _) =>
+                  Some((std.type_params, std.body))
+                _ => None
+              }
+          }
+          match binding {
+            Some((type_params, body)) => {
               seen[n] = true
               let bindings : Map[String, @ast.TsType] = {}
-              let limit = if args.length() < aliased.type_params.length() {
+              let limit = if args.length() < type_params.length() {
                 args.length()
               } else {
-                aliased.type_params.length()
+                type_params.length()
               }
               let mut i = 0
               while i < limit {
-                bindings[aliased.type_params[i]] = args[i]
+                bindings[type_params[i]] = args[i]
                 i = i + 1
               }
-              cur = substitute_params(aliased.type_, bindings)
+              cur = substitute_params(body, bindings)
             }
-            _ => keep_going = false
+            None => keep_going = false
           }
         }
       // `typeof varName` in type position — resolve the variable's current type.
@@ -1949,6 +2020,46 @@ fn Resolver::unwrap(self : Resolver, ty : @ast.TsType) -> @ast.TsType {
         let simplified = simplify_type(cur)
         match simplified {
           TemplateLiteralType(_, _) => keep_going = false
+          _ => cur = simplified
+        }
+      }
+      // A CONDITIONAL is the sixth computed-type form this loop reduces,
+      // and the only one that was missing: `Keyof`, `TypeOf`,
+      // `MappedType`, `IndexedAccess` and `TemplateLiteralType` all
+      // reduce above, and `Conditional` fell through to the catch-all.
+      //
+      // What that cost was NOT the conditional evaluator, which works:
+      // an inline `string extends string ? number : boolean` and a
+      // non-generic alias for one both resolve already, because neither
+      // needs anything substituted first. It was the COMPOSITION with a
+      // generic alias -- `type E<T> = T extends string ? … ` applied as
+      // `E<string>` substitutes correctly in the `Applied` arm above and
+      // then arrived here unreduced. That matters far beyond conditional
+      // types themselves: every standard utility type is a generic alias
+      // over a conditional body, so `ReturnType`, `Exclude`,
+      // `NonNullable`, `Parameters` and `Awaited` were all inert, and a
+      // `.d.ts` using them type-checked by ABSTAINING.
+      //
+      // The two operands are resolved through the resolver BEFORE
+      // simplifying, for the reason the `IndexedAccess` arm below
+      // records in its own comment: `simplify_type` carries no resolver,
+      // so a `Named` operand hits its catch-all and `extends_decision`
+      // comes back `None`. Only the operands are resolved, not the
+      // branches -- a branch is the RESULT and the caller unwraps it in
+      // turn, while resolving both eagerly would expand types the
+      // decision is about to discard.
+      //
+      // `simplify_type` returns the `Conditional` unchanged whenever
+      // `extends_decision` cannot decide. That is what makes this arm
+      // terminate (an undecided conditional stops the loop rather than
+      // re-entering it) and what keeps an undecidable conditional a MISS
+      // instead of a wrong answer.
+      Conditional(check, ext, t_branch, f_branch) => {
+        let simplified = simplify_type(
+          Conditional(self.unwrap(check), self.unwrap(ext), t_branch, f_branch),
+        )
+        match simplified {
+          Conditional(_, _, _, _) => keep_going = false
           _ => cur = simplified
         }
       }

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -33020,11 +33020,42 @@ fn check_interface_extends_compat(
     }
   }
 
+  // Interface declarations MERGE, and an index signature constrains the
+  // members of the MERGED type — so the two halves of
+  //
+  //     interface A { [x: number]: string }
+  //     interface A { [y: string]: { length: string } }
+  //
+  // conflict with each other and neither half conflicts with itself.
+  // This loop reads `module_.interfaces`, the per-DECLARATION list, so
+  // every cross-declaration conflict was invisible: the identical
+  // members written in ONE body are reported and the same members split
+  // across two are silent (mergedInterfacesWithIndexers2).
+  //
+  // A name with several declarations is therefore checked once, on the
+  // merged interface from the resolver, and skipped here — checking both
+  // would report every within-one-body conflict twice.
+  //
+  // Only names THIS module declares more than once are looked up, rather
+  // than iterating `resolver.interfaces` wholesale: that table also
+  // holds interfaces ingested from imported modules and the lib, and
+  // those are not this module's to report on.
+  let iface_decl_counts : Map[String, Int] = {}
+  for iface in module_.interfaces {
+    iface_decl_counts[iface.name] = (match iface_decl_counts.get(iface.name) {
+        Some(v) => v
+        None => 0
+      }) +
+      1
+  }
   for iface in module_.interfaces {
     // Generic interfaces are processed too: a property whose type is one of
     // the interface's own type parameters resolves to a bare `Named` that is
     // not object-shaped and not scalar, so `violates_index_value` leaves it
     // alone -- only concrete object / scalar properties are decided.
+    if iface_decl_counts.get(iface.name) is Some(n) && n > 1 {
+      continue
+    }
     check_index_props(
       iface.index_signatures,
       iface.fields,
@@ -33069,6 +33100,38 @@ fn check_interface_extends_compat(
       if inherited.length() > 0 {
         check_index_props(inherited, iface.fields, "interface \{iface.name}")
       }
+    }
+  }
+  // The merged pass for the names skipped above. `merge_interface_group`
+  // concatenates `index_signatures` and folds `fields`, so the entry in
+  // the resolver already IS the type an index signature has to constrain.
+  let merged_seen : Map[String, Unit] = {}
+  for iface in module_.interfaces {
+    if !(iface_decl_counts.get(iface.name) is Some(n) && n > 1) {
+      continue
+    }
+    if merged_seen.contains(iface.name) {
+      continue
+    }
+    merged_seen[iface.name] = ()
+    match resolver.interfaces.get(iface.name) {
+      Some(merged) => {
+        check_index_props(
+          merged.index_signatures,
+          merged.fields,
+          "interface \{merged.name}",
+        )
+        if merged.type_params.length() == 0 {
+          check_num_vs_str_sigs(
+            merged.index_signatures,
+            "interface \{merged.name}",
+          )
+        }
+      }
+      // No merged entry (a prefix mismatch, or a name the resolver did
+      // not ingest) — abstain rather than fall back to the halves, which
+      // is what produced the silence this pass exists to remove.
+      None => ()
     }
   }
   // Non-generic classes by name for the base-chain walks below.

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -11471,6 +11471,130 @@ fn single_call_signature_params(
 }
 
 ///|
+/// TS2769 ("No overload matches this call") for a callee that is a union
+/// of call signatures — which is how an overload set ingests.
+///
+/// `check_union_callee_arity` is the complementary rule and is
+/// deliberately kept off overload sets: it requires EVERY member to
+/// accept, which is right for a union-typed VALUE and wrong for an
+/// overload set, where one match is enough. That exclusion was correct
+/// and left a hole, because nothing took over — an overloaded call had
+/// its arguments checked by nothing at all, so `g(true)` against
+/// `g(a: string)` / `g(a: number)` was silent while the identical call
+/// to a single-signature `h(a: string)` was reported. Most of the
+/// standard library is overloaded, so that hole is wide on real input.
+///
+/// This reports only when EVERY member is PROVEN unable to accept the
+/// call, which makes it sound for a union-typed value too: if no
+/// constituent can accept, the call is wrong under either reading, so
+/// the two rules need not be told apart.
+///
+/// A member is proven unacceptable only by:
+///  - arity — fewer arguments than its required count, or more than its
+///    parameter count when it has no rest parameter;
+///  - a definite PRIMITIVE argument against a definite primitive
+///    parameter that it is not assignable to.
+///
+/// Everything else abstains, and abstention is per-MEMBER with an early
+/// return: one member that merely MIGHT accept silences the whole call.
+/// That is what keeps a generic overload (`f<T>(x: T): T`, whose
+/// parameter is a bare `Named`), an object-typed parameter, a rest
+/// parameter, a spread argument and an unreadable member from ever
+/// producing a finding.
+fn check_overload_set_no_match(
+  env : ExprEnv,
+  ctx : CheckCtx,
+  callee_ty : @ast.TsType,
+  args : Array[@ast.TsExpr],
+  call_path : String,
+) -> Unit {
+  guard ctx.resolver.unwrap(callee_ty) is Union(members) else { return }
+  if members.length() < 2 {
+    return
+  }
+  // A spread hides the argument count entirely.
+  for a in args {
+    if a is Spread(_) {
+      return
+    }
+  }
+  // Every member has to be a call signature this can read; one that is
+  // not might accept anything.
+  let sigs : Array[(Array[@ast.TsType], Array[Bool])] = []
+  for m in members {
+    match callable_source_params(m, ctx.resolver) {
+      Some(pair) => sigs.push(pair)
+      None => return
+    }
+  }
+  let n = args.length()
+  let arg_tys : Array[@ast.TsType] = []
+  for a in args {
+    arg_tys.push(ctx.resolver.unwrap(infer_expr(env, ctx.resolver, a)))
+  }
+  for sig in sigs {
+    let (ps, optional_params) = sig
+    let mut has_rest = false
+    for p in ps {
+      if p is Rest(_) {
+        has_rest = true
+      }
+    }
+    // Proven by arity. The minimum is computed here rather than through
+    // `required_arity_from_callable_source` because a `declare function`
+    // overload arrives with its optionality WIDENED into the parameter
+    // type (`a?: string` becomes `string | undefined`) and an empty
+    // `optional_params` — which is the hazard
+    // `check_union_callee_arity`'s own comment records ("two callables
+    // can have identical widened parameter types while differing in
+    // whether that parameter was written with `?`"), and it cost a false
+    // positive here: `t()` against `t(a?: string)` was reported.
+    //
+    // A parameter that ACCEPTS undefined is treated as omittable. That
+    // over-counts optionals — a genuinely required `a: string |
+    // undefined` is counted omittable too — and over-counting only ever
+    // makes this proof weaker, so it costs a MISS and never a finding.
+    // Batch CU's decorator arity took the same trade for the same reason.
+    let mut min_arity = 0
+    for i in 0..<ps.length() {
+      let declared_optional = i < optional_params.length() && optional_params[i]
+      if !(ps[i] is Rest(_)) &&
+        !declared_optional &&
+        !(ps[i] is Void) &&
+        !type_accepts_undefined(ctx.resolver.unwrap(ps[i])) {
+        min_arity = i + 1
+      }
+    }
+    if n < min_arity {
+      continue
+    }
+    if !has_rest && n > ps.length() {
+      continue
+    }
+    // Proven by a primitive-to-primitive mismatch.
+    let mut proven_bad = false
+    for i in 0..<n {
+      if i >= ps.length() {
+        break
+      }
+      let pt = ctx.resolver.unwrap(ps[i])
+      if is_definite_primitive_type(pt) &&
+        is_definite_primitive_type(arg_tys[i]) &&
+        !is_assignable_to(arg_tys[i], pt) {
+        proven_bad = true
+        break
+      }
+    }
+    if proven_bad {
+      continue
+    }
+    // This member might accept — the call stands.
+    return
+  }
+  record_unfiltered(ctx, call_path, "no overload matches this call")
+}
+
+///|
 /// TS2554 for a union-of-functions callee whose members have *different*
 /// signatures. TypeScript first reduces same-arity union signatures to the
 /// narrowest parameter domain: `(x: "a" | undefined)` beats
@@ -17778,6 +17902,18 @@ fn check_call_args_in_expr(
               if ctx.resolver.signatures.get(name) is None {
                 check_union_callee_arity(ctx, other, args, "call `\{name}`")
               }
+              // Unlike the every-member arity rule above, this one is
+              // sound for an overload set AND for a union-typed value,
+              // so it is not gated on `signatures`: it fires only when
+              // NO member can accept, which is wrong under either
+              // reading.
+              check_overload_set_no_match(
+                env,
+                ctx,
+                other,
+                args,
+                "call `\{name}`",
+              )
               if is_construct_only_callee(other) {
                 record_unfiltered(
                   ctx,
@@ -17888,6 +18024,7 @@ fn check_call_args_in_expr(
           // can have identical widened parameter types while differing in
           // whether that parameter was written with `?`.
           check_union_callee_arity(ctx, raw_callee_ty, args, "call")
+          check_overload_set_no_match(env, ctx, raw_callee_ty, args, "call")
           match union_common_call_params(callee_ty, ctx.resolver) {
             Some(params) => check_arguments(env, params, args, ctx, "call")
             None => ()

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -17696,3 +17696,84 @@ test "expr_check: infer-binding utility types decide through reduce_conditional"
     0,
   )
 }
+
+///|
+/// `InstanceType` / `ConstructorParameters`, and the correction of a
+/// wrong diagnosis worth keeping.
+///
+/// The obvious suspect was `typeof C`: `Resolver::unwrap`'s `TypeOf` arm
+/// resolves through `self.globals` and a class lives in `self.classes`,
+/// so `typeof C` really does arrive unresolved. That was NOT the cause.
+/// `InstanceType<new () => C>`, with no `typeof` anywhere, was equally
+/// silent — which is what pointed at the real defect:
+/// `contains_infer_marker` descended into `Func` and had no
+/// `Constructor` arm, so it answered "no markers here" and the infer
+/// path never ran at all. `match_infer_pattern` and
+/// `substitute_inferred_type` both already handled `Constructor`; two of
+/// the trio were right and the gate was wrong.
+///
+/// Both fixes are needed, and the inline case is the one that proves the
+/// gate was the problem rather than the class lookup.
+test "expr_check: InstanceType / ConstructorParameters through a construct signature" {
+  let n = fn(src : String) -> Int {
+    check_module_function_bodies(parse_module_or_empty(src)).length()
+  }
+  // No `typeof`: this is the case that isolates `contains_infer_marker`.
+  assert_true(
+    n(
+      "class C {}\nfunction f() { const x: InstanceType<new () => C> = \"s\"; return x }",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    n(
+      "class C {}\nfunction f() { const x: InstanceType<new () => C> = new C(); return x }",
+    ),
+    0,
+  )
+  // Through `typeof C`, which needs `class_construct_signature`.
+  let c = "class C { m(): void {} }\n"
+  assert_true(
+    n(c + "function f() { const x: InstanceType<typeof C> = \"s\"; return x }") >
+    0,
+  )
+  @test.assert_eq(
+    n(
+      c + "function f() { const x: InstanceType<typeof C> = new C(); return x }",
+    ),
+    0,
+  )
+  let ca = "class C { constructor(a: string) {} }\n"
+  assert_true(
+    n(
+      ca +
+      "function f() { const x: ConstructorParameters<typeof C> = [1]; return x }",
+    ) >
+    0,
+  )
+  @test.assert_eq(
+    n(
+      ca +
+      "function f() { const x: ConstructorParameters<typeof C> = [\"s\"]; return x }",
+    ),
+    0,
+  )
+  // The construct signature is supplied for the DECISION only. A class's
+  // constructor side also carries its statics, which this checker does
+  // not model, so resolving `typeof C` everywhere would make every
+  // static access through such a binding a missing property.
+  @test.assert_eq(
+    n(
+      "class C { static s(): number { return 1 } }\ndeclare const k: typeof C;\nfunction f() { const q: number = k.s(); return q }",
+    ),
+    0,
+  )
+  // Abstains where the real signature is somewhere the helper cannot
+  // see: a derived class with no constructor INHERITS the base's.
+  @test.assert_eq(
+    n(
+      "class B { constructor(a: string) {} }\nclass D extends B { }\nfunction f() { const x: ConstructorParameters<typeof D> = [1]; return x }",
+    ),
+    0,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -17846,3 +17846,86 @@ test "expr_check: index-signature conflicts across merged interface halves" {
     1,
   )
 }
+
+///|
+/// TS2769: no overload matches this call.
+///
+/// Overload sets ingest as a `Union` of call signatures, and
+/// `check_union_callee_arity` is deliberately kept off them — its rule is
+/// that EVERY member must accept, which is right for a union-typed value
+/// and wrong for an overload set where one match is enough. That
+/// exclusion was correct and nothing took over, so an overloaded call had
+/// its arguments checked by nothing at all: `g(true)` against
+/// `g(a: string)` / `g(a: number)` was silent while the identical call to
+/// a single-signature `h(a: string)` was reported. Most of the standard
+/// library is overloaded, so the hole is wide on real input.
+///
+/// The rule reports only when EVERY member is PROVEN unable to accept,
+/// which makes it sound for a union-typed value too. Abstention is
+/// per-member with an early return, so one member that merely MIGHT
+/// accept silences the call — that is what the five abstention cases pin.
+test "expr_check: TS2769 when no overload can accept the call" {
+  let n = fn(src : String) -> Int {
+    check_module_function_bodies(parse_module_or_empty(src)).length()
+  }
+  let g = "declare function g(a: string): void;\ndeclare function g(a: number): void;\n"
+  // Proven unacceptable by type, and by arity in both directions.
+  assert_true(n(g + "function f() { g(true) }") > 0)
+  assert_true(n(g + "function f() { g(\"s\", 1) }") > 0)
+  assert_true(n(g + "function f() { g() }") > 0)
+  // A call that does match either overload must stay silent.
+  @test.assert_eq(n(g + "function f() { g(\"s\") }"), 0)
+  @test.assert_eq(n(g + "function f() { g(1) }"), 0)
+  // Abstentions. Each is a member this cannot prove unacceptable, and one
+  // such member silences the whole call.
+  //  - a generic overload's parameter is a bare `Named`;
+  @test.assert_eq(
+    n(
+      "declare function p(a: string): void;\ndeclare function p(a: number): void;\ndeclare function p<T>(a: T): void;\nfunction f() { p(true) }",
+    ),
+    0,
+  )
+  //  - an object-typed parameter is not a definite primitive;
+  @test.assert_eq(
+    n(
+      "interface X { k: number }\ndeclare function q(a: string): void;\ndeclare function q(a: X): void;\nfunction f() { q({ k: 1 }) }",
+    ),
+    0,
+  )
+  //  - a rest parameter lifts the arity bound;
+  @test.assert_eq(
+    n(
+      "declare function s(a: string): void;\ndeclare function s(...xs: number[]): void;\nfunction f() { s(true) }",
+    ),
+    0,
+  )
+  //  - a spread argument hides the count;
+  @test.assert_eq(n(g + "function f(xs: any[]) { g(...xs) }"), 0)
+  //  - and the false positive this cost first: a `declare function`
+  //    overload arrives with its optionality WIDENED into the parameter
+  //    type (`a?: string` becomes `string | undefined`) and an empty
+  //    `optional_params`, so the shared arity helper called `t()` one
+  //    argument short. A parameter that accepts undefined is treated as
+  //    omittable here, which over-counts optionals and therefore only
+  //    ever weakens the proof.
+  @test.assert_eq(
+    n(
+      "declare function t(a?: string): void;\ndeclare function t(a: number, b: number): void;\nfunction f() { t() }",
+    ),
+    0,
+  )
+  @test.assert_eq(
+    n(
+      "declare function v(a: string | undefined): void;\ndeclare function v(a: number, b: number): void;\nfunction f() { v() }",
+    ),
+    0,
+  )
+  // Sound for a union-typed VALUE as well, which is why the rule is not
+  // gated on `resolver.signatures`.
+  assert_true(
+    n(
+      "declare const u: ((a: string) => void) | ((a: number) => void);\nfunction f() { u(true) }",
+    ) >
+    0,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -17777,3 +17777,72 @@ test "expr_check: InstanceType / ConstructorParameters through a construct signa
     0,
   )
 }
+
+///|
+/// TS2411 / TS2413 across MERGED interface declarations.
+///
+/// The rule itself was complete and correct — a member incompatible with
+/// a string index signature, a numeric index signature incompatible with
+/// a string one, unions, classes, inherited signatures, the legal
+/// subtype cases — and it read `module_.interfaces`, the per-DECLARATION
+/// list. Interface declarations merge, and an index signature constrains
+/// the members of the MERGED type, so the two halves of
+///
+///     interface A { [x: number]: string }
+///     interface A { [y: string]: { length: string } }
+///
+/// conflict with each other while neither half conflicts with itself.
+/// Written in one body it was reported; split across two it was silent.
+///
+/// A name with several declarations is checked once on the merged entry
+/// and skipped in the per-declaration loop, so a within-one-body
+/// conflict is not reported twice — which is what `single-declaration
+/// still reports exactly once` pins.
+test "expr_check: index-signature conflicts across merged interface halves" {
+  let n = fn(src : String) -> Int {
+    check_module_function_bodies(parse_module_or_empty(src)).length()
+  }
+  // Cross-declaration: the case that was silent.
+  assert_true(
+    n(
+      "interface A { [x: number]: string }\ninterface A { [y: string]: { length: string } }\nfunction f(a: A) { return a }",
+    ) >
+    0,
+  )
+  assert_true(
+    n(
+      "interface B { [k: string]: string }\ninterface B { port: number }\nfunction f(b: B) { return b }",
+    ) >
+    0,
+  )
+  // Legal neighbours — a compatible member and a compatible numeric
+  // signature, both split across halves.
+  @test.assert_eq(
+    n(
+      "interface C { [k: string]: string }\ninterface C { host: string }\nfunction f(c: C) { return c }",
+    ),
+    0,
+  )
+  @test.assert_eq(
+    n(
+      "interface D { [x: number]: string }\ninterface D { [y: string]: string }\nfunction f(d: D) { return d }",
+    ),
+    0,
+  )
+  // A generic interface abstains: a property typed by the interface's own
+  // parameter is a bare `Named`, which `violates_index_value` leaves
+  // alone.
+  @test.assert_eq(
+    n(
+      "interface E<T> { [k: string]: T }\ninterface E<T> { v: T }\nfunction f(e: E<string>) { return e }",
+    ),
+    0,
+  )
+  // Single declaration: still reported, and exactly once.
+  @test.assert_eq(
+    n(
+      "interface F { [k: string]: string; port: number }\nfunction f(x: F) { return x }",
+    ),
+    1,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -17484,3 +17484,147 @@ test "merge_interface_group matches pairwise fold" {
   // takes for all but a handful of names in any real file.
   @test.assert_eq(merge_interface_group([halves[0]]).fields.length(), 4)
 }
+
+///|
+/// Tier 1: a CONDITIONAL reached through a generic alias, and the
+/// standard utility types that unlocks.
+///
+/// `Resolver::unwrap` reduces `Keyof`, `TypeOf`, `MappedType`,
+/// `IndexedAccess` and `TemplateLiteralType` and had no `Conditional`
+/// arm, so it fell to the catch-all. The evaluator itself was never the
+/// problem — an inline conditional and a NON-generic alias for one both
+/// resolved already, because neither needs anything substituted first.
+/// Only the composition with a generic alias abstained.
+///
+/// Every case is paired with its LEGAL neighbour, because "flags the
+/// wrong assignment" and "stays silent on the right one" are separate
+/// claims and only the second keeps the gate at FP 0. That is not
+/// hypothetical here: wiring the whole utility table in flagged
+/// `thisTypeInObjectLiterals2` (see the `ThisType` case below) and broke
+/// `Record` / `Partial` field lookup.
+test "expr_check: conditional via generic alias + the conditional utility types" {
+  let n = fn(src : String) -> Int {
+    check_module_function_bodies(parse_module_or_empty(src)).length()
+  }
+  // The gap itself: substitution happens, then the conditional has to
+  // reduce. Both branches of the decision, each with its neighbour.
+  let cond = "type E<T> = T extends string ? number : boolean;\n"
+  assert_true(
+    n(cond + "function f() { const x: E<string> = true; return x }") > 0,
+  )
+  @test.assert_eq(
+    n(cond + "function f() { const x: E<string> = 1; return x }"),
+    0,
+  )
+  assert_true(n(cond + "function f() { const x: E<number> = 1; return x }") > 0)
+  @test.assert_eq(
+    n(cond + "function f() { const x: E<number> = true; return x }"),
+    0,
+  )
+  // The shapes that already worked, kept here so a future change cannot
+  // "fix" the arm by breaking them.
+  assert_true(
+    n(
+      "function f() { const x: (string extends string ? number : boolean) = true; return x }",
+    ) >
+    0,
+  )
+  assert_true(
+    n(
+      "type E2 = string extends string ? number : boolean;\nfunction f() { const x: E2 = true; return x }",
+    ) >
+    0,
+  )
+  // The conditional-bodied utility types, which were inert because the
+  // table they live in is only reachable through `module_alias_resolver`
+  // — a `pub fn` with no caller outside its own file and its tests.
+  assert_true(
+    n("function f() { const x: Exclude<\"a\"|\"b\",\"a\"> = \"a\"; return x }") >
+    0,
+  )
+  @test.assert_eq(
+    n("function f() { const x: Exclude<\"a\"|\"b\",\"a\"> = \"b\"; return x }"),
+    0,
+  )
+  assert_true(
+    n("function f() { const x: Extract<\"a\"|\"b\",\"a\"> = \"b\"; return x }") >
+    0,
+  )
+  @test.assert_eq(
+    n("function f() { const x: Extract<\"a\"|\"b\",\"a\"> = \"a\"; return x }"),
+    0,
+  )
+  assert_true(
+    n("function f() { const x: NonNullable<string|null> = null; return x }") > 0,
+  )
+  @test.assert_eq(
+    n("function f() { const x: NonNullable<string|null> = \"s\"; return x }"),
+    0,
+  )
+  // A module's own alias SHADOWS the standard table, which is what lets
+  // a module override a stdlib utility shape.
+  @test.assert_eq(
+    n(
+      "type Exclude<T,U> = string;\nfunction f() { const x: Exclude<\"a\"|\"b\",\"a\"> = \"anything\"; return x }",
+    ),
+    0,
+  )
+  // Still abstains where the conditional cannot be DECIDED: an
+  // unresolved generic name, and a type parameter as the check type.
+  @test.assert_eq(
+    n("function f() { const x: Bogus<number> = \"s\"; return x }"),
+    0,
+  )
+  @test.assert_eq(
+    n(cond + "function f<U>(u: U) { const x: E<U> = true; return x }"),
+    0,
+  )
+  // A self-referential conditional alias must not spin: `simplify_type`
+  // returns the `Conditional` unchanged when it cannot decide, which is
+  // what terminates the arm.
+  @test.assert_eq(
+    n(
+      "type R<T> = T extends [] ? never : R<T>;\nfunction f() { const x: R<[]> = 1; return x }",
+    ),
+    0,
+  )
+}
+
+///|
+/// `ThisType<T>` is `interface ThisType<T> {}` in `lib.es5.d.ts` — an
+/// EMPTY marker that only sets the contextual `this` of an object
+/// literal's methods. The standard-utility table encodes it as the
+/// identity, and says why in its own comment: without contextual
+/// inference that is the useful answer to "what is `this` here".
+///
+/// That is a different question from "what members does this type have",
+/// and taking the identity answer for the structural one makes
+/// `PropDesc<U> & ThisType<T>` demand every member of `T`. The
+/// conformance gate caught exactly that on `thisTypeInObjectLiterals2`
+/// the moment the resolver started reading the table, so the marker is
+/// resolved to `{}` ahead of the generic `Applied` arm and the shared
+/// table is left alone for the consumer it was written for.
+test "expr_check: ThisType is an empty marker, not the identity" {
+  let n = fn(src : String) -> Int {
+    check_module_function_bodies(parse_module_or_empty(src)).length()
+  }
+  @test.assert_eq(
+    n(
+      "interface PD<U> { value?: U }\ndeclare function dp<T,U>(o: T, d: PD<U> & ThisType<T>): void;\nfunction f() { dp({ x: 1 }, { value: 2 }) }",
+    ),
+    0,
+  )
+  // The property-shape utilities keep their existing dedicated handling
+  // in `lookup_field`; resolving them through the table instead moved
+  // the shape out from under those arms. Measured, not predicted — these
+  // two are the regressions that produced the body-shape gate.
+  assert_true(
+    n("function f(r: Record<string, number>): string { return r.foo }") > 0,
+  )
+  assert_true(
+    n(
+      "interface C { name: string }\nfunction f(p: Partial<C>): string { return p.name }",
+    ) >
+    0,
+  )
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -17628,3 +17628,71 @@ test "expr_check: ThisType is an empty marker, not the identity" {
     0,
   )
 }
+
+///|
+/// The `infer`-binding utility types: `ReturnType`, `Parameters`,
+/// `Awaited` and friends.
+///
+/// `simplify_type` decides a conditional through the three-valued
+/// `extends_decision`, which cannot bind an `infer`, so every one of
+/// these abstained even after the `Conditional` arm existed.
+/// `reduce_conditional` is the reducer that can — it runs
+/// `match_infer_pattern` and substitutes the captures — and it is tried
+/// ONLY when the extends type actually carries a marker.
+///
+/// That restriction is the whole safety argument, so it is worth stating
+/// where a test can see it: `reduce_conditional`'s non-infer path is
+/// `is_assignable_to`, which is two-valued, so used as a general
+/// fallback it would take the FALSE branch on an undecidable `extends`
+/// and answer confidently exactly where `extends_decision` correctly
+/// says "don't know". The `unresolved` case below is the one that would
+/// regress if the gate were dropped.
+test "expr_check: infer-binding utility types decide through reduce_conditional" {
+  let n = fn(src : String) -> Int {
+    check_module_function_bodies(parse_module_or_empty(src)).length()
+  }
+  let g = "declare function g(): number;\n"
+  assert_true(
+    n(g + "function f() { const x: ReturnType<typeof g> = \"s\"; return x }") >
+    0,
+  )
+  @test.assert_eq(
+    n(g + "function f() { const x: ReturnType<typeof g> = 1; return x }"),
+    0,
+  )
+  assert_true(
+    n("function f() { const x: Awaited<Promise<number>> = \"s\"; return x }") >
+    0,
+  )
+  @test.assert_eq(
+    n("function f() { const x: Awaited<Promise<number>> = 1; return x }"),
+    0,
+  )
+  let ga = "declare function ga(a: string): void;\n"
+  assert_true(
+    n(ga + "function f() { const x: Parameters<typeof ga> = [1]; return x }") >
+    0,
+  )
+  @test.assert_eq(
+    n(
+      ga + "function f() { const x: Parameters<typeof ga> = [\"s\"]; return x }",
+    ),
+    0,
+  )
+  // Abstains when the check type is an unbound type parameter. This is
+  // the case that pins the `has_infer` gate: a two-valued reducer would
+  // take the false branch here and report.
+  @test.assert_eq(
+    n("function f<U>(u: U) { const x: ReturnType<U> = 1; return x }"),
+    0,
+  )
+  // The non-infer conditional path is untouched by the fallback.
+  assert_true(
+    n("function f() { const x: Exclude<\"a\"|\"b\",\"a\"> = \"a\"; return x }") >
+    0,
+  )
+  @test.assert_eq(
+    n("function f() { const x: Exclude<\"a\"|\"b\",\"a\"> = \"b\"; return x }"),
+    0,
+  )
+}

--- a/src/cmd/mtsc/main_wbtest.mbt
+++ b/src/cmd/mtsc/main_wbtest.mbt
@@ -28,7 +28,7 @@ test "mtsc typecheck accepts an imported binding" {
 async test "mtsc known-gap corpus records current missed diagnostics" {
   let cases = [
     "fixtures/mtsc/known-gaps/no-implicit-any.ts", "fixtures/mtsc/known-gaps/primitive-member.ts",
-    "fixtures/mtsc/known-gaps/aliased-discriminant.ts", "fixtures/mtsc/known-gaps/overload-resolution.ts",
+    "fixtures/mtsc/known-gaps/aliased-discriminant.ts",
   ]
   for path in cases {
     let source = @fs.read_file(path).text() catch {
@@ -37,6 +37,31 @@ async test "mtsc known-gap corpus records current missed diagnostics" {
     let issues = mtsc_collect_type_issues(source, false).unwrap()
     assert_eq(issues.length(), 0)
   }
+}
+
+///|
+/// `overload-resolution.ts` used to be one of the known gaps above and is
+/// now CLOSED, so it moves from "records what we miss" to a regression
+/// pin. Overload sets ingest as a union of call signatures, and
+/// `check_union_callee_arity` is deliberately not applied to them (its
+/// rule is that every member must accept, which is right for a
+/// union-typed value and wrong for an overload set). Nothing took over,
+/// so an overloaded call's arguments were checked by nothing at all —
+/// `check_overload_set_no_match` reports when NO member can accept.
+async test "mtsc reports TS2769 for a call matching no overload" {
+  let path = "fixtures/mtsc/known-gaps/overload-resolution.ts"
+  let source = @fs.read_file(path).text() catch {
+    e => fail("failed to read \{path}: \{e}")
+  }
+  let issues = mtsc_collect_type_issues(source, false).unwrap()
+  assert_true(issues.length() > 0)
+  let mut found = false
+  for i in issues {
+    if i.message.contains("no overload matches this call") {
+      found = true
+    }
+  }
+  assert_true(found)
 }
 
 ///|


### PR DESCRIPTION
Two things: a triage that argues `MISS` is the wrong number to chase, and
the Tier 1 work that triage ranked.

```
              TP     MISS    FP   PFLEGAL
main        2558      176     0         0
this        2560      174     0         0
```

The count barely moves, and that is the honest result rather than a
disappointment — `docs/checker-triage.md` predicted it in writing before
any of the code was written: *"take these for the capability, not the
count."* What moved is what the checker can decide at all.

## Why `MISS 176` cannot rank work

It sums work worth doing now with files nobody should ever fix, so it
answers neither "what next?" nor "are we done?" — the same defect that
retired `docs/checker-priority.md`.

All 176 are classified by the **machinery a rule would need** (not by
error code — a code is not a difficulty class), priced against how often
the feature appears in **3,000 real `.d.ts` files and 2,697 real `.ts`
sources**, and assigned four tiers with the reason written down.

Two measurements decide two tiers outright. **`using` declarations occur
in zero of 5,697 real files** and are 6 of the misses. And the largest
bucket ranks no work at all: opening all 48 `assignability-core` files
gives ~10 unrelated causes (variadic tuples, intersections, contextual
typing, `globalThis`, index-signature subtyping, spread types) — the same
label-standing-in-for-the-objective substitution this repo has recorded
four times.

**The recommendation is not a rule:** report two numbers instead of one —
in-scope backlog (~152, which can reach zero) and declared out-of-scope
(~24) — and gate on the former. The FP budget is explicitly unchanged:
out-of-scope means "we will not add a rule for it", never "we may flag it
wrongly". That scope-file split is the one item here left unimplemented.

## The capability probe, which reordered everything

The classification says what a file *needs*; it does not say what we
already *have*, and guessing at that was wrong twice in one session. So
each family's common shape was probed directly.

Its own first run reported every family blind, and that was harness error
rather than a finding: these entry points check function **bodies** and
the probes put the error at top level, where nothing visits it. Re-probed
inside a function — mapped types, `keyof`, strictNullChecks, `this`-types,
index signatures, variadic tuples, generic function inference and basic
assignability are all **caught** at the common shape, while
conditional-via-generic-alias, the whole utility-type table,
template-literal types with a placeholder, computed `unique symbol` keys
and overload resolution were **blind** at the shape real code writes.

## Tier 1: four levels of one family, inside one feature

Every batch turned out to be *one rule written in several places and
applied in some of them*, stacked four deep:

| | |
|---|---|
| **DI** | `Resolver::unwrap` reduces `Keyof`, `TypeOf`, `MappedType`, `IndexedAccess`, `TemplateLiteralType` — and had **no `Conditional` arm**. The evaluator works: an inline conditional and a non-generic alias both resolve; only the composition with a generic alias abstained. |
| | `standard_utility_types()` had been unit-tested for years behind `module_alias_resolver` — **a `pub fn` with no caller outside its own file and its tests** — so a `.d.ts` using `ReturnType<typeof f>` type-checked *by abstaining*. |
| **DJ** | `simplify_type` decides through the three-valued `extends_decision`, which cannot bind an `infer`. `reduce_conditional` **can**, and was reachable from `is_assignable_to` but not from alias resolution. |
| **DK** | `contains_infer_marker` descended into `Func` with **no `Constructor` arm**, so `new (...args) => infer R` never ran the infer path — while `match_infer_pattern` and `substitute_inferred_type` both handled `Constructor` already. Two of the trio right, the **gate** wrong. |
| **DL** | An index signature constrains the **merged** interface; the check read `module_.interfaces`, the per-declaration list. Written in one body it reported; split across two halves it was silent. |
| **DM** | An overloaded call's arguments were checked by **nothing at all**. |

Net: `Exclude` / `Extract` / `NonNullable` / `ReturnType` / `Parameters` /
`Awaited` / `InstanceType` / `ConstructorParameters` now decide.

## Three wrong diagnoses, and what corrected each

Worth more than the fixes, because each correction is reusable:

- **`typeof C` was not why `InstanceType` was inert.** It really does
  arrive unresolved (the `TypeOf` arm reads `globals`, a class lives in
  `classes`) — but `InstanceType<new () => C>`, with no `typeof`
  anywhere, was equally silent. That inline case is kept as a test
  precisely because it is what distinguishes the gate from the class
  lookup; without it the wrong diagnosis would have looked confirmed.
- **Wiring the whole utility table in was wrong.** `Partial`, `Record`,
  `Pick` and friends already have dedicated `lookup_field` arms, and
  resolving them here moved the shape out from under those arms — three
  *real* regressions, not tests pinning old behaviour. The fallback is
  gated on the body being a `Conditional`: a **shape** test, not a name
  list, because a second copy of those names is the defect the batch
  removes.
- **`unique symbol` was my label, not a feature.** All 16 files carry
  **eleven** distinct error codes: two already rejected with measured
  evidence, two needing overload resolution, two lib interface merging,
  two block-scope resolution of a shadowed `Infinity`, the rest one
  unrelated thing each. The one genuinely cheap file turned out not to be
  a symbol rule at all. Recorded so the 16 are not re-attacked as a group.

## What the gates caught

- **A false positive, the moment the resolver read the utility table.**
  `ThisType<T>` is `interface ThisType<T> {}` in `lib.es5.d.ts` — an
  *empty* marker — while the table encodes it as the identity and says
  why in its own comment: without contextual inference that is the useful
  answer to "what is `this` here". That is a different question from
  "what members does this type have", and the identity answer used
  structurally makes `PropDesc<U> & ThisType<T>` demand every member of
  `T`. Resolved to `{}` ahead of the generic arm; the shared table left
  alone for the consumer it was written for.
- **A second false positive whose hazard was written down twenty lines
  away.** `check_union_callee_arity`'s comment records that "two
  callables can have identical widened parameter types while differing in
  whether that parameter was written with `?`" — and a `declare function`
  overload arrives with its optionality widened into the type, so `t()`
  against `t(a?: string)` was reported. A parameter that accepts
  `undefined` is now treated as omittable, which over-counts optionals
  and therefore only ever *weakens* the proof.

## Soundness argument for TS2769

It reports only when **every** member is proven unable to accept — by
arity, or by a definite-primitive argument against a definite-primitive
parameter. That makes it sound for a union-typed *value* too (if no
constituent can accept, the call is wrong under either reading), so it is
not gated on `resolver.signatures`. Abstention is per-member with an early
return: one member that merely *might* accept silences the call, which is
what keeps a generic overload, an object-typed parameter, a rest
parameter, a spread argument and an unreadable member silent.

`fixtures/mtsc/known-gaps/overload-resolution.ts` moves from "records what
we miss" to a regression pin.

## Known limits, filed rather than papered over

- An overload set declared as real `function` declarations **with an
  implementation** does not reach the new check on the strict path — the
  `resolver.signatures` branch claims the callee first. It works on the
  permissive path (which the fixture exercises). Silence, not a finding;
  fixing it means touching the single-signature argument checker.
- `ThisParameterType` / `OmitThisParameter` remain untested.
- The Tier 4 scope file and two-number oracle reporting are unimplemented.

## Verification

- `checker_conformance_oracle.sh --max-fp 0 --max-legal-parsefail 0` — TP 2560 / MISS 174 / **FP 0 / PFLEGAL 0** over 4,484 files
- `moon test --target native` — 2,973 / 2,973
- `verify_checker_scaling.mjs` — all 7 asserted axes linear
- `verify-mangle-safety` 185/185, plus generated-fixtures, scaffolds, examples and mbti→.d.ts — the fixture-compiling checklist batch CH's TS2591 taught us to run
- `moon check` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ygRti5U1q3rrdrLM5euqM


---
_Generated by [Claude Code](https://claude.ai/code/session_016ygRti5U1q3rrdrLM5euqM)_