### PR TITLE
bridge: close the unconverted enum-crossing backlog (18/18); checker batches DW–DZ

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2818,6 +2818,71 @@ product surfaces now.
   report gains a `duplicate declared fn names` metric that FAILS on any
   occurrence, mutation-tested in both directions and verified not to fire
   on the `Type::method` forms that fooled the first measurement.
+  The other half of that split is a gate that contradicted its own doc
+  comment for a whole commit, and it is worth recording as its own
+  failure mode: a comment describing intent, written in the same change
+  that left the code doing the opposite. 8d227ad rewrote
+  `ffi_tagged_union_return_is_safe_to_wrap`'s header to say that a global
+  constructor "resolves and is kept … which is why `PathLike = string |
+  Buffer | URL` gets a working wrapper", and left
+  `Some(InstanceOfNamed(_)) => return false` in the body — so `PathLike`'s
+  `_from_js` was emitted, exercised by `verify-bridge-runtime`, and never
+  CALLED, and the declared enum came back holding a raw JS string.
+  Refusing an ERASED name is `tagged_union_case_runtime_discriminator`'s
+  job and it already does it by returning `None`; a second, blunter copy
+  of that judgement could only disagree with the first, which is exactly
+  what it did.
+  Measured ALONE that gate change is a zero-diff no-op, because nothing
+  else consults it for a global-`Named` union return — and it is
+  load-bearing all the same, proven by mutation: with the old arm back the
+  regenerated accessor is `#| (self) => self.path` again. A change whose
+  own corpus delta is zero is not automatically the rejected kind this
+  file records; the question is whether something downstream needs it.
+  What needed it is FOUR accessor paths that never asked about tagged
+  unions at all. `ffi_class_property_getter_decl_to_moonbit` and its
+  setter twin route through `ffi_rendered_generated_enum_info` /
+  `ffi_enum_arg_expr`, which walk `state.enums` — the LITERAL-union
+  enums, whose converters are MoonBit functions in `converters.mbt`. A
+  tagged union's converters live in `bridge.js`, so the class METHOD path
+  puts the argument direction in the JS BODY
+  (`ffi_inline_js_arg_expr_with_state`) and the accessor path had neither
+  direction: node_fs's `ReadStream.path: PathLike` declared the enum both
+  ways while moving the raw value, and no compile gate could see it
+  because the declared type is identical either way. Same
+  applied-in-some-places family with the axis swapped — not one rule
+  written at several SITES, but one site asking about one of two FAMILIES.
+  The return direction needed a helper that did not exist,
+  `ffi_inline_js_return_expr_with_state`, because an inline extern lambda
+  cannot import the named `bridge.js` helper —
+  `ffi_inline_js_tagged_union_to_js` says so in its own comment. It binds
+  the value before converting, since the from_js body repeats its argument
+  once per case predicate and the expression here is `self.path`, a
+  property READ, where the named helper reads a parameter. Statics keep
+  the named helpers, their binding being a real `bridge.js` function.
+  **The setter fix then covered a SECOND family nobody was looking for**,
+  and it is 26 of the 33 changed lines: `ffi_inline_js_arg_expr_with_state`
+  also unwraps an OPTION box, so `Context::set_context_env(value :
+  Bindings?)` had been assigning MoonBit's `{$tag: 1, _0: v}` straight
+  into JS's `env` field, across hono, hono-real, drizzle, vitest and
+  typescript. One missing call, two independent wrong values; every
+  package's `.mbti` declaration count is unchanged, so the public surface
+  is identical.
+  The probe was the stated precondition and widening it is where the
+  lesson sits. `bridge_enum_return_probe.mjs` matched `declare pub fn
+  NAME(`, so `fn[T]` and every `Type::method` form was skipped — but the
+  half that mattered was not the regex: a declaration's implementation
+  lands EITHER in a named `bridge.js` wrapper OR in an inline extern
+  lambda, and only the first was ever read. It now reads both (47 named
+  wrappers and 8 inline bodies cross a payload enum, 0 unconverted) and
+  is wired into `bridge_quality_report.sh` as a `run_check` rather than
+  reimplemented in shell. `verify-bridge-runtime` gets the same widening
+  on its static half, under the STRICTER rule that only a JS global can
+  resolve inside an inline lambda, which has no module scope at all. Its
+  first version walked every `.mbt` under `_build` and reported three
+  `instanceof` targets out of `moon fmt`'s copy of a checker whitebox
+  test, whose `#|` lines are TypeScript SOURCE for a test case: widening
+  the input set is not the same as widening the question, so it is scoped
+  to the directories holding a generated `bridge.js`.
 
 ## Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2883,6 +2883,64 @@ product surfaces now.
   test, whose `#|` lines are TypeScript SOURCE for a test case: widening
   the input set is not the same as widening the question, so it is scoped
   to the directories holding a generated `bridge.js`.
+  Asked to take the next item — bind a module-exported class so its
+  `instanceof` resolves — the measurement retired the item and found
+  eighteen live bugs beside it. The filed ceiling was "about ten names,
+  worth doing for the `stat()` family specifically", and importing each
+  generated package's OWN module and asking `typeof mod[name]` gives **2
+  bindable names of the 197 declined**. Every name the estimate listed
+  fails, for two separable reasons: hono__node_server's `Server` /
+  `Http2Server` / `IncomingMessage` / `ServerResponse` are exported by a
+  DIFFERENT module — `node:http` classes the package re-exports as TYPES,
+  so `__ts_mbt_module.Server` is `undefined` and binding needs another
+  module's import rather than the one-line threading the item described —
+  while `StatsFs` / `BigIntStats` / `BigIntStatsFs` are type-only. And the
+  ceiling is a question about CONVERTERS, not names: `_from_js` is withheld
+  unless EVERY case is discriminable, so `Stats` being a real class buys
+  nothing while `BigIntStats` stays erased, which is precisely the `stat()`
+  family the item called its prize. Two converters unblock, one of them in
+  a return position. Ninth instance of a label standing in for the
+  objective, and the first where the label was a NAME COUNT standing in for
+  a conjunction over cases.
+  What the measurement is actually worth is what it exposed. `aliasedTable`
+  converts its ARGUMENT and hands its return back raw while declaring
+  `-> Auto_ViewValue_or_TableValue` — the `ServerType` bug again — and the
+  probe written one commit earlier to catch exactly that could not see it,
+  for two independent reasons. It tested `/_from_js|_to_js|\$tag/` over the
+  whole body, so the `$tag` belonging to the PARAMETER's conversion passed
+  the return: "this body contains a conversion somewhere" is not "this body
+  converts its return", and the two directions are separate questions with
+  separate shapes (`"$tag":` / `_from_js(` BUILDS a MoonBit value,
+  `.$tag ===` / `_to_js(` READS one). And it read payload enums from
+  `bridge.mbti` alone, where a SYNTHESIZED `Auto_X_or_Y` is never
+  declared — **212 of the 231 payload enums live in `types.mbt`**. Fixing
+  both takes the probe from 0 findings to 18. Fifth time this session the
+  measuring instrument carried the same substitution bug as the code it was
+  hunting, after the payload filter, the `::` regex, the snake-case
+  function and the input-set widening.
+  The 15 erased-payload cases among the 18 want the widening that fixed
+  `ServerType`, and that widening never sees them: a synthesized union
+  keeps the original `Union(parts)` shape in the AST while its signature
+  already reads `Auto_X_or_Y`, which
+  `ffi_inline_js_tagged_union_to_js` states in its own comment sixty lines
+  away. Sixth fail-open shape arm in this file's ledger, and the first
+  written INSIDE the fix for the previous one. The arm was implemented and
+  REVERTED on a measured blocker rather than shipped: the widening lives in
+  the FFI layer and the public wrapper (`pub fn getNameOfJSDocTypedef(...)
+  -> Auto_IdentifierValue_or_PrivateIdentifierValue?`) is rendered by the
+  DECL layer, which holds no `MoonBitJsFfiState`, so widening one side
+  gives `[4014] Expr Type Mismatch: has type JSValue?, wanted Auto_...?` —
+  the two layers disagreeing, the same split that produced the duplicate
+  `.mbti` declarations. All 18 are declared in
+  `scripts/bridge_unconverted_enum_crossings.txt` with a kind and a reason
+  each (15 `erased-payload`, 2 `optional-gate`, 1 `module-class`);
+  undeclared fails, stale fails, both mutation-tested. Turning 18 invisible
+  wrong values into 18 named ones with reasons is the deliverable, and the
+  `optional-gate` pair also corrects a claim made one commit earlier in
+  writing: `ffi_inline_js_return_expr_with_state` said no corpus accessor
+  had the optional shape, and `TypeChecker::getConstantValue` returns
+  `Auto_NumberValue_or_StringValue?` — `String | Double`, both primitives,
+  fully buildable.
 
 ## Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2739,6 +2739,56 @@ product surfaces now.
   `BufferEncoding` is a node global this package does not resolve, so even
   a successful lowering would hand the user a case payload they cannot
   build.
+  The mirror-image defect is the DECLARED type promising a representation
+  the emitted JS never builds, and `scripts/bridge_enum_return_probe.mjs`
+  asks for it: `@hono/node-server` declared `serve(...) -> ServerType`
+  while the wrapper returned the raw Node server object, and the
+  representation is not a guess — the alias's own constructor emits
+  `{ "$tag": 0, "_0": value }`, so a MoonBit `match` read `$tag` off an
+  object that has none. Fixing it is worth recording mostly for HOW the
+  first attempt failed: it measured as a NO-OP, and the predicate was
+  never the reason. Two rounds of reading the code got the diagnosis
+  wrong; one `println` settled it in a single run, and the lesson is to
+  instrument a "this cannot be happening" gap rather than re-read it.
+  Two causes, both this file's recurring shapes. The walk had `Named` and
+  `Func` arms and no `CallableMeta`, which records source-level parameter
+  OPTIONALITY — so `get_serve`'s `(Options, ((AddressInfo) -> Unit)?) ->
+  ServerType` fell through the catch-all while the sibling
+  `get_create_adaptor_server`'s `(Options) -> ServerType`, having no
+  optional parameter and therefore no wrapper, widened correctly. That
+  asymmetry between two adjacent declarations is what exposed it.
+  `ffi_type_name` peels the same wrapper on its own FIRST line: a walk
+  that DECIDES a type has to peel every wrapper the renderer peels, or it
+  decides a different type from the one that gets printed. Fifth
+  wrapper-node fail-open arm here. And the ten renderer sites were found
+  by grepping the assignment `let return_type = ffi_type_name(state, …)`,
+  which missed `ffi_callable_value_decl_to_moonbit` — the renderer for
+  the direct call form, the one that emits `serve(...)` — because it
+  spells its local `return_type_src`. Writing a shared
+  `ffi_output_type_name` specifically to avoid the applied-in-some-places
+  family and then applying it by textual match on a variable NAME is that
+  family inside its own fix; the census is by ARGUMENT now.
+  The predicate was wrong too, and the TEST found it rather than the
+  corpus. `ffi_tagged_union_return_is_safe_to_wrap` refuses ANY
+  `InstanceOfNamed`, global constructors included, so `PathLike = string
+  | Buffer | URL` is "unsafe to wrap" while its `_from_js` exists and
+  works — widening on that gate would have widened node_fs's twelve
+  global-`Named` union returns as well. The right question is
+  `tagged_union_from_js_expression(decl, "value") is None`, which is
+  exactly what withholds the `_from_js` half. The three
+  `*_should_emit_wrapper` predicates deliberately do NOT consult the
+  widening: they refuse a wrapper whose rendered type uses `JSValue`, so
+  routing them through it would DELETE `serve(...)` instead of widening
+  it, and their real question — does this wrapper carry any type
+  information — is still answered yes by the typed PARAMETERS.
+  It also surfaced a pre-existing defect nothing could see while the two
+  renderings agreed: the `.mbti` carries declarations the `.mbt` does
+  not. `get_create_adaptor_server` appears twice, once with no impl
+  counterpart at all, and corpus-wide there are 52 duplicated declaration
+  names of 2,161 in the `typescript` package, 13 in vitest, 9 in node_fs.
+  A second emitter renders the same value exports independently of the
+  ffi layer and the two matched only by coincidence — which is also why
+  the enum-return probe still reports one residual.
 
 ## Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2918,34 +2918,81 @@ product surfaces now.
   measuring instrument carried the same substitution bug as the code it was
   hunting, after the payload filter, the `::` regex, the snake-case
   function and the input-set widening.
-  The 15 erased-payload cases among the 18 want the widening that fixed
-  `ServerType`, and that widening never sees them: a synthesized union
-  keeps the original `Union(parts)` shape in the AST while its signature
-  already reads `Auto_X_or_Y`, which
-  `ffi_inline_js_tagged_union_to_js` states in its own comment sixty lines
-  away. Sixth fail-open shape arm in this file's ledger, and the first
-  written INSIDE the fix for the previous one. The arm was implemented and
-  REVERTED, and the two halves of that have to be kept apart: what is
-  MEASURED is `[4014] Expr Type Mismatch: has type JSValue?, wanted
-  Auto_...?` — the FFI layer's private extern widened while `pub fn
-  getNameOfJSDocTypedef(...) -> Auto_IdentifierValue_or_PrivateIdentifierValue?`
-  in `bridge.mbt` did not, the same two-renderings-of-one-export split that
-  produced the duplicate `.mbti` declarations. What is NOT established is
-  the cause. The first note here asserted "the decl layer holds no
-  `MoonBitJsFfiState`, so this needs a cross-layer channel", written from
-  the error message alone — and `parse_bridge_pub_extern_fn_decl_line`
-  shows that layer DERIVING its return type from the FFI layer's emitted
-  text, so widening the FFI side should have carried, and the real cause is
-  more likely one renderer the widening does not route through. A blocker
-  asserted from a diagnostic is a hypothesis; the experiment is one command
-  and is written down in TODO.md.
-  All 18 are declared in `scripts/bridge_unconverted_enum_crossings.txt`
+  All 18 were declared in `scripts/bridge_unconverted_enum_crossings.txt`
   with a kind and a reason each; undeclared fails, stale fails, both
   mutation-tested. Turning 18 invisible wrong values into 18 named ones
-  with reasons is the deliverable — and the STALE half earned itself back
-  immediately, because the `optional-gate` pair is FIXED and the report is
-  what said so, taking the declared backlog to **16** (15
-  `erased-payload`, 1 `module-class`).
+  with reasons was the deliverable — and the STALE half is what emptied the
+  file, twice: it retired the `optional-gate` pair as soon as that was
+  fixed, and then all 16 that were left. **The declared backlog is zero**,
+  which is the state where a NEW unconverted crossing fails immediately.
+  Those 16 were ONE decision made in three places plus two renderers that
+  had never been asked, and every step contradicted the step before it.
+  `ffi_widen_unbuildable_union_outputs` had no arm for a SYNTHESIZED union —
+  such a union keeps its `Union(parts)` shape in the AST while its signature
+  already reads `Auto_X_or_Y`, which `ffi_inline_js_tagged_union_to_js`
+  states in its own comment sixty lines away, the sixth fail-open shape arm
+  in this file's ledger and the first written INSIDE the fix for the fifth.
+  The arm's FIRST version was then ORDER-DEPENDENT, which is the finding
+  worth keeping: it asked whether the alias was already in
+  `state.tagged_union_decls_by_name`, a map filled as a SIDE EFFECT of
+  rendering, so the answer depended on whether an earlier declaration in the
+  file happened to mention the same union.
+  `Auto_IdentifierValue_or_PrivateIdentifierValue` is also a PARAMETER of
+  `idText` nine lines above and was registered;
+  `Auto_VariableDeclarationValue_or_ParameterDeclarationValue` occurs exactly
+  once and was not — so one declaration was fixed and its neighbour silently
+  was not, the applied-in-some-places family with the sites picked by
+  declaration ORDER rather than by anyone's decision.
+  `ffi_output_union_decl` builds the decl (`{ name, cases }`) on the spot.
+  Widening the extern alone gives `[4014] has type JSValue?, wanted
+  Auto_...?`, because there are THREE renderings of one export: the `.mbti`
+  line comes from the DECL layer and the public wrapper is rendered FROM that
+  line. `reconcile_bridge_widened_union_returns` makes the declaration agree
+  with the extern that implements it — the principle
+  `add_bridge_ergonomic_helper_decls` already states, that the `.mbt` is what
+  the package really is. It has to be SCOPED and that is the whole
+  difficulty: a declaration differing from its extern is the NORMAL case (a
+  literal-union enum crosses as an `Int` and the wrapper converts it; an
+  opaque type arrives as `JSValue` and the wrapper wraps it in an option), so
+  it fires only where the extern hands back `JSValue` at the SAME optionality
+  AND the declared type is one of the two things the widening can leave
+  behind. Both halves are needed and only one was written first: when the
+  union is still mentioned elsewhere the enum survives and the symptom is
+  `[4014]`, and when the widened return was its LAST mention nothing
+  synthesizes the enum any more and the identical stale line is `[4032] the
+  type Auto_... is undefined` — which is how `walkUpBindingElementsAndPatterns`
+  failed to COMPILE in the same run where `getNameOfJSDocTypedef` came out
+  right.
+  The `.mbti` emitter was found by INSTRUMENTING, and the first run of that
+  experiment was a FALSE ZERO of exactly the kind this file keeps recording:
+  markers in the three `declare pub fn` renderers of `parser_moonbit.mbt`
+  attributed 0 of 11 lines, because the fixture chosen was a class-only
+  `.d.ts` and a class declares no top-level function, so
+  `func_decl_to_moonbit` was never called. A zero from a probe whose shape is
+  ABSENT is not an answer, and the note that stood here — "it is not any of
+  the `declare pub fn` literals in `moonbit_bridge.mbt`, so the body comes
+  from elsewhere" — was drawn from it. It is `parser_moonbit.mbt:1426`,
+  reached through `moonbit_decl.mbt:12526`.
+  The last two sites are the family on a fresh axis each. An index
+  signature's two DIRECTIONS are two questions and were rendered with one
+  type name: `index_get` crosses JS -> MoonBit and widens, `index_set`
+  crosses the other way, where `_to_js` reads `$tag` and needs no runtime
+  predicate, so it keeps its type and converts in the body — and
+  `ffi_inline_js_arg_expr_with_state`'s own tagged-union test was
+  `Named`-only, which would have sent every synthesized union down the
+  generic option unwrap to read `value._0` off a value MoonBit does not box.
+  And a METHOD's return needed the widening, but NOT in
+  `ffi_function_type_parts`: a function type has no direction of its own, so
+  the same rendering types a method's return and a CALLBACK parameter's
+  return, and widening there threw away a type that works and broke
+  `Matcher::_call_`, whose wrapper reads a struct FIELD rendered elsewhere
+  (`has type ExpectationResult, wanted JSValue`). It belongs in the one
+  branch of `ffi_function_field_method_decl` that binds straight to a JS
+  call. That leaves the struct FIELD itself still promising the enum
+  (`erasedMethod : (String) -> Auto_BetaValue_or_AlphaValue` in `types.mbt`)
+  — filed rather than half-applied, because the fix is a direction parameter
+  on `ffi_func_type_name` and the probe does not read struct fields yet, so
+  the honest first step is to COUNT them.
   That pair is the fourth time in this sequence that a declining note's
   own stated reason was false, and both of its reasons were.
   `ffi_inline_js_return_expr_with_state` said converting an optional would

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1378,6 +1378,42 @@ product surfaces now.
   work a second time, and what remains worth taking is what the corpus
   cannot score: 83 of the 134 misses carry exactly one error code and 25
   of the 39 solo codes have exactly one file.
+  Batch DZ is +1 and its value is what it says about the TRIAGE's own
+  family table rather than about the rule. The
+  "strict-null / narrowing" bucket is five files, and the label is wrong
+  about **all five**: opening each one, the cheapest lever is pure grammar
+  (TS18030), a `this`-rebinding context (TS2331), name resolution in a
+  type-argument position (TS2749), `[]`-to-`never[]` inference plus flow
+  analysis (TS2403 / TS2454), and aliased control flow (TS18046) — five
+  unrelated kinds of work, not one. Eighth instance of a label standing in
+  for the objective, and the first in a bucket small enough that the count
+  looked trustworthy; a bucket of five is not safer than a bucket of
+  forty-eight, it is just faster to disprove.
+  The rule that shipped is TS18030, an optional chain containing a
+  private identifier, and it lives in the parser because the POSITION of
+  the `?.` relative to the `#name` is the whole rule. One chain-local
+  flag set where `?.` is consumed and tested at both sites that read a
+  chain property, rather than a condition at each — `this?.#b` (directly
+  after the `?.` that opens the chain) and `this?.a.#b` (later, through a
+  plain `.`) are one fact. Chain-LOCAL is what makes two legal
+  neighbours automatic instead of needing rules: a private access inside
+  a call argument within the chain (`this?.getA(o.#b)`) is parsed by its
+  own invocation of the postfix loop, and so is the inner expression of
+  `(this?.c).#b` — and that second one is the case worth probing, because
+  `(this?.c).#b` is TS2532 and NOT TS18030, so parenthesizing really does
+  end the chain. Reasoning would have got it wrong either way; the probe
+  settled it, and tscheck now agrees with tsc on all seven spellings.
+  TS2331 is DEFERRED on a measured cost rather than on difficulty, which
+  is worth recording because the rule looks free. Probed cell by cell: an
+  arrow inside a namespace body fires at any depth, a `function`
+  declaration OR expression inside one does not (it rebinds `this`), a
+  class method does not, and neither script top level nor module top
+  level does — so the fact needed is "inside a namespace body and not
+  inside a `this`-rebinding function". `in_function` cannot serve,
+  because it is true inside arrows too, and a new field needs the same
+  save / clear / restore discipline `self.labels` already needs at
+  fifteen function-body sites. That is precisely how the
+  applied-in-some-places bug gets written, for +1 file.
 - `src/transform` is the JS-side pipeline behind `mtsc`: bundling, folding,
   tree-shaking, and the property mangler. Its safety story is type-driven and
   has two halves — `export_surface.mbt` (names reachable from the entry's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2925,22 +2925,47 @@ product surfaces now.
   `ffi_inline_js_tagged_union_to_js` states in its own comment sixty lines
   away. Sixth fail-open shape arm in this file's ledger, and the first
   written INSIDE the fix for the previous one. The arm was implemented and
-  REVERTED on a measured blocker rather than shipped: the widening lives in
-  the FFI layer and the public wrapper (`pub fn getNameOfJSDocTypedef(...)
-  -> Auto_IdentifierValue_or_PrivateIdentifierValue?`) is rendered by the
-  DECL layer, which holds no `MoonBitJsFfiState`, so widening one side
-  gives `[4014] Expr Type Mismatch: has type JSValue?, wanted Auto_...?` —
-  the two layers disagreeing, the same split that produced the duplicate
-  `.mbti` declarations. All 18 are declared in
-  `scripts/bridge_unconverted_enum_crossings.txt` with a kind and a reason
-  each (15 `erased-payload`, 2 `optional-gate`, 1 `module-class`);
-  undeclared fails, stale fails, both mutation-tested. Turning 18 invisible
-  wrong values into 18 named ones with reasons is the deliverable, and the
-  `optional-gate` pair also corrects a claim made one commit earlier in
-  writing: `ffi_inline_js_return_expr_with_state` said no corpus accessor
-  had the optional shape, and `TypeChecker::getConstantValue` returns
-  `Auto_NumberValue_or_StringValue?` — `String | Double`, both primitives,
-  fully buildable.
+  REVERTED, and the two halves of that have to be kept apart: what is
+  MEASURED is `[4014] Expr Type Mismatch: has type JSValue?, wanted
+  Auto_...?` — the FFI layer's private extern widened while `pub fn
+  getNameOfJSDocTypedef(...) -> Auto_IdentifierValue_or_PrivateIdentifierValue?`
+  in `bridge.mbt` did not, the same two-renderings-of-one-export split that
+  produced the duplicate `.mbti` declarations. What is NOT established is
+  the cause. The first note here asserted "the decl layer holds no
+  `MoonBitJsFfiState`, so this needs a cross-layer channel", written from
+  the error message alone — and `parse_bridge_pub_extern_fn_decl_line`
+  shows that layer DERIVING its return type from the FFI layer's emitted
+  text, so widening the FFI side should have carried, and the real cause is
+  more likely one renderer the widening does not route through. A blocker
+  asserted from a diagnostic is a hypothesis; the experiment is one command
+  and is written down in TODO.md.
+  All 18 are declared in `scripts/bridge_unconverted_enum_crossings.txt`
+  with a kind and a reason each; undeclared fails, stale fails, both
+  mutation-tested. Turning 18 invisible wrong values into 18 named ones
+  with reasons is the deliverable — and the STALE half earned itself back
+  immediately, because the `optional-gate` pair is FIXED and the report is
+  what said so, taking the declared backlog to **16** (15
+  `erased-payload`, 1 `module-class`).
+  That pair is the fourth time in this sequence that a declining note's
+  own stated reason was false, and both of its reasons were.
+  `ffi_inline_js_return_expr_with_state` said converting an optional would
+  "box a value that path already boxed" — CHECKABLE and unchecked, since
+  `ffi_option_return_inner_is_boxed` returns FALSE for a tagged-union
+  alias, so `ffi_option_return_needs_wrap` never fires for one and no
+  MoonBit-side wrap exists to collide with (`Some(v)` IS `v`, `None` IS
+  `undefined`), confirmed against the emitted code rather than the source.
+  It also said no corpus declaration had the shape, and
+  `TypeChecker::getConstantValue` returns `Auto_NumberValue_or_StringValue?`
+  — `String | Double`, both primitives, so `typeof` discriminates.
+  And the site was a THIRD renderer. `TypeChecker` is an INTERFACE, so
+  `getConstantValue` never reached the class-method path; patching that
+  path, regenerating, and finding the count UNCHANGED is what found
+  `ffi_function_field_method_decl`. Interface methods, class methods and
+  the four accessor paths are three separate renderers of one decision, and
+  the ARGUMENTS were routed through the conversion at all of them while the
+  RETURN was routed at none — the same family as the accessors, one axis
+  further out, and the reason to fix a renderer and then MEASURE rather
+  than assume the site was the one that looked obvious.
 
 ## Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2629,6 +2629,80 @@ product surfaces now.
   keeps domain-specific specialization for Node FS / React / Hono / crypto /
   class-shape generation, plus `.mbti` -> `.d.ts` emission for MoonBit-generated
   packages.
+  Its gates all asked one of two questions and neither was the important
+  one. `verify-scaffolds` / `verify-generated-fixtures` /
+  `verify-examples` ask whether a generated package COMPILES;
+  `scripts/bridge_quality_report.sh` asks whether a REJECTED export is
+  budgeted. **Nothing asked whether the code emitted for an ACCEPTED
+  export RUNS**, and the answer was no. A tagged-union case whose payload
+  is `Named(N)` was discriminated with `value instanceof N` whether or not
+  `N` exists at runtime: `tagged_union_named_constructor_name` asks
+  whether a name is PascalCase and MoonBit-spellable — a NAMING test —
+  and the discriminator read that as licence to emit the predicate, so an
+  interface, a type alias, an enum and a type parameter all got one. 411
+  unbound sites over 197 distinct names, against 14 globals and 4 bound;
+  **2,126 of 2,530 converter calls threw `ReferenceError`** under Node.
+  The names are the diagnosis on their own — `T` / `TResult` /
+  `TDriverParam` are type parameters, `PathLike` / `Booleanish` are
+  aliases, `ScriptTarget` / `ModifierFlags` are enums, `Expression` /
+  `SourceFile` / `Identifier` are TypeScript interfaces.
+  The rule ALREADY EXISTED, which makes this the family this file keeps
+  recording rather than a missing feature.
+  `moonbit_inline_union_runtime_named_ok` is the global-constructor
+  allowlist and its own doc comment states this exact hazard ("interfaces,
+  type aliases, and type parameters have no runtime binding, so `value
+  instanceof Name` would throw in the generated converter"); it was
+  consulted at ONE site, and there only when the union has a FUNCTION
+  member, because the call sits inside `if func_members > 0`. That
+  condition is right for the check immediately above it — a second
+  function case collides on `typeof === "function"` — and has nothing to
+  do with whether a sibling's `instanceof` resolves, so it is the
+  namespace `if outer_modules.length() == 0` shape again: one item's
+  condition inherited by others that do not share it.
+  What made declining cheap is splitting the two converter DIRECTIONS,
+  which had been emitted as a pair: `_to_js` reads `$tag` and needs no
+  runtime predicate at all, so parameter positions keep their types and
+  only the return-side `_from_js` is withheld, with a note naming the
+  case. Before the split a declined `_from_js` took the sound `_to_js`
+  down with it. The whole fix costs ZERO product surface — the bridge
+  quality report is identical on every metric — because
+  `ffi_tagged_union_return_is_safe_to_wrap` already refused to CALL these
+  converters, so the 411 sites were dead broken code. That is also why
+  nothing noticed: `just verify-bridge-runtime`
+  (`scripts/verify_bridge_runtime.mjs`) is the harness that was missing,
+  and it needs BOTH of its halves — a static check that every
+  `instanceof X` has `X` a JS global or a module binding (complete, since
+  it sees a site whichever arm a probe value reaches) and a runtime check
+  that imports all 86 generated bridge modules and calls every exported
+  `_from_js` over a value battery (which is what proves the static list is
+  real rather than a grep artifact). The reason the corpus could not reach
+  it is the recurring one: the ONLY fixture with live `_from_js` calls is
+  `boolean | "boundary"`, with no `Named` member anywhere, so not one
+  fixture put a named type in a return position.
+  The rejection side got the same treatment, and its lesson is the
+  count-versus-item one. `heterogeneous_union_unsupported_export_budget`
+  was set to 0 when the count was 0, an example added later
+  reintroduced two, and the report had been exiting 1 ever since with no
+  way to tell an accepted limitation from a regression — the defect that
+  retired `docs/checker-priority.md`, in a shell script.
+  `scripts/bridge_widened_unions.txt` declares each occurrence with a kind
+  and a reason; an UNDECLARED occurrence fails, and a declared entry that
+  no longer occurs is reported STALE, which is the one mechanism that
+  keeps such a file from becoming a suppression list (both directions
+  proven by mutation, not asserted). The diagnostic it declares had to be
+  fixed first, because it named a cause that CANNOT OCCUR: "non-PascalCase
+  named, function, or unsupported shape" lists a function member, which is
+  accepted as `FnValue`, and put everything real under "unsupported
+  shape" — so an anonymous object type and an object intersection, the two
+  actual occurrences, could not be told apart from a lowercase name by
+  reading the message. And the honest verdict on those two is that neither
+  earns the object-payload feature they both want:
+  `BufferEncodingOption`'s `{ encoding: "buffer" }` is redundant with its
+  `"buffer"` string member, which the existing fallback already
+  constructs, and `WriteFileOptions` needs a SECOND thing — its sibling
+  `BufferEncoding` is a node global this package does not resolve, so even
+  a successful lowering would hand the user a case payload they cannot
+  build.
 
 ## Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2783,12 +2783,41 @@ product surfaces now.
   information — is still answered yes by the typed PARAMETERS.
   It also surfaced a pre-existing defect nothing could see while the two
   renderings agreed: the `.mbti` carries declarations the `.mbt` does
-  not. `get_create_adaptor_server` appears twice, once with no impl
-  counterpart at all, and corpus-wide there are 52 duplicated declaration
-  names of 2,161 in the `typescript` package, 13 in vitest, 9 in node_fs.
-  A second emitter renders the same value exports independently of the
-  ffi layer and the two matched only by coincidence — which is also why
-  the enum-return probe still reports one residual.
+  not, because the decl layer and the ffi layer render the same value
+  export independently and `add_bridge_ergonomic_helper_decls` guarded on
+  `contains(helper_decl)` — a substring test using the full SIGNATURE,
+  asking "is this exact line present" where the question is "is this
+  FUNCTION declared". MoonBit has no overloading, so a second
+  `declare pub fn` of one name is always wrong; while the two layers
+  happened to render identical text the duplicate was skipped and the
+  disagreement was invisible.
+  **The first measurement of it was wrong, and the way it was wrong is
+  this file's own recurring mistake in the instrument**: a pattern
+  `^declare pub fn [A-Za-z_][A-Za-z0-9_]*` stops at `::`, so
+  `BuilderProgram::getProgram` and six sibling METHODS collapsed onto
+  `BuilderProgram` and read as a duplicated name — reported as "52
+  duplicated names of 2,161 in the `typescript` package, 13 in vitest, 9
+  in node_fs", which is an artifact of the regex and not a defect.
+  Taking the name up to the `(` that must follow it immediately gives the
+  real answer: **4 duplicated names in 2 packages**, all four with no
+  impl counterpart at all — three `get_*` value getters in
+  hono__node_server and node_fs's `mkdir` (one `pub extern "js" fn
+  mkdir`, so not overloading either). In every case the stale line is the
+  LESS precise one (`get_serve() -> JSValue` against the impl's
+  `() -> (Options, cb?) -> JSValue`; `mkdir`'s `callback : JSValue`
+  against its real callback type), except `get_create_adaptor_server`,
+  whose stale line was more precise and simply untrue.
+  The fix makes the `.mbti` AGREE with the `.mbt` by construction rather
+  than accumulate beside it: the derived declaration REPLACES a
+  same-named line in place, keyed by name through one map lookup per line
+  (a scan per name over the `typescript` package's 2,161 declarations is
+  the quadratic this file keeps paying for). Proven to touch nothing
+  else — regenerating the whole corpus before and after and diffing every
+  declaration line order-independently leaves **85 of 87 packages
+  byte-identical**, with the 2 changed losing exactly those 4 lines. The
+  report gains a `duplicate declared fn names` metric that FAILS on any
+  occurrence, mutation-tested in both directions and verified not to fire
+  on the `Type::method` forms that fooled the first measurement.
 
 ## Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1343,6 +1343,41 @@ product surfaces now.
   means no bound can have been inlined — and is filed rather than built,
   because it buys no conformance file and the real-world diagnostic is
   its only argument.
+  Batches DX and DY are the first two in this series whose conformance
+  yield is ZERO BY DESIGN, and they are the answer to a question the gate
+  cannot ask. DX runs the excess-property check at a CALL argument — the
+  commonest place real code hits TS2353, and a position the corpus does
+  not test at all — behind the one fact that makes it decidable:
+  `callee_non_generic`, proven only at a direct call to a resolved
+  function declaration and at `new` on a resolved class, defaulting to
+  `false` so any site that cannot answer keeps the suppression. An
+  ABSENT entry in `func_type_params` is explicitly not proof, since a
+  call-signature-typed variable and a lib method have no entry either.
+  Both nested shapes under an argument come along, because a nested
+  target came from a `lookup_field` on a written parameter type. A method
+  call and a call through a function-typed binding stay MISSes, neither
+  site being able to prove the callee's genericity.
+  DY is the assignment-form `for…of` target at its other two spellings:
+  the check fired for a bare `Var` and was blind to `o.x`, `foo().x` and
+  `arr[0]`, because the parser wraps a non-identifier head as
+  `TsBinding::Target(expr)` and that fell through to the
+  destructuring-pattern arm. Its zero is more informative than the rule:
+  `ES5For-of8` is `function foo() { return { x: 0 } }`, and an
+  UN-ANNOTATED function's return type does not resolve here at all —
+  `const bad: string = foo().x` is silent too — so the file needs
+  return-type inference from a BODY and never needed this rule.
+  The same round priced the rest of the assignability bucket by opening
+  every file, and the answer settles the strategy: **35 files, ~35
+  causes.** The four cheapest-LOOKING (a plain `number` / `string`
+  mismatch, a shape this checker does flag) each need something
+  different — a well-known-symbol accessor pair's inferred type,
+  object-literal union normalization on widening, expando + namespace
+  declaration merging, and the return-type inference above. `globalThis`
+  at 3 files is the only mini-cluster. The measured rate is about one
+  file per investigation, so the conformance number has stopped ranking
+  work a second time, and what remains worth taking is what the corpus
+  cannot score: 83 of the 134 misses carry exactly one error code and 25
+  of the 39 solo codes have exactly one file.
 - `src/transform` is the JS-side pipeline behind `mtsc`: bundling, folding,
   tree-shaking, and the property mangler. Its safety story is type-driven and
   has two halves — `export_surface.mbt` (names reachable from the entry's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1309,6 +1309,40 @@ product surfaces now.
   reports while `let x = g(() => x)` with `g` declaring its return type
   is ACCEPTED, as are `let x = function () { return x }`, `[() => x]`
   and `{ m: () => x }`.
+  Batch DW is +1 and is the first batch here whose target abstention
+  probing CONFIRMED, which is worth as much as the four it refuted. The
+  rule that shipped is a different bug: two sites held one decision and
+  gave opposite answers. `check_expr_against`'s
+  `(ObjectLit, Applied(name, _))` arm deliberately routes the six
+  projectable utility types into `check_object_lit_against_target` — its
+  own comment says so, "since `lookup_field` / `collect_declared_fields`
+  know how to project their field shapes" — and that function threw them
+  straight back out through TWO early returns, `member_recv_unmodeled`
+  and `type_contains_unresolved_named`, both of which call any `Applied`
+  to a non-class, non-interface name unresolvable. So
+  `{ black: { r, g, d } } satisfies Record<string, Color>` reported
+  nothing. The exemption is `Record` ONLY and only with a bare
+  `string` / `number` key, and the wider version was implemented and
+  MEASURED before being cut down: every projectable utility judged by all
+  of its arguments is +1 TP and +1 FP, the false positive being
+  `f20<T, K extends keyof T>(obj: Pick<T, K>)`, which accepts any object
+  literal because `T` is inferred FROM the argument.
+  The confirmed abstention is the excess-property check at CALL
+  ARGUMENTS. A position matrix says the check covers the annotated
+  declaration, `return`, an array element, `satisfies`, assignment and a
+  nested property and is missing at every CALL position, which is the
+  commonest place real code hits TS2353 — and the one-line suppression
+  guarding it (`sub_path.contains("arg[") && target is Object(_)`) is
+  load-bearing: removing it is +0 TP and +3 FPs on hand-written
+  TS7-accepted code, because a constrained type parameter's bound really
+  IS inlined into the parameter position, so
+  `foo<U extends { length: number }>(x: U)` accepts
+  `{ length: 1, extra: 2 }` and the earlier early returns do not catch
+  it. Corpus-wide the blunt removal is +0 TP / +1 FP. The shippable
+  version gates on the CALLEE being non-generic — no type parameters
+  means no bound can have been inlined — and is filed rather than built,
+  because it buys no conformance file and the real-world diagnostic is
+  its only argument.
 - `src/transform` is the JS-side pipeline behind `mtsc`: bundling, folding,
   tree-shaking, and the property mangler. Its safety story is type-driven and
   has two halves — `export_surface.mbt` (names reachable from the entry's

--- a/TODO.md
+++ b/TODO.md
@@ -279,49 +279,103 @@ repo has been removed. Items below are scoped to the bridge generator only.
     with a kind and a reason each — 15 `erased-payload`, 2
     `optional-gate`, 1 `module-class`. Undeclared fails, stale fails, both
     mutation-tested.
-- [ ] **Give `ffi_widen_unbuildable_union_outputs` a `Union(parts)` arm —
-  needs a cross-layer channel first.** 15 of the 18 declared crossings
-  above are erased payloads whose honest answer is the same widening that
-  fixed `ServerType`, and it never sees them: a synthesized union keeps the
-  original `Union(parts)` shape in the AST while its signature already
-  reads `Auto_X_or_Y`, which `ffi_inline_js_tagged_union_to_js` states in
-  its own comment sixty lines away. Sixth fail-open shape arm here, and the
-  first one written INSIDE the fix for the previous one.
-  Implemented (`ffi_output_union_alias_name`, resolving both spellings),
-  **RUN as an experiment, and REVERTED** — and the experiment retired the
-  blocker this entry used to assert. There are THREE renderings of one
-  export, not two, and only one of them moved:
-
-      mbti    : getNameOfJSDocTypedef(...) -> Auto_Identifier…?   (unchanged)
-      bridge  : getNameOfJSDocTypedef(...) -> Auto_Identifier…?   (unchanged)
-      externs : get_name_of_jsdoc_typedef(...) -> JSValue?        (WIDENED)
-
-  So `[4014] Expr Type Mismatch: has type JSValue?, wanted Auto_…?`
-  reproduces, and the first diagnosis — "the decl layer holds no
-  `MoonBitJsFfiState`, so this needs a cross-layer channel", written from
-  the error message alone — is WRONG in the direction the correction
-  suspected. The decl layer builds that wrapper by iterating
-  **`bridge_mbti.split("\n")`** and parsing
-  `parse_bridge_top_level_fn_decl_line`, so `fn_decl.return_type` is read
-  off the `.mbti` LINE, not off the FFI layer's `.mbt` text. The `.mbti`
-  declaration rendering is therefore one more site the widening does not
-  route through — applied-in-some-places again — and because the wrapper
-  DERIVES from that line, there is exactly ONE place to fix and no channel
-  to build: correct the `.mbti` type and the wrapper follows.
-  What is still unlocated is which emitter renders that `.mbti` line. It is
-  not any of the `"declare pub fn "` literals in `moonbit_bridge.mbt` —
-  those are the parser prefix and the helper/getter forms — so the `.mbti`
-  body comes from elsewhere and needs one more step to find. Start there,
-  not at the FFI layer.
-  **The experiment's own FIRST run measured nothing, and the fault was in
-  the experiment.** The arm was written as `Named(_) | Union(_)` ABOVE the
-  optional-like branch, and `Auto_X_or_Y?` is `Union([…, Undefined])` in the
-  AST — so the new arm swallowed every optional, derived a synthesized name
-  from parts that include `Undefined`, found it registered nowhere, and
-  declined silently. Ordering the optional classification FIRST is what made
-  the widening fire at all. An experiment can fail in the instrument exactly
-  the way the code under test does; the reading to trust is the one where
-  something visibly moved.
+- [x] **The unconverted-crossing backlog is EMPTY — all 18 fixed, and the
+  gate's STALE half is what said so.** `bridge_unconverted_enum_crossings.txt`
+  now declares nothing, the probe reports `0 / 0 / 0`, and every generated
+  package still compiles and runs. What follows is the order the last 16
+  fell in, because each step contradicted the step before it.
+  - **The arm was missing, and then it was order-dependent.**
+    `ffi_widen_unbuildable_union_outputs` never saw a SYNTHESIZED union: such
+    a union keeps its `Union(parts)` shape in the AST while its signature
+    already reads `Auto_X_or_Y`, exactly as
+    `ffi_inline_js_tagged_union_to_js` states in its own comment sixty lines
+    away — sixth fail-open shape arm here, and the first written INSIDE the
+    fix for the fifth. The first version of the arm then asked whether the
+    alias was already in `state.tagged_union_decls_by_name`, which is filled
+    as a SIDE EFFECT of rendering, so the answer depended on whether an
+    earlier declaration in the file happened to mention the same union:
+    `Auto_IdentifierValue_or_PrivateIdentifierValue` is also a parameter of
+    `idText` NINE LINES ABOVE and was registered;
+    `Auto_VariableDeclarationValue_or_ParameterDeclarationValue` occurs
+    exactly once and was not. One fixed, its neighbour silently not — the
+    applied-in-some-places family with the sites chosen by declaration
+    order. `ffi_output_union_decl` builds the decl on the spot instead; a
+    synthesized decl is only `{ name, cases }`, and registration is the
+    emission pass's business, not this decision's.
+  - **Three renderings of one export, and only the ffi one moved.** The
+    `.mbti` line comes from the DECL layer and the public wrapper is rendered
+    FROM that line, so widening the extern alone gives `[4014] has type
+    JSValue?, wanted Auto_…?`. `reconcile_bridge_widened_union_returns` makes
+    the declaration agree with the extern that implements it, which is the
+    principle `add_bridge_ergonomic_helper_decls` already states — the `.mbt`
+    is what the package really is. It has to be SCOPED, and that is the whole
+    difficulty: a declaration differing from its extern is the NORMAL case (a
+    literal-union enum crosses as an `Int`, an opaque type arrives as
+    `JSValue` and the wrapper wraps it in an option), so it fires only when
+    the extern hands back `JSValue` at the SAME optionality and the declared
+    type is one of the two things the widening can leave behind. Both halves
+    are needed and one was written first: when the union is still mentioned
+    elsewhere the enum survives and the symptom is `[4014]`; when the widened
+    return was its LAST mention nothing synthesizes the enum any more and the
+    same stale line is `[4032] the type Auto_… is undefined`, which is
+    exactly how `walkUpBindingElementsAndPatterns` failed to compile while
+    `getNameOfJSDocTypedef` came out right.
+  - **The `.mbti` emitter was found by INSTRUMENTING, and the first run of
+    that experiment was a false zero.** Markers in the three `declare pub fn`
+    renderers of `parser_moonbit.mbt` attributed 0 of 11 lines — because the
+    fixture used was a class-only `.d.ts`, which declares no top-level
+    function, so `func_decl_to_moonbit` was never called at all. A zero from
+    a probe whose shape is ABSENT is not an answer, and the previous note in
+    this entry ("it is not any of the `declare pub fn` literals in
+    `moonbit_bridge.mbt`, so the body comes from elsewhere") was drawn from
+    that zero. It is `parser_moonbit.mbt:1426`, reached through
+    `moonbit_decl.mbt:12526`.
+  - **An index signature's two directions are two questions and were
+    rendered with ONE type name.** `index_get` crosses JS -> MoonBit and
+    widens; `index_set` crosses the other way, where `_to_js` reads `$tag`
+    and needs no runtime predicate, so it keeps its type and converts in the
+    body. `ffi_inline_js_arg_expr_with_state`'s tagged-union detection was
+    also `Named`-only, which would have sent every synthesized union down the
+    generic option unwrap and read `value._0` off a value MoonBit does not
+    box.
+  - **A METHOD's return needed the widening and `ffi_function_type_parts` is
+    the wrong place for it, measured rather than reasoned.** A function type
+    has no direction of its own: the same rendering types a method's return
+    (JS -> MoonBit) and a CALLBACK parameter's return (MoonBit -> JS, where
+    the enum works and widening throws away a working type). Putting it there
+    broke `Matcher::_call_`, whose wrapper reads a struct FIELD rendered
+    elsewhere — `has type ExpectationResult, wanted JSValue`. It belongs in
+    the one branch of `ffi_function_field_method_decl` that binds straight to
+    a JS call, guarded on the unwidened rendering still matching so the
+    `This` / `This?` substitution above is not undone.
+  - The `module-class` entry went with them: binding `drizzle-orm`'s real
+    `Table` / `View` would have made `aliasedTable`'s `instanceof` resolve,
+    and widening needed no new machinery. The measured ceiling for that
+    binding was 2 bindable names of the 197 declined, which is why it was
+    never worth taking on its own.
+  - Gates: probe 0/0/0, `verify-bridge-runtime` 86 modules / 14,630 converter
+    calls / 0 failures / 0 unbound `instanceof`, `bridge_quality_report.sh`
+    `pass` with `duplicate declared fn names 0`, scaffolds + fixtures +
+    examples all 0, `verify-mbti-dts` 0, `moon test` 2994/2994. Both halves
+    mutation-proven by
+    `fixtures/resolver/project/types/widened-union-output-entry.d.ts` and the
+    test over it, which carries a NEGATIVE control (`string | URL`
+    discriminates, so that union keeps its enum) so the fix cannot be
+    "switch the lowering off".
+- [ ] **A function-typed struct FIELD's return is the same widening one axis
+  out, and is NOT covered.** `Service::erasedMethod`'s extern and declaration
+  now say `JSValue`, and the struct field the same interface renders —
+  `erasedMethod : (String) -> Auto_BetaValue_or_AlphaValue` in `types.mbt` —
+  still promises the enum over a raw JS value. Pre-existing, and strictly
+  improved rather than introduced: before the change the extern was wrong the
+  same way. The blocker is the one the method fix ran into and is mechanical:
+  `ffi_func_type_name` has no direction parameter, and it renders both an
+  interface member's function type (return crosses JS -> MoonBit) and a
+  callback parameter's (return crosses MoonBit -> JS, where the enum is
+  real). Giving it a direction is the fix; widening it blindly is what broke
+  `Matcher::_call_`. The probe does not read struct fields either, so the
+  first step is to teach `bridge_enum_return_probe.mjs` to count them — a
+  count of the occurrences is what says whether this is worth the parameter.
 - [x] **Convert an OPTIONAL tagged-union crossing — DONE**, and both of the
   reasons the previous note gave for declining it were false, which is the
   part worth keeping.

--- a/TODO.md
+++ b/TODO.md
@@ -130,19 +130,46 @@ repo has been removed. Items below are scoped to the bridge generator only.
     different path, and they DO build `{ "$tag": 0, "_0": value }`.
     Pinned by a unit test that fails under mutation of the `CallableMeta`
     arm with `"(Options) -> ServerType" != "(Options) -> JSValue"`.
-- [ ] **The `.mbti` carries declarations the `.mbt` does not** —
-  pre-existing, corpus-wide, and only VISIBLE because the fix above made
-  two renderings of one declaration disagree. `hono__node_server`'s
-  `.mbti` has `get_create_adaptor_server` twice, once `-> (Options) ->
-  ServerType` with no `.mbt` counterpart at all and once `-> (Options) ->
-  JSValue` matching the impl; before the widening both printed
-  identically and the duplication was invisible. Corpus-wide: 52
-  duplicated declaration names of 2,161 in the `typescript` package, 13
-  of 253 in vitest, 9 of 320 in node_fs, 5 in drizzle, 3 in
-  hono__node_server, 2 in react-types. So a second emitter renders the
-  same value exports independently of the ffi layer, and the two agreed
-  only by coincidence. This is the residual `1` the enum-return probe
-  still reports.
+- [x] **The `.mbti` carries declarations the `.mbt` does not** — DONE.
+  Pre-existing, and only VISIBLE because the return-type widening above
+  made two renderings of one declaration disagree.
+  `add_bridge_ergonomic_helper_decls` derives a `declare pub fn` from
+  every emitted extern and guarded on
+  `if !next_bridge_mbti.contains(helper_decl)` — a substring test over
+  the whole file using the full SIGNATURE, which asks "is this exact line
+  present" where the question is "is this FUNCTION declared". MoonBit has
+  no overloading, so a second `declare pub fn` of one name is always
+  wrong; while the two layers rendered identical text the append was
+  skipped and nothing was visible.
+  - **The first measurement was WRONG, in the instrument**, and the
+    correction is the finding worth keeping. The scan
+    `^declare pub fn [A-Za-z_][A-Za-z0-9_]*` stops at `::`, so
+    `BuilderProgram::getProgram` and six sibling METHODS collapsed onto
+    `BuilderProgram`; the "52 duplicated names of 2,161 in the
+    `typescript` package, 13 in vitest, 9 in node_fs" recorded one commit
+    earlier is an artifact of that regex. Taking the name up to the `(`
+    that must follow it immediately gives **4 duplicated names in 2
+    packages** — and all 2,161 declare-lines in that package match the
+    full-line form, so the refined scan is not under-counting either.
+  - All four have NO impl counterpart: `get_serve`,
+    `get_get_request_listener`, `get_create_adaptor_server` in
+    hono__node_server, and `mkdir` in node_fs (one `pub extern "js" fn
+    mkdir`, so not overloading). The stale line is the less precise one
+    in three cases and precise-but-untrue in the fourth.
+  - The derived declaration now REPLACES a same-named line in place, so
+    the `.mbti` agrees with the `.mbt` by construction and the next
+    disagreement cannot hide the same way. Keyed by name through one map
+    lookup per line rather than a scan per name — 2,161 names over a
+    10k-line file is the quadratic this repo keeps paying for.
+  - Proven to change nothing else: regenerating the whole corpus before
+    and after and diffing every declaration line order-independently
+    leaves **85 of 87 packages byte-identical**, the 2 changed losing
+    exactly those 4 lines. `MoonBit declared functions` 5410 -> 5406, so
+    the report had been over-counting by exactly the redundant lines.
+  - `bridge_quality_report.sh` gains `duplicate declared fn names`, which
+    FAILS on any occurrence. Mutation-tested both directions, and
+    verified NOT to fire on the `Type::method` forms that fooled the
+    first measurement.
 - [ ] **`_from_js` exists but the return wrapper still declines it.**
   The other half of the same defect, now that the predicate distinction
   above is written down: for a union whose cases are a primitive plus a

--- a/TODO.md
+++ b/TODO.md
@@ -52,6 +52,37 @@ repo has been removed. Items below are scoped to the bridge generator only.
     (`scaffold_ts_to_moonbit_heterogeneous_union`) is `boolean | "boundary"`
     — no `Named` member at all. That is why the bug survived: not one
     fixture in the corpus put a named type in a return position.
+- [ ] **A tagged-union RETURN type the wrapper never builds** (4 sites,
+  `scripts/bridge_enum_return_probe.mjs`). `@hono/node-server` declares
+  `serve(...) -> ServerType` and `create_adaptor_server(...) -> ServerType`
+  (plus the two `get_*` forms that return a function returning it) while the
+  JS wrapper is `return __ts_mbt_module.serve(...)` — the raw Node server
+  object. `ServerType` is payload-bearing, and the representation is not a
+  guess: the alias's own constructor emits
+  `__ts_mbt_server_type_from_server(value) { return { "$tag": 0, "_0": value
+  }; }`, so a MoonBit `match` on the returned value reads `$tag` off an
+  object that has none. The declared type and the wrapper are decided in
+  different places and are free to disagree; when
+  `ffi_tagged_union_return_is_safe_to_wrap` says no, the declared return
+  should widen to `JSValue`.
+  - Attempted and REVERTED rather than left as a no-op: routing all eleven
+    return-type renderers through one `ffi_output_type_name` that widens
+    `Named(n)` (and a returned `Func`'s own return, recursively) when
+    `tagged_union_decls_by_name` has `n` and the wrap predicate refuses.
+    `moon check` clean, the example regenerated with the new binary
+    (timestamps confirm it), and all four sites still said `ServerType` — so
+    the predicate answers `false` and the reason is not yet known. The map is
+    keyed by `ffi_type_identifier(name, "OpaqueType")`, which is identity for
+    `ServerType`, so the obvious key-mismatch explanation is ruled out; the
+    next step is to find which renderer actually emits `pub extern "js" fn
+    serve` (the binding name `__ts_mbt_serve` points at
+    `ffi_func_decl_to_moonbit`, which WAS one of the eleven).
+  - The probe is worth keeping either way, and it corrected itself once: its
+    first version counted payload-FREE enums (`enum Mode { Read Write }`,
+    from a TS numeric enum, which is an integer tag where a raw numeric
+    passthrough is correct) and reported 11 sites. Its own comment claimed a
+    payload filter the code never implemented — the same substitution this
+    file keeps recording, in the measuring instrument. 4 of 73, not 11.
 - [ ] **Bind a module-exported class so its `instanceof` resolves.** The
   ceiling is measured and small: of the 197 declined names, the runtime
   classes are node_fs's `Stats` / `StatsFs` / `BigIntStats` /

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,38 @@
 The wasm interpreter / codegen / AOT compiler that originally lived in this
 repo has been removed. Items below are scoped to the bridge generator only.
 
+### Batch DZ (2026-09-08): the strict-null bucket, and what it really holds
+
+- [x] **TS18030** — an optional chain cannot contain private identifiers.
+  +1 file (TP 2582 -> 2583, MISS in scope 133 -> 132, FP 0, PFLEGAL 0).
+  Purely syntactic, so it lives in `parse_postfix`'s chain loop: one
+  chain-local `saw_optional_in_chain` flag, set where `?.` is consumed and
+  tested at BOTH sites that read a chain property, so `this?.#b` and
+  `this?.a.#b` are one condition rather than two. Chain-local (not a Parser
+  field) is what makes the two subtle legal neighbours automatic —
+  `this?.getA(o.#b)` and `(this?.c).#b` each parse their inner expression
+  in a nested invocation of the same loop, so neither inherits the flag.
+  - The probe earned itself back on `(this?.c).#b`: tsc reports TS2532
+    there and NOT TS18030, so parenthesizing ends the chain. Both answers
+    were plausible from the message text. All seven spellings now agree
+    with tsc exactly (3 fire, 4 silent).
+- [x] **The bucket label was wrong about every file in it.** "strict-null /
+  narrowing" is 5 files and 5 unrelated kinds of work — see
+  `docs/checker-triage.md` for each. Not one is fixed by a strict-null or
+  narrowing rule. Eighth instance of a label standing in for the
+  objective, and the first where the bucket was small enough that the
+  count looked trustworthy.
+- [ ] **TS2331** (`this` in a namespace body). Deferred on a measured
+  cost, not on difficulty. The boundary is exact and probed: an arrow
+  inside a namespace body fires at any nesting depth, a `function`
+  declaration or expression inside one does not, a class method does not,
+  script top level does not, and module top level does not. `in_function`
+  cannot express it (true inside arrows), so it needs a new
+  `this`-rebinding field with the save / clear / restore discipline
+  `self.labels` needs at fifteen function-body sites — the shape that
+  produces the applied-in-some-places bug, for +1 file. Take it together
+  with a refactor that centralizes those fifteen sites.
+
 ## Bridge runtime: the generated JS was never executed (2026-09-07) — DONE
 
 - [x] **`instanceof` against an erased TypeScript name.** A tagged-union

--- a/TODO.md
+++ b/TODO.md
@@ -5039,6 +5039,65 @@ inside a function body:
 - [x] strict-null / narrowing: 3 of 8 in batch DO (the `logicalAssignment`
   files). Five left.
 
+- [x] **Batch DW: the excess-property check reaches a `Record<string, V>`
+  target, +1 file at FP 0** (TP 2581 -> 2582, in-scope MISS 134 -> 133).
+  Two sites held one decision and gave opposite answers.
+  `check_expr_against`'s `(ObjectLit, Applied(name, _))` arm deliberately
+  routes the six projectable utility types into
+  `check_object_lit_against_target` — its own comment says so, "since
+  `lookup_field` / `collect_declared_fields` know how to project their
+  field shapes" — and that function threw them straight back out through
+  TWO early returns, `member_recv_unmodeled` and
+  `type_contains_unresolved_named`, both of which call any `Applied` to a
+  non-class, non-interface name unresolvable. So
+  `{ black: { r, g, d } } satisfies Record<string, Color>` reported
+  nothing.
+  The exemption is `Record` ONLY, and only with a bare `string` /
+  `number` key. The wider version — every projectable utility, judged by
+  all of its arguments — was implemented and MEASURED before being cut
+  down: +1 TP and **+1 FP**, the false positive being
+  `isomorphicMappedTypeInference`'s
+  `f20<T, K extends keyof T>(obj: Pick<T, K>)`, which accepts any object
+  literal because `T` is inferred FROM the argument. A type-parameter KEY
+  is the same hazard (`f<K extends string>(o: Record<K, number>)`), which
+  is why the key must be the concrete keyword. The missing-required half
+  stays vacuous for `Record` by construction, since
+  `collect_declared_fields` has no `Record` arm — which is right, as
+  `Record<string, V>` requires no particular key.
+- [ ] **MEASURED AND REJECTED: the excess-property check at CALL
+  ARGUMENTS.** A position matrix says the check covers the annotated
+  declaration, `return`, an array element, `satisfies`, assignment and a
+  nested property, and is missing at every CALL position — a
+  `declare function` argument, a method call, an arrow-typed binding's
+  call, and a `new` — which is the commonest place real code hits
+  TS2353. The suppression is one line
+  (`sub_path.contains("arg[") && target is Object(_)`) with a stated
+  reason, and this is the FIRST of five recorded abstentions in this
+  series whose reason probing CONFIRMED: removing it is **+0 TP and
+  +3 FPs** on hand-written TS7-accepted code, because a constrained type
+  parameter's bound really is inlined into the parameter position
+  (`foo<U extends { length: number }>(x: U)` accepts
+  `{ length: 1, extra: 2 }`) and the earlier early returns do not catch
+  it. Corpus-wide the blunt removal is **+0 TP / +1 FP** — so the
+  call-argument position is worth zero conformance files and the
+  suppression is load-bearing.
+  What would make it shippable is a gate on the CALLEE being
+  non-generic: no type parameters means no bound can have been inlined,
+  so an `Object(_)` parameter target must be a written inline object
+  type. That is sound and loses only a generic function's inline-object
+  parameters. It is not built here because it buys no corpus file and
+  needs a fact threaded through `check_expr_against`, which has ~30
+  callers; the real-world diagnostic is the only argument for it, and it
+  is a good one.
+- [ ] **FILED: `arrayLiterals.ts`** — the last excess-property MISS of
+  the three needs an object literal checked against a target whose shape
+  is a NUMERIC INDEX SIGNATURE (`{ [n: number]: { a: string; b: number } }`),
+  where each element's value must be checked against the index value
+  type. The `@@computed:` arm of `check_object_lit_against_target`
+  already does exactly this lookup for one narrow case, so the machinery
+  is there; the third file, `symbolProperty21`, is a computed
+  `[Symbol.toPrimitive]` key, which that function skips by design.
+
 ### Tier 3 — DEFER (~93 files, real but expensive)
 
 `assignability-core` (48), `generic-inference` (11), `iterator-protocol`

--- a/TODO.md
+++ b/TODO.md
@@ -5064,8 +5064,35 @@ inside a function body:
   stays vacuous for `Record` by construction, since
   `collect_declared_fields` has no `Record` arm — which is right, as
   `Record<string, V>` requires no particular key.
-- [ ] **MEASURED AND REJECTED: the excess-property check at CALL
-  ARGUMENTS.** A position matrix says the check covers the annotated
+- [x] **Batch DX: the excess-property check runs at a CALL argument when
+  the callee is provably non-generic.** Corpus yield is **ZERO** by
+  design and measured (TP 2582 -> 2582, FP 0) — the call position is
+  where real code hits TS2353 and the conformance corpus does not test
+  it, so the position matrix and the unit test ARE the measurement.
+  The fact that lifts the suppression is `callee_non_generic`: a callee
+  with no type parameters has no bound to inline, so an `Object(_)`
+  parameter target must be a written inline object type. It defaults to
+  `false` ("the caller cannot answer"), so every call site that does not
+  thread it keeps the suppression and loses a finding rather than
+  inventing one — and only two sites can prove it, a direct call to a
+  resolved function declaration and `new` on a resolved class. An ABSENT
+  entry in `func_type_params` is explicitly NOT proof (a
+  call-signature-typed variable or a lib method has no entry either), so
+  the direct-call site requires a resolver signature AND an empty
+  type-parameter list.
+  Recovered: a `declare function` argument, a `function` declaration
+  argument, `new` on a non-generic class, and BOTH nested shapes under an
+  argument (`f({ a: { x: 1, y: 2 } })` and `f({ a: { x: 1 }, b: 2 })`) —
+  the nested target came from a `lookup_field` on a written parameter
+  type, so the fact holds at depth. Still MISSes by design: a method call
+  and a call through a function-typed binding, neither of which can prove
+  the callee's genericity from its site.
+  The four false positives the gate exists to avoid are in the test:
+  `foo<U extends { length: number }>(x: U)`, its `function` form, a bare
+  `foo<U>(x: U)`, and `bar<U extends { a: number }>(x: U[])` — all
+  TS7-ACCEPTED.
+- [ ] **SUPERSEDED by batch DX — kept for the measurement: the
+  excess-property check at CALL ARGUMENTS.** A position matrix says the check covers the annotated
   declaration, `return`, an array element, `satisfies`, assignment and a
   nested property, and is missing at every CALL position — a
   `declare function` argument, a method call, an arrow-typed binding's

--- a/TODO.md
+++ b/TODO.md
@@ -240,16 +240,72 @@ repo has been removed. Items below are scoped to the bridge generator only.
     widening the question, so it is scoped to the directories holding a
     generated `bridge.js`. 1 source scanned, 0 unbound; fails when an
     erased name is injected into that body.
-- [ ] **Bind a module-exported class so its `instanceof` resolves.** The
-  ceiling is measured and small: of the 197 declined names, the runtime
-  classes are node_fs's `Stats` / `StatsFs` / `BigIntStats` /
-  `BigIntStatsFs`, hono__node_server's `Server` / `IncomingMessage` /
-  `ServerResponse` / the three `Http2*`, and drizzle's `Table` / `View` —
-  about ten. Each needs `const N = __ts_mbt_module.N` threaded through
-  `bridge_imports` at the converter-emission point, and then `Stats |
-  BigIntStats` returns get a typed enum instead of a raw passthrough. Worth
-  doing for the `stat()` family specifically; not worth it for the ~187
-  names that are erased no matter what.
+- [x] **Bind a module-exported class — MEASURED, ceiling is ONE return
+  position, and measuring it found 18 live bugs next door.** The estimate
+  above ("about ten", "worth doing for the `stat()` family specifically")
+  is wrong in both halves, and the runtime says so: importing each
+  generated package's own module and asking `typeof mod[name]` gives
+  **2 bindable names of the 197 declined**, `Table` (drizzle-orm) and
+  `Stats` (node:fs).
+  - Every name the estimate listed is NOT bindable, for two reasons worth
+    separating. hono__node_server's `Server` / `Http2Server` /
+    `Http2SecureServer` / `IncomingMessage` / `ServerResponse` are
+    **exported by a DIFFERENT module** — they are `node:http` / `node:http2`
+    classes that the package re-exports as TYPES — so `__ts_mbt_module.Server`
+    is `undefined` and binding them needs an import of another module, not
+    the one-line threading this item described. `StatsFs` /
+    `BigIntStatsFs` / `BigIntStats` are type-only on `node:fs`.
+  - And the ceiling is a question about CONVERTERS, not names: `_from_js` is
+    withheld unless EVERY case is discriminable, so `Stats` being bindable
+    buys nothing while `BigIntStats` stays erased — which is exactly the
+    `stat()` family this item called its main prize. Two converters are
+    fully unblocked (`Auto_SQLValue_or_TableValue`,
+    `Auto_ViewValue_or_TableValue`, both drizzle), and only ONE of them
+    occurs in a return position: `aliasedTable`. The binding mechanism
+    already exists — `bridge.js` emits `const Dir = __ts_mbt_module.Dir` —
+    so what is missing is the call at the converter-emission point.
+  - **The measurement's real output is 18 live wrong-value sites**, found
+    because `aliasedTable` turned out to convert its ARGUMENT and hand its
+    return back raw while declaring `-> Auto_ViewValue_or_TableValue`. The
+    probe had been blind to them twice over: it matched
+    `/_from_js|_to_js|\$tag/` over the whole body, so the `$tag` of the
+    PARAMETER's conversion passed the return; and it read payload enums
+    from `bridge.mbti` only, where the SYNTHESIZED `Auto_X_or_Y` unions are
+    never declared — **212 of 231 payload enums live in `types.mbt`**. Both
+    fixed: the directions are separate questions now (`"$tag":` /
+    `_from_js(` BUILDS a MoonBit value, `.$tag ===` / `_to_js(` READS one),
+    and the enum scan reads every `.mbt`.
+  - The 18 are declared in `scripts/bridge_unconverted_enum_crossings.txt`
+    with a kind and a reason each — 15 `erased-payload`, 2
+    `optional-gate`, 1 `module-class`. Undeclared fails, stale fails, both
+    mutation-tested.
+- [ ] **Give `ffi_widen_unbuildable_union_outputs` a `Union(parts)` arm —
+  needs a cross-layer channel first.** 15 of the 18 declared crossings
+  above are erased payloads whose honest answer is the same widening that
+  fixed `ServerType`, and it never sees them: a synthesized union keeps the
+  original `Union(parts)` shape in the AST while its signature already
+  reads `Auto_X_or_Y`, which `ffi_inline_js_tagged_union_to_js` states in
+  its own comment sixty lines away. Sixth fail-open shape arm here, and the
+  first one written INSIDE the fix for the previous one.
+  Implemented (`ffi_output_union_alias_name`, resolving both spellings) and
+  **REVERTED on a measured blocker**: the widening lives in the FFI layer
+  and the public wrapper — `pub fn getNameOfJSDocTypedef(...) ->
+  Auto_IdentifierValue_or_PrivateIdentifierValue?` — is rendered by the
+  DECL layer, which holds no `MoonBitJsFfiState`. Widening one side gives
+  `[4014] Expr Type Mismatch: has type JSValue?, wanted Auto_...?`, the two
+  layers disagreeing, which is the same split that produced the duplicate
+  `.mbti` declarations. Take it with the channel, not with a second copy of
+  the widening in the decl layer.
+- [ ] **Convert an OPTIONAL tagged-union crossing.** The cheapest real fix
+  on the declared list, and the previous note's claim that "no generated
+  accessor in the corpus has that shape" was wrong — there are 2:
+  `TypeChecker::getConstantValue` returns `Auto_NumberValue_or_StringValue?`,
+  whose cases are `String | Double`, so `typeof` discriminates and the
+  `_from_js` is fully buildable. `ffi_inline_js_return_expr_with_state`
+  leaves the optional form alone because MoonBit's `Option` repr is decided
+  separately by `ffi_option_return_needs_wrap` /
+  `ffi_converted_return_extern_pair`, and converting in both places would
+  box twice. Needs those two to agree on who wraps.
 - [ ] **Drop `ffi_synthesize_inline_union`'s `func_members > 0` gate.** Now
   that soundness lives centrally the gate is conservative rather than
   load-bearing: it refuses to synthesize an enum whose `_from_js` would be

--- a/TODO.md
+++ b/TODO.md
@@ -170,19 +170,76 @@ repo has been removed. Items below are scoped to the bridge generator only.
     FAILS on any occurrence. Mutation-tested both directions, and
     verified NOT to fire on the `Type::method` forms that fooled the
     first measurement.
-- [ ] **`_from_js` exists but the return wrapper still declines it.**
-  The other half of the same defect, now that the predicate distinction
-  above is written down: for a union whose cases are a primitive plus a
-  GLOBAL constructor (`PathLike`, `TimeLike`, `Mode`, `OpenMode`) the
-  `_from_js` converter is emitted and works, while
-  `ffi_tagged_union_return_is_safe_to_wrap` refuses the auto-wrap for any
-  `InstanceOfNamed` — so those returns declare the enum and deliver the
-  raw value. Letting the wrap gate accept a global-constructor
-  `instanceof` is what its own doc comment already claims it does.
-  `bridge_enum_return_probe.mjs` cannot currently see these: its regex
-  matches `declare pub fn NAME(`, so every `Type::method` form is
-  skipped, and node_fs's 12 such returns are mostly getters. Widen the
-  probe first, then measure.
+- [x] **`_from_js` exists but the wrapper still declines it** — DONE, and
+  the estimate above was wrong twice. "node_fs's 12 such returns are
+  mostly getters" was a guess; the widened probe says **4 sites, all in
+  node_fs, all `PathLike`, two getters and two setters**. And the fix is
+  in TWO places, not one: the gate, and the accessor paths that consult
+  it.
+  - **The gate contradicted its own doc comment for a full commit.**
+    8d227ad rewrote `ffi_tagged_union_return_is_safe_to_wrap`'s header to
+    say a global constructor "resolves and is kept … which is why
+    `PathLike = string | Buffer | URL` gets a working wrapper", and left
+    `Some(InstanceOfNamed(_)) => return false` in the body. So
+    `PathLike`'s `_from_js` was emitted, exercised by
+    `verify-bridge-runtime`, and never CALLED. Refusing an ERASED name is
+    `tagged_union_case_runtime_discriminator`'s job and it already does it
+    by returning `None`; the second, blunter copy of that judgement could
+    only disagree with the first.
+  - **Measured alone the gate change is a ZERO-diff no-op**, and that is
+    not the same as pointless — it is consulted by
+    `ffi_type_needs_js_return_conversion_with_state` and
+    `ffi_type_js_return_expr`, and no top-level function in the corpus
+    returns a global-`Named` union. It is LOAD-BEARING for the accessor
+    fix below, proven by mutation: with the old arm restored the
+    regenerated node_fs getter is `#| (self) => self.path` again.
+  - **The four accessor paths never asked about tagged unions at all.**
+    `ffi_class_property_getter_decl_to_moonbit` /
+    `_setter_decl_to_moonbit` route through
+    `ffi_rendered_generated_enum_info` and `ffi_enum_arg_expr`, which walk
+    `state.enums` — the LITERAL-union enums, whose converters are MoonBit
+    functions in `converters.mbt`. A tagged union's converters live in
+    `bridge.js`, so the class METHOD path puts the argument direction in
+    the JS BODY (`ffi_inline_js_arg_expr_with_state`) and the accessor
+    path had neither direction. Two enum families, one of them asked
+    about at these sites: the applied-in-some-places family with the axis
+    being the FAMILY rather than the site.
+  - The return direction needed a helper that did not exist —
+    `ffi_inline_js_return_expr_with_state`, the mirror of the argument
+    one — because an inline extern lambda cannot import the named
+    `bridge.js` helper (`ffi_inline_js_tagged_union_to_js` states that in
+    its own comment). It binds the value first: the from_js body repeats
+    its argument once per case predicate, and the expression here is
+    `self.path`, a property READ, where the named helper reads a
+    parameter. Statics take the named helpers instead, their binding
+    being a real `bridge.js` function.
+  - **The setter fix turned out to cover a SECOND family, 26 sites of
+    it.** `ffi_inline_js_arg_expr_with_state` also unwraps an OPTION box,
+    so `Context::set_context_env(value : Bindings?)` had been assigning
+    MoonBit's `{$tag: 1, _0: v}` straight into JS's `env` field — across
+    hono, hono-real, drizzle, vitest and typescript. One missing call,
+    two independent wrong values. Corpus totals: 33 emitted lines change,
+    26 option-box unwraps, 2 tagged-union getters, 2 setters, 2 static
+    struct converters, and every package's `.mbti` declaration count is
+    unchanged, so the public surface is identical.
+  - The probe was the precondition and it was widened as one: it now
+    reads `fn[T]` and `Type::method` forms, and — the half that matters —
+    scans INLINE EXTERN bodies as well as named `bridge.js` wrappers,
+    since the two are where a declaration's implementation can land and
+    only the second was ever checked. 47 named wrappers and 8 inline
+    bodies cross a payload enum, 0 unconverted; wired into
+    `bridge_quality_report.sh` as a `run_check`, called rather than
+    reimplemented in shell. Mutation-tested by putting the raw
+    passthrough back.
+  - `verify-bridge-runtime`'s static half now scans those inline bodies
+    too, under the STRICTER rule that only a JS global can resolve there
+    (an inline lambda has no module scope). Its first version walked
+    every `.mbt` under `_build` and reported three `instanceof` targets
+    out of `moon fmt`'s copy of a checker whitebox test, whose `#|` lines
+    are TypeScript source for a test case — widening the input set is not
+    widening the question, so it is scoped to the directories holding a
+    generated `bridge.js`. 1 source scanned, 0 unbound; fails when an
+    erased name is injected into that body.
 - [ ] **Bind a module-exported class so its `instanceof` resolves.** The
   ceiling is measured and small: of the 197 declined names, the runtime
   classes are node_fs's `Stats` / `StatsFs` / `BigIntStats` /

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,112 @@
 The wasm interpreter / codegen / AOT compiler that originally lived in this
 repo has been removed. Items below are scoped to the bridge generator only.
 
+## Bridge runtime: the generated JS was never executed (2026-09-07) — DONE
+
+- [x] **`instanceof` against an erased TypeScript name.** A tagged-union
+  case whose payload is `Named(N)` was discriminated with `value instanceof
+  N` whether or not `N` exists at runtime.
+  `tagged_union_named_constructor_name` asks whether a name is PascalCase
+  and MoonBit-spellable — a NAMING test — and the discriminator read that as
+  licence to emit the predicate, so an interface, a type alias, an enum and
+  a type parameter all got one. **411 unbound sites over 197 distinct names
+  across the generated corpus, against 14 globals and 4 bound; 2,126 of
+  2,530 converter calls threw `ReferenceError`.** The names say it: `T` /
+  `TResult` / `TDriverParam` are type parameters, `PathLike` / `Booleanish`
+  are aliases, `ScriptTarget` / `ModifierFlags` are enums, `Expression` /
+  `SourceFile` / `Identifier` are interfaces.
+  - The rule ALREADY EXISTED. `moonbit_inline_union_runtime_named_ok` is the
+    global-constructor allowlist and its own doc comment states this exact
+    hazard; it was consulted at ONE site and there only when the union has a
+    FUNCTION member, because the call sits inside `if func_members > 0` —
+    a condition that is right for the check next to it (a second function
+    case collides on `typeof === "function"`) and unrelated to whether a
+    sibling's `instanceof` resolves. Same shape as the namespace
+    `if outer_modules.length() == 0` case: one item's condition inherited by
+    others that do not share it.
+  - The two converter DIRECTIONS are now emitted independently, which is the
+    part that makes declining cheap: `_to_js` reads `$tag` and needs no
+    predicate, so parameters keep their types; only `_from_js` is withheld,
+    with a note naming the case. Before the split a declined `_from_js` took
+    the sound `_to_js` down with it.
+  - Costs nothing measurable: the bridge quality report is identical on
+    every metric (3 unsupported exports, 5409 declared functions, 2580
+    declared types, 5673 JSValue refs), because `ffi_tagged_union_return_is_safe_to_wrap`
+    already refused to CALL these converters. The 411 sites were dead
+    broken code — which is also why no harness noticed.
+- [x] **`scripts/verify_bridge_runtime.mjs`** (`just verify-bridge-runtime`,
+  wired into `just ci`). Every other bridge harness asks whether a generated
+  package COMPILES (`verify-scaffolds`, `verify-generated-fixtures`,
+  `verify-examples`) or whether a REJECTED export is budgeted
+  (`bridge_quality_report.sh`). **Nothing asked whether the code emitted for
+  an ACCEPTED export runs.** Two checks, because neither alone is complete:
+  static — every `instanceof X` must have `X` a JS global or a binding of
+  that module, which sees a site whichever arm a probe value reaches;
+  runtime — import each of the 86 generated bridge modules and call every
+  exported `_from_js` over a value battery, which is what proves the static
+  list is real rather than a grep artifact. 411 sites and 2,126 failures ->
+  0, with 363 calls still exercised so the harness is not merely emptied.
+  - The one fixture with live `_from_js` calls
+    (`scaffold_ts_to_moonbit_heterogeneous_union`) is `boolean | "boundary"`
+    — no `Named` member at all. That is why the bug survived: not one
+    fixture in the corpus put a named type in a return position.
+- [ ] **Bind a module-exported class so its `instanceof` resolves.** The
+  ceiling is measured and small: of the 197 declined names, the runtime
+  classes are node_fs's `Stats` / `StatsFs` / `BigIntStats` /
+  `BigIntStatsFs`, hono__node_server's `Server` / `IncomingMessage` /
+  `ServerResponse` / the three `Http2*`, and drizzle's `Table` / `View` —
+  about ten. Each needs `const N = __ts_mbt_module.N` threaded through
+  `bridge_imports` at the converter-emission point, and then `Stats |
+  BigIntStats` returns get a typed enum instead of a raw passthrough. Worth
+  doing for the `stat()` family specifically; not worth it for the ~187
+  names that are erased no matter what.
+- [ ] **Drop `ffi_synthesize_inline_union`'s `func_members > 0` gate.** Now
+  that soundness lives centrally the gate is conservative rather than
+  load-bearing: it refuses to synthesize an enum whose `_from_js` would be
+  withheld, while the same union WITHOUT a function member is synthesized
+  and keeps its `_to_js`. Dropping it types more parameter positions. Left
+  alone here because it changes generated output broadly and deserves its
+  own measurement.
+
+## Bridge quality report: the heterogeneous-union budget (2026-09-07) — DONE
+
+- [x] **A count could not rank the work, and had been failing silently.**
+  `heterogeneous_union_unsupported_export_budget` was set to 0 in `14a2a6c`
+  when the count was 0; the `typescript-node-imports` example landed later
+  (`b84b7cb`, NOT an ancestor of `14a2a6c`) and reintroduced two, so the
+  report has been exiting 1 ever since — verified pre-existing by re-running
+  it at `a94e5c6`, which fails identically. A bare count cannot say whether
+  an occurrence is an accepted limitation or a regression, which is the same
+  defect that retired `docs/checker-priority.md`.
+  `scripts/bridge_widened_unions.txt` declares each occurrence with a kind
+  and a reason, an UNDECLARED occurrence fails, and a declared entry that no
+  longer occurs is reported STALE — the mechanism
+  `scripts/checker_out_of_scope.txt` uses, including the stale report that
+  keeps it from decaying into a suppression list. **Both directions proven
+  by mutation**: an empty declaration file reports 2 UNDECLARED and exits 1;
+  a bogus entry is named as stale and exits 1. Report `Overall: pass` for
+  the first time in this branch.
+- [x] **The diagnostic named a cause that cannot occur.** "non-PascalCase
+  named, function, or unsupported shape" — a function member IS accepted
+  (as `FnValue`), and everything real fell into "unsupported shape", so the
+  two occurrences (an anonymous object type; an object intersection) could
+  not be told apart from a lowercase name by reading the message.
+  `tagged_union_member_shape_description` names the member and what would
+  have to be supported, which is what makes the declaration file legible.
+- [ ] **Object-payload union members** (the one capability both declared
+  entries need: a synthesized payload struct plus `typeof v === "object" &&
+  v !== null && !Array.isArray(v)`, admissible only when the union has
+  exactly one object-ish member). REJECTED for now with the reasons in the
+  declaration file, and the honest summary is that neither corpus occurrence
+  earns it: `BufferEncodingOption`'s `{ encoding: "buffer" }` is redundant
+  with its `"buffer"` string member, which `buffer_encoding_option_from_string`
+  already constructs; and `WriteFileOptions` needs a SECOND thing —
+  its sibling `BufferEncoding` is a node global this package does not
+  resolve, so even a successful lowering hands the user a case payload they
+  cannot build. Take it when a target needs an options object that is not
+  also spellable another way. `decl_synthesized_object_interfaces` is the
+  registry to reuse; `decl_normalize_alias_union_body` is the hook.
+
 ## Interop Bridge Quality Roadmap: 60% -> 90%
 
 Current assessment: the project is around 55-60% complete as a practical

--- a/TODO.md
+++ b/TODO.md
@@ -288,24 +288,56 @@ repo has been removed. Items below are scoped to the bridge generator only.
   its own comment sixty lines away. Sixth fail-open shape arm here, and the
   first one written INSIDE the fix for the previous one.
   Implemented (`ffi_output_union_alias_name`, resolving both spellings) and
-  **REVERTED on a measured blocker**: the widening lives in the FFI layer
-  and the public wrapper — `pub fn getNameOfJSDocTypedef(...) ->
-  Auto_IdentifierValue_or_PrivateIdentifierValue?` — is rendered by the
-  DECL layer, which holds no `MoonBitJsFfiState`. Widening one side gives
-  `[4014] Expr Type Mismatch: has type JSValue?, wanted Auto_...?`, the two
-  layers disagreeing, which is the same split that produced the duplicate
-  `.mbti` declarations. Take it with the channel, not with a second copy of
-  the widening in the decl layer.
-- [ ] **Convert an OPTIONAL tagged-union crossing.** The cheapest real fix
-  on the declared list, and the previous note's claim that "no generated
-  accessor in the corpus has that shape" was wrong — there are 2:
-  `TypeChecker::getConstantValue` returns `Auto_NumberValue_or_StringValue?`,
-  whose cases are `String | Double`, so `typeof` discriminates and the
-  `_from_js` is fully buildable. `ffi_inline_js_return_expr_with_state`
-  leaves the optional form alone because MoonBit's `Option` repr is decided
-  separately by `ffi_option_return_needs_wrap` /
-  `ffi_converted_return_extern_pair`, and converting in both places would
-  box twice. Needs those two to agree on who wraps.
+  **REVERTED**. What is MEASURED is the failure: widening makes the private
+  extern `JSValue?` while `pub fn getNameOfJSDocTypedef(...) ->
+  Auto_IdentifierValue_or_PrivateIdentifierValue?` in `bridge.mbt` still
+  declares the enum, giving `[4014] Expr Type Mismatch: has type JSValue?,
+  wanted Auto_...?` — the same two-renderings-of-one-export split that
+  produced the duplicate `.mbti` declarations.
+  What is NOT established is the cause, and the first diagnosis here said
+  "the decl layer holds no `MoonBitJsFfiState`, so this needs a cross-layer
+  channel" — which the code partly contradicts:
+  `parse_bridge_pub_extern_fn_decl_line` shows the decl layer DERIVING its
+  `return_type` from the FFI layer's emitted `pub extern "js" fn` text, so
+  widening the FFI side should have carried. Either that wrapper's type
+  comes from somewhere else, or one of the renderers the widening routes
+  through is not the line the decl layer parses — the
+  applied-in-some-places family again rather than a missing channel, and
+  much cheaper if so.
+  The experiment is one command: re-apply the arm, regenerate, and read
+  `bridge.mbt` beside `externs.mbt` for `getNameOfJSDocTypedef` to see which
+  of the two moved. Do that before building any channel; the note that
+  asserted the blocker was written from the error message alone.
+  `ffi_output_union_alias_name` is now in the tree for the optional-gate fix
+  below, so the arm itself is two lines.
+- [x] **Convert an OPTIONAL tagged-union crossing — DONE**, and both of the
+  reasons the previous note gave for declining it were false, which is the
+  part worth keeping.
+  - "The MoonBit side could box a value that path already boxed" was
+    CHECKABLE and unchecked: `ffi_option_return_inner_is_boxed` returns
+    FALSE for a tagged-union alias, so `ffi_option_return_needs_wrap` never
+    fires for one and there is no MoonBit-side wrap to collide with —
+    `Some(v)` IS `v` and `None` IS `undefined` at the boundary. Confirmed
+    against the emitted code, not the source: no `wrap_option_return`
+    appears anywhere near `getConstantValue`.
+  - "No generated accessor in the corpus has that shape" was also false;
+    there are 2, both `TypeChecker::getConstantValue` returning
+    `Auto_NumberValue_or_StringValue?` — `String | Double`, both
+    primitives, so `typeof` discriminates.
+  - The optional inner is a raw `Union(parts)`, so the fix needed
+    `ffi_output_union_alias_name` back to resolve BOTH spellings (a `Named`
+    alias, and an inline `A | B` whose signature reads `Auto_X_or_Y` while
+    the AST keeps `Union`).
+  - **And the site was a THIRD renderer.** `TypeChecker` is an INTERFACE, so
+    `getConstantValue` never reached the class-method path; patching the
+    class path, regenerating and finding the count unchanged is what found
+    `ffi_function_field_method_decl`. Interface methods, class methods and
+    the four accessor paths are three separate renderers of one decision, and
+    the arguments were routed through the conversion at all of them while the
+    RETURN was routed at none. Same family, one axis further out.
+  - Both entries retired from the declared list, and the STALE report is
+    what said so — the mechanism earning itself back on its first use.
+    Declared backlog 18 -> 16.
 - [ ] **Drop `ffi_synthesize_inline_union`'s `func_members > 0` gate.** Now
   that soundness lives centrally the gate is conservative rather than
   load-bearing: it refuses to synthesize an enum whose `_from_js` would be

--- a/TODO.md
+++ b/TODO.md
@@ -5125,6 +5125,54 @@ inside a function body:
   is there; the third file, `symbolProperty21`, is a computed
   `[Symbol.toPrimitive]` key, which that function skips by design.
 
+- [x] **Batch DY: the assignment-form `for…of` target at all three
+  spellings of the write.** The check fired for a bare `Var` and was
+  blind to `o.x`, `foo().x` and `arr[0]`: the parser wraps a
+  non-identifier assignment-form head as `TsBinding::Target(expr)`, and
+  that fell through to the destructuring-pattern arm and was dropped
+  there. One shared closure now holds the eight-condition guard chain so
+  the spellings cannot diverge again.
+  **Corpus yield is ZERO, and the reason is the finding.** `ES5For-of8`
+  is `function foo() { return { x: 0 } }` with
+  `for (foo().x of ['a','b','c'])`, and an UN-ANNOTATED function's return
+  type does not resolve in this checker at all — `const bad: string =
+  foo().x` is silent too. So that file needs return-type inference from a
+  BODY, which is a Tier 3 capability, not this rule. Annotated receivers
+  (`declare function foo(): { x: number }`) do fire, which is what the
+  test pins.
+- [ ] **FILED with both blockers: a DECORATOR expression's function body
+  is never type-checked.** Probed: `@((x, p, d) => { var a = 3; func(a);
+  return d; })` on a class member reports nothing while the identical
+  arrow assigned to a `const` reports TS2345, and a decorator FACTORY's
+  body (`@dec()` where `dec` is a declared function) also reports —
+  because that function is a top-level declaration the walk already
+  reaches. What is missing is an arrow / function written INLINE in the
+  decorator position. The two halves have different blockers:
+  - a CLASS decorator's expressions ARE retained
+    (`TsClassDecl.decorators : Array[TsExpr]`) and nothing type-checks
+    their bodies — `ts2683_walk_expr` walks them only for `this`. Cheap,
+    and buys no corpus file.
+  - a MEMBER decorator's expression is not in the AST at all:
+    `parser_class.mbt` keeps only `member_decorated : Bool` for
+    TS1249 / TS1207 and discards the expression. That half is what
+    `decoratorChecksFunctionBodies` needs, and it requires the parser to
+    retain the expression first.
+- [ ] **The remaining assignability bucket is 35 files with ~35 causes**,
+  confirmed by opening every one: variadic tuples, template-literal
+  types, generic bivariance, `globalThis` modelling (3 files — the only
+  visible mini-cluster), `SymbolConstructor` lib members, the generator
+  protocol, contextual typing of function expressions, `never`
+  narrowing, protected constructors, enum assignability, salsa/JS
+  expando+namespace merging, optional-chaining nullability, `Intl` lib
+  shapes. Four of the five cheapest-LOOKING (a plain
+  `number`/`string` mismatch) were opened in batch DY and each needs
+  something different: a well-known-symbol accessor pair's inferred type
+  (`symbolProperty46`), object-literal union normalization on widening
+  (`objectLiteralNormalization`), expando/namespace declaration merging
+  (`typeFromPropertyAssignment31`), and return-type inference from a body
+  (`ES5For-of8`, closed above as far as it can be). The measured rate
+  here is ~1 file per investigation.
+
 ### Tier 3 — DEFER (~93 files, real but expensive)
 
 `assignability-core` (48), `generic-inference` (11), `iterator-protocol`

--- a/TODO.md
+++ b/TODO.md
@@ -287,29 +287,41 @@ repo has been removed. Items below are scoped to the bridge generator only.
   reads `Auto_X_or_Y`, which `ffi_inline_js_tagged_union_to_js` states in
   its own comment sixty lines away. Sixth fail-open shape arm here, and the
   first one written INSIDE the fix for the previous one.
-  Implemented (`ffi_output_union_alias_name`, resolving both spellings) and
-  **REVERTED**. What is MEASURED is the failure: widening makes the private
-  extern `JSValue?` while `pub fn getNameOfJSDocTypedef(...) ->
-  Auto_IdentifierValue_or_PrivateIdentifierValue?` in `bridge.mbt` still
-  declares the enum, giving `[4014] Expr Type Mismatch: has type JSValue?,
-  wanted Auto_...?` — the same two-renderings-of-one-export split that
-  produced the duplicate `.mbti` declarations.
-  What is NOT established is the cause, and the first diagnosis here said
-  "the decl layer holds no `MoonBitJsFfiState`, so this needs a cross-layer
-  channel" — which the code partly contradicts:
-  `parse_bridge_pub_extern_fn_decl_line` shows the decl layer DERIVING its
-  `return_type` from the FFI layer's emitted `pub extern "js" fn` text, so
-  widening the FFI side should have carried. Either that wrapper's type
-  comes from somewhere else, or one of the renderers the widening routes
-  through is not the line the decl layer parses — the
-  applied-in-some-places family again rather than a missing channel, and
-  much cheaper if so.
-  The experiment is one command: re-apply the arm, regenerate, and read
-  `bridge.mbt` beside `externs.mbt` for `getNameOfJSDocTypedef` to see which
-  of the two moved. Do that before building any channel; the note that
-  asserted the blocker was written from the error message alone.
-  `ffi_output_union_alias_name` is now in the tree for the optional-gate fix
-  below, so the arm itself is two lines.
+  Implemented (`ffi_output_union_alias_name`, resolving both spellings),
+  **RUN as an experiment, and REVERTED** — and the experiment retired the
+  blocker this entry used to assert. There are THREE renderings of one
+  export, not two, and only one of them moved:
+
+      mbti    : getNameOfJSDocTypedef(...) -> Auto_Identifier…?   (unchanged)
+      bridge  : getNameOfJSDocTypedef(...) -> Auto_Identifier…?   (unchanged)
+      externs : get_name_of_jsdoc_typedef(...) -> JSValue?        (WIDENED)
+
+  So `[4014] Expr Type Mismatch: has type JSValue?, wanted Auto_…?`
+  reproduces, and the first diagnosis — "the decl layer holds no
+  `MoonBitJsFfiState`, so this needs a cross-layer channel", written from
+  the error message alone — is WRONG in the direction the correction
+  suspected. The decl layer builds that wrapper by iterating
+  **`bridge_mbti.split("\n")`** and parsing
+  `parse_bridge_top_level_fn_decl_line`, so `fn_decl.return_type` is read
+  off the `.mbti` LINE, not off the FFI layer's `.mbt` text. The `.mbti`
+  declaration rendering is therefore one more site the widening does not
+  route through — applied-in-some-places again — and because the wrapper
+  DERIVES from that line, there is exactly ONE place to fix and no channel
+  to build: correct the `.mbti` type and the wrapper follows.
+  What is still unlocated is which emitter renders that `.mbti` line. It is
+  not any of the `"declare pub fn "` literals in `moonbit_bridge.mbt` —
+  those are the parser prefix and the helper/getter forms — so the `.mbti`
+  body comes from elsewhere and needs one more step to find. Start there,
+  not at the FFI layer.
+  **The experiment's own FIRST run measured nothing, and the fault was in
+  the experiment.** The arm was written as `Named(_) | Union(_)` ABOVE the
+  optional-like branch, and `Auto_X_or_Y?` is `Union([…, Undefined])` in the
+  AST — so the new arm swallowed every optional, derived a synthesized name
+  from parts that include `Undefined`, found it registered nowhere, and
+  declined silently. Ordering the optional classification FIRST is what made
+  the widening fire at all. An experiment can fail in the instrument exactly
+  the way the code under test does; the reading to trust is the one where
+  something visibly moved.
 - [x] **Convert an OPTIONAL tagged-union crossing — DONE**, and both of the
   reasons the previous note gave for declining it were false, which is the
   part worth keeping.

--- a/TODO.md
+++ b/TODO.md
@@ -84,37 +84,78 @@ repo has been removed. Items below are scoped to the bridge generator only.
     (`scaffold_ts_to_moonbit_heterogeneous_union`) is `boolean | "boundary"`
     — no `Named` member at all. That is why the bug survived: not one
     fixture in the corpus put a named type in a return position.
-- [ ] **A tagged-union RETURN type the wrapper never builds** (4 sites,
-  `scripts/bridge_enum_return_probe.mjs`). `@hono/node-server` declares
-  `serve(...) -> ServerType` and `create_adaptor_server(...) -> ServerType`
-  (plus the two `get_*` forms that return a function returning it) while the
-  JS wrapper is `return __ts_mbt_module.serve(...)` — the raw Node server
-  object. `ServerType` is payload-bearing, and the representation is not a
-  guess: the alias's own constructor emits
-  `__ts_mbt_server_type_from_server(value) { return { "$tag": 0, "_0": value
-  }; }`, so a MoonBit `match` on the returned value reads `$tag` off an
-  object that has none. The declared type and the wrapper are decided in
-  different places and are free to disagree; when
-  `ffi_tagged_union_return_is_safe_to_wrap` says no, the declared return
-  should widen to `JSValue`.
-  - Attempted and REVERTED rather than left as a no-op: routing all eleven
-    return-type renderers through one `ffi_output_type_name` that widens
-    `Named(n)` (and a returned `Func`'s own return, recursively) when
-    `tagged_union_decls_by_name` has `n` and the wrap predicate refuses.
-    `moon check` clean, the example regenerated with the new binary
-    (timestamps confirm it), and all four sites still said `ServerType` — so
-    the predicate answers `false` and the reason is not yet known. The map is
-    keyed by `ffi_type_identifier(name, "OpaqueType")`, which is identity for
-    `ServerType`, so the obvious key-mismatch explanation is ruled out; the
-    next step is to find which renderer actually emits `pub extern "js" fn
-    serve` (the binding name `__ts_mbt_serve` points at
-    `ffi_func_decl_to_moonbit`, which WAS one of the eleven).
-  - The probe is worth keeping either way, and it corrected itself once: its
-    first version counted payload-FREE enums (`enum Mode { Read Write }`,
-    from a TS numeric enum, which is an integer tag where a raw numeric
-    passthrough is correct) and reported 11 sites. Its own comment claimed a
-    payload filter the code never implemented — the same substitution this
-    file keeps recording, in the measuring instrument. 4 of 73, not 11.
+- [x] **A tagged-union RETURN type the wrapper never builds** — DONE, 4
+  sites -> 1 (the residual is the pre-existing `.mbti` duplicate below).
+  The reverted attempt measured as a no-op for TWO reasons, and neither
+  was the predicate: `unbuildable("ServerType")` was TRUE all along, which
+  a `println` settled in one run after two rounds of reasoning had got it
+  wrong.
+  - **The `CallableMeta` wrapper.** The walk had `Named` and `Func` arms
+    and no `CallableMeta`, so a value whose type carries an OPTIONAL
+    parameter fell through the catch-all untouched. That is why the
+    sibling pair disagreed: `get_create_adaptor_server`'s `(Options) ->
+    ServerType` widened and `get_serve`'s `(Options, ((AddressInfo) ->
+    Unit)?) -> ServerType` did not. `ffi_type_name` peels the same wrapper
+    on its own FIRST line — a walk that decides a type has to peel every
+    wrapper the renderer peels, or it decides a different type from the
+    one that gets printed. Fifth wrapper-node fail-open arm in this repo,
+    exactly the third the `PureCall` note says to expect after the second.
+  - **A renderer the substitution missed.** Ten sites were found by
+    grepping the assignment `let return_type = ffi_type_name(state, …)`,
+    and `ffi_callable_value_decl_to_moonbit` — the renderer for the direct
+    call form of a callable value, which is what emits `serve(...)` —
+    spells its local `return_type_src`. Writing a shared
+    `ffi_output_type_name` helper specifically to avoid the
+    applied-in-some-places family, then applying it by textual match on a
+    variable NAME, is that family inside the fix for it. The census is by
+    ARGUMENT now (`func.return_type` / `import_.return_type` /
+    `value.type_` / `return_type`), which is what it should have keyed on.
+  - **The predicate was also asking the wrong question**, found while
+    writing the test rather than by the corpus.
+    `ffi_tagged_union_return_is_safe_to_wrap` refuses ANY
+    `InstanceOfNamed`, global constructors included, so `PathLike =
+    string | Buffer | URL` is "unsafe to wrap" while its `_from_js` exists
+    and works — widening on that gate would have widened node_fs's 12
+    global-`Named` union returns too. The shipped predicate asks
+    `tagged_union_from_js_expression(decl, "value") is None`, which is
+    exactly the condition that withholds the `_from_js` half.
+  - The three `*_should_emit_wrapper` predicates deliberately do NOT
+    consult the widening: they refuse a wrapper whose rendered type uses
+    `JSValue`, so routing them through it would DELETE `serve(...)` from
+    the surface rather than widen it, leaving only `get_serve()`. Their
+    question is whether the wrapper carries any type information, and the
+    answer stays yes because the PARAMETERS are typed.
+  - The three `server_type_from_*` CONSTRUCTORS correctly keep
+    `-> ServerType`: they come from `ffi_type_alias_constructors`, a
+    different path, and they DO build `{ "$tag": 0, "_0": value }`.
+    Pinned by a unit test that fails under mutation of the `CallableMeta`
+    arm with `"(Options) -> ServerType" != "(Options) -> JSValue"`.
+- [ ] **The `.mbti` carries declarations the `.mbt` does not** —
+  pre-existing, corpus-wide, and only VISIBLE because the fix above made
+  two renderings of one declaration disagree. `hono__node_server`'s
+  `.mbti` has `get_create_adaptor_server` twice, once `-> (Options) ->
+  ServerType` with no `.mbt` counterpart at all and once `-> (Options) ->
+  JSValue` matching the impl; before the widening both printed
+  identically and the duplication was invisible. Corpus-wide: 52
+  duplicated declaration names of 2,161 in the `typescript` package, 13
+  of 253 in vitest, 9 of 320 in node_fs, 5 in drizzle, 3 in
+  hono__node_server, 2 in react-types. So a second emitter renders the
+  same value exports independently of the ffi layer, and the two agreed
+  only by coincidence. This is the residual `1` the enum-return probe
+  still reports.
+- [ ] **`_from_js` exists but the return wrapper still declines it.**
+  The other half of the same defect, now that the predicate distinction
+  above is written down: for a union whose cases are a primitive plus a
+  GLOBAL constructor (`PathLike`, `TimeLike`, `Mode`, `OpenMode`) the
+  `_from_js` converter is emitted and works, while
+  `ffi_tagged_union_return_is_safe_to_wrap` refuses the auto-wrap for any
+  `InstanceOfNamed` — so those returns declare the enum and deliver the
+  raw value. Letting the wrap gate accept a global-constructor
+  `instanceof` is what its own doc comment already claims it does.
+  `bridge_enum_return_probe.mjs` cannot currently see these: its regex
+  matches `declare pub fn NAME(`, so every `Type::method` form is
+  skipped, and node_fs's 12 such returns are mostly getters. Widen the
+  probe first, then measure.
 - [ ] **Bind a module-exported class so its `instanceof` resolves.** The
   ceiling is measured and small: of the 197 declined names, the runtime
   classes are node_fs's `Stats` / `StatsFs` / `BigIntStats` /

--- a/docs/checker-triage.md
+++ b/docs/checker-triage.md
@@ -214,7 +214,40 @@ bridge's primary input.
   series that a stated abstention's reason turned out weaker than
   claimed, and the first where the abstention was one of my own from the
   batch before.
-- **strict-null / narrowing** (8 files).
+- **strict-null / narrowing** (8 files then, 5 now — and the label is
+  wrong about every one of them). Opening all five: the cheapest lever in
+  each file is not a strict-null rule, and no two of them are the same
+  kind of work. Eighth instance of a label standing in for the objective,
+  this time in a bucket small enough that a count looked trustworthy.
+  - `privateIdentifierChain.1` is **pure GRAMMAR** — TS18030, "an
+    optional chain cannot contain private identifiers", where the
+    position of the `?.` relative to the `#name` is the whole rule. TAKEN
+    (batch DZ, +1 at FP 0). Its TS2532 is incidental.
+  - `typeofThis` is TS2331, "`this` cannot be referenced in a module or
+    namespace body" — also grammar, and DEFERRED on a measured cost
+    rather than on difficulty. Probed cell by cell: an arrow inside a
+    namespace body fires at any nesting depth, a `function` declaration
+    OR expression inside one does not (it rebinds `this`), a class method
+    does not, and neither script nor module top level does — so the fact
+    needed is "inside a namespace body and not inside a `this`-rebinding
+    function". `in_function` cannot serve: it is true inside arrows too.
+    A new field means the save / clear / restore discipline `self.labels`
+    already needs at fifteen function-body sites, which is exactly how
+    the applied-in-some-places bug gets written. Worth +1 file; take it
+    with the label refactor, not before.
+  - `parserAmbiguityWithBinaryOperator4` is `if (a<b, b>(c + 1))`, which
+    parses as a generic call whose type ARGUMENT is a `var`. The lever is
+    TS2749 ("refers to a value, but is being used as a type here") — name
+    resolution, not narrowing.
+  - `ES5For-of7` needs `[]` to infer `never[]` so that two `var x`
+    declarations conflict (TS2403), plus flow analysis for TS2454.
+  - `controlFlowAliasingCatchVariables` is the only one that is really
+    about narrowing, and it is the most expensive: batch CS's TS18046
+    correctly withdraws on a `typeof e === 'string'` narrowing, and this
+    file's second block ALIASES the narrowing (`const isString = typeof e
+    === 'string'`) and then invalidates it with `e = 1`. Deciding that
+    needs aliased control flow, and the fail direction is a false
+    positive — claiming un-narrowed where it is narrowed.
 
 ### Tier 3 — DEFER (~93 files, real but expensive)
 
@@ -283,8 +316,8 @@ produced a retired strategy document.
 That is now what the gate does:
 
 ```
-TP  err+flag  : 2582   (of which via parse rejection: 390)
-MISS in scope : 133   (the backlog — this one can reach zero)
+TP  err+flag  : 2583   (of which via parse rejection: 390)
+MISS in scope : 132   (the backlog — this one can reach zero)
 OUT OF SCOPE  : 19     (declared in scripts/checker_out_of_scope.txt)
 FP  ok +flag  : 0     (soundness bugs — TS7 accepts these)
 PFLEGAL       : 0     (parser rejects TS7-legal files — parser bugs)

--- a/docs/checker-triage.md
+++ b/docs/checker-triage.md
@@ -283,8 +283,8 @@ produced a retired strategy document.
 That is now what the gate does:
 
 ```
-TP  err+flag  : 2581   (of which via parse rejection: 390)
-MISS in scope : 134   (the backlog — this one can reach zero)
+TP  err+flag  : 2582   (of which via parse rejection: 390)
+MISS in scope : 133   (the backlog — this one can reach zero)
 OUT OF SCOPE  : 19     (declared in scripts/checker_out_of_scope.txt)
 FP  ok +flag  : 0     (soundness bugs — TS7 accepts these)
 PFLEGAL       : 0     (parser rejects TS7-legal files — parser bugs)

--- a/examples/typescript-to-moonbit/typescript-node-imports/src/main/main.mbt
+++ b/examples/typescript-to-moonbit/typescript-node-imports/src/main/main.mbt
@@ -3,8 +3,45 @@
 extern "js" fn utf8_text(data : @fs.NonSharedBuffer) -> String =
   #| (data) => data.toString("utf8")
 
+///| A `ReadStream`-shaped object, so the accessor pair below can be observed
+///| without opening a file. `ReadStream` is an opaque `#external` type, and
+///| what the accessors touch is one property.
+extern "js" fn read_stream_with_path(path : String) -> @fs.ReadStream =
+  #| (path) => ({ path })
+
 fn script_target() -> @ts.ScriptTarget {
   @ts.ScriptTarget::ES2024
+}
+
+///| `ReadStream.path` is declared `PathLike` — a tagged union whose MoonBit
+///| repr is `{ "$tag": i, "_0": v }` and whose JS repr is the bare value — so
+///| both accessors have to convert. Neither did: the getter handed the raw JS
+///| string back as if it were the enum, and the setter stored the enum object
+///| into Node's field.
+///|
+///| Checked by VALUE rather than by compiling, because both bugs compile
+///| perfectly: the declared type is the same either way. The round trip is
+///| what catches the write direction — a setter that stored the box leaves the
+///| getter looking at an object that is neither string, Buffer nor URL, and
+///| its `_from_js` throws.
+fn check_tagged_union_property_accessors() -> Unit {
+  let stream = read_stream_with_path("read-stream-accessor.ts")
+  match stream.get_read_stream_path() {
+    StringValue(text) =>
+      if text != "read-stream-accessor.ts" {
+        abort("ReadStream.path getter returned the wrong string: " + text)
+      }
+    _ =>
+      abort("expected ReadStream.path to build PathLike::StringValue from a JS string")
+  }
+  stream.set_read_stream_path(@fs.path_like_from_string("reassigned.ts"))
+  match stream.get_read_stream_path() {
+    StringValue(text) =>
+      if text != "reassigned.ts" {
+        abort("ReadStream.path setter stored the wrong string: " + text)
+      }
+    _ => abort("expected ReadStream.path to round trip through PathLike")
+  }
 }
 
 fn main {
@@ -36,5 +73,6 @@ fn main {
   if disk_text != printed {
     abort("node:fs round trip changed the TypeScript output")
   }
+  check_tagged_union_property_accessors()
   println("ok")
 }

--- a/fixtures/resolver/project/types/class-property-tagged-union-entry.d.ts
+++ b/fixtures/resolver/project/types/class-property-tagged-union-entry.d.ts
@@ -1,0 +1,22 @@
+// A class property whose type is a heterogeneous union — the TAGGED-UNION
+// enum family, not the literal-union one `class-property-entry.d.ts` covers.
+//
+// Both members carry a runtime discriminator (`typeof === "string"` and a
+// global `URL` constructor), so the alias gets a working `_from_js` as well as
+// a `_to_js`, and every accessor path has to route through them: the MoonBit
+// side of `Key` is `{ "$tag": i, "_0": v }` and the JS side is the bare value.
+export type Key = string | URL;
+
+// The negative control. `Level` is the OTHER enum family — a literal union,
+// which lowers to a generated enum whose converters are MoonBit functions in
+// `converters.mbt`. Its accessors must convert on the MoonBit side and leave
+// the JS body a bare property read, so a property must not come out converted
+// twice.
+export type Level = "low" | "high";
+
+export declare class Holder {
+  key: Key;
+  level: Level;
+  static staticKey: Key;
+  static staticLevel: Level;
+}

--- a/fixtures/resolver/project/types/widened-union-output-entry.d.ts
+++ b/fixtures/resolver/project/types/widened-union-output-entry.d.ts
@@ -1,0 +1,36 @@
+// An OUTPUT position whose type is an inline union the bridge cannot build at
+// runtime, in each of the four places a generated package renders one.
+//
+// `Alpha` and `Beta` are interfaces, so they are erased: `value instanceof
+// Alpha` would throw, no `_from_js` can be emitted, and a declaration that
+// promises the enum hands back a raw JS value. The honest answer is `JSValue`.
+//
+// Each union is mentioned EXACTLY ONCE on purpose. The synthesized alias is
+// registered as a side effect of rendering, so a union that also appears as a
+// PARAMETER somewhere above happens to be registered by the time a return is
+// decided — which is how the first version of this widening fixed one
+// declaration and not its neighbour.
+export interface Alpha {
+  a: number;
+}
+export interface Beta {
+  b: string;
+}
+
+export declare function erasedReturn(x: number): Alpha | Beta;
+export declare function erasedOptionalReturn(x: number): Alpha | Beta | undefined;
+
+// The negative control: `string` and `URL` discriminate at runtime (`typeof`
+// and a real global constructor), so this union keeps its enum and converts.
+export declare function buildableReturn(x: number): string | URL;
+
+export interface Bag {
+  // Two directions, one written type. `index_get` crosses JS -> MoonBit and
+  // has to widen; `index_set` crosses the other way, where `_to_js` reads
+  // `$tag` and needs no runtime predicate, so it keeps the enum.
+  [key: string]: Alpha | Beta;
+}
+
+export interface Service {
+  erasedMethod(name: string): Alpha | Beta;
+}

--- a/justfile
+++ b/justfile
@@ -218,6 +218,8 @@ verify-bridge-runtime *ARGS:
 #
 # Assumes the three generation harnesses above have populated `_build`.
 verify-bridge-enum-returns:
+    # Declared backlog lives in scripts/bridge_unconverted_enum_crossings.txt;
+    # an undeclared occurrence and a stale declaration both fail.
     node scripts/bridge_enum_return_probe.mjs
 
 # Validate `--mangle-properties` against the mangle-safety corpus

--- a/justfile
+++ b/justfile
@@ -171,7 +171,7 @@ verify-checker-scaling *ARGS:
     node scripts/verify_checker_scaling.mjs {{ ARGS }}
 
 # Full CI check
-ci: fmt check test verify-mbti-dts verify-scaffolds verify-generated-fixtures verify-examples verify-mangle-safety verify-dce-coverage verify-rule-equivalence verify-graph-walk verify-checker-soundness verify-checker-scaling
+ci: fmt check test verify-mbti-dts verify-scaffolds verify-generated-fixtures verify-examples verify-bridge-runtime verify-mangle-safety verify-dce-coverage verify-rule-equivalence verify-graph-walk verify-checker-soundness verify-checker-scaling
 
 # Update dependencies
 update:
@@ -180,6 +180,28 @@ update:
 # Clean build artifacts
 clean:
     rm -rf _build target
+
+# Run the generated `bridge.js` converters under Node.
+#
+# verify-scaffolds / verify-generated-fixtures / verify-examples ask whether
+# a generated package COMPILES, and bridge_quality_report.sh asks whether a
+# REJECTED export is budgeted. Neither asks whether the code emitted for an
+# ACCEPTED export runs. It did not: a tagged-union case whose payload is
+# `Named(N)` was discriminated with `N instanceof` whether or not `N` exists
+# at runtime, so 411 sites across the corpus carried a ReferenceError.
+#
+# Two checks. Static: every `instanceof X` must have `X` a JS global or a
+# binding of that module — complete, since it sees a site whichever arm a
+# probe value reaches. Runtime: import each bridge.js and call every
+# exported `_from_js` over a value battery — this is what proves the static
+# list is real rather than a grep artifact.
+#
+# Assumes the three generation harnesses above have populated `_build`.
+#
+#   just verify-bridge-runtime
+#   just verify-bridge-runtime --verbose
+verify-bridge-runtime *ARGS:
+    node scripts/verify_bridge_runtime.mjs {{ ARGS }}
 
 # Validate `--mangle-properties` against the mangle-safety corpus
 verify-mangle-safety *ARGS:

--- a/justfile
+++ b/justfile
@@ -144,7 +144,7 @@ checker-miss-buckets *ARGS:
 # batch improves it, the same way the FP budget only ever tightened.
 verify-checker-soundness:
     moon build --target native
-    bash scripts/checker_conformance_oracle.sh --max-fp 0 --max-legal-parsefail 0 --max-miss 134
+    bash scripts/checker_conformance_oracle.sh --max-fp 0 --max-legal-parsefail 0 --max-miss 133
 
 # Is any checker rule superlinear in the size of a module-wide list?
 #

--- a/justfile
+++ b/justfile
@@ -144,7 +144,7 @@ checker-miss-buckets *ARGS:
 # batch improves it, the same way the FP budget only ever tightened.
 verify-checker-soundness:
     moon build --target native
-    bash scripts/checker_conformance_oracle.sh --max-fp 0 --max-legal-parsefail 0 --max-miss 133
+    bash scripts/checker_conformance_oracle.sh --max-fp 0 --max-legal-parsefail 0 --max-miss 132
 
 # Is any checker rule superlinear in the size of a module-wide list?
 #

--- a/justfile
+++ b/justfile
@@ -171,7 +171,7 @@ verify-checker-scaling *ARGS:
     node scripts/verify_checker_scaling.mjs {{ ARGS }}
 
 # Full CI check
-ci: fmt check test verify-mbti-dts verify-scaffolds verify-generated-fixtures verify-examples verify-bridge-runtime verify-mangle-safety verify-dce-coverage verify-rule-equivalence verify-graph-walk verify-checker-soundness verify-checker-scaling
+ci: fmt check test verify-mbti-dts verify-scaffolds verify-generated-fixtures verify-examples verify-bridge-runtime verify-bridge-enum-returns verify-mangle-safety verify-dce-coverage verify-rule-equivalence verify-graph-walk verify-checker-soundness verify-checker-scaling
 
 # Update dependencies
 update:
@@ -202,6 +202,23 @@ clean:
 #   just verify-bridge-runtime --verbose
 verify-bridge-runtime *ARGS:
     node scripts/verify_bridge_runtime.mjs {{ ARGS }}
+
+# Does the JS emitted for a declaration that PROMISES a payload-bearing enum
+# actually build one?
+#
+# verify-bridge-runtime asks whether a converter RUNS; this asks whether the
+# wrapper that should call it does. `serve(...) -> ServerType` returned the raw
+# Node server, and node_fs's `ReadStream.path: PathLike` moved the raw value in
+# both directions, with the declared type unchanged either way — so no compile
+# gate could see it and a MoonBit `match` read `$tag` off a string.
+#
+# Both places an implementation can land: a named `bridge.js` wrapper, and an
+# `extern "js" fn` whose body is an inline lambda. Reading only the first is
+# how the accessor sites stayed invisible.
+#
+# Assumes the three generation harnesses above have populated `_build`.
+verify-bridge-enum-returns:
+    node scripts/bridge_enum_return_probe.mjs
 
 # Validate `--mangle-properties` against the mangle-safety corpus
 verify-mangle-safety *ARGS:

--- a/scripts/bridge_enum_return_probe.mjs
+++ b/scripts/bridge_enum_return_probe.mjs
@@ -1,50 +1,150 @@
-import { readFileSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
-function walk(d, out=[]) {
+// Does the JS emitted for a declaration that PROMISES a payload-bearing enum
+// actually build one?
+//
+// A MoonBit `pub(all) enum` with a payload is `{ "$tag": i, "_0": v }` at the
+// JS boundary — the repo's own generated constructor says so
+// (`__ts_mbt_server_type_from_server(value) { return { "$tag": 0, "_0": value
+// }; }`). A wrapper that hands back the raw JS value instead leaves a MoonBit
+// `match` reading `$tag` off something that has none.
+//
+// Two sections, because a declaration's implementation lands in one of two
+// places and each needs a different question asked:
+//
+//   A. a named `bridge.js` wrapper (`export function __ts_mbt_<name>(…)`),
+//      which can call the `_from_js` helper by name;
+//   B. an `extern "js" fn` whose body is an INLINE lambda (`#| (self) =>
+//      self.path`), which cannot import that helper, so the conversion has to
+//      be inlined into the body.
+//
+// The first version of this probe had only section A and matched
+// `declare pub fn NAME(`, so every `Type::method` and `fn[T]` form was
+// skipped — which is most of what a class-heavy package declares, and all
+// four of the accessor sites that turned out to be broken.
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+
+function walk(d, out = []) {
   for (const e of readdirSync(d, { withFileTypes: true })) {
     const p = join(d, e.name);
-    if (e.isDirectory()) { if (e.name !== "node_modules") walk(p, out); }
-    else if (e.name === "bridge.mbti") out.push(p);
+    if (e.isDirectory()) {
+      if (e.name !== "node_modules") walk(p, out);
+    } else if (e.name === "bridge.mbti") out.push(p);
   }
   return out;
 }
-let totalEnums = 0, totalRet = 0, broken = 0;
-const byPkg = [];
-for (const mbti of walk("_build")) {
-  const js = mbti.replace(/bridge\.mbti$/, "bridge.js");
-  let jsSrc = ""; try { jsSrc = readFileSync(js, "utf8"); } catch { continue; }
-  const src = readFileSync(mbti, "utf8");
-  // tagged-union enum names: `pub(all) enum X {` where a case has a payload
-  // Only PAYLOAD-BEARING enums. A payload-free enum (`enum Mode { Read
-  // Write }`, from a TS numeric enum) is an integer tag on the MoonBit side,
-  // so a raw numeric passthrough is the correct wrapper -- counting those was
-  // the probe's own bug.
+
+const snake = (s) =>
+  s
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[^A-Za-z0-9]/g, "_")
+    .toLowerCase();
+
+// Payload-BEARING enums only. A payload-free enum (`enum Mode { Read Write }`,
+// from a TS numeric enum) is an integer tag on the MoonBit side, so a raw
+// numeric passthrough is the correct wrapper — counting those was this
+// probe's own first bug.
+function payloadEnums(src) {
   const enums = new Set();
-  for (const m of src.matchAll(/^pub\(all\) enum ([A-Za-z_][\w]*) \{\n((?:  .*\n)*)\}/gm)) {
+  for (const m of src.matchAll(
+    /^pub\(all\) enum ([A-Za-z_][\w]*) \{\n((?:  .*\n)*)\}/gm,
+  )) {
     if (/^  [A-Za-z_][\w]*\(/m.test(m[2])) enums.add(m[1]);
   }
-  totalEnums += enums.size;
-  const bad = [];
-  for (const m of src.matchAll(/^declare pub fn ([A-Za-z_][\w]*)\(.*?\) -> ([A-Za-z_][\w]*)\??$/gm)) {
-    const [, fn, ret] = m;
-    if (!enums.has(ret)) continue;
-    totalRet += 1;
-    // snake_case the fn name the way the emitter does, then look for a
-    // `_from_js` call or an inline `$tag` construction in its wrapper.
-    const snake = fn.replace(/([a-z0-9])([A-Z])/g, "$1_$2").replace(/[^A-Za-z0-9]/g, "_").toLowerCase();
-    const re = new RegExp("export function __ts_mbt_" + snake + "\\(([^)]*)\\) \\{([^\\n]*)", "m");
-    const w = jsSrc.match(re);
-    if (!w) continue;
-    const body = w[2];
-    if (!/_from_js\(|"\$tag"/.test(body)) { broken += 1; bad.push({ fn, ret }); }
-  }
-  if (bad.length) byPkg.push({ pkg: mbti.replace(/^_build\//, "").replace(/\/bridge\.mbti$/, ""), bad });
+  return enums;
 }
-console.log(`tagged-union enums declared:            ${totalEnums}`);
-console.log(`fns returning one:                      ${totalRet}`);
-console.log(`...whose wrapper builds no enum value:  ${broken}`);
+
+const APPLIES_CONVERTER = /_from_js|_to_js|\$tag/;
+
+let totalEnums = 0;
+let wrapperDecls = 0;
+let wrapperBad = 0;
+let inlineDecls = 0;
+let inlineBad = 0;
+const byPkg = [];
+
+for (const mbti of walk("_build")) {
+  const dir = dirname(mbti);
+  const src = readFileSync(mbti, "utf8");
+  const enums = payloadEnums(src);
+  totalEnums += enums.size;
+  if (enums.size === 0) continue;
+  const bad = [];
+
+  // ---- Section A: named bridge.js wrappers -------------------------------
+  let jsSrc = "";
+  try {
+    jsSrc = readFileSync(join(dir, "bridge.js"), "utf8");
+  } catch {
+    jsSrc = "";
+  }
+  if (jsSrc) {
+    for (const m of src.matchAll(
+      /^declare pub fn(?:\[[^\]]*\])? ([A-Za-z_][\w]*(?:::[A-Za-z_][\w]*)?)\(.*?\) -> ([A-Za-z_][\w]*)(\[[^\]]*\])?\??$/gm,
+    )) {
+      const [, fn, ret, typeArgs] = m;
+      // A generic instantiation (`Foo[T]`) is not the bare enum name.
+      if (typeArgs || !enums.has(ret)) continue;
+      // `Type::method` binds as `__ts_mbt_<type>_<method>`
+      // (`ffi_class_method_binding_name`); a plain name as `__ts_mbt_<name>`.
+      const binding = fn.includes("::")
+        ? "__ts_mbt_" + fn.split("::").map(snake).join("_")
+        : "__ts_mbt_" + snake(fn);
+      const w = jsSrc.match(
+        new RegExp("export function " + binding + "\\(([^)]*)\\) \\{([^\\n]*)", "m"),
+      );
+      // No named wrapper: this declaration is implemented by an inline
+      // extern, which section B reads directly. Not a finding here.
+      if (!w) continue;
+      wrapperDecls += 1;
+      if (!APPLIES_CONVERTER.test(w[2])) {
+        wrapperBad += 1;
+        bad.push({ kind: "wrapper", fn, ret, detail: `-> ${ret}` });
+      }
+    }
+  }
+
+  // ---- Section B: inline extern lambda bodies ----------------------------
+  // Both directions: a return promising the enum, and a parameter declared as
+  // the enum whose `{$tag, _0}` is handed to JS unconverted.
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith(".mbt")) continue;
+    const text = readFileSync(join(dir, file), "utf8");
+    for (const m of text.matchAll(
+      /^pub extern "js" fn(?:\[[^\]]*\])? ([A-Za-z_][\w:]*)\(([^)]*)\) -> ([A-Za-z_][\w]*)(\[[^\]]*\])?(\??)\s*=\n((?:\s*#\|.*\n)+)/gm,
+    )) {
+      const [, fn, params, ret, typeArgs, optional, body] = m;
+      const hits = [];
+      if (!typeArgs && enums.has(ret)) hits.push(`ret ${ret}${optional}`);
+      for (const p of params.matchAll(/:\s*([A-Za-z_][\w]*)(\??)\s*(?:,|$)/g)) {
+        if (enums.has(p[1])) hits.push(`param ${p[1]}${p[2]}`);
+      }
+      if (hits.length === 0) continue;
+      inlineDecls += 1;
+      if (!APPLIES_CONVERTER.test(body)) {
+        inlineBad += 1;
+        bad.push({ kind: "inline", fn, ret, detail: hits.join(", ") });
+      }
+    }
+  }
+
+  if (bad.length) {
+    byPkg.push({
+      pkg: mbti.replace(/^_build\//, "").replace(/\/bridge\.mbti$/, ""),
+      bad,
+    });
+  }
+}
+
+console.log(`tagged-union enums declared:                  ${totalEnums}`);
+console.log(`named bridge.js wrappers crossing one:        ${wrapperDecls}`);
+console.log(`...building no enum value:                    ${wrapperBad}`);
+console.log(`inline extern bodies crossing one:            ${inlineDecls}`);
+console.log(`...applying no converter:                     ${inlineBad}`);
 for (const p of byPkg) {
   console.log(`\n  ${p.pkg}`);
-  for (const b of p.bad.slice(0, 8)) console.log(`    ${b.fn} -> ${b.ret}`);
+  for (const b of p.bad.slice(0, 8)) {
+    console.log(`    [${b.kind}] ${b.fn}: ${b.detail}`);
+  }
   if (p.bad.length > 8) console.log(`    ... +${p.bad.length - 8} more`);
 }
+process.exitCode = wrapperBad + inlineBad > 0 ? 1 : 0;

--- a/scripts/bridge_enum_return_probe.mjs
+++ b/scripts/bridge_enum_return_probe.mjs
@@ -21,7 +21,40 @@
 // skipped — which is most of what a class-heavy package declares, and all
 // four of the accessor sites that turned out to be broken.
 import { readFileSync, readdirSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { join, dirname, basename } from "node:path";
+
+// The declared backlog. An occurrence not listed fails; a listed entry that no
+// longer occurs is STALE and also fails, which is the only mechanism that keeps
+// such a file from turning into a suppression list.
+const DECLARED_FILE = "scripts/bridge_unconverted_enum_crossings.txt";
+function readDeclared() {
+  let text = "";
+  try {
+    text = readFileSync(DECLARED_FILE, "utf8");
+  } catch {
+    return new Map();
+  }
+  const out = new Map();
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t || t.startsWith("#")) continue;
+    const [pkg, decl, dir, kind, ...rest] = t.split("|").map((s) => s.trim());
+    if (!pkg || !decl || !dir) continue;
+    out.set(`${pkg}|${decl}|${dir}`, { kind, reason: rest.join(" | ") });
+  }
+  return out;
+}
+// The package's own directory name is the stable key — the corpus path differs
+// between a scaffold, a fixture and an example for one generated package.
+function packageKey(dir) {
+  const parts = dir.split("/").filter((p) => p && p !== "_build");
+  for (let i = parts.length - 1; i >= 0; i -= 1) {
+    if (!["dist", "generated", "internal", "src"].includes(parts[i])) {
+      return parts[i].replace(/^(scaffold_|bridge_fixture_)/, "").replace(/^typescript-to-moonbit-/, "").replace(/-/g, "_");
+    }
+  }
+  return basename(dir);
+}
 
 function walk(d, out = []) {
   for (const e of readdirSync(d, { withFileTypes: true })) {
@@ -43,6 +76,12 @@ const snake = (s) =>
 // from a TS numeric enum) is an integer tag on the MoonBit side, so a raw
 // numeric passthrough is the correct wrapper — counting those was this
 // probe's own first bug.
+//
+// Read from the `.mbti` AND every `.mbt` in the package, because the
+// SYNTHESIZED unions — `Auto_ViewValue_or_TableValue`, the lowering of an
+// inline `A | B` — are declared in `types.mbt` and never in the interface.
+// Reading only the interface is what let this probe report 0 while
+// `aliasedTable` was handing back a raw drizzle object under that very type.
 function payloadEnums(src) {
   const enums = new Set();
   for (const m of src.matchAll(
@@ -53,7 +92,20 @@ function payloadEnums(src) {
   return enums;
 }
 
-const APPLIES_CONVERTER = /_from_js|_to_js|\$tag/;
+// The two directions are DIFFERENT QUESTIONS and have to be asked separately.
+//
+// The first version of this probe used one `/_from_js|_to_js|\$tag/` over the
+// whole body, and that is how `__ts_mbt_aliased_table` passed: it converts its
+// ARGUMENT (`.$tag === 0` dispatch, inlined) and hands the return back raw
+// while declaring `-> Auto_ViewValue_or_TableValue`, so the `$tag` the pattern
+// matched belonged to the parameter. "This body contains a conversion
+// somewhere" is not "this body converts its return".
+//
+// Direction shows in the shape, whichever spelling the emitter used:
+//   BUILDING a MoonBit value from JS writes the key   -> `"$tag":` / `_from_js(`
+//   DISPATCHING on a MoonBit value reads it           -> `.$tag ===` / `_to_js(`
+const BUILDS_MOONBIT_VALUE = /"\$tag":|_from_js\(/;
+const READS_MOONBIT_VALUE = /\.\$tag\s*===|_to_js\(/;
 
 let totalEnums = 0;
 let wrapperDecls = 0;
@@ -65,7 +117,11 @@ const byPkg = [];
 for (const mbti of walk("_build")) {
   const dir = dirname(mbti);
   const src = readFileSync(mbti, "utf8");
-  const enums = payloadEnums(src);
+  let declSrc = src;
+  for (const f of readdirSync(dir)) {
+    if (f.endsWith(".mbt")) declSrc += "\n" + readFileSync(join(dir, f), "utf8");
+  }
+  const enums = payloadEnums(declSrc);
   totalEnums += enums.size;
   if (enums.size === 0) continue;
   const bad = [];
@@ -96,9 +152,9 @@ for (const mbti of walk("_build")) {
       // extern, which section B reads directly. Not a finding here.
       if (!w) continue;
       wrapperDecls += 1;
-      if (!APPLIES_CONVERTER.test(w[2])) {
+      if (!BUILDS_MOONBIT_VALUE.test(w[2])) {
         wrapperBad += 1;
-        bad.push({ kind: "wrapper", fn, ret, detail: `-> ${ret}` });
+        bad.push({ kind: "wrapper", fn, ret, dir: "ret", detail: `-> ${ret}` });
       }
     }
   }
@@ -113,16 +169,33 @@ for (const mbti of walk("_build")) {
       /^pub extern "js" fn(?:\[[^\]]*\])? ([A-Za-z_][\w:]*)\(([^)]*)\) -> ([A-Za-z_][\w]*)(\[[^\]]*\])?(\??)\s*=\n((?:\s*#\|.*\n)+)/gm,
     )) {
       const [, fn, params, ret, typeArgs, optional, body] = m;
-      const hits = [];
-      if (!typeArgs && enums.has(ret)) hits.push(`ret ${ret}${optional}`);
-      for (const p of params.matchAll(/:\s*([A-Za-z_][\w]*)(\??)\s*(?:,|$)/g)) {
-        if (enums.has(p[1])) hits.push(`param ${p[1]}${p[2]}`);
+      const missing = [];
+      if (!typeArgs && enums.has(ret) && !BUILDS_MOONBIT_VALUE.test(body)) {
+        missing.push(`ret ${ret}${optional}`);
       }
-      if (hits.length === 0) continue;
+      for (const p of params.matchAll(/:\s*([A-Za-z_][\w]*)(\??)\s*(?:,|$)/g)) {
+        if (enums.has(p[1]) && !READS_MOONBIT_VALUE.test(body)) {
+          missing.push(`param ${p[1]}${p[2]}`);
+        }
+      }
+      const crosses =
+        (!typeArgs && enums.has(ret)) ||
+        [...params.matchAll(/:\s*([A-Za-z_][\w]*)\??\s*(?:,|$)/g)].some((p) =>
+          enums.has(p[1]),
+        );
+      if (!crosses) continue;
       inlineDecls += 1;
-      if (!APPLIES_CONVERTER.test(body)) {
+      if (missing.length > 0) {
         inlineBad += 1;
-        bad.push({ kind: "inline", fn, ret, detail: hits.join(", ") });
+        for (const m2 of missing) {
+          bad.push({
+            kind: "inline",
+            fn,
+            ret,
+            dir: m2.startsWith("param") ? "param" : "ret",
+            detail: m2,
+          });
+        }
       }
     }
   }
@@ -130,21 +203,56 @@ for (const mbti of walk("_build")) {
   if (bad.length) {
     byPkg.push({
       pkg: mbti.replace(/^_build\//, "").replace(/\/bridge\.mbti$/, ""),
+      key: packageKey(dir),
       bad,
     });
   }
 }
 
+const declared = readDeclared();
+const seenKeys = new Set();
+let undeclared = 0;
+let declaredSeen = 0;
+for (const p of byPkg) {
+  for (const b of p.bad) {
+    const key = `${p.key}|${b.fn}|${b.dir}`;
+    seenKeys.add(key);
+    if (declared.has(key)) declaredSeen += 1;
+    else undeclared += 1;
+  }
+}
+const stale = [...declared.keys()].filter((k) => !seenKeys.has(k));
+
 console.log(`tagged-union enums declared:                  ${totalEnums}`);
 console.log(`named bridge.js wrappers crossing one:        ${wrapperDecls}`);
 console.log(`...building no enum value:                    ${wrapperBad}`);
 console.log(`inline extern bodies crossing one:            ${inlineDecls}`);
-console.log(`...applying no converter:                     ${inlineBad}`);
+console.log(`...missing a conversion:                      ${inlineBad}`);
+console.log(`declared unconverted crossings:               ${declaredSeen}`);
+console.log(`UNDECLARED unconverted crossings:             ${undeclared}`);
+console.log(`stale declarations:                           ${stale.length}`);
+
 for (const p of byPkg) {
-  console.log(`\n  ${p.pkg}`);
-  for (const b of p.bad.slice(0, 8)) {
-    console.log(`    [${b.kind}] ${b.fn}: ${b.detail}`);
-  }
-  if (p.bad.length > 8) console.log(`    ... +${p.bad.length - 8} more`);
+  const rows = p.bad.filter((b) => !declared.has(`${p.key}|${b.fn}|${b.dir}`));
+  if (rows.length === 0) continue;
+  console.log(`\n  UNDECLARED in ${p.pkg}  (key: ${p.key})`);
+  for (const b of rows) console.log(`    [${b.kind}] ${b.fn}: ${b.detail}`);
 }
-process.exitCode = wrapperBad + inlineBad > 0 ? 1 : 0;
+if (stale.length) {
+  console.log("\nstale declarations (listed but no longer occurring):");
+  for (const k of stale) console.log(`    ${k}`);
+}
+if (undeclared === 0 && stale.length === 0 && declaredSeen > 0) {
+  const byKind = {};
+  for (const p of byPkg) {
+    for (const b of p.bad) {
+      const d = declared.get(`${p.key}|${b.fn}|${b.dir}`);
+      if (d) (byKind[d.kind] ??= []).push(`${p.key} ${b.fn}`);
+    }
+  }
+  console.log("\ndeclared backlog by kind:");
+  for (const [k, v] of Object.entries(byKind).sort((a, b) => b[1].length - a[1].length)) {
+    console.log(`  ${String(k).padEnd(16)} ${v.length}`);
+  }
+}
+process.exitCode = undeclared > 0 || stale.length > 0 ? 1 : 0;

--- a/scripts/bridge_enum_return_probe.mjs
+++ b/scripts/bridge_enum_return_probe.mjs
@@ -1,0 +1,50 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+function walk(d, out=[]) {
+  for (const e of readdirSync(d, { withFileTypes: true })) {
+    const p = join(d, e.name);
+    if (e.isDirectory()) { if (e.name !== "node_modules") walk(p, out); }
+    else if (e.name === "bridge.mbti") out.push(p);
+  }
+  return out;
+}
+let totalEnums = 0, totalRet = 0, broken = 0;
+const byPkg = [];
+for (const mbti of walk("_build")) {
+  const js = mbti.replace(/bridge\.mbti$/, "bridge.js");
+  let jsSrc = ""; try { jsSrc = readFileSync(js, "utf8"); } catch { continue; }
+  const src = readFileSync(mbti, "utf8");
+  // tagged-union enum names: `pub(all) enum X {` where a case has a payload
+  // Only PAYLOAD-BEARING enums. A payload-free enum (`enum Mode { Read
+  // Write }`, from a TS numeric enum) is an integer tag on the MoonBit side,
+  // so a raw numeric passthrough is the correct wrapper -- counting those was
+  // the probe's own bug.
+  const enums = new Set();
+  for (const m of src.matchAll(/^pub\(all\) enum ([A-Za-z_][\w]*) \{\n((?:  .*\n)*)\}/gm)) {
+    if (/^  [A-Za-z_][\w]*\(/m.test(m[2])) enums.add(m[1]);
+  }
+  totalEnums += enums.size;
+  const bad = [];
+  for (const m of src.matchAll(/^declare pub fn ([A-Za-z_][\w]*)\(.*?\) -> ([A-Za-z_][\w]*)\??$/gm)) {
+    const [, fn, ret] = m;
+    if (!enums.has(ret)) continue;
+    totalRet += 1;
+    // snake_case the fn name the way the emitter does, then look for a
+    // `_from_js` call or an inline `$tag` construction in its wrapper.
+    const snake = fn.replace(/([a-z0-9])([A-Z])/g, "$1_$2").replace(/[^A-Za-z0-9]/g, "_").toLowerCase();
+    const re = new RegExp("export function __ts_mbt_" + snake + "\\(([^)]*)\\) \\{([^\\n]*)", "m");
+    const w = jsSrc.match(re);
+    if (!w) continue;
+    const body = w[2];
+    if (!/_from_js\(|"\$tag"/.test(body)) { broken += 1; bad.push({ fn, ret }); }
+  }
+  if (bad.length) byPkg.push({ pkg: mbti.replace(/^_build\//, "").replace(/\/bridge\.mbti$/, ""), bad });
+}
+console.log(`tagged-union enums declared:            ${totalEnums}`);
+console.log(`fns returning one:                      ${totalRet}`);
+console.log(`...whose wrapper builds no enum value:  ${broken}`);
+for (const p of byPkg) {
+  console.log(`\n  ${p.pkg}`);
+  for (const b of p.bad.slice(0, 8)) console.log(`    ${b.fn} -> ${b.ret}`);
+  if (p.bad.length > 8) console.log(`    ... +${p.bad.length - 8} more`);
+}

--- a/scripts/bridge_mbti_duplicate_probe.mjs
+++ b/scripts/bridge_mbti_duplicate_probe.mjs
@@ -1,0 +1,54 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+function walk(d, out = []) {
+  for (const e of readdirSync(d, { withFileTypes: true })) {
+    const p = join(d, e.name);
+    if (e.isDirectory()) { if (e.name !== "node_modules") walk(p, out); }
+    else if (e.name === "bridge.mbti") out.push(p);
+  }
+  return out;
+}
+let totFns = 0, totDupNames = 0, totExtraLines = 0, pkgs = 0, mismatched = 0;
+const detail = [];
+for (const mbti of walk("_build")) {
+  const src = readFileSync(mbti, "utf8");
+  const mbt = (() => { try { return readFileSync(mbti.replace(/mbti$/, "mbt"), "utf8"); } catch { return ""; } })();
+  const byName = new Map();
+  for (const m of src.matchAll(/^declare pub fn ([A-Za-z_][\w]*)\((.*?)\) -> (.*)$/gm)) {
+    const [, name, params, ret] = m;
+    if (!byName.has(name)) byName.set(name, []);
+    byName.get(name).push(`(${params}) -> ${ret}`);
+  }
+  const fns = [...byName.values()].reduce((n, v) => n + v.length, 0);
+  totFns += fns;
+  const dups = [...byName.entries()].filter(([, v]) => v.length > 1);
+  if (!dups.length) continue;
+  pkgs += 1;
+  totDupNames += dups.length;
+  totExtraLines += dups.reduce((n, [, v]) => n + v.length - 1, 0);
+  // How many of the duplicate signatures have NO counterpart in the impl?
+  const orphans = [];
+  for (const [name, sigs] of dups) {
+    for (const sig of sigs) {
+      // the impl spells it `pub extern "js" fn name(...) -> T` or `pub fn name(...) -> T`
+      const ret = sig.slice(sig.indexOf(") -> ") + 5);
+      const re = new RegExp("fn " + name + "\\(.*\\) -> " + ret.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+      if (!re.test(mbt)) orphans.push(`${name}${sig}`);
+    }
+  }
+  mismatched += orphans.length;
+  detail.push({ pkg: mbti.replace(/^_build\//, "").replace(/\/bridge\.mbti$/, ""), dups, orphans });
+}
+console.log(`packages with duplicates:        ${pkgs}`);
+console.log(`duplicated declaration names:    ${totDupNames}`);
+console.log(`redundant declare lines:         ${totExtraLines}  (of ${totFns} total -> the report over-counts by this)`);
+console.log(`duplicate sigs with NO impl:     ${mismatched}`);
+for (const d of detail.slice(0, 4)) {
+  console.log(`\n  ${d.pkg}`);
+  for (const [name, sigs] of d.dups.slice(0, 4)) {
+    console.log(`    ${name}  x${sigs.length}`);
+    for (const s of sigs) console.log(`       ${s.length > 96 ? s.slice(0, 96) + "…" : s}`);
+  }
+  if (d.dups.length > 4) console.log(`    ... +${d.dups.length - 4} more names`);
+  if (d.orphans.length) console.log(`    NO IMPL: ${d.orphans.slice(0,3).map(o => o.slice(0,80)).join(" | ")}`);
+}

--- a/scripts/bridge_quality_report.sh
+++ b/scripts/bridge_quality_report.sh
@@ -251,6 +251,45 @@ collect_unsupported_export_counts() {
     "$unbudgeted"
 }
 
+# A top-level `declare pub fn` name declared more than once in one package.
+#
+# MoonBit has no overloading, so two `pub fn` of one name cannot both exist —
+# a second declaration is therefore always wrong, and the `.mbti` is supposed
+# to describe the `.mbt`. Nothing checked the two against each other, and the
+# decl layer and the ffi layer render the same value export independently, so
+# a disagreement showed up as an extra declaration rather than as an error.
+# Four of them were in the corpus (`get_serve`, `get_get_request_listener`,
+# `get_create_adaptor_server`, `mkdir`), invisible for as long as the two
+# renderings happened to match.
+#
+# The name is taken up to the `(` that must follow it immediately, which is
+# what excludes a `Type::method` form — those are methods on one receiver, not
+# duplicates. Getting that wrong is how the first measurement of this reported
+# 52 duplicates in one package when the real answer was zero: a pattern that
+# stopped at `::` collapsed `BuilderProgram::getProgram` and six siblings onto
+# `BuilderProgram`.
+duplicate_declared_fn_names() {
+  local details_file="$1"
+  local total=0
+  local file
+  local name
+
+  : > "$details_file"
+
+  while IFS= read -r file; do
+    while IFS= read -r name; do
+      [ -n "$name" ] || continue
+      printf '%s\t%s\n' "$file" "$name" >> "$details_file"
+      total=$((total + 1))
+    done < <(
+      sed -n 's/^declare pub fn \([A-Za-z_][A-Za-z0-9_]*\)(.*/\1/p' "$file" \
+        | sort | uniq -d
+    )
+  done < <(find_metric_files 'bridge.mbti')
+
+  printf '%s\n' "$total"
+}
+
 jsvalue_cause_counts() {
   local surface_total=0
   local unknown_any=0
@@ -356,6 +395,8 @@ typescript_exported_declarations="$(count_matching_files '*.d.ts' '^export (decl
 jsvalue_refs="$(count_matching_files 'bridge.mbti' 'JSValue')"
 jsvalue_functions="$(count_matching_files 'bridge.mbti' '^declare pub fn .*JSValue')"
 moon_build_smokes="$(find_metric_dirs '__tsmbt_build_smoke__' | wc -l | tr -d ' ')"
+duplicate_decl_details_file="$report_root/duplicate-declarations.tsv"
+duplicate_declared_fns="$(duplicate_declared_fn_names "$duplicate_decl_details_file")"
 IFS='|' read -r \
   jsvalue_surface_lines \
   jsvalue_unknown_any \
@@ -384,6 +425,9 @@ if [ "$namespace_widened_unsupported_exports" -gt "$namespace_widened_unsupporte
   overall="fail"
 fi
 if [ "$heterogeneous_union_undeclared_exports" -gt 0 ]; then
+  overall="fail"
+fi
+if [ "$duplicate_declared_fns" -gt 0 ]; then
   overall="fail"
 fi
 if [ "${#stale_widened_unions[@]}" -gt 0 ]; then
@@ -429,6 +473,7 @@ fi
   printf '| JSValue surface lines | %s |\n' "$jsvalue_surface_lines"
   printf '| JSValue functions | %s |\n' "$jsvalue_functions"
   printf '| generated build-smoke packages | %s |\n' "$moon_build_smokes"
+  printf '| duplicate declared fn names | %s |\n' "$duplicate_declared_fns"
   printf '\n'
   printf '## JSValue Cause Breakdown\n\n'
   printf 'This is a heuristic classification over generated `bridge.mbti` surface lines that contain `JSValue`, excluding the shared banner and type declaration.\n\n'
@@ -453,6 +498,16 @@ fi
     done < "$unsupported_details_file"
   else
     printf '| none |  |  |\n'
+  fi
+  printf '\n'
+  printf '### Duplicate declared function names\n\n'
+  if [ "$duplicate_declared_fns" -gt 0 ]; then
+    printf 'MoonBit has no overloading, so a name declared twice in one `bridge.mbti` cannot both exist in the `.mbt`. The `.mbti` describes the `.mbt`; a duplicate means two emitters rendered one export and disagreed.\n\n'
+    while IFS=$'\t' read -r location name; do
+      printf -- '- `%s` in `%s`\n' "$name" "${location#"$repo_root"/}"
+    done < "$duplicate_decl_details_file"
+  else
+    printf 'none\n'
   fi
   printf '\n'
   printf '### Stale heterogeneous-union declarations\n\n'

--- a/scripts/bridge_quality_report.sh
+++ b/scripts/bridge_quality_report.sh
@@ -13,11 +13,11 @@ ambiguous_unsupported_export_budget=1
 namespace_omitted_unsupported_export_budget=0
 namespace_widened_unsupported_export_budget=0
 # Heterogeneous unions whose members carry no runtime-discriminable
-# constructor name. Function members, branded-string intersections,
-# empty-registry indexed accesses, and qualified namespace refs now
-# lower (2026-07-15), so the budget is 0: any new occurrence is a real
-# regression.
-heterogeneous_union_unsupported_export_budget=0
+# constructor name are DECLARED rather than counted -- see
+# scripts/bridge_widened_unions.txt for why a count could not rank work,
+# and for the two entries. An undeclared occurrence fails this report; a
+# declared entry that no longer occurs is reported as STALE.
+heterogeneous_union_declared_file="${BRIDGE_WIDENED_UNIONS_FILE:-$repo_root/scripts/bridge_widened_unions.txt}"
 
 rm -rf "$report_root"
 mkdir -p "$log_root"
@@ -147,20 +147,58 @@ count_matching_files() {
   printf '%s\n' "$total"
 }
 
+# Export names declared in scripts/bridge_widened_unions.txt, one per line.
+declared_widened_union_names() {
+  if [ ! -f "$heterogeneous_union_declared_file" ]; then
+    return
+  fi
+  # `<name> | <kind> | <reason>`; ignore comments and blanks.
+  sed -e 's/#.*$//' "$heterogeneous_union_declared_file" \
+    | awk -F'|' 'NF >= 1 { gsub(/^[ \t]+|[ \t]+$/, "", $1); if ($1 != "") print $1 }'
+}
+
+declared_widened_union_kind() {
+  local want="$1"
+  if [ ! -f "$heterogeneous_union_declared_file" ]; then
+    printf 'undeclared\n'
+    return
+  fi
+  sed -e 's/#.*$//' "$heterogeneous_union_declared_file" \
+    | awk -F'|' -v want="$want" '
+        NF >= 2 {
+          name = $1; kind = $2
+          gsub(/^[ \t]+|[ \t]+$/, "", name)
+          gsub(/^[ \t]+|[ \t]+$/, "", kind)
+          if (name == want) { print kind; found = 1; exit }
+        }
+        END { if (!found) print "undeclared" }
+      '
+}
+
+# The export name out of a `/// Unsupported export <name>: ...` line.
+unsupported_export_name() {
+  printf '%s\n' "$1" \
+    | sed -e 's|^/// Unsupported export ||' -e 's|:.*$||'
+}
+
 collect_unsupported_export_counts() {
   local details_file="$1"
+  local seen_file="$2"
   local total=0
   local ambiguous=0
   local namespace_omitted=0
   local namespace_widened=0
   local heterogeneous_union=0
+  local heterogeneous_union_undeclared=0
   local unbudgeted=0
   local file
   local line
   local line_no
   local classification
+  local export_name
 
   : > "$details_file"
+  : > "$seen_file"
 
   while IFS= read -r file; do
     line_no=0
@@ -182,8 +220,15 @@ collect_unsupported_export_counts() {
         classification="namespace-widened"
         namespace_widened=$((namespace_widened + 1))
       elif [[ "$line" == *"heterogeneous union member is not runtime-discriminable"* ]]; then
-        classification="heterogeneous-union-widened"
         heterogeneous_union=$((heterogeneous_union + 1))
+        export_name="$(unsupported_export_name "$line")"
+        printf '%s\n' "$export_name" >> "$seen_file"
+        if [ "$(declared_widened_union_kind "$export_name")" = "undeclared" ]; then
+          classification="heterogeneous-union-UNDECLARED"
+          heterogeneous_union_undeclared=$((heterogeneous_union_undeclared + 1))
+        else
+          classification="heterogeneous-union-declared"
+        fi
       else
         unbudgeted=$((unbudgeted + 1))
       fi
@@ -196,12 +241,13 @@ collect_unsupported_export_counts() {
     done < "$file"
   done < <(find_metric_files 'bridge.mbti')
 
-  printf '%s|%s|%s|%s|%s|%s\n' \
+  printf '%s|%s|%s|%s|%s|%s|%s\n' \
     "$total" \
     "$ambiguous" \
     "$namespace_omitted" \
     "$namespace_widened" \
     "$heterogeneous_union" \
+    "$heterogeneous_union_undeclared" \
     "$unbudgeted"
 }
 
@@ -283,13 +329,27 @@ moonbit_decl_lines="$(sum_lines 'bridge.mbti')"
 typescript_decl_lines="$(sum_lines '*.d.ts')"
 javascript_lines="$(sum_lines '*.js')"
 diagnostic_files=$(( $(count_files 'SCAFFOLD_DIAGNOSTICS.md') + $(count_files 'AUTOLINK_DIAGNOSTICS.md') ))
+widened_union_seen_file="$report_root/widened-unions-seen.txt"
 IFS='|' read -r \
   unsupported_exports \
   ambiguous_unsupported_exports \
   namespace_omitted_unsupported_exports \
   namespace_widened_unsupported_exports \
   heterogeneous_union_unsupported_exports \
-  unbudgeted_unsupported_exports < <(collect_unsupported_export_counts "$unsupported_details_file")
+  heterogeneous_union_undeclared_exports \
+  unbudgeted_unsupported_exports < <(collect_unsupported_export_counts "$unsupported_details_file" "$widened_union_seen_file")
+
+# A declared entry that no longer occurs. This is the mechanism that keeps
+# the file from decaying into a suppression list: the whole point of
+# declaring an occurrence is that removing the limitation removes the entry,
+# and nothing else would notice.
+stale_widened_unions=()
+while IFS= read -r declared_name; do
+  [ -n "$declared_name" ] || continue
+  if ! grep -Fxq "$declared_name" "$widened_union_seen_file" 2>/dev/null; then
+    stale_widened_unions+=("$declared_name")
+  fi
+done < <(declared_widened_union_names)
 moonbit_declared_functions="$(count_matching_files 'bridge.mbti' '^declare pub fn ')"
 moonbit_declared_types="$(count_matching_files 'bridge.mbti' '^declare pub type ')"
 typescript_exported_declarations="$(count_matching_files '*.d.ts' '^export (declare )?(function|interface|class|const|type) ')"
@@ -323,7 +383,10 @@ fi
 if [ "$namespace_widened_unsupported_exports" -gt "$namespace_widened_unsupported_export_budget" ]; then
   overall="fail"
 fi
-if [ "$heterogeneous_union_unsupported_exports" -gt "$heterogeneous_union_unsupported_export_budget" ]; then
+if [ "$heterogeneous_union_undeclared_exports" -gt 0 ]; then
+  overall="fail"
+fi
+if [ "${#stale_widened_unions[@]}" -gt 0 ]; then
   overall="fail"
 fi
 
@@ -358,7 +421,9 @@ fi
   printf '| budgeted ambiguous unsupported exports | %s / %s |\n' "$ambiguous_unsupported_exports" "$ambiguous_unsupported_export_budget"
   printf '| budgeted namespace-runtime omitted exports | %s / %s |\n' "$namespace_omitted_unsupported_exports" "$namespace_omitted_unsupported_export_budget"
   printf '| budgeted namespace-widened exports | %s / %s |\n' "$namespace_widened_unsupported_exports" "$namespace_widened_unsupported_export_budget"
-  printf '| budgeted heterogeneous-union widened exports | %s / %s |\n' "$heterogeneous_union_unsupported_exports" "$heterogeneous_union_unsupported_export_budget"
+  printf '| declared heterogeneous-union widened exports | %s |\n' "$heterogeneous_union_unsupported_exports"
+  printf '| UNDECLARED heterogeneous-union widened exports | %s |\n' "$heterogeneous_union_undeclared_exports"
+  printf '| stale heterogeneous-union declarations | %s |\n' "${#stale_widened_unions[@]}"
   printf '| unbudgeted unsupported exports | %s |\n' "$unbudgeted_unsupported_exports"
   printf '| JSValue refs | %s |\n' "$jsvalue_refs"
   printf '| JSValue surface lines | %s |\n' "$jsvalue_surface_lines"
@@ -378,6 +443,8 @@ fi
   printf '\n'
   printf '## Unsupported Export Budget\n\n'
   printf 'Only ambiguous re-export surfaces with explicit candidate diagnostics are budgeted in this fixture corpus. Any other unsupported export class fails this report unless its budget is raised deliberately.\n\n'
+  printf 'Heterogeneous-union widenings are DECLARED rather than counted: every occurrence must appear in `%s` with a kind and a reason. An `heterogeneous-union-UNDECLARED` row fails this report, and so does a declared entry that no longer occurs (a count could do neither).\n\n' \
+    "${heterogeneous_union_declared_file#"$repo_root"/}"
   printf '| class | location | diagnostic |\n'
   printf '| --- | --- | --- |\n'
   if [ -s "$unsupported_details_file" ]; then
@@ -386,6 +453,17 @@ fi
     done < "$unsupported_details_file"
   else
     printf '| none |  |  |\n'
+  fi
+  printf '\n'
+  printf '### Stale heterogeneous-union declarations\n\n'
+  if [ "${#stale_widened_unions[@]}" -gt 0 ]; then
+    printf 'These exports are declared in `%s` but no longer widen. The limitation is gone: delete the entry.\n\n' \
+      "${heterogeneous_union_declared_file#"$repo_root"/}"
+    for name in "${stale_widened_unions[@]}"; do
+      printf -- '- `%s`\n' "$name"
+    done
+  else
+    printf 'none\n'
   fi
 } > "$report_file"
 

--- a/scripts/bridge_quality_report.sh
+++ b/scripts/bridge_quality_report.sh
@@ -355,6 +355,12 @@ jsvalue_cause_counts() {
 run_check "verify-scaffolds" bash scripts/verify_scaffolds.sh
 run_check "verify-generated-fixtures" bash scripts/verify_generated_fixtures.sh
 run_check "verify-examples" bash scripts/verify_examples.sh
+# Runs against the corpus the three above just generated. It asks the one
+# question none of them do: a declaration that PROMISES a payload-bearing enum
+# has to be implemented by JS that BUILDS one. Called rather than reimplemented
+# in shell — a second copy of the rule is the defect this report already
+# carries three notes about.
+run_check "bridge-enum-return-probe" node scripts/bridge_enum_return_probe.mjs
 
 collect_metric_roots
 

--- a/scripts/bridge_unconverted_enum_crossings.txt
+++ b/scripts/bridge_unconverted_enum_crossings.txt
@@ -1,0 +1,65 @@
+# Declarations that PROMISE a payload-bearing enum and whose emitted JS never
+# builds (return) or reads (parameter) one.
+#
+# Read by `scripts/bridge_enum_return_probe.mjs`. Format, `|`-separated:
+#
+#   <package> | <declaration> | <direction> | <kind> | <reason>
+#
+# An occurrence NOT listed here fails the probe. A listed entry that no longer
+# occurs is reported STALE and also fails — that report is the only thing that
+# keeps a file like this from decaying into a suppression list, and it is the
+# lesson `scripts/bridge_widened_unions.txt` and
+# `scripts/checker_out_of_scope.txt` were both written for.
+#
+# The package key is the generated package's own directory name, so the same
+# `typescript.d.ts` appears twice: once as `typescript_ast` (its own example)
+# and once as `typescript` (nested under the node-imports example).
+#
+# WHY THESE ARE DECLARED RATHER THAN FIXED
+#
+# The honest answer for an erased-payload union is to WIDEN the declared type
+# to `JSValue`, which is what `ffi_widen_unbuildable_union_outputs` does for
+# `ServerType`. That function has no `Union(parts)` arm, so it never sees a
+# SYNTHESIZED union: the AST keeps the original `Union` shape while the
+# signature already reads `Auto_X_or_Y`, exactly as
+# `ffi_inline_js_tagged_union_to_js` describes in its own comment. Adding the
+# arm was implemented and REVERTED, with a measured blocker: the widening lives
+# in the FFI layer and the public wrapper (`pub fn getNameOfJSDocTypedef(...) ->
+# Auto_IdentifierValue_or_PrivateIdentifierValue?`) is rendered by the DECL
+# layer, which holds no `MoonBitJsFfiState`. Widening one side gives
+# `Expr Type Mismatch: has type JSValue?, wanted Auto_...?` — the two layers
+# disagreeing, which is the same split that produced the duplicate `.mbti`
+# declarations fixed in b1e20fe. The fix is a cross-layer channel, filed in
+# TODO.md; shipping it half-applied is what this repo keeps paying for.
+#
+# kinds
+#   erased-payload   a case payload is a TS interface / alias / type parameter,
+#                    so no `instanceof` can ever resolve. WIDEN.
+#   optional-gate    the `_from_js` is buildable and the OPTIONAL form declines
+#                    it, because MoonBit's `Option` repr is decided separately.
+#                    CONVERTIBLE — the cheapest real fix on this list.
+#   module-class     every payload is a class the module exports at runtime, so
+#                    binding `const N = __ts_mbt_module.N` would make the
+#                    `instanceof` resolve. CONVERTIBLE.
+
+drizzle_orm | aliasedTable | ret | module-class | Table and View are both real classes on `drizzle-orm`; binding them is the whole fix, and this is the ONLY return position in the corpus that the class binding would improve
+
+typescript_ast | walkUpBindingElementsAndPatterns | ret | erased-payload | VariableDeclaration and ParameterDeclaration are TypeScript interfaces
+typescript_ast | getNameOfJSDocTypedef | ret | erased-payload | Identifier and PrivateIdentifier are TypeScript interfaces
+typescript_ast | CompilerOptions::index_get | ret | erased-payload | TsConfigSourceFile and CompilerOptionsValue are erased, and the position is optional as well
+typescript_ast | CompilerOptions::index_set | param | erased-payload | mirror of index_get; the write direction needs no runtime predicate but is declined by the same optional handling
+typescript_ast | TypeChecker::getConstantValue | ret | optional-gate | `String | Double` — BOTH primitives, so `typeof` discriminates and the `_from_js` is fully buildable. Declined only because the return is optional and `ffi_inline_js_return_expr_with_state` leaves the optional form alone
+typescript_ast | LanguageService::prepareCallHierarchy | ret | erased-payload | CallHierarchyItem is an interface; its array sibling would discriminate on its own
+
+typescript | walkUpBindingElementsAndPatterns | ret | erased-payload | same declaration as the typescript_ast package
+typescript | getNameOfJSDocTypedef | ret | erased-payload | same declaration as the typescript_ast package
+typescript | CompilerOptions::index_get | ret | erased-payload | same declaration as the typescript_ast package
+typescript | CompilerOptions::index_set | param | erased-payload | same declaration as the typescript_ast package
+typescript | TypeChecker::getConstantValue | ret | optional-gate | same declaration as the typescript_ast package
+typescript | LanguageService::prepareCallHierarchy | ret | erased-payload | same declaration as the typescript_ast package
+
+node_fs | fstatSync_number_stat_options_optional | ret | erased-payload | `Stats` IS a runtime class on node:fs but `BigIntStats` is type-only, and a union needs EVERY case discriminable — which is why binding module classes buys nothing here, against the estimate that named the stat() family as its main prize
+node_fs | statfsSync_path_like_stat_fs_options_optional | ret | erased-payload | StatsFs and BigIntStatsFs are both type-only on node:fs
+node_fs | mkdtempSync_string_encoding_option_optional | ret | erased-payload | NonSharedBuffer is a node alias for Buffer; resolving the alias would make `instanceof Buffer` discriminate, so this is alias resolution rather than class binding
+node_fs | readlinkSync_path_like_encoding_option_optional | ret | erased-payload | same `String | NonSharedBuffer` shape as mkdtempSync
+node_fs | realpathSync_path_like_encoding_option_optional | ret | erased-payload | same `String | NonSharedBuffer` shape as mkdtempSync

--- a/scripts/bridge_unconverted_enum_crossings.txt
+++ b/scripts/bridge_unconverted_enum_crossings.txt
@@ -12,55 +12,62 @@
 # `scripts/checker_out_of_scope.txt` were both written for.
 #
 # The package key is the generated package's own directory name, so the same
-# `typescript.d.ts` appears twice: once as `typescript_ast` (its own example)
-# and once as `typescript` (nested under the node-imports example).
+# `typescript.d.ts` would appear twice: once as `typescript_ast` (its own
+# example) and once as `typescript` (nested under the node-imports example).
 #
-# WHY THESE ARE DECLARED RATHER THAN FIXED
+# THE BACKLOG IS EMPTY, AND THE STALE REPORT IS WHAT EMPTIED IT
 #
-# The honest answer for an erased-payload union is to WIDEN the declared type
-# to `JSValue`, which is what `ffi_widen_unbuildable_union_outputs` does for
-# `ServerType`. That function has no `Union(parts)` arm, so it never sees a
-# SYNTHESIZED union: the AST keeps the original `Union` shape while the
-# signature already reads `Auto_X_or_Y`, exactly as
-# `ffi_inline_js_tagged_union_to_js` describes in its own comment. Adding the
-# arm was implemented and REVERTED, with a measured blocker: the widening lives
-# in the FFI layer and the public wrapper (`pub fn getNameOfJSDocTypedef(...) ->
-# Auto_IdentifierValue_or_PrivateIdentifierValue?`) is rendered by the DECL
-# layer, which holds no `MoonBitJsFfiState`. Widening one side gives
-# `Expr Type Mismatch: has type JSValue?, wanted Auto_...?` — the two layers
-# disagreeing, which is the same split that produced the duplicate `.mbti`
-# declarations fixed in b1e20fe. The fix is a cross-layer channel, filed in
-# TODO.md; shipping it half-applied is what this repo keeps paying for.
+# All 18 occurrences this file was written to declare are fixed. The list is
+# kept — with its format and its history — because the probe's value is the
+# two directions it fails in, and an empty declared set is the state where a
+# NEW unconverted crossing fails immediately.
 #
-# kinds
+# The 16 that closed last were one decision made in three places, and the
+# order they fell in is the record worth keeping:
+#
+#   1. `ffi_widen_unbuildable_union_outputs` had no arm for a SYNTHESIZED
+#      union. Such a union keeps its `Union(parts)` shape in the AST while its
+#      signature already reads `Auto_X_or_Y`, so the walk decided about a type
+#      that was not the one being printed.
+#   2. The first version of that arm asked whether the alias was already in
+#      `state.tagged_union_decls_by_name`, which is filled as a SIDE EFFECT of
+#      rendering — so the answer depended on whether an earlier declaration in
+#      the file happened to mention the same union.
+#      `Auto_IdentifierValue_or_PrivateIdentifierValue` is also a parameter of
+#      `idText`, nine lines above, and was therefore registered;
+#      `Auto_VariableDeclarationValue_or_ParameterDeclarationValue` occurs
+#      exactly once and was not. `ffi_output_union_decl` builds the decl on the
+#      spot instead.
+#   3. Widening the extern alone gives `[4014] has type JSValue?, wanted
+#      Auto_...?`, because the `.mbti` line comes from the DECL layer and the
+#      public wrapper is rendered FROM that line — three renderings of one
+#      export. `reconcile_bridge_widened_union_returns` makes the declaration
+#      agree with the extern that implements it. Both aftermaths of the
+#      widening had to be covered: when the union is still mentioned elsewhere
+#      the stale declaration is `[4014]`, and when the widened return was its
+#      last mention nothing synthesizes the enum any more and the same stale
+#      declaration is `[4032] the type Auto_... is undefined`.
+#   4. An index signature's two directions are two questions and were rendered
+#      with ONE type name. `index_get` crosses JS -> MoonBit and widens;
+#      `index_set` crosses the other way, where `_to_js` needs no runtime
+#      predicate, so it keeps its type and converts in the body.
+#   5. A METHOD's return needed the widening too, and it does NOT belong in
+#      `ffi_function_type_parts`: a function type has no direction of its own,
+#      so widening there also widened callback returns (MoonBit -> JS, where
+#      the enum works) and broke `Matcher::_call_`, whose wrapper reads a
+#      struct FIELD rendered elsewhere — `has type ExpectationResult, wanted
+#      JSValue`. It belongs in the one branch that binds straight to a JS call.
+#
+# The `module-class` entry (`aliasedTable`) went with them: binding
+# `drizzle-orm`'s real `Table` / `View` classes would have made its
+# `instanceof` resolve, and widening is the answer that needed no new
+# machinery. The measured ceiling for that binding was 2 bindable names of the
+# 197 declined and 2 unblockable converters, which is why it was never worth
+# taking on its own.
+#
+# kinds (kept for whatever lands here next)
 #   erased-payload   a case payload is a TS interface / alias / type parameter,
 #                    so no `instanceof` can ever resolve. WIDEN.
-#   optional-gate    RETIRED: the `_from_js` is buildable and the optional
-#                    form declined it. The stated reason ("the MoonBit side
-#                    could box a value that path already boxed") was checkable
-#                    and false — `ffi_option_return_inner_is_boxed` returns
-#                    FALSE for a tagged-union alias, so no MoonBit-side wrap
-#                    exists to collide with. Both occurrences are converted.
 #   module-class     every payload is a class the module exports at runtime, so
 #                    binding `const N = __ts_mbt_module.N` would make the
 #                    `instanceof` resolve. CONVERTIBLE.
-
-drizzle_orm | aliasedTable | ret | module-class | Table and View are both real classes on `drizzle-orm`; binding them is the whole fix, and this is the ONLY return position in the corpus that the class binding would improve
-
-typescript_ast | walkUpBindingElementsAndPatterns | ret | erased-payload | VariableDeclaration and ParameterDeclaration are TypeScript interfaces
-typescript_ast | getNameOfJSDocTypedef | ret | erased-payload | Identifier and PrivateIdentifier are TypeScript interfaces
-typescript_ast | CompilerOptions::index_get | ret | erased-payload | TsConfigSourceFile and CompilerOptionsValue are erased, and the position is optional as well
-typescript_ast | CompilerOptions::index_set | param | erased-payload | mirror of index_get; the write direction needs no runtime predicate but is declined by the same optional handling
-typescript_ast | LanguageService::prepareCallHierarchy | ret | erased-payload | CallHierarchyItem is an interface; its array sibling would discriminate on its own
-
-typescript | walkUpBindingElementsAndPatterns | ret | erased-payload | same declaration as the typescript_ast package
-typescript | getNameOfJSDocTypedef | ret | erased-payload | same declaration as the typescript_ast package
-typescript | CompilerOptions::index_get | ret | erased-payload | same declaration as the typescript_ast package
-typescript | CompilerOptions::index_set | param | erased-payload | same declaration as the typescript_ast package
-typescript | LanguageService::prepareCallHierarchy | ret | erased-payload | same declaration as the typescript_ast package
-
-node_fs | fstatSync_number_stat_options_optional | ret | erased-payload | `Stats` IS a runtime class on node:fs but `BigIntStats` is type-only, and a union needs EVERY case discriminable — which is why binding module classes buys nothing here, against the estimate that named the stat() family as its main prize
-node_fs | statfsSync_path_like_stat_fs_options_optional | ret | erased-payload | StatsFs and BigIntStatsFs are both type-only on node:fs
-node_fs | mkdtempSync_string_encoding_option_optional | ret | erased-payload | NonSharedBuffer is a node alias for Buffer; resolving the alias would make `instanceof Buffer` discriminate, so this is alias resolution rather than class binding
-node_fs | readlinkSync_path_like_encoding_option_optional | ret | erased-payload | same `String | NonSharedBuffer` shape as mkdtempSync
-node_fs | realpathSync_path_like_encoding_option_optional | ret | erased-payload | same `String | NonSharedBuffer` shape as mkdtempSync

--- a/scripts/bridge_unconverted_enum_crossings.txt
+++ b/scripts/bridge_unconverted_enum_crossings.txt
@@ -35,9 +35,12 @@
 # kinds
 #   erased-payload   a case payload is a TS interface / alias / type parameter,
 #                    so no `instanceof` can ever resolve. WIDEN.
-#   optional-gate    the `_from_js` is buildable and the OPTIONAL form declines
-#                    it, because MoonBit's `Option` repr is decided separately.
-#                    CONVERTIBLE — the cheapest real fix on this list.
+#   optional-gate    RETIRED: the `_from_js` is buildable and the optional
+#                    form declined it. The stated reason ("the MoonBit side
+#                    could box a value that path already boxed") was checkable
+#                    and false — `ffi_option_return_inner_is_boxed` returns
+#                    FALSE for a tagged-union alias, so no MoonBit-side wrap
+#                    exists to collide with. Both occurrences are converted.
 #   module-class     every payload is a class the module exports at runtime, so
 #                    binding `const N = __ts_mbt_module.N` would make the
 #                    `instanceof` resolve. CONVERTIBLE.
@@ -48,14 +51,12 @@ typescript_ast | walkUpBindingElementsAndPatterns | ret | erased-payload | Varia
 typescript_ast | getNameOfJSDocTypedef | ret | erased-payload | Identifier and PrivateIdentifier are TypeScript interfaces
 typescript_ast | CompilerOptions::index_get | ret | erased-payload | TsConfigSourceFile and CompilerOptionsValue are erased, and the position is optional as well
 typescript_ast | CompilerOptions::index_set | param | erased-payload | mirror of index_get; the write direction needs no runtime predicate but is declined by the same optional handling
-typescript_ast | TypeChecker::getConstantValue | ret | optional-gate | `String | Double` — BOTH primitives, so `typeof` discriminates and the `_from_js` is fully buildable. Declined only because the return is optional and `ffi_inline_js_return_expr_with_state` leaves the optional form alone
 typescript_ast | LanguageService::prepareCallHierarchy | ret | erased-payload | CallHierarchyItem is an interface; its array sibling would discriminate on its own
 
 typescript | walkUpBindingElementsAndPatterns | ret | erased-payload | same declaration as the typescript_ast package
 typescript | getNameOfJSDocTypedef | ret | erased-payload | same declaration as the typescript_ast package
 typescript | CompilerOptions::index_get | ret | erased-payload | same declaration as the typescript_ast package
 typescript | CompilerOptions::index_set | param | erased-payload | same declaration as the typescript_ast package
-typescript | TypeChecker::getConstantValue | ret | optional-gate | same declaration as the typescript_ast package
 typescript | LanguageService::prepareCallHierarchy | ret | erased-payload | same declaration as the typescript_ast package
 
 node_fs | fstatSync_number_stat_options_optional | ret | erased-payload | `Stats` IS a runtime class on node:fs but `BigIntStats` is type-only, and a union needs EVERY case discriminable — which is why binding module classes buys nothing here, against the estimate that named the stat() family as its main prize

--- a/scripts/bridge_widened_unions.txt
+++ b/scripts/bridge_widened_unions.txt
@@ -1,0 +1,34 @@
+# Heterogeneous-union exports that are DECLARED to widen to JSValue.
+#
+# `bridge_quality_report.sh` used to budget these as a COUNT, which cannot
+# rank work and cannot say whether a given occurrence is one somebody should
+# fix. The budget was set to 0 on 2026-07-15 when the count was 0, and the
+# `typescript-node-imports` example added later reintroduced two — so the
+# report has been failing with `2 / 0` and no way to tell an accepted
+# limitation from a regression. This file is the same mechanism
+# `scripts/checker_out_of_scope.txt` uses for the checker's MISS bucket:
+# every occurrence must be declared here with a kind and a reason, an
+# UNDECLARED occurrence fails the report, and a declared entry that no
+# longer occurs is reported as STALE so the list cannot decay into a
+# suppression list.
+#
+# Format: <export name> | <kind> | <reason>
+# Blank lines and `#` comments are ignored. The export name is matched
+# against the `/// Unsupported export <name>:` line in a generated
+# `bridge.mbti`, so one entry covers every package that vendors the same
+# declaration.
+#
+# Kinds:
+#   object-payload    the offending member is an anonymous object type or an
+#                     object intersection. Lowering needs a synthesized
+#                     payload struct AND an object-shaped predicate
+#                     (`typeof v === "object" && v !== null &&
+#                     !Array.isArray(v)`), admissible only when the union has
+#                     exactly one object-ish member.
+#   unresolved-global the offending member, or a sibling it would have to be
+#                     discriminated against, resolves to a declaration this
+#                     package cannot see.
+
+WriteFileOptions | object-payload | `(ObjectEncodingOptions & Abortable & { mode?; flag?; flush? }) | BufferEncoding | null`. Two things are missing, not one: the intersection needs a flattened payload struct, and the sibling `BufferEncoding` is a node GLOBAL alias this package does not resolve ("Unresolved type reference BufferEncoding" in the same file), so it lowers to an opaque type. Discriminating string-vs-object is only sound once we know `BufferEncoding` is a string union, and even a successful lowering would hand the user a case payload they cannot construct. The existing fallback already emits `write_file_options_from_buffer_encoding` and `write_file_options_null`; the options-object constructor is what is genuinely absent.
+
+BufferEncodingOption | object-payload | `"buffer" | { encoding: "buffer" }`. The object member is semantically redundant with the string member: Node accepts either and `buffer_encoding_option_from_string` already constructs the useful one. So this occurrence costs a spelling nobody needs, which is why it does not justify the object-payload feature on its own.

--- a/scripts/verify_bridge_runtime.mjs
+++ b/scripts/verify_bridge_runtime.mjs
@@ -14,9 +14,13 @@
 // Two checks, because neither alone is complete:
 //
 //   static  — every `instanceof X` in a generated `bridge.js` must have `X`
-//             either a JS global or bound in that module. This is the
-//             COMPLETE check: it sees a site whichever arm of the converter
-//             the probe value happens to reach.
+//             either a JS global or bound in that module, and every
+//             `instanceof X` in an inline `extern "js" fn` body — where the
+//             accessor paths put their own copy of the conversion, a lambda
+//             having no module scope to import into — must have `X` a JS
+//             global, full stop. This is the COMPLETE check: it sees a site
+//             whichever arm of the converter the probe value happens to
+//             reach.
 //   runtime — import each `bridge.js` and call every exported
 //             `__ts_mbt_tagged_union_*_from_js` over a value battery. A
 //             `ReferenceError` is a failure; the converter's own
@@ -138,8 +142,7 @@ function boundNames(src) {
   return bound;
 }
 
-function staticCheck(file, src) {
-  const bound = boundNames(src);
+function staticCheck(file, src, bound) {
   const unbound = new Map();
   for (const m of src.matchAll(/instanceof\s+([A-Za-z_$][\w$.]*)/g)) {
     const name = m[1];
@@ -149,6 +152,51 @@ function staticCheck(file, src) {
     unbound.set(name, (unbound.get(name) ?? 0) + 1);
   }
   return { file, unbound: [...unbound.entries()].map(([n, c]) => ({ name: n, count: c })) };
+}
+
+// `bridge.js` is not the only place a generated `instanceof` lands. An
+// `extern "js" fn` whose body is an inline lambda carries its own copy of the
+// conversion, because MoonBit's JS backend will not import a named helper into
+// one — so the class-accessor paths inline `tagged_union_from_js_expression`
+// directly.
+//
+// Those bodies get the STRICTER test: an inline lambda has no module scope of
+// its own, so a JS global is the only thing that can resolve there. Nothing
+// this side can be rescued by a `bridge.js` import.
+//
+// Scoped to the directories that hold a generated `bridge.js`, not to `_build`
+// at large. Walking every `.mbt` under `_build` reaches MoonBit's own build
+// output — including `moon fmt`'s copy of the checker's whitebox tests, whose
+// `#|` lines are TypeScript SOURCE for a test case and reported three
+// `instanceof` targets that are not generated code at all. Widening the input
+// set is not the same as widening the question.
+async function findInlineExternSources(bridgeFiles) {
+  const out = [];
+  for (const bridge of bridgeFiles) {
+    const dir = dirname(bridge);
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      if (e.isFile() && e.name.endsWith(".mbt")) out.push(join(dir, e.name));
+    }
+  }
+  out.sort();
+  return out;
+}
+
+// Only the inline `#|` continuation lines, so a MoonBit comment mentioning
+// `instanceof` is not read as generated JS.
+function inlineExternJs(src) {
+  const lines = [];
+  for (const line of src.split("\n")) {
+    const m = line.match(/^\s*#\|(.*)$/);
+    if (m) lines.push(m[1]);
+  }
+  return lines.join("\n");
 }
 
 // Which exports are safe to call with an arbitrary probe value.
@@ -243,8 +291,16 @@ async function main() {
   const runtimeResults = [];
   for (const file of files) {
     const src = readFileSync(file, "utf8");
-    staticResults.push(staticCheck(file, src));
+    staticResults.push(staticCheck(file, src, boundNames(src)));
     runtimeResults.push(await runtimeCheck(file, opts));
+  }
+
+  let inlineExternFiles = 0;
+  for (const file of await findInlineExternSources(files)) {
+    const js = inlineExternJs(readFileSync(file, "utf8"));
+    if (!js.includes("instanceof")) continue;
+    inlineExternFiles += 1;
+    staticResults.push(staticCheck(file, js, new Set()));
   }
 
   const unboundSites = staticResults.reduce(
@@ -261,6 +317,7 @@ async function main() {
 
   const fns = runtimeResults.reduce((n, r) => n + r.fns, 0);
   console.log(`bridge modules found:            ${files.length}`);
+  console.log(`inline-extern sources scanned:   ${inlineExternFiles}`);
   console.log(`bridge modules imported:         ${loaded}`);
   console.log(`converters called:               ${fns}`);
   console.log(`converter calls exercised:       ${calls}`);

--- a/scripts/verify_bridge_runtime.mjs
+++ b/scripts/verify_bridge_runtime.mjs
@@ -151,8 +151,47 @@ function staticCheck(file, src) {
   return { file, unbound: [...unbound.entries()].map(([n, c]) => ({ name: n, count: c })) };
 }
 
+// Which exports are safe to call with an arbitrary probe value.
+//
+// Every `_to_js` / `_from_js` export is a pure data transform between the
+// MoonBit and JS shapes of one type: it reads its argument and builds a
+// value. Everything else — `__ts_mbt_write_file_sync`, `new_hono`,
+// `get_runtime_version`, `promise_then` — is a wrapper around the vendored
+// package's real behaviour, so calling it would run the library (and, in
+// node:fs's case, touch the filesystem). Those are excluded, which is why
+// the static half of this harness matters: it covers them.
+function isPureConverterExport(name) {
+  return /_(?:to|from)_js(?:_optional)?$/.test(name);
+}
+
+// A failure is a reference to something the module does not have. The
+// converters legitimately throw on a value they were not given
+// (`unexpected <Alias> value`, a missing field, a bad shape), and since the
+// probe battery is deliberately ill-typed most calls SHOULD throw — so
+// asking "did it throw" would be useless, while asking "did it name
+// something undefined" is exactly the emitted-code bug this harness exists
+// to find, and needs no well-formed input at all. That asymmetry is what
+// lets the harness call all 536 converters rather than only the 33 whose
+// input shape it could construct.
+function referenceFailure(e) {
+  if (e instanceof ReferenceError) {
+    return `ReferenceError: ${e.message}`;
+  }
+  // `const X = mod.X` for an export the runtime does not have leaves `X`
+  // undefined rather than unbound, so the call site fails as a TypeError.
+  if (
+    e instanceof TypeError &&
+    /is not a function|is not a constructor|of undefined|of null|undefined is not/.test(
+      e.message ?? "",
+    )
+  ) {
+    return `TypeError: ${e.message}`;
+  }
+  return null;
+}
+
 async function runtimeCheck(file, opts) {
-  const result = { file, loaded: false, loadError: null, calls: 0, failures: [] };
+  const result = { file, loaded: false, loadError: null, calls: 0, fns: 0, failures: [] };
   let mod;
   try {
     mod = await import(pathToFileURL(file).href);
@@ -163,23 +202,22 @@ async function runtimeCheck(file, opts) {
   result.loaded = true;
   for (const [name, fn] of Object.entries(mod)) {
     if (typeof fn !== "function") continue;
-    if (!/^__ts_mbt_tagged_union_.*_from_js$/.test(name)) continue;
+    if (!isPureConverterExport(name)) continue;
+    result.fns += 1;
     for (const [label, value] of probeValues()) {
       result.calls += 1;
       try {
         fn(value);
       } catch (e) {
-        // The converter's own "no case matched" throw is correct behaviour.
-        if (e instanceof ReferenceError) {
-          result.failures.push({ fn: name, probe: label, error: `ReferenceError: ${e.message}` });
-        } else if (!/^unexpected /.test(e.message ?? "")) {
-          result.failures.push({ fn: name, probe: label, error: `${e.constructor?.name ?? "Error"}: ${e.message}` });
+        const failure = referenceFailure(e);
+        if (failure !== null) {
+          result.failures.push({ fn: name, probe: label, error: failure });
         }
       }
     }
   }
-  if (opts.verbose && result.calls === 0) {
-    console.log(`  (no tagged-union converters) ${file}`);
+  if (opts.verbose && result.fns === 0) {
+    console.log(`  (no converter exports) ${file}`);
   }
   return result;
 }
@@ -221,8 +259,10 @@ async function main() {
     r.failures.map((f) => ({ file: r.file, ...f })),
   );
 
+  const fns = runtimeResults.reduce((n, r) => n + r.fns, 0);
   console.log(`bridge modules found:            ${files.length}`);
   console.log(`bridge modules imported:         ${loaded}`);
+  console.log(`converters called:               ${fns}`);
   console.log(`converter calls exercised:       ${calls}`);
   console.log(`unbound \`instanceof\` sites:      ${unboundSites} (${unboundNames.size} distinct names)`);
   console.log(`converter runtime failures:      ${failures.length}`);

--- a/scripts/verify_bridge_runtime.mjs
+++ b/scripts/verify_bridge_runtime.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+// Run the generated `bridge.js` converters under Node.
+//
+// Every other bridge harness in this repo asks whether the generated
+// package COMPILES (`verify-scaffolds`, `verify-generated-fixtures`,
+// `verify-examples`) or whether a REJECTED export is budgeted
+// (`bridge_quality_report.sh`). Nothing asked whether the code we emit for
+// an ACCEPTED export runs, and the answer was no: a tagged-union case whose
+// payload is `Named(N)` is discriminated with `N instanceof`, and `N` is a
+// TypeScript type as often as it is a runtime class. An interface, a type
+// alias, an enum and a type parameter are all erased, so the emitted
+// predicate is a `ReferenceError` on its first call.
+//
+// Two checks, because neither alone is complete:
+//
+//   static  — every `instanceof X` in a generated `bridge.js` must have `X`
+//             either a JS global or bound in that module. This is the
+//             COMPLETE check: it sees a site whichever arm of the converter
+//             the probe value happens to reach.
+//   runtime — import each `bridge.js` and call every exported
+//             `__ts_mbt_tagged_union_*_from_js` over a value battery. A
+//             `ReferenceError` is a failure; the converter's own
+//             `unexpected <Alias> value` throw is the designed no-match
+//             path and passes. This is what proves the static list is real
+//             rather than a grep artifact.
+//
+// Usage: node scripts/verify_bridge_runtime.mjs [--json <path>] [--verbose]
+//
+// Exits non-zero when a generated module references an unbound
+// `instanceof` target, or when a converter throws a ReferenceError.
+
+import { readFileSync, existsSync, statSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+// Names a generated `bridge.js` may use without binding them: JS globals
+// plus the Node globals available in an ESM module. `instanceof` against
+// any of these is sound wherever the bridge runs.
+const JS_GLOBALS = new Set([
+  "Array", "Object", "Function", "String", "Number", "Boolean", "Symbol",
+  "BigInt", "Date", "RegExp", "Error", "TypeError", "RangeError",
+  "SyntaxError", "ReferenceError", "EvalError", "URIError", "AggregateError",
+  "Map", "Set", "WeakMap", "WeakSet", "WeakRef", "Promise", "Proxy",
+  "ArrayBuffer", "SharedArrayBuffer", "DataView", "Int8Array", "Uint8Array",
+  "Uint8ClampedArray", "Int16Array", "Uint16Array", "Int32Array",
+  "Uint32Array", "Float32Array", "Float64Array", "BigInt64Array",
+  "BigUint64Array", "URL", "URLSearchParams", "Buffer", "AbortController",
+  "AbortSignal", "TextEncoder", "TextDecoder", "Blob", "File", "FormData",
+  "Headers", "Request", "Response", "ReadableStream", "WritableStream",
+  "TransformStream", "MessageChannel", "MessagePort", "Event", "EventTarget",
+  "BroadcastChannel", "CompressionStream", "DecompressionStream",
+  "CustomEvent", "Worker", "Performance", "Crypto", "CryptoKey", "SubtleCrypto",
+]);
+
+// The probe battery. One value per JS runtime type the discriminators can
+// test, so a converter that reaches its `instanceof` arm at all reaches it
+// for at least one of these.
+function probeValues() {
+  return [
+    ["string", "some/path.txt"],
+    ["number", 7],
+    ["boolean", true],
+    ["bigint", 10n],
+    ["null", null],
+    ["undefined", undefined],
+    ["array", [1, 2]],
+    ["object", { encoding: "buffer" }],
+    ["function", () => 1],
+    ["date", new Date(0)],
+    ["regexp", /x/],
+  ];
+}
+
+function parseArgs(argv) {
+  const opts = { json: null, verbose: false };
+  for (let i = 2; i < argv.length; i += 1) {
+    if (argv[i] === "--json") {
+      opts.json = argv[i + 1];
+      i += 1;
+    } else if (argv[i] === "--verbose") {
+      opts.verbose = true;
+    } else {
+      throw new Error(`unknown flag: ${argv[i]}`);
+    }
+  }
+  return opts;
+}
+
+async function findBridgeModules(root) {
+  const out = [];
+  async function walk(dir) {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) {
+        // `_build` inside a generated package is MoonBit's own output.
+        if (e.name === "node_modules" || e.name === ".git") continue;
+        await walk(p);
+      } else if (e.isFile() && e.name === "bridge.js") {
+        out.push(p);
+      }
+    }
+  }
+  await walk(root);
+  out.sort();
+  return out;
+}
+
+// Names the module binds itself, in any of the spellings the emitters use.
+function boundNames(src) {
+  const bound = new Set();
+  const patterns = [
+    /^\s*(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=/gm,
+    /^\s*(?:export\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(/gm,
+    /^\s*(?:export\s+)?class\s+([A-Za-z_$][\w$]*)\b/gm,
+    /^\s*import\s+(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s+from/gm,
+  ];
+  for (const re of patterns) {
+    for (const m of src.matchAll(re)) bound.add(m[1]);
+  }
+  // `import { a as b, c } from "m"` — collect the local names.
+  for (const m of src.matchAll(/^\s*import\s*\{([^}]*)\}\s*from/gm)) {
+    for (const part of m[1].split(",")) {
+      const t = part.trim();
+      if (!t) continue;
+      const as = t.split(/\s+as\s+/);
+      bound.add((as.length > 1 ? as[1] : as[0]).trim());
+    }
+  }
+  return bound;
+}
+
+function staticCheck(file, src) {
+  const bound = boundNames(src);
+  const unbound = new Map();
+  for (const m of src.matchAll(/instanceof\s+([A-Za-z_$][\w$.]*)/g)) {
+    const name = m[1];
+    // A qualified target (`ns.Cls`) is bound iff its head is.
+    const head = name.split(".")[0];
+    if (JS_GLOBALS.has(head) || bound.has(head)) continue;
+    unbound.set(name, (unbound.get(name) ?? 0) + 1);
+  }
+  return { file, unbound: [...unbound.entries()].map(([n, c]) => ({ name: n, count: c })) };
+}
+
+async function runtimeCheck(file, opts) {
+  const result = { file, loaded: false, loadError: null, calls: 0, failures: [] };
+  let mod;
+  try {
+    mod = await import(pathToFileURL(file).href);
+  } catch (e) {
+    result.loadError = `${e.constructor?.name ?? "Error"}: ${e.message}`;
+    return result;
+  }
+  result.loaded = true;
+  for (const [name, fn] of Object.entries(mod)) {
+    if (typeof fn !== "function") continue;
+    if (!/^__ts_mbt_tagged_union_.*_from_js$/.test(name)) continue;
+    for (const [label, value] of probeValues()) {
+      result.calls += 1;
+      try {
+        fn(value);
+      } catch (e) {
+        // The converter's own "no case matched" throw is correct behaviour.
+        if (e instanceof ReferenceError) {
+          result.failures.push({ fn: name, probe: label, error: `ReferenceError: ${e.message}` });
+        } else if (!/^unexpected /.test(e.message ?? "")) {
+          result.failures.push({ fn: name, probe: label, error: `${e.constructor?.name ?? "Error"}: ${e.message}` });
+        }
+      }
+    }
+  }
+  if (opts.verbose && result.calls === 0) {
+    console.log(`  (no tagged-union converters) ${file}`);
+  }
+  return result;
+}
+
+async function main() {
+  const opts = parseArgs(process.argv);
+  const buildRoot = join(repoRoot, "_build");
+  if (!existsSync(buildRoot) || !statSync(buildRoot).isDirectory()) {
+    console.error(
+      "no _build directory: run `just verify-scaffolds`, " +
+        "`just verify-generated-fixtures` and `just verify-examples` first",
+    );
+    process.exit(2);
+  }
+
+  const files = await findBridgeModules(buildRoot);
+  if (files.length === 0) {
+    console.error("no generated bridge.js found under _build");
+    process.exit(2);
+  }
+
+  const staticResults = [];
+  const runtimeResults = [];
+  for (const file of files) {
+    const src = readFileSync(file, "utf8");
+    staticResults.push(staticCheck(file, src));
+    runtimeResults.push(await runtimeCheck(file, opts));
+  }
+
+  const unboundSites = staticResults.reduce(
+    (n, r) => n + r.unbound.reduce((m, u) => m + u.count, 0),
+    0,
+  );
+  const unboundNames = new Set();
+  for (const r of staticResults) for (const u of r.unbound) unboundNames.add(u.name);
+  const loaded = runtimeResults.filter((r) => r.loaded).length;
+  const calls = runtimeResults.reduce((n, r) => n + r.calls, 0);
+  const failures = runtimeResults.flatMap((r) =>
+    r.failures.map((f) => ({ file: r.file, ...f })),
+  );
+
+  console.log(`bridge modules found:            ${files.length}`);
+  console.log(`bridge modules imported:         ${loaded}`);
+  console.log(`converter calls exercised:       ${calls}`);
+  console.log(`unbound \`instanceof\` sites:      ${unboundSites} (${unboundNames.size} distinct names)`);
+  console.log(`converter runtime failures:      ${failures.length}`);
+
+  if (unboundSites > 0) {
+    console.log("\nunbound `instanceof` targets (a ReferenceError if reached):");
+    for (const r of staticResults) {
+      if (r.unbound.length === 0) continue;
+      const rel = r.file.slice(repoRoot.length + 1);
+      const names = r.unbound
+        .sort((a, b) => b.count - a.count)
+        .slice(0, 12)
+        .map((u) => (u.count > 1 ? `${u.name} x${u.count}` : u.name));
+      const more = r.unbound.length > 12 ? `, +${r.unbound.length - 12} more` : "";
+      console.log(`  ${rel}\n    ${names.join(", ")}${more}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.log("\nconverter runtime failures:");
+    for (const f of failures.slice(0, 40)) {
+      console.log(`  ${f.file.slice(repoRoot.length + 1)}\n    ${f.fn}(${f.probe}) -> ${f.error}`);
+    }
+    if (failures.length > 40) console.log(`  ... +${failures.length - 40} more`);
+  }
+
+  const loadErrors = runtimeResults.filter((r) => !r.loaded);
+  if (loadErrors.length > 0 && opts.verbose) {
+    console.log("\nmodules that could not be imported (not a failure — the");
+    console.log("generated package may need a runtime dependency that is not");
+    console.log("installed; the static check still covers them):");
+    for (const r of loadErrors) {
+      console.log(`  ${r.file.slice(repoRoot.length + 1)}\n    ${r.loadError}`);
+    }
+  } else if (loadErrors.length > 0) {
+    console.log(
+      `\n${loadErrors.length} module(s) could not be imported (static check ` +
+        "still applies; re-run with --verbose for the reasons)",
+    );
+  }
+
+  if (opts.json) {
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(
+      opts.json,
+      JSON.stringify(
+        {
+          modules: files.length,
+          imported: loaded,
+          calls,
+          unboundSites,
+          unboundNames: [...unboundNames].sort(),
+          failures,
+          static: staticResults.filter((r) => r.unbound.length > 0),
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  if (unboundSites > 0 || failures.length > 0) {
+    console.log("\nFAIL");
+    process.exit(1);
+  }
+  console.log("\nOK");
+}
+
+await main();

--- a/src/bridge/moonbit_bridge.mbt
+++ b/src/bridge/moonbit_bridge.mbt
@@ -1130,6 +1130,213 @@ fn bridge_mbti_declared_fn_name(line : String) -> String? {
 }
 
 ///|
+/// Names of the PAYLOAD-bearing `pub(all) enum`s this package declares.
+///
+/// A payload-free enum -- what a TypeScript numeric or string-literal union
+/// lowers to -- is an integer or string tag at the JS boundary, and that is
+/// the family `collect_bridge_enum_converters` handles. Only a
+/// payload-bearing one is a tagged union, whose JS representation is
+/// `{ "$tag": i, "_0": v }`.
+fn collect_bridge_payload_enum_names(bridge_mbt : String) -> Array[String] {
+  let names : Array[String] = []
+  let prefix = "pub(all) enum "
+  let mut current = ""
+  for line_view in bridge_mbt.split("\n") {
+    let trimmed = line_view.to_owned().trim().to_owned()
+    if trimmed.has_prefix(prefix) && trimmed.has_suffix("{") {
+      let rest = trimmed[prefix.length():trimmed.length() - 1]
+        .to_owned()
+        .trim()
+        .to_owned()
+      current = if rest.contains("[") { "" } else { rest }
+      continue
+    }
+    if current == "" {
+      continue
+    }
+    if trimmed == "}" {
+      current = ""
+      continue
+    }
+    // `Case(Payload)` is a payload-bearing constructor; a bare `Case` is not.
+    if trimmed.contains("(") && !names.contains(current) {
+      names.push(current)
+    }
+  }
+  names
+}
+
+///|
+/// `(name, params_src, return_type)` for a `<prefix>NAME(params) -> RET` line,
+/// accepting a `Type::method` name where
+/// `parse_bridge_top_level_fn_decl_line` and
+/// `parse_bridge_pub_extern_fn_decl_line` both reject one -- they feed the
+/// public-wrapper machinery, which is about top-level names only. The trailing
+/// ` = "..."` / ` =` of an extern is cut, so one parse serves both surfaces.
+fn bridge_split_fn_decl_line(
+  line : String,
+  prefix : String,
+) -> (String, String, String)? {
+  if !line.has_prefix(prefix) {
+    return None
+  }
+  let rest = line[prefix.length():].to_owned()
+  let open = match rest.find("(") {
+    Some(i) => i
+    None => return None
+  }
+  let close = match bridge_find_matching_paren(rest, open) {
+    Some(i) => i
+    None => return None
+  }
+  let name = rest[:open].to_owned().trim().to_owned()
+  if name == "" {
+    return None
+  }
+  let params_src = rest[open + 1:close].to_owned()
+  let after = rest[close + 1:].to_owned().trim().to_owned()
+  if !after.has_prefix("->") {
+    return None
+  }
+  let return_src = after[2:].to_owned().trim().to_owned()
+  let return_type = match return_src.find("=") {
+    Some(i) => return_src[:i].to_owned().trim().to_owned()
+    None => return_src
+  }
+  if return_type == "" {
+    return None
+  }
+  Some((name, params_src, return_type))
+}
+
+///|
+/// Split a declared type into `(base, is_optional)`.
+fn bridge_split_optional_type(type_src : String) -> (String, Bool) {
+  let trimmed = type_src.trim().to_owned()
+  if trimmed.has_suffix("?") {
+    (trimmed[:trimmed.length() - 1].to_owned().trim().to_owned(), true)
+  } else {
+    (trimmed, false)
+  }
+}
+
+///|
+/// Make a `declare pub fn` line's RETURN type agree with the extern that
+/// implements it, for the one decision the two layers make separately and can
+/// therefore disagree about: a tagged-union return the bridge cannot BUILD at
+/// runtime.
+///
+/// `ffi_widen_unbuildable_union_outputs` widens such a return to `JSValue`,
+/// because no `_from_js` exists for it and the extern binds straight to the
+/// raw JS function. That decision needs `MoonBitJsFfiState`. The `.mbti` line
+/// comes from the DECL layer (`func_decl_to_moonbit` -> `moonbit_type_name`),
+/// which holds no such state, and `add_bridge_public_wrappers` renders the
+/// public wrapper FROM that line -- so one export has THREE renderings and
+/// only the ffi one moved. `[4014] Expr Type Mismatch: has type JSValue?,
+/// wanted Auto_...?` is what came out, and reverting the widening twice on
+/// that message is what kept the erased-payload backlog open.
+///
+/// Located by instrumenting rather than reading: markers in the three
+/// `declare pub fn` renderers of `parser_moonbit.mbt` attributed 0 of 11
+/// lines, and the reason was the FIXTURE -- a class-only `.d.ts` declares no
+/// top-level function, so `func_decl_to_moonbit` was never called. A zero
+/// from a probe whose shape is absent is not an answer.
+///
+/// Scoped rather than blanket, and that is the whole difficulty: a `.mbti`
+/// return type differing from its extern's is the NORMAL case. A literal-union
+/// enum crosses as an `Int` and the wrapper converts it; an opaque type
+/// arrives as `JSValue` and the wrapper wraps it in an option. Rewriting on
+/// "they differ" would delete both families of wrapper. The extern handing
+/// back `JSValue` at the SAME optionality as the declaration already excludes
+/// both of those -- a literal enum crosses as `Int` or `String`, and the
+/// option wrap turns a non-optional `JSValue` into a `T?`.
+///
+/// On top of that, the declared type has to be one of the two things the
+/// widening can leave behind, and it takes both because they are the same
+/// event seen from either side. When the union is mentioned somewhere else in
+/// the package -- `Auto_IdentifierValue_or_PrivateIdentifierValue` is also a
+/// PARAMETER of `idText` -- the enum stays declared and the stale declaration
+/// is `[4014] has type JSValue?, wanted Auto_...?`. When the widened return
+/// was the union's only mention, nothing synthesizes the enum any more and
+/// the same stale declaration is `[4032] the type Auto_... is undefined`.
+/// Writing only the first half is what made `walkUpBindingElementsAndPatterns`
+/// fail to compile while `getNameOfJSDocTypedef` came out right.
+fn reconcile_bridge_widened_union_returns(
+  bridge_mbti : String,
+  bridge_mbt : String,
+) -> String {
+  let payload_enums = collect_bridge_payload_enum_names(bridge_mbt)
+  let implemented = collect_bridge_implemented_type_names(bridge_mbt)
+  // A top-level extern is named for its snake_case binding
+  // (`get_name_of_jsdoc_typedef`); a member extern keeps the `Type::method`
+  // spelling the declaration uses. Both are keyed here under the name the
+  // `.mbti` side will look up.
+  let extern_returns : Map[String, String] = {}
+  for line_view in bridge_mbt.split("\n") {
+    let line = line_view.to_owned().trim().to_owned()
+    match bridge_split_fn_decl_line(line, "pub extern \"js\" fn ") {
+      Some((name, _, return_type)) =>
+        if !extern_returns.contains(name) {
+          extern_returns[name] = return_type
+        }
+      None => ()
+    }
+  }
+  let kept : Array[String] = []
+  for line_view in bridge_mbti.split("\n") {
+    let line = line_view.to_owned()
+    let mut rewritten : String? = None
+    // Only an unindented line, so a nested declaration is left verbatim
+    // rather than reconstructed without its indentation.
+    if line == line.trim().to_owned() {
+      match bridge_split_fn_decl_line(line, "declare pub fn ") {
+        Some((name, params_src, declared_ret)) => {
+          let (declared, declared_opt) = bridge_split_optional_type(
+            declared_ret,
+          )
+          // A bare identifier only: a generic instantiation (`Token[JSValue]`)
+          // is not a name either list can be consulted about, and reading one
+          // as absent would rewrite a return the widening never touched.
+          let is_plain_name = declared != "" &&
+            declared != "JSValue" &&
+            !declared.contains("[") &&
+            !declared.contains("(") &&
+            !declared.contains(" ")
+          let extern_key = if name.contains("::") {
+            name
+          } else {
+            bridge_value_fn_name(name)
+          }
+          if is_plain_name &&
+            (
+              payload_enums.contains(declared) ||
+              !implemented.contains(declared)
+            ) {
+            match extern_returns.get(extern_key) {
+              Some(extern_ret) => {
+                let (ext_base, ext_opt) = bridge_split_optional_type(extern_ret)
+                if ext_base == "JSValue" && ext_opt == declared_opt {
+                  rewritten = Some(
+                    "declare pub fn \{name}(\{params_src}) -> \{extern_ret}",
+                  )
+                }
+              }
+              None => ()
+            }
+          }
+        }
+        None => ()
+      }
+    }
+    match rewritten {
+      Some(next) => kept.push(next)
+      None => kept.push(line)
+    }
+  }
+  kept.join("\n")
+}
+
+///|
 /// Derive a `declare pub fn` for every emitted extern, and make the `.mbti`
 /// AGREE with the `.mbt` rather than merely accumulate beside it.
 ///
@@ -1804,9 +2011,9 @@ pub async fn emit_moonbit_ts_bridge_package_bundle_from_entry_path(
   )
   let graph = load_type_module_graph(entry_path)
   let export_surface = resolve_export_surface(graph)
-  let base_bridge_mbti = add_bridge_namespace_public_decls(
-    bundle.decl_mbt,
-    export_surface,
+  let base_bridge_mbti = reconcile_bridge_widened_union_returns(
+    add_bridge_namespace_public_decls(bundle.decl_mbt, export_surface),
+    bundle.ffi_mbt,
   )
   let (bridge_mbt, wrapped_bridge_mbti) = add_bridge_public_wrappers(
     base_bridge_mbti,

--- a/src/bridge/moonbit_bridge.mbt
+++ b/src/bridge/moonbit_bridge.mbt
@@ -1106,21 +1106,105 @@ fn prune_mismatched_upcast_helpers(
 }
 
 ///|
+/// The top-level function name a `declare pub fn NAME(...)` line declares.
+/// `None` for any other line, and for a `Type::method` form — those are not
+/// what `parse_bridge_pub_extern_fn_decl_line` produces, so they can never
+/// collide with a derived declaration.
+fn bridge_mbti_declared_fn_name(line : String) -> String? {
+  let prefix = "declare pub fn "
+  if !line.has_prefix(prefix) {
+    return None
+  }
+  let rest = line[prefix.length():].to_owned()
+  match rest.find("(") {
+    Some(open) => {
+      let name = rest[:open].to_owned()
+      if name == "" || name.contains("::") {
+        None
+      } else {
+        Some(name)
+      }
+    }
+    None => None
+  }
+}
+
+///|
+/// Derive a `declare pub fn` for every emitted extern, and make the `.mbti`
+/// AGREE with the `.mbt` rather than merely accumulate beside it.
+///
+/// The guard here used to be `if !next_bridge_mbti.contains(helper_decl)` — a
+/// substring test on the whole file using the full SIGNATURE, which asks "is
+/// this exact line already present" where the question is "is this FUNCTION
+/// already declared". MoonBit has no overloading, so two `pub fn` of one name
+/// cannot both exist in a package; a second `declare pub fn` of that name is
+/// therefore always wrong, and the `.mbt` is the one that says what the
+/// package really is.
+///
+/// While the two layers happened to render the same text the duplication was
+/// invisible, which is why it survived: the decl layer describes an exported
+/// value independently of the ffi layer, and widening a tagged-union RETURN
+/// made two renderings of `get_create_adaptor_server` differ for the first
+/// time. Four cases in the corpus, all the same shape — the stale line is the
+/// less precise one (`get_serve() -> JSValue` against the impl's
+/// `() -> (Options, cb?) -> JSValue`, `mkdir`'s `callback : JSValue` against
+/// its real callback type), except `get_create_adaptor_server`, whose stale
+/// line was MORE precise and simply untrue.
+///
+/// Replacing in place rather than appending is what makes the agreement hold
+/// by construction, so the next disagreement cannot hide the same way. Keyed
+/// on the name via one map lookup per line, not a scan per name: the
+/// `typescript` package has 2,161 of these, and a nested scan there is the
+/// quadratic this repo keeps paying for.
 fn add_bridge_ergonomic_helper_decls(
   bridge_mbti : String,
   bridge_mbt : String,
 ) -> String {
-  let mut next_bridge_mbti = bridge_mbti
+  let derived_names : Array[String] = []
+  let derived_decl : Map[String, String] = {}
   for line_view in bridge_mbt.split("\n") {
     let line = line_view.to_owned().trim().to_owned()
     match parse_bridge_pub_extern_fn_decl_line(line) {
       Some(fn_decl) => {
         let helper_decl = "declare pub fn \{fn_decl.public_name}(\{fn_decl.params_src}) -> \{fn_decl.return_type}"
-        if !next_bridge_mbti.contains(helper_decl) {
-          next_bridge_mbti += "\n\n///|\n" + helper_decl
+        if !derived_decl.contains(fn_decl.public_name) {
+          derived_names.push(fn_decl.public_name)
+          derived_decl[fn_decl.public_name] = helper_decl
         }
       }
       None => ()
+    }
+  }
+  let consumed : Array[String] = []
+  let kept : Array[String] = []
+  for line_view in bridge_mbti.split("\n") {
+    let line = line_view.to_owned()
+    let mut rewritten = false
+    match bridge_mbti_declared_fn_name(line) {
+      Some(name) =>
+        match derived_decl.get(name) {
+          Some(decl) => {
+            // First occurrence becomes the impl's own signature; a further
+            // declaration of the same name is dropped, since only one can
+            // exist.
+            if !consumed.contains(name) {
+              consumed.push(name)
+              kept.push(decl)
+            }
+            rewritten = true
+          }
+          None => ()
+        }
+      None => ()
+    }
+    if !rewritten {
+      kept.push(line)
+    }
+  }
+  let mut next_bridge_mbti = kept.join("\n")
+  for name in derived_names {
+    if !consumed.contains(name) {
+      next_bridge_mbti += "\n\n///|\n" + derived_decl.get(name).unwrap()
     }
   }
   for helper in collect_bridge_type_guard_helpers(bridge_mbti, bridge_mbt) {

--- a/src/bridge/moonbit_bridge_wbtest.mbt
+++ b/src/bridge/moonbit_bridge_wbtest.mbt
@@ -1345,3 +1345,125 @@ test "bridge: prune upcast helpers whose base arity mismatches the emitted decl"
   assert_false(pruned_mbti.contains("Broken::asWidget"))
   assert_false(pruned_mbti.contains("Ghost::asMissing"))
 }
+
+///|
+/// An OUTPUT position typed as a tagged union the bridge cannot BUILD widens
+/// to `JSValue`, and all three renderings of the export agree about it.
+///
+/// The three are the point. The widening is decided in the ffi layer, the
+/// `.mbti` line is rendered by the DECL layer, and the public wrapper is
+/// rendered FROM that line -- so moving one gives
+/// `[4014] has type JSValue?, wanted Auto_...?`, and when the widened return
+/// was the union's LAST mention the enum stops being synthesized at all and
+/// the same stale line is `[4032] the type Auto_... is undefined`. Both
+/// aftermaths are covered here: `Alpha | Beta` is mentioned by `Bag`'s index
+/// setter, so its enum survives, while nothing else mentions it in the plain
+/// return's own right.
+///
+/// Every union in the fixture is mentioned once per position ON PURPOSE. The
+/// synthesized alias is registered as a side effect of rendering, so the first
+/// version of the widening -- which asked whether the alias was already
+/// registered -- fixed a declaration whose union happened to appear as a
+/// parameter above it and silently skipped its neighbour.
+async test "bridge: an unbuildable tagged-union output widens in all three renderings" {
+  let bundle = emit_moonbit_ts_bridge_package_bundle_from_entry_path(
+    "fixtures/resolver/project/types/widened-union-output-entry.d.ts", "./runtime/widened.js",
+  ) catch {
+    e => {
+      match e {
+        ReadError(msg) | ParseError(msg) | ResolveError(msg) =>
+          fail("Emit error: \{msg}")
+      }
+      return
+    }
+  }
+  // A plain return, and the optional form: extern, wrapper and declaration.
+  assert_true(
+    bundle.bridge_mbt.contains(
+      "extern \"js\" fn erased_return(x : Double) -> JSValue = \"__ts_mbt_erased_return\"",
+    ),
+  )
+  assert_true(
+    bundle.bridge_mbt.contains("pub fn erasedReturn(x : Double) -> JSValue {"),
+  )
+  assert_true(
+    bundle.bridge_mbti.contains(
+      "declare pub fn erasedReturn(x : Double) -> JSValue",
+    ),
+  )
+  assert_true(
+    bundle.bridge_mbt.contains(
+      "extern \"js\" fn erased_optional_return(x : Double) -> JSValue? = \"__ts_mbt_erased_optional_return\"",
+    ),
+  )
+  assert_true(
+    bundle.bridge_mbti.contains(
+      "declare pub fn erasedOptionalReturn(x : Double) -> JSValue?",
+    ),
+  )
+  // The NEGATIVE control, and it is what keeps this from being "switch the
+  // lowering off": `string` and `URL` discriminate at runtime, so that union
+  // keeps its enum in every rendering.
+  assert_true(
+    bundle.bridge_mbt.contains(
+      "extern \"js\" fn buildable_return(x : Double) -> Auto_URLValue_or_StringValue = \"__ts_mbt_buildable_return\"",
+    ),
+  )
+  assert_true(
+    bundle.bridge_mbti.contains(
+      "declare pub fn buildableReturn(x : Double) -> Auto_URLValue_or_StringValue",
+    ),
+  )
+  // An index signature's two directions are two questions. The read widens;
+  // the write keeps the enum and converts in the body, `_to_js` needing no
+  // runtime predicate.
+  assert_true(
+    bundle.bridge_mbt.contains(
+      "pub fn Bag::index_get(self : Bag, key : String) -> JSValue? {",
+    ),
+  )
+  assert_true(
+    bundle.bridge_mbt.contains(
+      "pub extern \"js\" fn Bag::index_set(self : Bag, key : String, value : Auto_BetaValue_or_AlphaValue) -> Unit =",
+    ),
+  )
+  assert_true(
+    bundle.bridge_mbt.contains(
+      "#| (self, key, value) => { self[key] = (() => { if (value === null || typeof value !== \"object\" || !(\"$tag\" in value)) return value; if (value.$tag === 0) return value._0; else if (value.$tag === 1) return value._0; throw new Error(\"unexpected Auto_BetaValue_or_AlphaValue tag: \" + value.$tag); })(); }",
+    ),
+  )
+  // A METHOD's return: the extern binds straight to a JS call, so the
+  // direction is known there and only there.
+  assert_true(
+    bundle.bridge_mbt.contains(
+      "pub extern \"js\" fn Service::erasedMethod(self : Service, arg0 : String) -> JSValue =",
+    ),
+  )
+  assert_true(
+    bundle.bridge_mbti.contains(
+      "declare pub fn Service::erasedMethod(self : Service, arg0 : String) -> JSValue",
+    ),
+  )
+  // The raw passthrough each of them used to emit: a declaration promising
+  // the enum over a JS value that has no `$tag`.
+  assert_false(
+    bundle.bridge_mbti.contains(
+      "declare pub fn erasedReturn(x : Double) -> Auto_",
+    ),
+  )
+  assert_false(
+    bundle.bridge_mbti.contains(
+      "declare pub fn erasedOptionalReturn(x : Double) -> Auto_",
+    ),
+  )
+  assert_false(
+    bundle.bridge_mbti.contains(
+      "declare pub fn Service::erasedMethod(self : Service, arg0 : String) -> Auto_",
+    ),
+  )
+  assert_false(
+    bundle.bridge_mbt.contains(
+      "#| (self, key, value) => { self[key] = value; }",
+    ),
+  )
+}

--- a/src/bridge/moonbit_js_ffi.mbt
+++ b/src/bridge/moonbit_js_ffi.mbt
@@ -4218,7 +4218,7 @@ fn ffi_import_decl_to_moonbit(
     let param_type = ffi_type_name(state, type_)
     params.push("\{param_name} : \{param_type}")
   }
-  let return_type = ffi_type_name(state, import_.return_type)
+  let return_type = ffi_output_type_name(state, import_.return_type)
   let fn_name = ffi_value_fn_name(import_.name)
   let params_str = params.join(", ")
   "pub extern \"js\" fn \{fn_name}(\{params_str}) -> \{return_type} = \"\{ffi_binding_name(import_.name)}\""
@@ -4238,7 +4238,7 @@ fn ffi_import_decl_to_moonbit_direct(
     let param_type = ffi_type_name(state, type_)
     params.push("\{param_name} : \{param_type}")
   }
-  let return_type = ffi_type_name(state, import_.return_type)
+  let return_type = ffi_output_type_name(state, import_.return_type)
   let fn_name = ffi_value_fn_name(import_.name)
   let params_str = params.join(", ")
   ffi_direct_module_decl(
@@ -4259,7 +4259,7 @@ fn ffi_import_string_subset_decl_to_moonbit(
     let param_type = ffi_func_string_subset_param_type_name(state, type_)
     params.push("\{param_name} : \{param_type}")
   }
-  let return_type = ffi_type_name(state, import_.return_type)
+  let return_type = ffi_output_type_name(state, import_.return_type)
   let fn_name = ffi_func_string_subset_name(import_.name)
   let params_str = params.join(", ")
   "pub extern \"js\" fn \{fn_name}(\{params_str}) -> \{return_type} = \"\{ffi_func_string_subset_binding_name(import_.name)}\""
@@ -4279,13 +4279,119 @@ fn ffi_import_string_subset_decl_to_moonbit_direct(
     let param_type = ffi_func_string_subset_param_type_name(state, type_)
     params.push("\{param_name} : \{param_type}")
   }
-  let return_type = ffi_type_name(state, import_.return_type)
+  let return_type = ffi_output_type_name(state, import_.return_type)
   let fn_name = ffi_func_string_subset_name(import_.name)
   let params_str = params.join(", ")
   ffi_direct_module_decl(
     module_spec,
     "pub extern \"js\" fn \{fn_name}(\{params_str}) -> \{return_type} = \"\{runtime_export_name}\"",
   )
+}
+
+///|
+/// Widen an OUTPUT position whose type is a tagged-union alias the bridge
+/// cannot build at runtime.
+///
+/// The declared MoonBit type and the JS wrapper are decided in different
+/// places and were free to disagree. A payload-bearing `pub(all) enum` is
+/// represented as `{ "$tag": i, "_0": v }` — which is not a guess: the
+/// alias's own constructors emit exactly that
+/// (`__ts_mbt_server_type_from_server(value) { return { "$tag": 0, "_0":
+/// value }; }`). When `ffi_tagged_union_return_is_safe_to_wrap` says no, no
+/// `_from_js` exists and the extern binds straight to the raw JS function,
+/// so `@hono/node-server`'s `serve(...) -> ServerType` handed back a raw
+/// Node server object while promising the enum. A MoonBit `match` on that
+/// reads `$tag` off an object that has none.
+///
+/// Widening to `JSValue` is the honest answer: the caller has to cast, which
+/// is what it was already doing whether it knew or not. The one thing this
+/// must not touch is the alias's own CONSTRUCTORS
+/// (`server_type_from_server(value : Server) -> ServerType`), which DO build
+/// the representation — they come from `ffi_type_alias_constructors`, a
+/// different path, so restricting this to the imported-function / imported-
+/// value renderers is what keeps them working.
+///
+/// The `CallableMeta` arm is load-bearing and was missing in the first
+/// version, which is the fifth time in this repo a wrapper node's fail-open
+/// default arm has cost a bug. `CallableMeta` records source-level parameter
+/// optionality, so a value whose type has an OPTIONAL parameter arrives
+/// wrapped: `get_serve`'s `(Options, ((AddressInfo) -> Unit)?) -> ServerType`
+/// fell through the catch-all untouched while `get_create_adaptor_server`'s
+/// `(Options) -> ServerType` — no optional parameter, so no wrapper — widened
+/// correctly. `ffi_type_name` peels the same wrapper on its own first line;
+/// this walk has to peel every wrapper `ffi_type_name` does or it decides a
+/// different type from the one that gets rendered.
+///
+/// Recurses through a returned FUNCTION's own return type, since that value
+/// crosses the boundary in the same direction, and leaves its PARAMETERS
+/// alone — those go MoonBit -> JS, where `_to_js` needs no runtime predicate
+/// and the enum is real.
+fn ffi_widen_unbuildable_union_outputs(
+  state : MoonBitJsFfiState,
+  type_ : @ast.TsType,
+) -> @ast.TsType {
+  // `Named("any")` is what `ffi_type_name` renders as `JSValue` (and what
+  // sets `needs_js_any`), so producing it here needs no second spelling of
+  // the widening.
+  // The question is whether the enum representation can be BUILT from a raw
+  // JS value at all, which is exactly what withholds the `_from_js` half —
+  // so ask that function, not `ffi_tagged_union_return_is_safe_to_wrap`.
+  // The two are not the same: the wrap gate refuses ANY `InstanceOfNamed`,
+  // global constructors included, so `PathLike = string | Buffer | URL` is
+  // "unsafe to wrap" while its `_from_js` exists and works. Widening on the
+  // wrap gate would have widened those returns too.
+  fn unbuildable(name : String) -> Bool {
+    match state.tagged_union_decls_by_name.get(name) {
+      Some(decl) => tagged_union_from_js_expression(decl, "value") is None
+      None => false
+    }
+  }
+
+  match type_ {
+    CallableMeta(inner, meta) =>
+      CallableMeta(ffi_widen_unbuildable_union_outputs(state, inner), meta)
+    Named(name) => if unbuildable(name) { Named("any") } else { type_ }
+    Func(params, ret) =>
+      Func(params, ffi_widen_unbuildable_union_outputs(state, ret))
+    _ =>
+      match @checker.classify_optional_like_union(type_) {
+        Some((Named(name), true)) =>
+          if unbuildable(name) {
+            Union([Named("any"), Undefined])
+          } else {
+            type_
+          }
+        _ => type_
+      }
+  }
+}
+
+///|
+/// `ffi_type_name` for a value crossing JS -> MoonBit. Every RENDERER of an
+/// imported function's / value's return type goes through this.
+///
+/// Finding the sites by grepping the assignment `let return_type =
+/// ffi_type_name(state, …)` is how the first attempt missed one and measured
+/// as a no-op: `ffi_callable_value_decl_to_moonbit` — the renderer for the
+/// direct call form of a callable value, which is what emits `serve(...)` —
+/// spells its local `return_type_src`, so a textual substitution keyed on the
+/// variable NAME skipped it. Writing this helper to avoid the
+/// applied-in-some-places family and then applying it by variable name is
+/// that family, in the fix for it. The sites are enumerated by ARGUMENT
+/// (`func.return_type`, `import_.return_type`, `value.type_`, `return_type`),
+/// which is what the census should have keyed on.
+///
+/// The three `*_should_emit_wrapper` PREDICATES deliberately do NOT use this.
+/// They decide whether a typed wrapper is emitted at all, and they refuse one
+/// whose rendered type uses `JSValue` — so consulting the widening there would
+/// DELETE `serve(...)` from the surface instead of widening it, leaving only
+/// `get_serve()`. Their question is "would this wrapper carry any type
+/// information", and the answer stays yes because the PARAMETERS are typed.
+fn ffi_output_type_name(
+  state : MoonBitJsFfiState,
+  type_ : @ast.TsType,
+) -> String {
+  ffi_type_name(state, ffi_widen_unbuildable_union_outputs(state, type_))
 }
 
 ///|
@@ -4307,7 +4413,7 @@ fn ffi_func_decl_to_moonbit(
     let safe_type = ffi_type_name(state, param.type_)
     params.push("\{safe_name} : \{safe_type}")
   }
-  let return_type = ffi_type_name(state, func.return_type)
+  let return_type = ffi_output_type_name(state, func.return_type)
   let fn_name = ffi_value_fn_name(func.name)
   let params_str = params.join(", ")
   "pub extern \"js\" fn \{fn_name}(\{params_str}) -> \{return_type} = \"\{ffi_binding_name(func.name)}\""
@@ -4334,7 +4440,7 @@ fn ffi_func_decl_to_moonbit_direct(
     let safe_type = ffi_type_name(state, param.type_)
     params.push("\{safe_name} : \{safe_type}")
   }
-  let return_type = ffi_type_name(state, func.return_type)
+  let return_type = ffi_output_type_name(state, func.return_type)
   let fn_name = ffi_value_fn_name(func.name)
   let params_str = params.join(", ")
   ffi_direct_module_decl(
@@ -4485,7 +4591,7 @@ fn ffi_func_string_subset_decl_to_moonbit(
     let safe_type = ffi_func_string_subset_param_type_name(state, param.type_)
     params.push("\{safe_name} : \{safe_type}")
   }
-  let return_type = ffi_type_name(state, func.return_type)
+  let return_type = ffi_output_type_name(state, func.return_type)
   let fn_name = ffi_func_string_subset_name(func.name)
   let params_str = params.join(", ")
   "pub extern \"js\" fn \{fn_name}(\{params_str}) -> \{return_type} = \"\{ffi_func_string_subset_binding_name(func.name)}\""
@@ -4512,7 +4618,7 @@ fn ffi_func_string_subset_decl_to_moonbit_direct(
     let safe_type = ffi_func_string_subset_param_type_name(state, param.type_)
     params.push("\{safe_name} : \{safe_type}")
   }
-  let return_type = ffi_type_name(state, func.return_type)
+  let return_type = ffi_output_type_name(state, func.return_type)
   let fn_name = ffi_func_string_subset_name(func.name)
   let params_str = params.join(", ")
   ffi_direct_module_decl(
@@ -4526,7 +4632,7 @@ fn ffi_value_decl_to_moonbit(
   state : MoonBitJsFfiState,
   value : @ast.TsValueDecl,
 ) -> String {
-  let return_type = ffi_type_name(state, value.type_)
+  let return_type = ffi_output_type_name(state, value.type_)
   let fn_name = ffi_namespace_getter_name(value.name)
   "pub extern \"js\" fn \{fn_name}() -> \{return_type} = \"__ts_mbt_get_\{ffi_to_snake_case(value.name)}\""
 }
@@ -4544,7 +4650,7 @@ fn ffi_callable_value_decl_to_moonbit(
     let safe_type = ffi_callable_value_param_type_name(state, param)
     moonbit_params.push("\{param_name} : \{safe_type}")
   }
-  let return_type_src = ffi_type_name(state, return_type)
+  let return_type_src = ffi_output_type_name(state, return_type)
   let fn_name = ffi_value_fn_name(value.name)
   let params_str = moonbit_params.join(", ")
   "pub extern \"js\" fn \{fn_name}(\{params_str}) -> \{return_type_src} = \"\{ffi_binding_name(value.name)}\""

--- a/src/bridge/moonbit_js_ffi.mbt
+++ b/src/bridge/moonbit_js_ffi.mbt
@@ -1243,12 +1243,19 @@ fn ffi_synthesize_inline_union(
       }
     }
   }
-  // A function-armed union only synthesizes when every Named sibling
-  // is a well-known JS global whose `instanceof` discriminator works at
-  // runtime. A bare type parameter or interface member
-  // (`useState(initialState: S | (() => S))`) has no runtime binding —
-  // the from_js converter would test `value instanceof S` against a
-  // name that does not exist in the bridge module.
+  // A function-armed union only synthesizes when every Named sibling is a
+  // well-known JS global whose `instanceof` discriminator works at runtime.
+  //
+  // The soundness this used to carry now lives in
+  // `tagged_union_case_runtime_discriminator`, which withholds the
+  // `_from_js` half for an erased name whatever the union's shape — this
+  // check had been the rule's ONLY site, and `func_members > 0` is right
+  // for the collision test above it and unrelated to whether a sibling's
+  // `instanceof` resolves. What is left here is conservative rather than
+  // load-bearing: it declines to synthesize an enum whose `_from_js` would
+  // be withheld, where the same union without a function member is
+  // synthesized and keeps its `_to_js`. Dropping it would type more
+  // parameter positions; that is a separate, measurable change.
   if func_members > 0 {
     for part in parts {
       match part {
@@ -3689,13 +3696,22 @@ fn ffi_returned_func_needs_arg_wrap(
 
 ///|
 /// Decide whether the auto-emitted return-side `__ts_mbt_<alias>_from_js`
-/// wrapper would actually run cleanly in `bridge.js`. The discriminator
-/// `instanceof <Name>` requires the named JS class to be in scope; for
-/// alias surfaces synthesised from ambient `node:*` exports those classes
-/// are not reachable from the generated bridge module, so we skip the
-/// auto-wrap and let the raw JS value flow through unchanged. Tagged
-/// unions whose cases all use primitive `typeof` / `Array.isArray` /
-/// strict-equality predicates are always safe to wrap.
+/// wrapper exists and would run cleanly in `bridge.js`.
+///
+/// This must agree with `tagged_union_bridge_js_converter_decls_with_nested`,
+/// which is what decides whether the `_from_js` half is emitted at all: a
+/// case with no RUNTIME discriminator withholds it, so wrapping a return in
+/// a call to it would reference a function that is not there. Hence `None`
+/// from the runtime discriminator is unsafe — it used to fall through the
+/// catch-all arm and read as safe, which was only harmless because the
+/// `InstanceOfNamed` arm below caught the same cases by shape.
+///
+/// `instanceof <Name>` for a global constructor (`Buffer`, `URL`, `Date`)
+/// resolves and is kept; the old comment's "those classes are not reachable
+/// from the generated bridge module" was true of an erased TypeScript name
+/// and wrong about a global, which is why `PathLike = string | Buffer | URL`
+/// gets a working wrapper while `PathOrFileDescriptor = PathLike | number`
+/// does not.
 fn ffi_tagged_union_return_is_safe_to_wrap(
   state : MoonBitJsFfiState,
   name : String,
@@ -3704,12 +3720,14 @@ fn ffi_tagged_union_return_is_safe_to_wrap(
     Some(decl) => {
       for entry in decl.cases {
         let (_, inner) = entry
-        match tagged_union_case_discriminator(inner) {
+        match tagged_union_case_runtime_discriminator(inner) {
           Some(InstanceOfNamed(_)) => return false
           // Function payloads stay on the raw passthrough: the generic
           // wrapper would need closure conversion in both directions,
           // which the auto-wrap doesn't model.
           Some(TypeofFunction) => return false
+          // No executable predicate: the `_from_js` half was not emitted.
+          None => return false
           _ => ()
         }
       }

--- a/src/bridge/moonbit_js_ffi.mbt
+++ b/src/bridge/moonbit_js_ffi.mbt
@@ -1436,6 +1436,16 @@ fn ffi_function_type_parts(
       // Mirror of `ffi_func_type_name`: `T | Promise<T>` returns read as
       // `Promise[T]` so the method wrappers stay consistent with the
       // struct-field rendering of the same member.
+      //
+      // Deliberately NOT `ffi_output_type_name`: a function type has no
+      // direction of its own. The same rendering types a method's return
+      // (JS -> MoonBit, where an unbuildable tagged union must widen) and a
+      // CALLBACK parameter's return (MoonBit -> JS, where `_to_js` needs no
+      // predicate and widening would throw away a type that works). Widening
+      // here also broke `Matcher::_call_`, whose wrapper reads a struct FIELD
+      // rendered by `ffi_func_type_name`: `has type ExpectationResult, wanted
+      // JSValue`. The widening belongs where the direction is known -- the
+      // extern branch of `ffi_function_field_method_decl`.
       Some(
         (
           params,
@@ -1477,17 +1487,16 @@ fn ffi_inline_js_arg_expr_with_state(
       // `T` does not wrap with `{$tag, _0}`. Going through the generic
       // option unwrap would mis-read `value._0` (undefined for no-payload
       // cases like `Boundary`), so detect the tagged-union case first.
+      //
+      // BOTH spellings, for the reason `ffi_output_union_decl` records: an
+      // alias the module declared arrives as `Named`, while an inline `A | B`
+      // keeps its `Union(parts)` shape and only its RENDERED name is
+      // `Auto_X_or_Y`. Reading the `Named` spelling alone sent every
+      // synthesized union down the generic option unwrap, so
+      // `CompilerOptions::index_set(value : Auto_...?)` would have read
+      // `value._0` off a value MoonBit does not box.
       let tagged_named_name = match state {
-        Some(s) =>
-          match collapsed {
-            @ast.TsType::Named(name) =>
-              if s.tagged_union_decls_by_name.contains(name) {
-                Some(name)
-              } else {
-                None
-              }
-            _ => None
-          }
+        Some(s) => ffi_output_union_alias_name(s, collapsed)
         None => None
       }
       match tagged_named_name {
@@ -1607,6 +1616,48 @@ fn ffi_output_union_alias_name(
             Some(name)
           } else {
             None
+          }
+        }
+        None => None
+      }
+    _ => None
+  }
+}
+
+///|
+/// The tagged-union DECL a type will render against, for both spellings, and
+/// WITHOUT registering anything.
+///
+/// `ffi_output_union_alias_name` answers the same question by asking whether
+/// the name is already in `state.tagged_union_decls_by_name`, and for a
+/// SYNTHESIZED union that map is filled as a side effect of rendering
+/// (`ffi_synthesize_inline_union`). So the answer depends on whether some
+/// EARLIER declaration in the file happened to mention the same union — which
+/// is how the first version of the output widening fixed
+/// `getNameOfJSDocTypedef` and not `walkUpBindingElementsAndPatterns`: the
+/// first union is also a PARAMETER of `idText` nine lines above, so it was
+/// registered by the time the return was decided, and the second occurs
+/// exactly once. A rule whose answer depends on declaration order is the
+/// applied-in-some-places family with the sites chosen by the corpus.
+///
+/// A synthesized decl is just `{ name, cases }`, so it can be built on the
+/// spot; registration is the emission pass's business, not this decision's.
+/// Returning `None` when the union does not tag-lower at all costs nothing —
+/// such a type renders as `JSValue` through the existing `@js.Any` widening,
+/// which is the same answer this would have produced.
+fn ffi_output_union_decl(
+  state : MoonBitJsFfiState,
+  type_ : @ast.TsType,
+) -> BridgeTaggedUnionDecl? {
+  match type_ {
+    @ast.TsType::Named(name) => state.tagged_union_decls_by_name.get(name)
+    @ast.TsType::Union(parts) =>
+      match ffi_inline_union_shaped_cases(parts) {
+        Some(cases) => {
+          let name = ffi_inline_union_synthesized_name(cases)
+          match state.tagged_union_decls_by_name.get(name) {
+            Some(decl) => Some(decl)
+            None => Some({ name, cases })
           }
         }
         None => None
@@ -1852,6 +1903,27 @@ fn ffi_function_field_method_decl(
               js_call_raw,
             )
           _ => js_call_raw
+        }
+        // Only THIS branch binds straight to a JS call, so only here is the
+        // return's direction known to be JS -> MoonBit and the output
+        // widening applicable. The conversion above declines exactly when the
+        // tagged union has no `_from_js`, which is exactly when the declared
+        // type has to widen, so the pair cannot disagree.
+        //
+        // Guarded on the unwidened rendering still MATCHING, because
+        // `return_type` may already have been rewritten from the `This` /
+        // `This?` sentinel to the receiver above, and re-deriving it from the
+        // AST node would undo that.
+        let return_type = match generic_inner {
+          Func(_, ret) => {
+            let normalized = @checker.normalize_promise_like_union_return(ret)
+            if ffi_type_name(state, normalized) == return_type {
+              ffi_output_type_name(state, normalized)
+            } else {
+              return_type
+            }
+          }
+          _ => return_type
         }
         let forward_args : Array[String] = ["self"]
         for arg_expr in arg_exprs {
@@ -2247,14 +2319,26 @@ fn ffi_index_signature_accessor_decls(
     }
     out.join("\n")
   }
+  // The two directions of one index signature are two different questions,
+  // and this rendered ONE name for both. `index_get` crosses JS -> MoonBit,
+  // so a tagged union the bridge cannot BUILD has to be widened there exactly
+  // as an imported function's return is; `index_set` crosses the other way,
+  // where `_to_js` needs no runtime predicate and the enum is real. Reading
+  // one name for both is why `CompilerOptions::index_get` declared
+  // `Auto_TsConfigSourceFileValue_or_CompilerOptionsValueValue?` over a raw
+  // JS value.
+  let getter_value_name = ffi_struct_field_type_name(
+    state,
+    ffi_widen_unbuildable_union_outputs(state, value_type),
+  )
   // Avoid double-wrapping when the value type is already an Option (e.g.
   // `[k: string]: string | undefined`). The accessor semantics — `None` for
   // missing keys — fold the explicit-undefined case into the same outer
   // `None`, which matches how callers use op_get on a record.
-  let getter_return = if value_name.has_suffix("?") {
-    value_name
+  let getter_return = if getter_value_name.has_suffix("?") {
+    getter_value_name
   } else {
-    value_name + "?"
+    getter_value_name + "?"
   }
   let getter = attach_alias(
     match
@@ -2290,12 +2374,22 @@ fn ffi_index_signature_accessor_decls(
       let wrapper_decl = "pub fn \{type_name}::index_set(self : \{type_name}, key : \{key_name}, value : \{value_name}) -> Unit {\n  \{extern_name}(self, key, \{to_js_name}(value))\n}"
       attach_alias(extern_decl + "\n\n" + wrapper_decl, "#alias(\"_[_]=_\")")
     }
-    None =>
+    None => {
+      // A tagged-union value crosses MoonBit -> JS as `{$tag, _0}`, so the
+      // write needs `_to_js` inlined into the body. Unlike the getter this
+      // direction needs no runtime predicate and keeps its type. A no-op for
+      // every other value type, which is what makes it safe here.
+      let js_value = ffi_inline_js_arg_expr_with_state(
+        Some(state),
+        value_type,
+        "value",
+      )
       attach_alias(
         "pub extern \"js\" fn \{type_name}::index_set(self : \{type_name}, key : \{key_name}, value : \{value_name}) -> Unit =\n" +
-        "  #| (self, key, value) => { self[key] = value; }",
+        "  #| (self, key, value) => { self[key] = \{js_value}; }",
         "#alias(\"_[_]=_\")",
       )
+    }
   }
   Some([getter, setter])
 }
@@ -4466,8 +4560,8 @@ fn ffi_widen_unbuildable_union_outputs(
   // global constructors included, so `PathLike = string | Buffer | URL` is
   // "unsafe to wrap" while its `_from_js` exists and works. Widening on the
   // wrap gate would have widened those returns too.
-  fn unbuildable(name : String) -> Bool {
-    match state.tagged_union_decls_by_name.get(name) {
+  fn unbuildable(t : @ast.TsType) -> Bool {
+    match ffi_output_union_decl(state, t) {
       Some(decl) => tagged_union_from_js_expression(decl, "value") is None
       None => false
     }
@@ -4476,18 +4570,34 @@ fn ffi_widen_unbuildable_union_outputs(
   match type_ {
     CallableMeta(inner, meta) =>
       CallableMeta(ffi_widen_unbuildable_union_outputs(state, inner), meta)
-    Named(name) => if unbuildable(name) { Named("any") } else { type_ }
     Func(params, ret) =>
       Func(params, ffi_widen_unbuildable_union_outputs(state, ret))
+    Named(_) => if unbuildable(type_) { Named("any") } else { type_ }
     _ =>
+      // The OPTIONAL classification has to run FIRST. `Auto_X_or_Y?` is
+      // `Union([A, B, Undefined])`, so a `Union` arm placed above this one
+      // swallows every optional and then derives an alias name from parts
+      // that include `Undefined` — which is how the first two attempts at
+      // this arm measured as doing nothing at all.
       match @checker.classify_optional_like_union(type_) {
-        Some((Named(name), true)) =>
-          if unbuildable(name) {
+        Some((inner, true)) =>
+          if unbuildable(inner) {
             Union([Named("any"), Undefined])
           } else {
             type_
           }
-        _ => type_
+        _ =>
+          // A SYNTHESIZED inline union keeps its `Union(parts)` shape in the
+          // AST while its signature already reads `Auto_X_or_Y`, so a walk
+          // that only knows the `Named` spelling decides about a type that is
+          // not the one being printed. Sixth fail-open shape arm in this
+          // file's ledger, and the first written inside the fix for the
+          // fifth.
+          if unbuildable(type_) {
+            Named("any")
+          } else {
+            type_
+          }
       }
   }
 }

--- a/src/bridge/moonbit_js_ffi.mbt
+++ b/src/bridge/moonbit_js_ffi.mbt
@@ -1515,6 +1515,50 @@ fn ffi_inline_js_arg_expr_with_state(
 }
 
 ///|
+/// The return-direction mirror of `ffi_inline_js_arg_expr_with_state`: wrap a
+/// JS expression flowing OUT of JS in the tagged-union alias's `_from_js`
+/// construction, so an `extern "js" fn` whose declared MoonBit return type is
+/// the generated enum hands back `{$tag, _0}` instead of the raw JS value.
+///
+/// Inlined for the same reason the `_to_js` direction is (see
+/// `ffi_inline_js_tagged_union_to_js`): an extern's inline lambda body cannot
+/// import the named `bridge.js` helper. The value is bound to a local first,
+/// because `tagged_union_from_js_expression` substitutes its argument once per
+/// case predicate and the expression here is a PROPERTY READ — `self.path`
+/// evaluated three times is three reads of a member that may be an accessor,
+/// where the named `bridge.js` helper reads its parameter.
+///
+/// Returns `expr` unchanged for an OPTIONAL tagged-union type: the MoonBit
+/// side of an optional return is decided separately by
+/// `ffi_option_return_needs_wrap` / `ffi_converted_return_extern_pair`, and
+/// converting here as well could box a value that path already boxed. No
+/// generated accessor in the corpus has that shape; when one appears it keeps
+/// today's raw passthrough rather than a double conversion.
+fn ffi_inline_js_return_expr_with_state(
+  state : MoonBitJsFfiState,
+  type_ : @ast.TsType,
+  expr : String,
+) -> String {
+  let name = match type_ {
+    @ast.TsType::Named(n) => n
+    _ => return expr
+  }
+  // The same gate the function return paths consult, so the accessor and the
+  // function form cannot disagree about whether `_from_js` exists.
+  if !ffi_tagged_union_return_is_safe_to_wrap(state, name) {
+    return expr
+  }
+  match state.tagged_union_decls_by_name.get(name) {
+    Some(decl) =>
+      match tagged_union_from_js_expression(decl, "__ts_mbt_raw") {
+        Some(body) => "((__ts_mbt_raw) => \{body})(\{expr})"
+        None => expr
+      }
+    None => expr
+  }
+}
+
+///|
 fn ffi_inline_js_tagged_union_to_js(
   state : MoonBitJsFfiState?,
   type_ : @ast.TsType,
@@ -3712,6 +3756,16 @@ fn ffi_returned_func_needs_arg_wrap(
 /// and wrong about a global, which is why `PathLike = string | Buffer | URL`
 /// gets a working wrapper while `PathOrFileDescriptor = PathLike | number`
 /// does not.
+///
+/// That paragraph described the intended behaviour and the code below did the
+/// opposite for a full commit: `Some(InstanceOfNamed(_)) => return false`
+/// refused every named payload, globals included, so `PathLike`'s `_from_js`
+/// was emitted, exercised by `verify-bridge-runtime`, and never CALLED — the
+/// declared enum came back holding the raw JS string. Refusing an erased name
+/// is `tagged_union_case_runtime_discriminator`'s job and it already does it
+/// (returning `None`, the arm below), so an `InstanceOfNamed` that reaches
+/// here is resolvable by construction and a second, blunter copy of the same
+/// judgement could only disagree with the first.
 fn ffi_tagged_union_return_is_safe_to_wrap(
   state : MoonBitJsFfiState,
   name : String,
@@ -3721,7 +3775,6 @@ fn ffi_tagged_union_return_is_safe_to_wrap(
       for entry in decl.cases {
         let (_, inner) = entry
         match tagged_union_case_runtime_discriminator(inner) {
-          Some(InstanceOfNamed(_)) => return false
           // Function payloads stay on the raw passthrough: the generic
           // wrapper would need closure conversion in both directions,
           // which the auto-wrap doesn't model.
@@ -5095,6 +5148,13 @@ fn ffi_class_property_getter_decl_to_moonbit(
   // body / converted pair below.
   let return_type = ffi_struct_field_type_name(state, class_property.type_)
   let getter_params = params.join(", ")
+  // A TAGGED-UNION-typed property is a second enum family, and neither
+  // `ffi_converted_return_extern_pair` nor `ffi_wrapper_return_body_expr`
+  // knows it: both ask `ffi_rendered_generated_enum_info`, which walks
+  // `state.enums` — the literal-union enums, whose converters are MoonBit
+  // functions in `converters.mbt`. A tagged union's converters live in
+  // `bridge.js`, so the conversion has to go in the JS body, which is where
+  // the class METHOD path already puts the argument direction.
   let result = if preserve {
     state.needs_js_any = true
     let fn_prefix = ffi_function_type_param_prefix(class_type_params)
@@ -5109,7 +5169,11 @@ fn ffi_class_property_getter_decl_to_moonbit(
       let wrapper_decl = "pub \{fn_prefix} \{fn_name}(\{getter_params}) -> \{return_type} {\n  \{body_expr}\n}"
       "\{extern_decl}\n\n\{wrapper_decl}"
     } else {
-      let js_get = ffi_js_access("self", class_property.name)
+      let js_get = ffi_inline_js_return_expr_with_state(
+        state,
+        class_property.type_,
+        ffi_js_access("self", class_property.name),
+      )
       // First param can't be named `self` — MoonBit parses
       // `extern "js" fn foo(self : T, ...)` as a deprecated method.
       let extern_decl = "extern \"js\" fn \{extern_name}(this_ : JSValue) -> JSValue =\n  #| (self) => \{js_get}"
@@ -5138,7 +5202,11 @@ fn ffi_class_property_getter_decl_to_moonbit(
         "pub extern \"js\" fn \{fn_name}(\{getter_params}) -> \{return_type} = \"\{binding_name}\""
     }
   } else {
-    let js_get = ffi_js_access("self", class_property.name)
+    let js_get = ffi_inline_js_return_expr_with_state(
+      state,
+      class_property.type_,
+      ffi_js_access("self", class_property.name),
+    )
     let extern_params = "this_ : " +
       getter_params["self : ".length():].to_owned()
     match
@@ -5191,6 +5259,16 @@ fn ffi_class_property_setter_decl_to_moonbit(
   params.push("value : \{value_type}")
   let value_expr = ffi_enum_arg_expr(state, value_type, "value")
   let value_raw_type = ffi_enum_param_raw_type(state, value_type)
+  // Mirror of the getter's tagged-union note: `ffi_enum_arg_expr` covers the
+  // literal-union enum family only, so a tagged-union-typed property assigned
+  // `{$tag, _0}` straight into the JS field is the same defect in the write
+  // direction. The class METHOD path already routes its arguments through
+  // this helper; the accessor path is where it was missing.
+  let js_value = ffi_inline_js_arg_expr_with_state(
+    Some(state),
+    class_property.type_,
+    "value",
+  )
   let fn_name = "set_" +
     ffi_to_snake_case(class_.name) +
     "_" +
@@ -5212,7 +5290,7 @@ fn ffi_class_property_setter_decl_to_moonbit(
       let js_set = ffi_js_access("self", class_property.name)
       // First param can't be named `self` — MoonBit parses
       // `extern "js" fn foo(self : T, ...)` as a deprecated method.
-      let extern_decl = "extern \"js\" fn \{extern_name}(this_ : JSValue, value : JSValue) -> Unit =\n  #| (self, value) => (\{js_set} = value)"
+      let extern_decl = "extern \"js\" fn \{extern_name}(this_ : JSValue, value : JSValue) -> Unit =\n  #| (self, value) => (\{js_set} = \{js_value})"
       let wrapper_decl = "pub \{fn_prefix} \{class_type_name}::\{fn_name}(\{setter_params}) -> Unit {\n  \{extern_name}(unsafeCast(self), unsafeCast(\{value_expr}))\n}"
       Some("\{extern_decl}\n\n\{wrapper_decl}")
     }
@@ -5231,12 +5309,12 @@ fn ffi_class_property_setter_decl_to_moonbit(
     let js_set = ffi_js_access("self", class_property.name)
     if value_expr != "value" {
       let extern_name = "_\{fn_name}_ret_conv_js"
-      let extern_decl = "extern \"js\" fn \{extern_name}(this_ : \{class_type_name}, value : \{value_raw_type}) -> Unit =\n  #| (self, value) => (\{js_set} = value)"
+      let extern_decl = "extern \"js\" fn \{extern_name}(this_ : \{class_type_name}, value : \{value_raw_type}) -> Unit =\n  #| (self, value) => (\{js_set} = \{js_value})"
       let wrapper_decl = "pub fn \{class_type_name}::\{fn_name}(\{setter_params}) -> Unit {\n  \{extern_name}(self, \{value_expr})\n}"
       Some("\{extern_decl}\n\n\{wrapper_decl}")
     } else {
       Some(
-        "pub extern \"js\" fn \{class_type_name}::\{fn_name}(\{setter_params}) -> Unit =\n  #| (self, value) => (\{js_set} = value)",
+        "pub extern \"js\" fn \{class_type_name}::\{fn_name}(\{setter_params}) -> Unit =\n  #| (self, value) => (\{js_set} = \{js_value})",
       )
     }
   }
@@ -6582,7 +6660,15 @@ pub async fn emit_moonbit_js_ffi_bundle_from_entry_path(
       let class_access = ensure_bridge_runtime_access(
         seen_bridge_import_keys, bridge_imports, namespace_import_roots, class_runtime_export_name,
       )
-      let getter_access = ffi_js_access(class_access, class_property.name)
+      // A static accessor's binding is a named `bridge.js` function rather
+      // than an inline extern lambda, so it can call the `_from_js` / `_to_js`
+      // helpers by name — but it was passing the raw value through in both
+      // directions, the same omission as the instance forms above.
+      let getter_access = ffi_type_js_return_expr(
+        state,
+        class_property.type_,
+        ffi_js_access(class_access, class_property.name),
+      )
       push_unique_bridge_binding(
         seen_bridge_binding_names,
         bridge_lines,
@@ -6595,6 +6681,11 @@ pub async fn emit_moonbit_js_ffi_bundle_from_entry_path(
           class_property.name,
         )
         let setter_target = ffi_js_access(class_access, class_property.name)
+        let setter_value = ffi_type_js_converter_expr(
+          state,
+          class_property.type_,
+          "value",
+        )
         push_unique_bridge_binding(
           seen_bridge_binding_names,
           bridge_lines,
@@ -6602,7 +6693,7 @@ pub async fn emit_moonbit_js_ffi_bundle_from_entry_path(
           ffi_bridge_function_line(
             setter_binding,
             ["value"],
-            "(\{setter_target} = value)",
+            "(\{setter_target} = \{setter_value})",
           ),
         )
       }

--- a/src/bridge/moonbit_js_ffi.mbt
+++ b/src/bridge/moonbit_js_ffi.mbt
@@ -1528,20 +1528,35 @@ fn ffi_inline_js_arg_expr_with_state(
 /// evaluated three times is three reads of a member that may be an accessor,
 /// where the named `bridge.js` helper reads its parameter.
 ///
-/// Returns `expr` unchanged for an OPTIONAL tagged-union type: the MoonBit
-/// side of an optional return is decided separately by
-/// `ffi_option_return_needs_wrap` / `ffi_converted_return_extern_pair`, and
-/// converting here as well could box a value that path already boxed. No
-/// generated accessor in the corpus has that shape; when one appears it keeps
-/// today's raw passthrough rather than a double conversion.
+/// The OPTIONAL form converts too, and the reason this once declined it was
+/// wrong. That note said the MoonBit side "could box a value that path already
+/// boxed" — but `ffi_option_return_inner_is_boxed` returns FALSE for a
+/// tagged-union alias, so `ffi_option_return_needs_wrap` never fires for one
+/// and no MoonBit-side wrap exists to collide with: `Some(v)` IS `v` and
+/// `None` IS `undefined` at the boundary. The two machineries cannot overlap
+/// here, which was checkable and was not checked. The same note also claimed
+/// no corpus declaration had the shape, and `TypeChecker::getConstantValue`
+/// returns `Auto_NumberValue_or_StringValue?` — `String | Double`, both
+/// primitives, so `typeof` discriminates and the converter is fully buildable.
+///
+/// Resolves BOTH spellings a tagged union arrives in, because the optional
+/// inner is a raw `Union(parts)`: an alias the module declared comes through as
+/// `Named`, while an inline `A | B` keeps its `Union` shape in the AST and only
+/// the signature reads `Auto_X_or_Y`. `ffi_inline_js_tagged_union_to_js` needs
+/// the same pair and says so in its own comment.
 fn ffi_inline_js_return_expr_with_state(
   state : MoonBitJsFfiState,
   type_ : @ast.TsType,
   expr : String,
 ) -> String {
-  let name = match type_ {
-    @ast.TsType::Named(n) => n
-    _ => return expr
+  let (inner, is_optional) = match
+    @checker.classify_optional_like_union(type_) {
+    Some((collapsed, true)) => (collapsed, true)
+    _ => (type_, false)
+  }
+  let name = match ffi_output_union_alias_name(state, inner) {
+    Some(n) => n
+    None => return expr
   }
   // The same gate the function return paths consult, so the accessor and the
   // function form cannot disagree about whether `_from_js` exists.
@@ -1551,10 +1566,52 @@ fn ffi_inline_js_return_expr_with_state(
   match state.tagged_union_decls_by_name.get(name) {
     Some(decl) =>
       match tagged_union_from_js_expression(decl, "__ts_mbt_raw") {
-        Some(body) => "((__ts_mbt_raw) => \{body})(\{expr})"
+        Some(body) =>
+          if is_optional {
+            "((__ts_mbt_raw) => __ts_mbt_raw == null ? undefined : \{body})(\{expr})"
+          } else {
+            "((__ts_mbt_raw) => \{body})(\{expr})"
+          }
         None => expr
       }
     None => expr
+  }
+}
+
+///|
+/// The alias name a type will RENDER as, for BOTH spellings a tagged union
+/// arrives in: a `Named` alias the module declared, and a raw `Union(parts)`
+/// that lowers to a synthesized `Auto_X_or_Y`.
+///
+/// The second is the one that gets forgotten, and
+/// `ffi_inline_js_tagged_union_to_js` says why in its own comment: the
+/// signature already reads `Auto_ViewValue_or_TableValue` while the AST keeps
+/// the original `Union(parts)` shape. A walk that decides on the `Named`
+/// spelling alone decides about a type that is not the one being printed.
+fn ffi_output_union_alias_name(
+  state : MoonBitJsFfiState,
+  type_ : @ast.TsType,
+) -> String? {
+  match type_ {
+    @ast.TsType::Named(name) =>
+      if state.tagged_union_decls_by_name.contains(name) {
+        Some(name)
+      } else {
+        None
+      }
+    @ast.TsType::Union(parts) =>
+      match ffi_inline_union_shaped_cases(parts) {
+        Some(cases) => {
+          let name = ffi_inline_union_synthesized_name(cases)
+          if state.tagged_union_decls_by_name.contains(name) {
+            Some(name)
+          } else {
+            None
+          }
+        }
+        None => None
+      }
+    _ => None
   }
 }
 
@@ -1775,10 +1832,26 @@ fn ffi_function_field_method_decl(
           js_params.push(arg)
         }
         let js_params_src = js_params.join(", ")
-        let js_call = if field_name == "_call_" {
+        let js_call_raw = if field_name == "_call_" {
           "self(\{js_args_src})"
         } else {
           ffi_js_access("self", js_field_name) + "(" + js_args_src + ")"
+        }
+        // An INTERFACE method is a third renderer, and it needed the same
+        // return conversion the class-method and accessor paths did.
+        // `TypeChecker` is an interface, so `getConstantValue` never reached
+        // the class path: patching that one and measuring is what found this.
+        // `ffi_function_type_parts` hands back the RENDERED return type and not
+        // the node, so the AST return is taken off `generic_inner` here, with
+        // the same promise normalization that function applies.
+        let js_call = match generic_inner {
+          Func(_, ret) =>
+            ffi_inline_js_return_expr_with_state(
+              state,
+              @checker.normalize_promise_like_union_return(ret),
+              js_call_raw,
+            )
+          _ => js_call_raw
         }
         let forward_args : Array[String] = ["self"]
         for arg_expr in arg_exprs {
@@ -4950,10 +5023,16 @@ fn ffi_class_method_decl_to_moonbit(
         js_params.push(arg)
       }
       let js_param_list = js_params.join(", ")
-      let js_call = ffi_js_access("self", event_js_member) +
+      // Same conversion on the generic-preserved path; its wrapper returns
+      // `JSValue` and casts, so the JS body is the only place to do it.
+      let js_call = ffi_inline_js_return_expr_with_state(
+        state,
+        class_method.return_type,
+        ffi_js_access("self", event_js_member) +
         "(" +
         ffi_event_js_args_src(event_literal, js_args) +
-        ")"
+        ")",
+      )
       let extern_name = "_\{fn_name}_extern_js"
       let extern_decl = "extern \"js\" fn \{extern_name}(\{extern_params_src}) -> JSValue =\n  #| (\{js_param_list}) => \{js_call}"
       let instance_params = if method_params == "" {
@@ -4992,10 +5071,20 @@ fn ffi_class_method_decl_to_moonbit(
       js_params.push(arg)
     }
     let js_param_list = js_params.join(", ")
-    let js_call = ffi_js_access("self", event_js_member) +
+    // A method's RETURN needs the tagged-union conversion for the same reason
+    // its arguments do (`js_args` above), and for the same reason the accessor
+    // paths do: `ffi_converted_return_extern_pair` below asks
+    // `ffi_rendered_generated_enum_info`, which knows only the literal-union
+    // enum family. `TypeChecker::getConstantValue` declared
+    // `Auto_NumberValue_or_StringValue?` and returned tsc's raw string.
+    let js_call = ffi_inline_js_return_expr_with_state(
+      state,
+      class_method.return_type,
+      ffi_js_access("self", event_js_member) +
       "(" +
       ffi_event_js_args_src(event_literal, js_args) +
-      ")"
+      ")",
+    )
     let instance_params = if method_params == "" {
       "self : \{class_type_name}"
     } else {

--- a/src/bridge/moonbit_js_ffi_wbtest.mbt
+++ b/src/bridge/moonbit_js_ffi_wbtest.mbt
@@ -393,6 +393,106 @@ async test "bridge: emit MoonBit JS FFI bundle for exported class properties" {
 }
 
 ///|
+/// A class property typed by a TAGGED UNION has to route through the alias's
+/// converters at all four accessor paths — instance get / set and static
+/// get / set. None of them did: they asked `ffi_rendered_generated_enum_info`
+/// and `ffi_enum_arg_expr`, which walk `state.enums` (the literal-union enums,
+/// whose converters are MoonBit functions), so the second enum family fell
+/// through and node_fs's `ReadStream.path: PathLike` declared the enum in both
+/// directions while moving the raw JS value.
+///
+/// The declared type is unchanged either way, which is why no compile gate
+/// could see it: a MoonBit `match` on the getter's result read `$tag` off a
+/// string, and the setter stored `{ "$tag": 0, "_0": … }` into a Node field.
+///
+/// `Key = string | URL` is the shape that has a working `_from_js`: `URL` is a
+/// JS global, so `tagged_union_case_runtime_discriminator` keeps its
+/// `instanceof` — the case `ffi_tagged_union_return_is_safe_to_wrap` used to
+/// refuse outright while its own doc comment said it was kept.
+async test "bridge: a tagged-union class property converts at all four accessor paths" {
+  let bundle = emit_moonbit_js_ffi_bundle_from_entry_path(
+    "fixtures/resolver/project/types/class-property-tagged-union-entry.d.ts", "./runtime/class-property.js",
+  ) catch {
+    e => {
+      match e {
+        ReadError(msg) | ParseError(msg) | ResolveError(msg) =>
+          fail("Emit error: \{msg}")
+      }
+      return
+    }
+  }
+  // Instance getter: the raw JS value is bound once and built into `{$tag,
+  // _0}`. Bound rather than substituted, because the from_js body repeats its
+  // argument per case predicate and `self.key` is a property READ.
+  assert_true(
+    bundle.ffi_mbt.contains(
+      "pub extern \"js\" fn Holder::get_holder_key(self : Holder) -> Key =\n" +
+      "  #| (self) => ((__ts_mbt_raw) => (() => { if (typeof __ts_mbt_raw === \"string\") return { \"$tag\": 0, \"_0\": __ts_mbt_raw }; else if (__ts_mbt_raw instanceof URL) return { \"$tag\": 1, \"_0\": __ts_mbt_raw }; throw new Error(\"unexpected Key value\"); })())(self.key)",
+    ),
+  )
+  // Instance setter: the `$tag` dispatch back to the bare JS value.
+  assert_true(
+    bundle.ffi_mbt.contains(
+      "pub extern \"js\" fn Holder::set_holder_key(self : Holder, value : Key) -> Unit =\n" +
+      "  #| (self, value) => (self.key = (() => { if (value === null || typeof value !== \"object\" || !(\"$tag\" in value)) return value; if (value.$tag === 0) return value._0; else if (value.$tag === 1) return value._0; throw new Error(\"unexpected Key tag: \" + value.$tag); })())",
+    ),
+  )
+  // The static pair binds a NAMED `bridge.js` function rather than an inline
+  // extern lambda, so there it can call the helper by name.
+  assert_true(
+    bundle.bridge_js.contains(
+      "export function __ts_mbt_get_holder_static_key() { return __ts_mbt_tagged_union_key_from_js(Holder.staticKey); }",
+    ),
+  )
+  assert_true(
+    bundle.bridge_js.contains(
+      "export function __ts_mbt_set_holder_static_key(value) { return (Holder.staticKey = (() => { if (value === null || typeof value !== \"object\" || !(\"$tag\" in value)) return value; if (value.$tag === 0) return value._0; else if (value.$tag === 1) return value._0; throw new Error(\"unexpected Key tag: \" + value.$tag); })()); }",
+    ),
+  )
+  // The raw passthrough each of the four used to emit.
+  assert_false(bundle.ffi_mbt.contains("#| (self) => self.key"))
+  assert_false(bundle.ffi_mbt.contains("(self.key = value)"))
+  assert_false(
+    bundle.bridge_js.contains(
+      "export function __ts_mbt_get_holder_static_key() { return Holder.staticKey; }",
+    ),
+  )
+  assert_false(bundle.bridge_js.contains("(Holder.staticKey = value)"))
+  // The negative control, and the reason it matters: `Level` is the LITERAL-
+  // union family, converted on the MoonBit side by `converters.mbt`
+  // functions. Its JS body has to stay a bare read, or a property could come
+  // out converted TWICE — which is the way this change could have been wrong.
+  assert_true(
+    bundle.ffi_mbt.contains(
+      "extern \"js\" fn _get_holder_level_ret_conv_js(this_ : Holder) -> String =\n" +
+      "  #| (self) => self.level",
+    ),
+  )
+  assert_true(
+    bundle.ffi_mbt.contains(
+      "pub fn Holder::get_holder_level(self : Holder) -> Level {\n" +
+      "  __ts_mbt_level_from_js(_get_holder_level_ret_conv_js(self))\n}",
+    ),
+  )
+  assert_true(
+    bundle.ffi_mbt.contains(
+      "extern \"js\" fn _set_holder_level_ret_conv_js(this_ : Holder, value : String) -> Unit =\n" +
+      "  #| (self, value) => (self.level = value)",
+    ),
+  )
+  assert_true(
+    bundle.bridge_js.contains(
+      "export function __ts_mbt_get_holder_static_level() { return Holder.staticLevel; }",
+    ),
+  )
+  assert_true(
+    bundle.bridge_js.contains(
+      "export function __ts_mbt_set_holder_static_level(value) { return (Holder.staticLevel = value); }",
+    ),
+  )
+}
+
+///|
 async test "bridge: emit MoonBit JS FFI bundle expands inherited callable class properties" {
   let bundle = emit_moonbit_js_ffi_bundle_from_entry_path(
     "fixtures/resolver/project/types/class-callable-property-alias-entry.d.ts", "./runtime/app.js",

--- a/src/bridge/moonbit_js_ffi_wbtest.mbt
+++ b/src/bridge/moonbit_js_ffi_wbtest.mbt
@@ -5731,3 +5731,76 @@ test "bridge: promise layer section variants stay coherent" {
     ),
   )
 }
+
+///|
+/// The `CallableMeta` arm of `ffi_widen_unbuildable_union_outputs`, and the
+/// predicate it uses.
+///
+/// This is a regression pin for a fix that measured as a NO-OP twice. A
+/// tagged-union return the bridge cannot build must widen to `JSValue`,
+/// and `@hono/node-server`'s `get_serve` did not, because its type carries
+/// an OPTIONAL parameter and therefore arrives wrapped in `CallableMeta` —
+/// which fell through the catch-all untouched while the sibling
+/// `get_create_adaptor_server`, whose parameter list has no optional, went
+/// through the `Func` arm and widened correctly. Fifth wrapper-node
+/// fail-open arm in this repo.
+test "bridge: an unbuildable tagged-union output widens through every wrapper" {
+  let unbuildable_cases : Array[(String, @ast.TsType)] = [
+    // `Server` is a node:http interface, not a JS global constructor, so no
+    // `instanceof` predicate resolves and no `_from_js` is emitted.
+    ("ServerValue", @ast.TsType::Named("Server")),
+    ("Http2ServerValue", @ast.TsType::Named("Http2Server")),
+  ]
+  let buildable_cases : Array[(String, @ast.TsType)] = [
+    ("StringValue", @ast.TsType::String_),
+    ("BufferValue", @ast.TsType::Named("Buffer")),
+  ]
+  let state : MoonBitJsFfiState = {
+    declared_type_names: [],
+    struct_type_names: [],
+    generic_type_params_by_name: {},
+    enums: [],
+    external_type_names: [],
+    local_type_param_names: [],
+    function_field_method_wrapper_limit: ffi_function_field_method_wrapper_limit,
+    tagged_union_decls_by_name: {
+      "ServerType": { name: "ServerType", cases: unbuildable_cases },
+      "PathLike": { name: "PathLike", cases: buildable_cases },
+    },
+    synthesized_inline_unions: {},
+    needs_js_any: false,
+    needs_promise: false,
+    needs_option_return_wrap: false,
+  }
+  let server_type = @ast.TsType::Named("ServerType")
+  let opts = @ast.TsType::Named("Options")
+
+  // Bare, and through a returned function.
+  assert_eq(ffi_output_type_name(state, server_type), "JSValue")
+  assert_eq(
+    ffi_output_type_name(state, Func([opts], server_type)),
+    "(Options) -> JSValue",
+  )
+  // Through `CallableMeta` — the arm that was missing. `ffi_type_name` peels
+  // this wrapper on its own first line, so a walk that decides the type has
+  // to peel it too or it decides a different type from the rendered one.
+  assert_eq(
+    ffi_output_type_name(
+      state,
+      CallableMeta(Func([opts], server_type), [false]),
+    ),
+    "(Options) -> JSValue",
+  )
+  // The legal neighbour, and the reason the predicate asks
+  // `tagged_union_from_js_expression` rather than
+  // `ffi_tagged_union_return_is_safe_to_wrap`: `PathLike`'s cases are a
+  // primitive and a GLOBAL constructor, so its `_from_js` exists and works.
+  // The wrap gate refuses any `InstanceOfNamed` and would have widened this.
+  assert_eq(ffi_output_type_name(state, Named("PathLike")), "PathLike")
+  assert_eq(
+    ffi_output_type_name(state, Func([opts], Named("PathLike"))),
+    "(Options) -> PathLike",
+  )
+  // A name that is not a tagged union at all is untouched.
+  assert_eq(ffi_output_type_name(state, Named("Options")), "Options")
+}

--- a/src/bridge/pkg.generated.mbti
+++ b/src/bridge/pkg.generated.mbti
@@ -61,6 +61,8 @@ pub fn tagged_union_case_is_no_payload(@ast.TsType) -> Bool
 
 pub fn tagged_union_case_named_refs(@ast.TsType, Array[String]) -> Unit
 
+pub fn tagged_union_case_runtime_discriminator(@ast.TsType) -> TaggedUnionCaseDiscriminator?
+
 pub fn tagged_union_cases(Array[@ast.TsType]) -> Array[(String, @ast.TsType)]?
 
 pub fn tagged_union_decl_to_moonbit_section(BridgeTaggedUnionDecl) -> String?

--- a/src/bridge/tagged_union_lowering.mbt
+++ b/src/bridge/tagged_union_lowering.mbt
@@ -387,6 +387,11 @@ pub fn tagged_union_widen_reason_for_alias(
 /// Discrimination strategy for one heterogeneous-union case at the JS
 /// boundary. The detector restricts inner types to runtime-discriminable
 /// shapes; this enum names the JS predicate the converter should use.
+///
+/// `InstanceOfNamed` is a SHAPE answer, not a runtime one: it says the
+/// payload is a single named type, which is what the enum renderer and the
+/// `$tag` dispatch need. Whether `value instanceof <Name>` can actually run
+/// is a different question — see `tagged_union_case_runtime_discriminator`.
 pub(all) enum TaggedUnionCaseDiscriminator {
   TypeofString
   TypeofNumber
@@ -420,6 +425,76 @@ pub fn tagged_union_case_discriminator(
     @ast.TsType::BooleanLiteral(value) => Some(StrictEqualsBool(value))
     _ => None
   }
+}
+
+///|
+/// The runtime half of `tagged_union_case_discriminator`: the same answer,
+/// except that a `Named` payload only keeps its `instanceof` predicate when
+/// the name denotes a JS global constructor that exists at the bridge
+/// boundary.
+///
+/// This distinction is the whole point. `tagged_union_named_constructor_name`
+/// asks whether a name is PascalCase and MoonBit-spellable — a NAMING test —
+/// and the discriminator took that as licence to emit `value instanceof
+/// <Name>`. A TypeScript interface, type alias, enum or type parameter is
+/// erased, so that predicate is a `ReferenceError` the first time it runs:
+/// `_from_js` converters carrying `instanceof PathLike` (an alias),
+/// `instanceof Expression` (an interface), `instanceof ScriptTarget` (an
+/// enum) and `instanceof T` (a type parameter) were emitted 411 times across
+/// the generated corpus, and 2,126 converter calls threw.
+///
+/// `moonbit_inline_union_runtime_named_ok` already knew this, and states it
+/// in its own doc comment; it was consulted at exactly one site
+/// (`ffi_synthesize_inline_union`) and there only for a union that has a
+/// FUNCTION member, because the check was written inside the
+/// `func_members > 0` branch. That condition is right for the thing next to
+/// it — a second function case collides on `typeof === "function"` — and has
+/// nothing to do with whether a sibling's `instanceof` resolves. Routing the
+/// predicate through one place is what keeps the two from disagreeing again.
+///
+/// Declining costs a MISS, never a false positive: the alias still lowers to
+/// an enum and its `_to_js` direction (a `$tag` dispatch that needs no
+/// runtime predicate at all) is unaffected, so parameters keep their types.
+/// Only the return-side `_from_js` wrapper is withheld — which is exactly
+/// what `ffi_tagged_union_return_is_safe_to_wrap` already refused to call
+/// for these cases, so the JS being dropped was never reachable.
+pub fn tagged_union_case_runtime_discriminator(
+  inner : @ast.TsType,
+) -> TaggedUnionCaseDiscriminator? {
+  match tagged_union_case_discriminator(inner) {
+    Some(InstanceOfNamed(name)) =>
+      if @parser.moonbit_inline_union_runtime_named_ok(name) {
+        Some(InstanceOfNamed(name))
+      } else {
+        None
+      }
+    other => other
+  }
+}
+
+///|
+/// The first case whose payload has no RUNTIME discriminator, as
+/// `(case name, payload name)`. Drives the generated-source note that
+/// replaces a `_from_js` converter we decline to emit, so the reason is
+/// legible in `bridge.js` instead of only in this file.
+fn tagged_union_first_undiscriminable_case(
+  decl : BridgeTaggedUnionDecl,
+) -> (String, String)? {
+  for entry in decl.cases {
+    let (case_name, inner) = entry
+    if tagged_union_case_runtime_discriminator(inner) is None {
+      let payload = match inner {
+        @ast.TsType::Named(name) => name
+        _ =>
+          match tagged_union_inner_moonbit_text(inner) {
+            Some(text) => text
+            None => "<unsupported payload>"
+          }
+      }
+      return Some((case_name, payload))
+    }
+  }
+  None
 }
 
 ///|
@@ -578,7 +653,11 @@ pub fn tagged_union_from_js_expression(
   let mut body = "(() => { "
   for i, entry in decl.cases {
     let (_, inner) = entry
-    let predicate = match tagged_union_case_discriminator(inner) {
+    // The RUNTIME discriminator, not the shape one: a case whose payload is
+    // an erased TypeScript name has no predicate that can execute, and
+    // emitting `value instanceof <erased name>` here is a `ReferenceError`
+    // at the boundary rather than a type we failed to narrow.
+    let predicate = match tagged_union_case_runtime_discriminator(inner) {
       Some(d) => tagged_union_case_predicate_text(d, expr)
       None => return None
     }
@@ -743,9 +822,19 @@ fn tagged_union_to_snake_case(name : String) -> String {
 }
 
 ///|
-/// Render the bridge.js converter pair for one tagged-union alias.
-/// Returns `None` when any case payload lacks a discriminator (the alias
-/// then falls back to existing JSValue widening).
+/// Render the bridge.js converters for one tagged-union alias.
+///
+/// The two directions are emitted independently, because only one of them
+/// needs a runtime predicate. `_to_js` reads `$tag` off the MoonBit value
+/// and can always be written; `_from_js` has to TEST an incoming JS value,
+/// so it is withheld when a case payload has no executable discriminator
+/// (`tagged_union_case_runtime_discriminator`). The withheld half is
+/// replaced by a note naming the case, and the surviving `_to_js` keeps
+/// parameter positions typed — before this split a declined `_from_js`
+/// took the sound `_to_js` down with it.
+///
+/// Never returns `None` today; the option is kept for callers that already
+/// handle a fully-undecidable alias.
 pub fn tagged_union_bridge_js_converter_decls(
   decl : BridgeTaggedUnionDecl,
 ) -> String? {
@@ -764,10 +853,6 @@ pub fn tagged_union_bridge_js_converter_decls_with_nested(
     nested,
     struct_converter_names~,
   )
-  let from_js_body = match tagged_union_from_js_expression(decl, "value") {
-    Some(body) => body
-    None => return None
-  }
   let to_name = tagged_union_to_js_function_name(decl.name)
   let from_name = tagged_union_from_js_function_name(decl.name)
   // `export function` so MoonBit `extern "js" fn ... = "<name>"` ESM
@@ -777,12 +862,33 @@ pub fn tagged_union_bridge_js_converter_decls_with_nested(
     "(value) { return " +
     to_js_body +
     "; }"
-  let from_decl = "export function " +
-    from_name +
-    "(value) { return " +
-    from_js_body +
-    "; }"
-  Some(to_decl + "\n" + from_decl)
+  match tagged_union_from_js_expression(decl, "value") {
+    Some(from_js_body) => {
+      let from_decl = "export function " +
+        from_name +
+        "(value) { return " +
+        from_js_body +
+        "; }"
+      Some(to_decl + "\n" + from_decl)
+    }
+    None => {
+      // Say which case and why, because the two reasons need different
+      // fixes: an interface / alias / enum / type parameter has no runtime
+      // value at all and never will, while a class the module exports could
+      // be bound in `bridge.js` and then discriminated (see TODO.md).
+      let reason = match tagged_union_first_undiscriminable_case(decl) {
+        Some((case_name, payload)) =>
+          "case " +
+          case_name +
+          " carries " +
+          payload +
+          ", which is not a JS global constructor, so no `instanceof` " +
+          "predicate resolves in this module"
+        None => "a case payload has no runtime discriminator"
+      }
+      Some(to_decl + "\n// No " + from_name + ": " + reason + ".")
+    }
+  }
 }
 
 ///|

--- a/src/bridge/tagged_union_lowering.mbt
+++ b/src/bridge/tagged_union_lowering.mbt
@@ -299,6 +299,42 @@ pub(all) struct BridgeTaggedUnionDecl {
 /// the decl through bridge emission.
 
 ///|
+/// Human-readable shape of a union member that has no tagged-union case, for
+/// the widening diagnostic. The point is to say what would have to be
+/// SUPPORTED, not merely that something was not: an anonymous object type
+/// and an object intersection both need a synthesized payload struct plus an
+/// object-shaped predicate, a lowercase `Named` needs nothing (it is simply
+/// not spellable), and a qualified name needs namespace flattening. Those are
+/// four different pieces of work and the old wording made them one line.
+fn tagged_union_member_shape_description(t : @ast.TsType) -> String {
+  match t {
+    @ast.TsType::Named(name) =>
+      if name.contains(".") {
+        "the qualified name `\{name}` cannot be spelled as an enum case"
+      } else {
+        "the name `\{name}` is not PascalCase-spellable as an enum case"
+      }
+    @ast.TsType::Applied(name, _) =>
+      "the generic reference `\{name}<...>` has no monomorphic payload type"
+    @ast.TsType::Object(_) =>
+      "an anonymous object type needs a synthesized payload struct and an object-shaped predicate"
+    @ast.TsType::Intersection(_) =>
+      "an object intersection needs a flattened payload struct and an object-shaped predicate"
+    @ast.TsType::Tuple(_) =>
+      "a tuple type has no discriminator distinct from an array member"
+    @ast.TsType::Constructor(_, _, _) =>
+      "a constructor type is indistinguishable from a function member at runtime"
+    @ast.TsType::Any | @ast.TsType::Unknown =>
+      "`any` / `unknown` admits every runtime value, so no sibling stays discriminable"
+    @ast.TsType::NonPrimitiveObject =>
+      "the `object` keyword type admits every non-primitive, so no object sibling stays discriminable"
+    @ast.TsType::Symbol | @ast.TsType::UniqueSymbol(_) =>
+      "a symbol member has no MoonBit payload type"
+    _ => "the member shape has no runtime discriminator"
+  }
+}
+
+///|
 /// Diagnose why a tagged-union-shaped alias would be widened to `JSValue`.
 /// Returns `Some(reason)` for unions of at least two members where every
 /// member is a literal but `tagged_union_cases` rejects (e.g. literal
@@ -356,12 +392,20 @@ pub fn tagged_union_widen_reason_for_alias(
       "heterogeneous union has overlapping primitive discriminators (a literal collides with a non-literal sibling).",
     )
   }
-  // Member with no constructor name: non-PascalCase Named, function type,
-  // or another shape not representable as a tagged-union case.
+  // Member with no constructor name. The old wording listed
+  // "non-PascalCase named, function, or unsupported shape", which named a
+  // cause that cannot occur — a function member IS accepted, as `FnValue` —
+  // and lumped everything real under "unsupported shape". The two
+  // occurrences in the fixture corpus are an anonymous object type and an
+  // object intersection, and neither could be told apart from a lowercase
+  // name by reading the message. Name the member instead, so
+  // `scripts/bridge_widened_unions.txt` can declare it by cause.
   for m in load_bearing {
     if tagged_union_member_constructor_name(m) is None {
       return Some(
-        "heterogeneous union member is not runtime-discriminable (non-PascalCase named, function, or unsupported shape).",
+        "heterogeneous union member is not runtime-discriminable: " +
+        tagged_union_member_shape_description(m) +
+        ".",
       )
     }
   }

--- a/src/bridge/tagged_union_lowering_wbtest.mbt
+++ b/src/bridge/tagged_union_lowering_wbtest.mbt
@@ -449,6 +449,88 @@ test "tagged union: from-JS snippet uses instanceof for Named" {
 }
 
 ///|
+test "tagged union: an erased Named payload gets no instanceof predicate" {
+  // `PathOrFileDescriptor = PathLike | number`, where `PathLike` is a TYPE
+  // ALIAS. `tagged_union_named_constructor_name` accepts it — it is
+  // PascalCase and MoonBit-spellable — and the discriminator used to read
+  // that as licence to emit `value instanceof PathLike`, which is a
+  // ReferenceError the first time it runs. 411 such sites were emitted
+  // across the generated corpus and 2,126 converter calls threw.
+  let decl : BridgeTaggedUnionDecl = {
+    name: "PathOrFileDescriptor",
+    cases: [
+      ("PathLikeValue", @ast.TsType::Named("PathLike")),
+      ("NumberValue", @ast.TsType::Number),
+    ],
+  }
+  // The SHAPE answer is unchanged: the enum renderer and the `$tag`
+  // dispatch still need to know the payload is one named type.
+  match tagged_union_case_discriminator(@ast.TsType::Named("PathLike")) {
+    Some(InstanceOfNamed("PathLike")) => ()
+    _ => fail("shape discriminator should still name the payload")
+  }
+  // The RUNTIME answer declines.
+  assert_true(
+    tagged_union_case_runtime_discriminator(@ast.TsType::Named("PathLike"))
+    is None,
+  )
+  assert_true(tagged_union_from_js_expression(decl, "v") is None)
+  // ...and the sound `_to_js` half survives, so parameter positions keep
+  // their type. Before the two directions were split, a declined `_from_js`
+  // took the whole converter pair down with it.
+  match tagged_union_bridge_js_converter_decls(decl) {
+    Some(snippet) => {
+      assert_true(
+        snippet.contains(
+          "export function __ts_mbt_tagged_union_path_or_file_descriptor_to_js",
+        ),
+      )
+      assert_false(
+        snippet.contains(
+          "export function __ts_mbt_tagged_union_path_or_file_descriptor_from_js",
+        ),
+      )
+      assert_false(snippet.contains("instanceof PathLike"))
+      // The note names the case and the reason.
+      assert_true(snippet.contains("PathLikeValue carries PathLike"))
+    }
+    None => fail("the to_js half is always available")
+  }
+}
+
+///|
+test "tagged union: a global-constructor Named payload keeps its predicate" {
+  // The legal neighbour of the case above, and the reason this is a
+  // narrowing rather than a removal: `Buffer`, `URL` and `Date` DO resolve
+  // in the generated module, so `PathLike = string | Buffer | URL` keeps a
+  // working `_from_js`.
+  let decl : BridgeTaggedUnionDecl = {
+    name: "PathLike",
+    cases: [
+      ("StringValue", @ast.TsType::String_),
+      ("BufferValue", @ast.TsType::Named("Buffer")),
+      ("URLValue", @ast.TsType::Named("URL")),
+    ],
+  }
+  match tagged_union_from_js_expression(decl, "v") {
+    Some(snippet) => {
+      assert_true(snippet.contains("v instanceof Buffer"))
+      assert_true(snippet.contains("v instanceof URL"))
+    }
+    None => fail("global constructors are discriminable")
+  }
+  match tagged_union_bridge_js_converter_decls(decl) {
+    Some(snippet) =>
+      assert_true(
+        snippet.contains(
+          "export function __ts_mbt_tagged_union_path_like_from_js",
+        ),
+      )
+    None => fail("expected both halves")
+  }
+}
+
+///|
 test "tagged union: from-JS snippet uses Array.isArray for arrays" {
   let decl : BridgeTaggedUnionDecl = {
     name: "Path",

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -17056,6 +17056,32 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
       // instead of re-declaring (which would otherwise pin the
       // declared slot to the iterable element type and reject
       // any later wider-typed assignments inside the body).
+      // TS2322 for the assignment-form target, shared by all three
+      // spellings of the write. One closure rather than a copy per arm:
+      // the rule fired for a bare `Var` and was blind to `o.x`,
+      // `foo().x` and `arr[0]` — the same guard chain written once and
+      // reached from one of the three places it applies (`ES5For-of8` is
+      // the property spelling).
+      let report_forof_target = fn(target_ty : @ast.TsType, what : String) {
+        if is_checkable(target_ty) &&
+          is_checkable(elem_ty) &&
+          !is_in_scope_type_param(ctx, target_ty) &&
+          !type_contains_unresolved_named(target_ty, ctx.resolver) &&
+          !type_contains_unresolved_named(elem_ty, ctx.resolver) &&
+          !type_deeply_contains_unmodeled(target_ty, ctx.resolver) &&
+          !type_deeply_contains_unmodeled(elem_ty, ctx.resolver) &&
+          !is_assignable_to(
+            ctx.resolver.unwrap(widen_literal(elem_ty)),
+            ctx.resolver.unwrap(target_ty),
+          ) &&
+          !is_structurally_assignable_named(elem_ty, target_ty, ctx.resolver) {
+          record(
+            ctx,
+            what,
+            "iterable yields `\{type_display(widen_literal(elem_ty))}` which is not assignable to `\{type_display(target_ty)}`",
+          )
+        }
+      }
       match (kind, binding) {
         (@ast.TsForOfKind::Assign, @ast.TsBinding::Ident(n)) => {
           // TS2304: the assignment-form target must be an existing binding
@@ -17067,34 +17093,29 @@ fn check_stmt(env : ExprEnv, stmt : @ast.TsStmt, ctx : CheckCtx) -> Unit {
           // declared slot -- not the narrowed one -- is the assignment
           // target (`x = true; for (x of nums)` re-widens `x`).
           match env.lookup_declared(n) {
-            Some(target_ty) =>
-              if is_checkable(target_ty) &&
-                is_checkable(elem_ty) &&
-                !is_in_scope_type_param(ctx, target_ty) &&
-                !type_contains_unresolved_named(target_ty, ctx.resolver) &&
-                !type_contains_unresolved_named(elem_ty, ctx.resolver) &&
-                !type_deeply_contains_unmodeled(target_ty, ctx.resolver) &&
-                !type_deeply_contains_unmodeled(elem_ty, ctx.resolver) &&
-                !is_assignable_to(
-                  ctx.resolver.unwrap(widen_literal(elem_ty)),
-                  ctx.resolver.unwrap(target_ty),
-                ) &&
-                !is_structurally_assignable_named(
-                  elem_ty,
-                  target_ty,
-                  ctx.resolver,
-                ) {
-                record(
-                  ctx,
-                  "for-of target",
-                  "iterable yields `\{type_display(widen_literal(elem_ty))}` which is not assignable to `\{type_display(target_ty)}`",
-                )
-              }
+            Some(target_ty) => report_forof_target(target_ty, "for-of target")
             None => ()
           }
           if is_checkable(elem_ty) {
             env.narrow(n, elem_ty)
           }
+        }
+        // The PROPERTY / INDEX spellings of the same write. The parser
+        // wraps a non-identifier assignment-form head as
+        // `TsBinding::Target(expr)`, which used to fall through to the
+        // destructuring-pattern arm below and be dropped there. Restricted
+        // to a member reference: an arbitrary expression in that position
+        // is not a valid assignment target and is somebody else's
+        // diagnostic.
+        (
+          @ast.TsForOfKind::Assign,
+          @ast.TsBinding::Target(PropAccess(_, _) | IndexAccess(_, _) as tgt),
+        ) => {
+          check_call_args_in_expr(env, tgt, ctx)
+          report_forof_target(
+            infer_expr(env, ctx.resolver, tgt),
+            "for-of target",
+          )
         }
         (@ast.TsForOfKind::Assign, _) => {
           // Assignment-form destructuring PATTERN: the named targets keep

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -12617,6 +12617,34 @@ fn optionality_level(t : @ast.TsType) -> (@ast.TsType, Int) {
 }
 
 ///|
+/// The utility types whose field shape `lookup_field` and
+/// `collect_declared_fields` can actually project. `Record<K, V>` answers
+/// every key with `V`; the other five project their argument's fields.
+///
+/// One predicate rather than a second literal list, because a second list
+/// is the defect this exists to fix: the `(ObjectLit, Applied(name, _))`
+/// dispatcher in `check_expr_against` deliberately routes these six into
+/// `check_object_lit_against_target` — its comment says so, "since
+/// `lookup_field` / `collect_declared_fields` know how to project their
+/// field shapes" — and that function then threw them out again through
+/// `member_recv_unmodeled`, which calls any `Applied` to a non-class,
+/// non-interface name unmodeled. Two sites, one decision, opposite
+/// answers.
+fn target_is_projectable_record(
+  ty : @ast.TsType,
+  resolver : Resolver,
+  ctx : CheckCtx,
+) -> Bool {
+  match resolver.unwrap(ty) {
+    Applied("Record", [k, v]) =>
+      resolver.unwrap(k) is (String_ | Number | Int) &&
+      not(type_contains_unresolved_named(v, resolver)) &&
+      not(is_in_scope_type_param(ctx, v))
+    _ => false
+  }
+}
+
+///|
 fn check_object_lit_against_target(
   env : ExprEnv,
   entries : Array[(String, @ast.TsExpr)],
@@ -12642,14 +12670,45 @@ fn check_object_lit_against_target(
   // supplied key would look like an excess property and every declared field
   // like a missing one. TypeScript resolves these fully — suppress the whole
   // excess/missing check rather than emit false positives.
-  if member_recv_unmodeled(target, resolver) {
+  //
+  // The six projectable utility types are exempt: `member_recv_unmodeled`
+  // calls every `Applied` to a non-class, non-interface name unmodeled,
+  // which catches `Record<string, Color>` — and the caller routed it here
+  // precisely because its shape CAN be projected. Without the exemption
+  // the two sites disagree and `{ black: { r, g, d } } satisfies
+  // Record<string, Color>` reports nothing.
+  //
+  // The missing-required half stays vacuous for `Record` by construction:
+  // `collect_declared_fields` has no `Record` arm, so it returns no
+  // declared names and nothing can be reported missing — which is right,
+  // since `Record<string, V>` requires no particular key.
+  if member_recv_unmodeled(target, resolver) &&
+    not(target_is_projectable_record(target, resolver, ctx)) {
     return
   }
   // An unresolved `Named` / `Applied` target — typically a method-level type
   // parameter (`foo<U extends T>(x: U)`) the enclosing-scope check above
   // doesn't track — has an unknown shape, so TypeScript allows extra
   // properties (the instantiation may be wider). Suppress excess/missing.
-  if type_contains_unresolved_named(target, resolver) {
+  //
+  // `Record<string, V>` is judged by its VALUE argument instead of as a
+  // whole. `Record` is not a class or an interface, so the predicate calls
+  // it unresolved, and that is the second of the two early returns that
+  // made `{ black: { r, g, d } } satisfies Record<string, Color>` silent —
+  // while `lookup_field` answers every key of a `Record` with `V`, which
+  // is why the caller routed it here in the first place.
+  //
+  // Only `Record`, and only with a bare `string` / `number` KEY. The wider
+  // version — every projectable utility, judged by all of its arguments —
+  // was implemented and MEASURED, and it is a false positive on
+  // `isomorphicMappedTypeInference`: `f20<T, K extends keyof T>(obj:
+  // Pick<T, K>)` accepts any object literal, because `T` is inferred FROM
+  // the argument, and `Pick`'s arguments there are type parameters that
+  // this predicate does not recognise as unresolved. A type-parameter KEY
+  // is the same hazard (`f<K extends string>(o: Record<K, number>)`), so
+  // the key must be the concrete keyword.
+  if not(target_is_projectable_record(target, resolver, ctx)) &&
+    type_contains_unresolved_named(target, resolver) {
     return
   }
   // Excess-property reporting is suppressed for a bare anonymous `Object`

--- a/src/checker/expr_check.mbt
+++ b/src/checker/expr_check.mbt
@@ -9056,12 +9056,19 @@ fn symbol_member_shape_blocks(
 }
 
 ///|
+/// `arg_callee_non_generic` is the one fact that lets the excess-property
+/// check run at a CALL argument. See `check_object_lit_against_target`'s
+/// `suppress_excess` for why the position is suppressed by default and why
+/// this is the exact fact that lifts it. It defaults to `false` — "the
+/// caller cannot answer" — which keeps the suppression, so a call site that
+/// does not thread it loses a finding rather than inventing one.
 fn check_expr_against(
   env : ExprEnv,
   expr : @ast.TsExpr,
   expected : @ast.TsType,
   ctx : CheckCtx,
   sub_path : String,
+  arg_callee_non_generic? : Bool = false,
 ) -> Unit {
   // Always walk for nested call-site argument errors, even when the outer
   // expected type is `Any` (e.g. an unannotated return where we still want
@@ -9741,6 +9748,7 @@ fn check_expr_against(
         ctx.resolver,
         ctx,
         sub_path,
+        arg_callee_non_generic~,
       )
       return
     }
@@ -9754,6 +9762,7 @@ fn check_expr_against(
             ctx.resolver,
             ctx,
             sub_path,
+            arg_callee_non_generic~,
           )
           return
         }
@@ -9779,6 +9788,7 @@ fn check_expr_against(
           ctx.resolver,
           ctx,
           sub_path,
+          arg_callee_non_generic~,
         )
         return
       }
@@ -12652,6 +12662,7 @@ fn check_object_lit_against_target(
   resolver : Resolver,
   ctx : CheckCtx,
   sub_path : String,
+  arg_callee_non_generic? : Bool = false,
 ) -> Unit {
   // When the target is a bare in-scope type parameter (`T extends Foo`),
   // we don't know the concrete shape — TS allows objects with additional
@@ -12721,8 +12732,31 @@ fn check_object_lit_against_target(
   // variable/property assignments to an explicit object type (`var x: { a:
   // string } = { a, b }`) keep their excess-property diagnostic. Field-type
   // and missing-required checks below still run regardless.
+  // Probed, and this is the ONE recorded abstention in this series whose
+  // stated reason turned out to be right: removing the suppression
+  // outright is +0 conformance files and +3 false positives on
+  // hand-written TS7-accepted code, because a constrained type
+  // parameter's bound really IS inlined into the parameter position —
+  // `foo<U extends { length: number }>(x: U)` accepts
+  // `{ length: 1, extra: 2 }`, and the earlier early returns do not catch
+  // it. Corpus-wide the blunt removal measures +0 TP / +1 FP.
+  //
+  // `arg_callee_non_generic` is what makes the position decidable without
+  // that hazard: a callee with NO type parameters has no bound to inline,
+  // so an `Object(_)` parameter target must be a written inline object
+  // type. Only the call sites that can prove it set the flag (a direct
+  // call to a resolved function declaration, and `new` on a resolved
+  // class); everything else keeps the suppression, which loses a finding
+  // rather than inventing one. The cost of the gate is a generic
+  // function's genuinely-inline object parameter, also a MISS.
+  //
+  // The conformance corpus scores this at ZERO — the call position is
+  // where real code hits TS2353, and the corpus does not test it, so the
+  // measurement that justifies the rule is the position matrix and the
+  // unit test, not the gate.
   let suppress_excess = sub_path.contains("arg[") &&
-    resolver.unwrap(target) is Object(_)
+    resolver.unwrap(target) is Object(_) &&
+    not(arg_callee_non_generic)
   // Per-field type checks for each provided key.
   for entry in entries {
     let key = entry.0
@@ -12774,7 +12808,14 @@ fn check_object_lit_against_target(
     }
     match resolver.lookup_field(target, key) {
       Some(declared) =>
-        check_expr_against(env, value, declared, ctx, "\{sub_path}.\{key}")
+        check_expr_against(
+          env,
+          value,
+          declared,
+          ctx,
+          "\{sub_path}.\{key}",
+          arg_callee_non_generic~,
+        )
       None =>
         // Unknown key on the target — TS calls this an excess-property
         // error. Skip class/struct opaque shapes by relying on lookup_field
@@ -13636,6 +13677,11 @@ fn check_arguments_with_sig(
   call_path : String,
   arity_reliable? : Bool = false,
   check_spread? : Bool = false,
+  // True only when the caller has PROVEN the callee declares no type
+  // parameters. That is what lets the excess-property check run at an
+  // argument position — see `check_object_lit_against_target`. Default
+  // `false` means "cannot answer", which keeps the suppression.
+  callee_non_generic? : Bool = false,
 ) -> Unit {
   // TS2556 ("A spread argument must either have a tuple type or be passed
   // to a rest parameter"): tsc's arity rule for the first non-tuple spread
@@ -13979,7 +14025,14 @@ fn check_arguments_with_sig(
       check_expr_against(env, args[i], rest_elem_type, ctx, sub_path)
     } else if i < params.length() {
       check_generator_arg_treturn(ctx, args[i], params[i], sub_path)
-      check_expr_against(env, args[i], params[i], ctx, sub_path)
+      check_expr_against(
+        env,
+        args[i],
+        params[i],
+        ctx,
+        sub_path,
+        arg_callee_non_generic=callee_non_generic,
+      )
       // TS2345: an unannotated array-destructuring parameter is tuple-like
       // (`function fun([a, b]) {}` types as `[any, any]`), so an iterable
       // that is not array-like never satisfies it (`fun(new FooIterator)`).
@@ -18113,6 +18166,18 @@ fn check_call_args_in_expr(
             // type is a `Union`), so the signature is exact and the TS2556
             // spread-argument arity rule can run.
             check_spread=true,
+            // A callee with NO type parameters cannot have had a bound
+            // inlined into a parameter position, which is what makes the
+            // excess-property check decidable at an argument. An ABSENT
+            // entry in `func_type_params` is not proof — a call-signature
+            // -typed variable or a lib method has no entry either — so the
+            // fact is only claimed when the resolver has a signature for
+            // this name AND its type-parameter list is empty.
+            callee_non_generic=(match ctx.resolver.func_type_params.get(name) {
+                Some(tps) => tps.length() == 0
+                None => false
+              }) &&
+              sig is Some(_),
           )
         }
         other =>
@@ -18605,6 +18670,13 @@ fn check_call_args_in_expr(
             ctx,
             "new `\{class_name}`",
             arity_reliable=true,
+            // Same fact as the direct-call site: a non-generic class's
+            // constructor parameters are written types, so an object
+            // literal argument's excess keys are decidable.
+            callee_non_generic=match ctx.resolver.classes.get(class_name) {
+              Some(c) => c.type_params.length() == 0
+              None => false
+            },
           )
           for a in args {
             check_call_args_in_expr(env, a, ctx)

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -18873,3 +18873,50 @@ test "checker: excess properties at a call argument (batch DX)" {
     @test.assert_eq(issues(t + src), 0)
   }
 }
+
+///|
+/// Batch DY: the assignment-form `for…of` target check at its other two
+/// spellings. It fired for a bare `Var` and was blind to `o.x`,
+/// `foo().x` and `arr[0]` — the parser wraps a non-identifier
+/// assignment-form head as `TsBinding::Target(expr)`, which fell through
+/// to the destructuring-pattern arm and was dropped there. One shared
+/// closure now holds the guard chain, so the three spellings cannot
+/// diverge again.
+///
+/// Corpus yield is ZERO, and the reason is worth more than the rule:
+/// `ES5For-of8` is `function foo() { return { x: 0 } }` with
+/// `for (foo().x of ['a','b','c'])`, and an UN-ANNOTATED function's
+/// return type does not resolve here at all — `const bad: string =
+/// foo().x` is silent too. So the file needs return-type inference from a
+/// body, not this rule.
+test "checker: assignment-form for-of target, all three spellings (batch DY)" {
+  let issues = fn(src : String) -> Int {
+    let mut n = 0
+    for i in check_module_function_bodies_permissive(parse_module_or_empty(src)) {
+      if i.path.contains("for-of target") {
+        n = n + 1
+      }
+    }
+    n
+  }
+  for
+    src in [
+      "declare let n: number;\nfor (n of [\"a\", \"b\"]) { }", "declare const o: { x: number };\nfor (o.x of [\"a\", \"b\"]) { }",
+      "declare const arr: number[];\nfor (arr[0] of [\"a\", \"b\"]) { }", "declare function foo(): { x: number };\nfor (foo().x of [\"a\", \"b\"]) { }",
+      "function foo(): { x: number } { return { x: 0 }; }\nfor (foo().x of [\"a\", \"b\"]) { }",
+    ] {
+    assert_true(issues(src) > 0)
+  }
+  // Silent: a matching target type, `any`, and a union that admits the
+  // element type. Plus the shape the corpus file actually has — an
+  // un-annotated `foo()`, whose return type does not resolve, so this
+  // abstains rather than guessing.
+  for
+    src in [
+      "declare const o: { x: string };\nfor (o.x of [\"a\", \"b\"]) { }", "declare const arr: string[];\nfor (arr[0] of [\"a\", \"b\"]) { }",
+      "declare const o: { x: any };\nfor (o.x of [\"a\", \"b\"]) { }", "declare const o: { x: string | number };\nfor (o.x of [\"a\", \"b\"]) { }",
+      "function foo() { return { x: 0 }; }\nfor (foo().x of [\"a\", \"b\"]) { }",
+    ] {
+    @test.assert_eq(issues(src), 0)
+  }
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -18920,3 +18920,63 @@ test "checker: assignment-form for-of target, all three spellings (batch DY)" {
     @test.assert_eq(issues(src), 0)
   }
 }
+
+///|
+/// Batch DZ: TS18030, an optional chain containing a private identifier.
+///
+/// Taken from the "strict-null / narrowing" bucket, whose label is wrong
+/// about every file in it. Five files carry a strict-null code and the
+/// cheapest lever in each is something else entirely: this one is pure
+/// GRAMMAR (the position of the `?.` relative to the `#name` is the whole
+/// rule), `typeofThis` needs a `this`-rebinding context, another needs
+/// name resolution in a type-argument position, another declaration-merge
+/// inference, and the last one aliased control flow. Eighth instance of a
+/// label standing in for the objective.
+///
+/// Every row below was probed against the real compiler, and the one that
+/// mattered is the LAST silent case: `(this?.c).#b` is TS2532 and NOT
+/// TS18030, so parenthesizing ends the chain. This parser gets that right
+/// by construction rather than by a rule — the inner expression is parsed
+/// by its own invocation of the postfix loop, so the outer `.#b` never sees
+/// the flag — and the same mechanism is why a private access inside a call
+/// ARGUMENT within the chain stays legal.
+test "expr_check: an optional chain cannot contain private identifiers (batch DZ)" {
+  let issues = fn(src : String) -> Int {
+    check_module_function_bodies_permissive(parse_module_or_empty(src)).length()
+  }
+  let cls = "class A { #b?: A; c?: A; getA(x?: any): A { return new A(); }\n"
+  // --- fires: the `#private` sits after a `?.` in the same chain
+  for
+    src in [
+      // Directly after the `?.` that opens the chain.
+      cls + "  m() { this?.#b; } }",
+      // Later in the chain, through a plain `.` step.
+      cls + "  m() { this?.c.#b; } }",
+      // Later in the chain, through a call.
+      cls + "  m() { this?.getA().#b; } }",
+      // The receiver need not be `this`.
+      cls + "  m(o: A) { o?.c.#b; } }",
+    ] {
+    assert_true(issues(src) > 0)
+  }
+  // --- stays silent (the legal neighbours, all probed)
+  for
+    src in [
+      // No optional chain at all.
+      cls + "  m() { this.#b; } }",
+      // The `?.` comes AFTER the private name — this is the spelling real
+      // code writes, and the flag is still false when `.#b` is read.
+      cls + "  m() { this.#b?.c; } }",
+      // An optional chain with no private access.
+      cls + "  m() { this?.c; } }",
+      cls + "  m(k: any) { this?.getA()?.c; } }",
+      // Parenthesizing ends the chain: tsc reports TS2532 here and not
+      // TS18030, and the nested postfix loop is what makes that automatic.
+      cls + "  m() { (this?.c).#b; } }",
+      // A private access inside a call argument within the chain belongs
+      // to its own chain, for the same reason.
+      cls + "  m(o: A) { this?.getA(o.#b); } }",
+    ] {
+    @test.assert_eq(issues(src), 0)
+  }
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -18801,3 +18801,75 @@ test "checker: excess properties through Record<string, V> (batch DW)" {
     @test.assert_eq(issues(color + src), 0)
   }
 }
+
+///|
+/// Batch DX: the excess-property check runs at a CALL argument when the
+/// callee is provably non-generic.
+///
+/// A position matrix says the check covered the annotated declaration,
+/// `return`, an array element, `satisfies`, assignment and a nested
+/// property, and was missing at every CALL position — which is where real
+/// code hits TS2353. Batch DW measured the blunt fix: removing the
+/// suppression outright is +0 conformance files and +3 false positives on
+/// TS7-accepted code, because a constrained type parameter's bound IS
+/// inlined into the parameter position.
+///
+/// The fact that lifts it is `callee_non_generic`: no type parameters
+/// means no bound can have been inlined, so an `Object(_)` parameter
+/// target must be a written inline object type. Only two call sites can
+/// prove it — a direct call to a resolved function declaration, and `new`
+/// on a resolved class — and everything else keeps the suppression.
+///
+/// The conformance corpus scores this rule at ZERO, so this test IS the
+/// measurement.
+test "checker: excess properties at a call argument (batch DX)" {
+  let issues = fn(src : String) -> Int {
+    let mut n = 0
+    for i in check_module_function_bodies_permissive(parse_module_or_empty(src)) {
+      if i.message.contains("does not exist on target type") {
+        n = n + 1
+      }
+    }
+    n
+  }
+  let t = "type T = { a: number };\n"
+  for
+    src in [
+      // A direct call to a non-generic declaration — the commonest real
+      // TS2353 site, and the whole point of the batch.
+      "declare function f(o: T): void;\nf({ a: 1, b: 2 });", "declare function n(o: T): void;\nn({ a: 1, b: 2, c: 3 });",
+      "function g(o: T) {}\ng({ a: 1, b: 2 });",
+      // `new` on a non-generic class.
+       "class C { constructor(o: T) {} }\nnew C({ a: 1, b: 2 });",
+      // Nested under an argument: the target there came from a
+      // `lookup_field` on a written parameter type, so the fact holds at
+      // depth.
+       "declare function f(o: { a: { x: number } }): void;\nf({ a: { x: 1, y: 2 } });",
+      "declare function f(o: { a: { x: number } }): void;\nf({ a: { x: 1 }, b: 2 });",
+    ] {
+    assert_true(issues(t + src) > 0)
+  }
+  // Silent, and the first four are the false positives the gate exists to
+  // avoid — all TS7-ACCEPTED, because a type parameter's bound is inlined
+  // into the parameter position and excess properties are legal against a
+  // type parameter:
+  for
+    src in [
+      "declare function foo<U extends { length: number }>(x: U): void;\nfoo({ length: 1, extra: 2 });",
+      "function foo<U extends { length: number }>(x: U) {}\nfoo({ length: 1, extra: 2 });",
+      "declare function foo<U>(x: U): void;\nfoo({ a: 1, b: 2 });", "declare function bar<U extends { a: number }>(x: U[]): void;\nbar([{ a: 1, b: 2 }]);",
+      "class C<U extends T> { constructor(o: U) {} }\nnew C({ a: 1, b: 2 });",
+      // A type ASSERTION suppresses the check in tsc, and did here
+      // already — the gate must not turn that on.
+       "declare function f(o: T): void;\nf({ a: 1, b: 2 } as T);",
+      // A well-formed argument.
+       "declare function f(o: T): void;\nf({ a: 1 });",
+      // Positions the gate deliberately does NOT reach, because neither
+      // call site can prove the callee's genericity: a method call and a
+      // call through a function-typed binding. Both are MISSes, which is
+      // the affordable direction.
+       "class C { m(o: T) {} }\nnew C().m({ a: 1, b: 2 });", "const f: (o: T) => void = (o) => {};\nf({ a: 1, b: 2 });",
+    ] {
+    @test.assert_eq(issues(t + src), 0)
+  }
+}

--- a/src/checker/expr_check_wbtest.mbt
+++ b/src/checker/expr_check_wbtest.mbt
@@ -18750,3 +18750,54 @@ test "checker: TS7022 indirect through the iteration protocol (batch DV)" {
     @test.assert_eq(issues(h + src), 0)
   }
 }
+
+///|
+/// Batch DW: the excess-property check reaches a `Record<string, V>`
+/// target. Two sites held one decision and gave opposite answers.
+///
+/// `check_expr_against`'s `(ObjectLit, Applied(name, _))` arm
+/// deliberately routes the six projectable utility types into
+/// `check_object_lit_against_target` — its comment says so, "since
+/// `lookup_field` / `collect_declared_fields` know how to project their
+/// field shapes" — and that function then threw them straight back out
+/// through TWO early returns, `member_recv_unmodeled` and
+/// `type_contains_unresolved_named`, both of which call any `Applied` to
+/// a non-class, non-interface name unresolvable.
+///
+/// The exemption is `Record` only, and only with a bare `string` /
+/// `number` KEY. The wider version — every projectable utility, judged by
+/// all of its arguments — was implemented and MEASURED: it is +1 TP and
+/// +1 FP, the false positive being `isomorphicMappedTypeInference`'s
+/// `f20<T, K extends keyof T>(obj: Pick<T, K>)`, which accepts any object
+/// literal because `T` is inferred FROM the argument.
+test "checker: excess properties through Record<string, V> (batch DW)" {
+  let issues = fn(src : String) -> Int {
+    let mut n = 0
+    for i in check_module_function_bodies_permissive(parse_module_or_empty(src)) {
+      if i.message.contains("does not exist on target type") {
+        n = n + 1
+      }
+    }
+    n
+  }
+  let color = "type Color = { r: number, g: number, b: number };\n"
+  // The corpus shape (`typeSatisfaction_propertyValueConformance3`) and its
+  // plain-annotation twin.
+  for
+    src in [
+      "const P = { black: { r: 0, g: 0, d: 0 } } satisfies Record<string, Color>;",
+      "const P: Record<string, Color> = { black: { r: 0, g: 0, d: 0 } };", "const P: Record<number, Color> = { 1: { r: 0, g: 0, d: 0 } };",
+    ] {
+    assert_true(issues(color + src) > 0)
+  }
+  // Silent: a well-formed value; and the two shapes whose keys are not
+  // enumerable, where excess properties are legal because the
+  // instantiation may be wider.
+  for
+    src in [
+      "const P: Record<string, Color> = { black: { r: 0, g: 0, b: 0 } };", "declare function f20<T, K extends keyof T>(obj: Pick<T, K>): T;\nconst x = f20({ foo: 1, bar: 2 });",
+      "declare function g<K extends string>(o: Record<K, number>): void;\ng({ a: 1, b: 2 });",
+    ] {
+    @test.assert_eq(issues(color + src), 0)
+  }
+}

--- a/src/parser/parser_expr.mbt
+++ b/src/parser/parser_expr.mbt
@@ -681,6 +681,32 @@ fn Parser::resolve_private_name(self : Parser, name : String) -> String {
 }
 
 ///|
+/// TS18030 ("An optional chain cannot contain private identifiers"), recorded
+/// when the property name about to be read is a `#private` and the chain has
+/// already seen a `?.`.
+///
+/// Purely syntactic: the position of the `?.` relative to the `#name` is the
+/// whole rule, so it needs no type and belongs in the parser. Called before
+/// `parse_property_name_token` at BOTH sites that consume a chain property —
+/// the `?.` branch (`this?.#b`) and the plain `.` branch (`this?.a.#b`,
+/// `this?.getA().#b`) — with one flag, because writing the condition at one
+/// of them is what this repo's ledger keeps recording.
+///
+/// The legal neighbour is the same access with the `?.` AFTER the private
+/// name: `this.#b?.a` reads `.#b` at the plain-`.` branch before any `?.` has
+/// been seen, so the flag is false and nothing fires.
+fn Parser::record_optional_chain_private_name(
+  self : Parser,
+  saw_optional_in_chain : Bool,
+) -> Unit {
+  if saw_optional_in_chain && self.peek().kind is PrivateIdent(_) {
+    self.grammar_misuses.push(
+      "an optional chain cannot contain private identifiers",
+    )
+  }
+}
+
+///|
 fn Parser::parse_property_name_token(self : Parser) -> String raise ParseError {
   match self.advance().kind {
     Ident(name) => name
@@ -2517,6 +2543,15 @@ fn Parser::parse_call(self : Parser) -> @ast.TsExpr raise ParseError {
   // followed — bare `parse_primary()` results (`x` alone, no
   // `(args)`) shouldn't be tagged pure.
   let mut saw_call_in_chain = false
+  // TS18030: once a `?.` has appeared, a `#private` member access anywhere
+  // LATER in the same chain is an error. Chain-local rather than a Parser
+  // field on purpose: an argument to a call inside the chain
+  // (`this?.getA(other.#b)`) is parsed by its own invocation of this loop,
+  // so it gets its own flag and cannot inherit ours. Parenthesizing ends
+  // the chain for the same reason — `(this?.a).#b` parses the inner
+  // expression in a nested loop, and tsc agrees that the outer `.#b` is
+  // then legal.
+  let mut saw_optional_in_chain = false
   // Explicit type arguments captured for the call about to be built
   // (`foo<number>(x)`). Reset after each call form consumes them.
   let mut pending_type_args : Array[@ast.TsType] = []
@@ -2538,6 +2573,11 @@ fn Parser::parse_call(self : Parser) -> @ast.TsExpr raise ParseError {
     if self.check(Question) && self.peek_at(1).kind == Dot {
       let _ = self.advance()
       let _ = self.advance()
+      // Set BEFORE the property name below is read, so `this?.#b` — the
+      // private ident directly after the `?.` that opens the chain — and
+      // `this?.a.#b` are one condition tested at two sites rather than two
+      // conditions.
+      saw_optional_in_chain = true
       // `?.<T>(args)` — generic optional call. Consume the type
       // args then fall through to the `LParen` branch so the
       // OptionalChain wrap still happens.
@@ -2576,6 +2616,7 @@ fn Parser::parse_call(self : Parser) -> @ast.TsExpr raise ParseError {
           continue
         }
         _ => {
+          self.record_optional_chain_private_name(saw_optional_in_chain)
           let prop = self.parse_property_name_token()
           expr = @ast.TsExpr::OptionalChain(PropAccess(expr, prop))
           continue
@@ -2610,6 +2651,7 @@ fn Parser::parse_call(self : Parser) -> @ast.TsExpr raise ParseError {
     } else if self.check(Dot) {
       // property
       let _ = self.advance()
+      self.record_optional_chain_private_name(saw_optional_in_chain)
       let prop = self.parse_property_name_token()
       expr = PropAccess(expr, prop)
     } else {


### PR DESCRIPTION
Sixteen commits: four checker batches, then a bridge series that ends with an
empty declared backlog.

## Bridge — every declaration promising a payload-bearing enum now builds one

A MoonBit `pub(all) enum` with a payload is `{ "$tag": i, "_0": v }` at the JS
boundary. A wrapper that hands back the raw JS value instead leaves a MoonBit
`match` reading `$tag` off something that has none — a wrong value no compile
gate can see, since the declared type is identical either way.

`scripts/bridge_enum_return_probe.mjs` asks the question, and
`scripts/bridge_unconverted_enum_crossings.txt` declared the 18 occurrences it
found with a kind and a reason each. That file now declares **nothing**: the
probe reports 0 undeclared / 0 stale, and its STALE half is what emptied it —
first the two `optional-gate` entries, then the 16 that were left.

Those 16 were one decision made in three places plus two renderers nobody had
asked, and each step contradicted the previous one:

1. `ffi_widen_unbuildable_union_outputs` had no arm for a SYNTHESIZED union —
   it keeps its `Union(parts)` shape in the AST while its signature already
   reads `Auto_X_or_Y`.
2. The arm's first version was ORDER-DEPENDENT, which is worth more than the
   arm: it asked whether the alias was already in
   `state.tagged_union_decls_by_name`, a map filled as a side effect of
   rendering. `Auto_IdentifierValue_or_PrivateIdentifierValue` is also a
   parameter of `idText` nine lines above, so it was registered;
   `Auto_VariableDeclarationValue_or_ParameterDeclarationValue` occurs exactly
   once and was not — one declaration fixed, its neighbour silently not.
   `ffi_output_union_decl` builds the decl on the spot instead.
3. Widening the extern alone gives `[4014] has type JSValue?, wanted
   Auto_...?`, because one export has THREE renderings: the `.mbti` line comes
   from the decl layer and the public wrapper is rendered from that line.
   `reconcile_bridge_widened_union_returns` makes the declaration agree with
   the extern that implements it, scoped so it cannot touch the two families
   where a declaration legitimately differs from its extern. Both aftermaths
   of the widening are covered — with the union still mentioned elsewhere the
   enum survives and the symptom is `[4014]`; when the widened return was its
   last mention nothing synthesizes the enum and the identical stale line is
   `[4032] the type Auto_... is undefined`, which is how
   `walkUpBindingElementsAndPatterns` failed to compile in the same run where
   `getNameOfJSDocTypedef` came out right.
4. An index signature's two directions are two questions and shared one type
   name: `index_get` crosses JS -> MoonBit and widens, `index_set` crosses the
   other way and keeps its type while converting in the body.
5. A method's return needed the widening but NOT in
   `ffi_function_type_parts`: a function type has no direction of its own, so
   widening there also widened callback returns and broke `Matcher::_call_`
   (`has type ExpectationResult, wanted JSValue`). It belongs in the one
   branch that binds straight to a JS call.

Earlier in the series: `instanceof` against an erased TypeScript name is no
longer emitted (411 unbound sites over 197 names; 2,126 of 2,530 converter
calls had been throwing `ReferenceError`), tagged unions convert at the four
class-accessor paths, the `.mbti` agrees with the `.mbt` by construction
instead of accumulating beside it, and heterogeneous-union widenings are
declared rather than counted.

The `.mbti` emitter was located by instrumenting, and the first run was a
false zero worth recording: markers in the three `declare pub fn` renderers of
`parser_moonbit.mbt` attributed 0 of 11 lines, because the fixture chosen was
a class-only `.d.ts` and a class declares no top-level function. It is
`parser_moonbit.mbt:1426` through `moonbit_decl.mbt:12526`.

Left filed rather than half-applied: a function-typed struct FIELD still
promises the enum, because `ffi_func_type_name` has no direction parameter and
the probe does not read struct fields yet.

## Checker — batches DW to DZ

- **DW**: the excess-property check reaches a `Record<string, V>` target. Two
  sites held one decision and gave opposite answers; the wider version was
  measured (+1 TP / +1 FP) before being cut to `Record` with a bare key.
- **DX**: excess properties at a CALL argument, gated on a callee proven
  non-generic. Zero conformance files by design — the corpus does not test
  that position, and it is the commonest place real code hits TS2353.
- **DY**: the assignment-form `for…of` target at all three spellings.
- **DZ**: TS18030, and the finding that the triage's "strict-null / narrowing"
  bucket of five files holds five unrelated kinds of work.

## Verification

- `moon check` 0 errors; `moon test --target native` 2994/2994
- `bridge_enum_return_probe` 0 undeclared / 0 stale
- `verify-bridge-runtime`: 86 modules, 14,630 converter calls, 0 failures,
  0 unbound `instanceof` sites
- `bridge_quality_report.sh` `pass`, with `duplicate declared fn names 0`
- `verify-scaffolds`, `verify-generated-fixtures`, `verify-examples`,
  `verify-mbti-dts` all pass
- Checker oracle at FP 0 throughout

New coverage is mutation-proven, not asserted:
`fixtures/resolver/project/types/widened-union-output-entry.d.ts` carries a
negative control (`string | URL` discriminates at runtime, so that union keeps
its enum), so the fix cannot be "switch the lowering off"; both halves of it
fail the test when reverted individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ygRti5U1q3rrdrLM5euqM


---
_Generated by [Claude Code](https://claude.ai/code/session_016ygRti5U1q3rrdrLM5euqM)_